### PR TITLE
Solves GH-42 Refresh rebar lock (unlock, tree, lock)

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -21,8 +21,7 @@
             {test, [{relx, [{dev_mode, true},
                             {include_erts, false},
                             {include_src, true}]},
-                    {deps, [{lager, ".*", {git, "https://github.com/erlang-lager/lager.git", {tag, "3.5.1"}}},
-                            {meck, ".*", {git, "git://github.com/eproxus/meck.git", {tag, "0.8.6"}}}
+                    {deps, [{meck, ".*", {git, "git://github.com/eproxus/meck.git", {tag, "0.8.6"}}}
                            ]}
                    ]},
             {prod, [{relx, [{dev_mode, false},

--- a/rebar.lock
+++ b/rebar.lock
@@ -3,10 +3,6 @@
  {<<"lager">>,
   {git,"https://github.com/erlang-lager/lager.git",
        {ref,"c3970a99131c7c73de7eba3c2a569806fe47e40a"}},
-  0},
- {<<"meck">>,
-  {git,"git://github.com/eproxus/meck.git",
-       {ref,"36b208e2d4d7d09ef7ef7f7aa7979da79fa97ef3"}},
   0}]}.
 [
 {pkg_hash,[


### PR DESCRIPTION
Also delete duplicated lager dependency.

----

This ticket does not close ticket 42, but I made this improvement while I was working on it.