### PR TITLE
GH-69 Block header hash

### DIFF
--- a/apps/aecore/include/blocks.hrl
+++ b/apps/aecore/include/blocks.hrl
@@ -1,8 +1,11 @@
 -include("trees.hrl").
 
+-define(BLOCK_HEADER_HASH_BYTES, 32).
+-type(block_header_hash() :: <<_:(?BLOCK_HEADER_HASH_BYTES*8)>>).
+
 -record(block, {
           height = 0             :: height(),
-          prev_hash = <<>>       :: binary(),
+          prev_hash = <<0:?BLOCK_HEADER_HASH_BYTES/unit:8>> :: block_header_hash(),
           root_hash = <<>>       :: binary(), % Hash of all state Merkle trees included in #block.trees
           trees = #trees{}       :: trees(),
           txs = []               :: list(),
@@ -14,7 +17,7 @@
 
 -record(header, {
           height = 0             :: height(),
-          prev_hash = <<>>       :: binary(),
+          prev_hash = <<0:?BLOCK_HEADER_HASH_BYTES/unit:8>> :: block_header_hash(),
           root_hash = <<>>       :: binary(),
           difficulty = 0         :: non_neg_integer(),
           nonce = 0              :: non_neg_integer(),

--- a/apps/aecore/include/blocks.hrl
+++ b/apps/aecore/include/blocks.hrl
@@ -1,7 +1,7 @@
 -include("trees.hrl").
 
 -record(block, {
-          height = 0             :: non_neg_integer(),
+          height = 0             :: height(),
           prev_hash = <<>>       :: binary(),
           root_hash = <<>>       :: binary(), % Hash of all state Merkle trees included in #block.trees
           trees = #trees{}       :: trees(),
@@ -13,7 +13,7 @@
 -type(block() :: #block{}).
 
 -record(header, {
-          height = 0             :: non_neg_integer(),
+          height = 0             :: height(),
           prev_hash = <<>>       :: binary(),
           root_hash = <<>>       :: binary(),
           difficulty = 0         :: non_neg_integer(),

--- a/apps/aecore/include/common.hrl
+++ b/apps/aecore/include/common.hrl
@@ -1,1 +1,2 @@
+-type(height() :: non_neg_integer()).
 -type(pubkey() :: binary()).

--- a/apps/aecore/include/trees.hrl
+++ b/apps/aecore/include/trees.hrl
@@ -8,5 +8,5 @@
           pubkey = <<>>  :: pubkey(),
           balance = 0    :: non_neg_integer(),
           nonce = 0      :: non_neg_integer(),
-          height = 0     :: non_neg_integer()}).
+          height = 0     :: height()}).
 -type(account() :: #account{}).

--- a/apps/aecore/src/aec_blocks.erl
+++ b/apps/aecore/src/aec_blocks.erl
@@ -1,7 +1,8 @@
 -module(aec_blocks).
 
 %% API
--export([height/1,
+-export([prev_hash/1,
+         height/1,
          trees/1,
          difficulty/1,
          set_nonce/2,
@@ -18,6 +19,9 @@
 -include("txs.hrl").
 
 -define(CURRENT_BLOCK_VERSION, 1).
+
+prev_hash(Block) ->
+    Block#block.prev_hash.
 
 height(Block) ->
     Block#block.height.

--- a/apps/aecore/src/aec_blocks.erl
+++ b/apps/aecore/src/aec_blocks.erl
@@ -8,17 +8,26 @@
          set_nonce/2,
          top/0,
          new/3,
-         to_header/1]).
+         to_header/1,
+         serialize_for_network/1,
+         deserialize_from_network/1,
+         hash_internal_representation/1]).
 
 -ifdef(TEST).
 -compile(export_all).
 -endif.
+
+-export_type([block_serialized_for_network/0,
+              block_deserialized_from_network/0]).
 
 -include("common.hrl").
 -include("blocks.hrl").
 -include("txs.hrl").
 
 -define(CURRENT_BLOCK_VERSION, 1).
+
+-type block_serialized_for_network() :: binary().
+-type block_deserialized_from_network() :: #block{trees :: DummyTrees::trees()}.
 
 prev_hash(Block) ->
     Block#block.prev_hash.
@@ -43,12 +52,12 @@ top() ->
 -spec new(block(), list(signed_tx()), trees()) -> {ok, block()} | {error, term()}.
 new(LastBlock, Txs, Trees0) ->
     LastBlockHeight = height(LastBlock),
-    LastBlockHeader = to_header(LastBlock),
+    {ok, LastBlockHeaderHash} = hash_internal_representation(LastBlock),
     Height = LastBlockHeight + 1,
     case aec_tx:apply_signed(Txs, Trees0, Height) of
         {ok, Trees} ->
             {ok, #block{height = Height,
-                        prev_hash = aec_sha256:hash(LastBlockHeader),
+                        prev_hash = LastBlockHeaderHash,
                         root_hash = aec_trees:all_trees_hash(Trees),
                         trees = Trees,
                         txs = Txs,
@@ -74,3 +83,23 @@ to_header(#block{height = Height,
             nonce = Nonce,
             time = Time,
             version = Version}.
+
+-spec serialize_for_network(BlockInternalRepresentation) ->
+                                   {ok, block_serialized_for_network()} when
+      BlockInternalRepresentation :: block()
+                                   | block_deserialized_from_network().
+serialize_for_network(B = #block{}) ->
+    %% TODO: Define serialization format.
+    DummyTrees = #trees{},
+    {ok, term_to_binary(B#block{trees = DummyTrees})}.
+
+-spec deserialize_from_network(block_serialized_for_network()) ->
+                                      {ok, block_deserialized_from_network()}.
+deserialize_from_network(B) when is_binary(B) ->
+    %% TODO: Define serialization format.
+    DummyTrees = #trees{},
+    {ok, #block{trees = DummyTrees} = binary_to_term(B)}.
+
+-spec hash_internal_representation(block()) -> {ok, block_header_hash()}.
+hash_internal_representation(B = #block{}) ->
+    aec_headers:hash_internal_representation(to_header(B)).

--- a/apps/aecore/src/aec_headers.erl
+++ b/apps/aecore/src/aec_headers.erl
@@ -2,6 +2,7 @@
 
 %% API
 -export([prev_hash/1,
+         height/1,
          time_in_secs/1,
          get_by_height/1,
          get_by_hash/1]).
@@ -11,6 +12,9 @@
 
 prev_hash(Header) ->
     Header#header.prev_hash.
+
+height(Header) ->
+    Header#header.height.
 
 time_in_secs(Header) ->
     Time = Header#header.time,

--- a/apps/aecore/src/aec_headers.erl
+++ b/apps/aecore/src/aec_headers.erl
@@ -5,10 +5,18 @@
          height/1,
          time_in_secs/1,
          get_by_height/1,
-         get_by_hash/1]).
+         get_by_hash/1,
+         serialize_for_network/1,
+         deserialize_from_network/1,
+         hash_network_serialization/1,
+         hash_internal_representation/1]).
+
+-export_type([block_header_serialized_for_network/0]).
 
 -include("common.hrl").
 -include("blocks.hrl").
+
+-type block_header_serialized_for_network() :: binary().
 
 prev_hash(Header) ->
     Header#header.prev_hash.
@@ -29,3 +37,25 @@ get_by_hash(_Hash) ->
     %% TODO: Return block header by hash
     %% This may go to aec_blocks
     {ok, #header{}}.
+
+-spec serialize_for_network(header()) ->
+                                   {ok, block_header_serialized_for_network()}.
+serialize_for_network(H = #header{}) ->
+    %% TODO: Define serialization format.
+    {ok, term_to_binary(H)}.
+
+-spec deserialize_from_network(block_header_serialized_for_network()) ->
+                                      {ok, header()}.
+deserialize_from_network(H) when is_binary(H) ->
+    %% TODO: Define serialization format.
+    {ok, #header{} = binary_to_term(H)}.
+
+-spec hash_network_serialization(block_header_serialized_for_network()) ->
+                                        {ok, block_header_hash()}.
+hash_network_serialization(H) when is_binary(H) ->
+    {ok, aec_sha256:hash(H)}.
+
+-spec hash_internal_representation(header()) -> {ok, block_header_hash()}.
+hash_internal_representation(H = #header{}) ->
+    {ok, HH} = serialize_for_network(H),
+    hash_network_serialization(HH).

--- a/apps/aecore/test/aec_blocks_tests.erl
+++ b/apps/aecore/test/aec_blocks_tests.erl
@@ -18,7 +18,8 @@ new_block_test_() ->
              {ok, NewBlock} = ?TEST_MODULE:new(PrevBlock, [], #trees{}),
 
              ?assertEqual(12, ?TEST_MODULE:height(NewBlock)),
-             ?assertEqual(aec_sha256:hash(BlockHeader), NewBlock#block.prev_hash),
+             ?assertEqual(aec_sha256:hash(BlockHeader),
+                          ?TEST_MODULE:prev_hash(NewBlock)),
              ?assertEqual([], NewBlock#block.txs),
              ?assertEqual(17, NewBlock#block.difficulty),
              ?assertEqual(1, NewBlock#block.version)

--- a/apps/aecore/test/aec_blocks_tests.erl
+++ b/apps/aecore/test/aec_blocks_tests.erl
@@ -26,4 +26,20 @@ new_block_test_() ->
      end
     }.
 
+network_serialization_test() ->
+    Block = #block{trees = #trees{accounts = foo}},
+    {ok, SerializedBlock} = ?TEST_MODULE:serialize_for_network(Block),
+    {ok, DeserializedBlock} =
+        ?TEST_MODULE:deserialize_from_network(SerializedBlock),
+    ?assertEqual(Block#block{trees = #trees{}}, DeserializedBlock),
+    ?assertEqual({ok, SerializedBlock},
+                 ?TEST_MODULE:serialize_for_network(DeserializedBlock)).
+
+hash_test() ->
+    Block = #block{},
+    {ok, SerializedHeader} =
+        aec_headers:serialize_for_network(?TEST_MODULE:to_header(Block)),
+    ?assertEqual({ok, aec_sha256:hash(SerializedHeader)},
+                 ?TEST_MODULE:hash_internal_representation(Block)).
+
 -endif.

--- a/apps/aecore/test/aec_blocks_tests.erl
+++ b/apps/aecore/test/aec_blocks_tests.erl
@@ -17,7 +17,7 @@ new_block_test_() ->
 
              {ok, NewBlock} = ?TEST_MODULE:new(PrevBlock, [], #trees{}),
 
-             ?assertEqual(12, NewBlock#block.height),
+             ?assertEqual(12, ?TEST_MODULE:height(NewBlock)),
              ?assertEqual(aec_sha256:hash(BlockHeader), NewBlock#block.prev_hash),
              ?assertEqual([], NewBlock#block.txs),
              ?assertEqual(17, NewBlock#block.difficulty),

--- a/apps/aecore/test/aec_headers_tests.erl
+++ b/apps/aecore/test/aec_headers_tests.erl
@@ -1,0 +1,12 @@
+-module(aec_headers_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-include("common.hrl").
+-include("blocks.hrl").
+
+-define(TEST_MODULE, aec_headers).
+
+getters_test() ->
+    BlockHeader = #header{height = 11},
+    ?assertEqual(11, ?TEST_MODULE:height(BlockHeader)).

--- a/apps/aecore/test/aec_headers_tests.erl
+++ b/apps/aecore/test/aec_headers_tests.erl
@@ -13,3 +13,21 @@ getters_test() ->
     ?assertEqual(11, ?TEST_MODULE:height(BlockHeader)),
     ?assertEqual(<<0:?BLOCK_HEADER_HASH_BYTES/unit:8>>,
                  ?TEST_MODULE:prev_hash(BlockHeader)).
+
+network_serialization_test() ->
+    Header = #header{},
+    {ok, SerializedHeader} = ?TEST_MODULE:serialize_for_network(Header),
+    {ok, DeserializedHeader} =
+        ?TEST_MODULE:deserialize_from_network(SerializedHeader),
+    ?assertEqual(Header, DeserializedHeader),
+    ?assertEqual({ok, SerializedHeader},
+                 ?TEST_MODULE:serialize_for_network(DeserializedHeader)).
+
+hash_test() ->
+    Header = #header{},
+    {ok, SerializedHeader} = ?TEST_MODULE:serialize_for_network(Header),
+    {ok, HeaderHash} =
+        ?TEST_MODULE:hash_network_serialization(SerializedHeader),
+    ?assertEqual({ok, HeaderHash},
+                 ?TEST_MODULE:hash_internal_representation(Header)),
+    ?assertEqual(aec_sha256:hash(SerializedHeader), HeaderHash).

--- a/apps/aecore/test/aec_headers_tests.erl
+++ b/apps/aecore/test/aec_headers_tests.erl
@@ -8,5 +8,8 @@
 -define(TEST_MODULE, aec_headers).
 
 getters_test() ->
-    BlockHeader = #header{height = 11},
-    ?assertEqual(11, ?TEST_MODULE:height(BlockHeader)).
+    BlockHeader = #header{height = 11,
+                          prev_hash = <<0:?BLOCK_HEADER_HASH_BYTES/unit:8>>},
+    ?assertEqual(11, ?TEST_MODULE:height(BlockHeader)),
+    ?assertEqual(<<0:?BLOCK_HEADER_HASH_BYTES/unit:8>>,
+                 ?TEST_MODULE:prev_hash(BlockHeader)).


### PR DESCRIPTION
This PR does not close any issues.

Depends on PR #89 (included in this PR).

I prepared this while working on the chain (#69), that uses block header hash. The hash depends on the network serialization, that is therefore planted in this PR too.