### PR TITLE
GH-5 Generate call with default number of trims and threads added

### DIFF
--- a/apps/aecore/c_src/aec_pow_cuckoo.cpp
+++ b/apps/aecore/c_src/aec_pow_cuckoo.cpp
@@ -18,7 +18,7 @@
 #define HEADERLEN 80
 
 
-node_t* generate(char* header, int nonce, int ntrims, int nthreads) {
+node_t* generate_single(char* header, int nonce, int ntrims, int nthreads) {
   printf("Looking for %d-cycle on cuckoo%d(\"%s\",%d) with 50%% edges, %d trims, %d threads\n",
          PROOFSIZE, EDGEBITS + 1, header, nonce, ntrims, nthreads);
 

--- a/apps/aecore/c_src/aec_pow_cuckoo_nif.cpp
+++ b/apps/aecore/c_src/aec_pow_cuckoo_nif.cpp
@@ -16,7 +16,7 @@
 #define HEADERLEN 80
 
 
-extern node_t* generate(char* header, int nonce, int ntrims, int nthreads);
+extern node_t* generate_single(char* header, int nonce, int ntrims, int nthreads);
 extern int verify(char* header, int nonce, node_t soln[PROOFSIZE]);
 
 int read_solution(ErlNifEnv* env, const ERL_NIF_TERM e_soln, node_t soln[PROOFSIZE]);
@@ -27,7 +27,7 @@ int get_uint64(ErlNifEnv* env, const ERL_NIF_TERM from, uint64_t* to);
 /// API
 ///=============================================================================
 
-static ERL_NIF_TERM generate_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+static ERL_NIF_TERM generate_single_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {
   int nonce, ntrims, nthreads;
   char header[HEADERLEN];
@@ -40,7 +40,7 @@ static ERL_NIF_TERM generate_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM ar
       !enif_get_int(env, argv[3], &nthreads))
     return enif_make_badarg(env);
 
-  node_t* result = generate(header, nonce, ntrims, nthreads);
+  node_t* result = generate_single(header, nonce, ntrims, nthreads);
 
   if (result) {
     // success: encode result
@@ -92,9 +92,9 @@ static ERL_NIF_TERM get_node_size_nif(ErlNifEnv* env, int argc, const ERL_NIF_TE
 }
 
 static ErlNifFunc nif_funcs[] = {
-  {"generate", 4, generate_nif, ERL_NIF_DIRTY_JOB_CPU_BOUND},
-  {"verify", 3, verify_nif, 0},
-  {"get_node_size", 0, get_node_size_nif, 0}
+  {"generate_single", 4, generate_single_nif, ERL_NIF_DIRTY_JOB_CPU_BOUND},
+  {"verify",          3, verify_nif,          0},
+  {"get_node_size",   0, get_node_size_nif,   0}
 };
 
 ERL_NIF_INIT(aec_pow_cuckoo, nif_funcs, NULL, NULL, NULL, NULL);

--- a/apps/aecore/test/aec_pow_cuckoo_tests.erl
+++ b/apps/aecore/test/aec_pow_cuckoo_tests.erl
@@ -28,7 +28,7 @@ pow_test_() ->
                 BigDiff = 256*256 + 255 + 1,
                 {T1, Res} = timer:tc(?TEST_MODULE, generate,
                                      [<<"wsffgujnjkqhduihsahswgdf">>, 169,
-                                      BigDiff, 7, 20, 100]),
+                                      BigDiff, 7, 5, 100]),
                 ?debugFmt("~nReceived result ~p~nin ~p microsecs~n~n", [Res, T1]),
                 ?assertEqual(ok, element(1, Res)),
 
@@ -46,7 +46,7 @@ pow_test_() ->
                 %% Unlikely to succeed after 2 steps
                 SmallDiff = 256*2 + 1,
                 Res = ?TEST_MODULE:generate(<<"wsffgujnjkqhduihsahswgdf">>, 169,
-                                            SmallDiff, 7, 20, 2),
+                                            SmallDiff, 7, 5, 2),
                 ?debugFmt("Received result ~p~n", [Res]),
                 ?assertEqual({error, generation_count_exhausted}, Res)
         end}


### PR DESCRIPTION
@wagerlabs supported the idea of adding a function with default values for the number of trims and threads, This PR implements it.