### PR TITLE
This fixes #51. rand:uniform instead of crypto:rand_unfiform

### DIFF
--- a/apps/aecore/src/aec_pow_sha256.erl
+++ b/apps/aecore/src/aec_pow_sha256.erl
@@ -108,4 +108,4 @@ log2(N) when N > 1 ->
     1 + log2(N div 2).
 
 pick_nonce() ->
-    crypto:rand_uniform(0, ?NONCE_RANGE).
+    rand:uniform(?NONCE_RANGE).


### PR DESCRIPTION
Small PR for #51. We are going to remove `aec_pow_sha256`, but till that this 5MinutesFix(tm) makes our code warning-less.