### PR TITLE
[RFC] GH-69 In-memory chain service

### DIFF
--- a/apps/aecore/include/blocks.hrl
+++ b/apps/aecore/include/blocks.hrl
@@ -1,8 +1,11 @@
 -include("trees.hrl").
 
+-define(BLOCK_HEADER_HASH_BYTES, 32).
+-type(block_header_hash() :: <<_:(?BLOCK_HEADER_HASH_BYTES*8)>>).
+
 -record(block, {
           height = 0             :: height(),
-          prev_hash = <<>>       :: binary(),
+          prev_hash = <<0:?BLOCK_HEADER_HASH_BYTES/unit:8>> :: block_header_hash(),
           root_hash = <<>>       :: binary(), % Hash of all state Merkle trees included in #block.trees
           trees = #trees{}       :: trees(),
           txs = []               :: list(),
@@ -14,7 +17,7 @@
 
 -record(header, {
           height = 0             :: height(),
-          prev_hash = <<>>       :: binary(),
+          prev_hash = <<0:?BLOCK_HEADER_HASH_BYTES/unit:8>> :: block_header_hash(),
           root_hash = <<>>       :: binary(),
           difficulty = 0         :: non_neg_integer(),
           nonce = 0              :: non_neg_integer(),

--- a/apps/aecore/include/blocks.hrl
+++ b/apps/aecore/include/blocks.hrl
@@ -1,7 +1,7 @@
 -include("trees.hrl").
 
 -record(block, {
-          height = 0             :: non_neg_integer(),
+          height = 0             :: height(),
           prev_hash = <<>>       :: binary(),
           root_hash = <<>>       :: binary(), % Hash of all state Merkle trees included in #block.trees
           trees = #trees{}       :: trees(),
@@ -13,7 +13,7 @@
 -type(block() :: #block{}).
 
 -record(header, {
-          height = 0             :: non_neg_integer(),
+          height = 0             :: height(),
           prev_hash = <<>>       :: binary(),
           root_hash = <<>>       :: binary(),
           difficulty = 0         :: non_neg_integer(),

--- a/apps/aecore/include/common.hrl
+++ b/apps/aecore/include/common.hrl
@@ -1,1 +1,2 @@
+-type(height() :: non_neg_integer()).
 -type(pubkey() :: binary()).

--- a/apps/aecore/include/trees.hrl
+++ b/apps/aecore/include/trees.hrl
@@ -8,5 +8,5 @@
           pubkey = <<>>  :: pubkey(),
           balance = 0    :: non_neg_integer(),
           nonce = 0      :: non_neg_integer(),
-          height = 0     :: non_neg_integer()}).
+          height = 0     :: height()}).
 -type(account() :: #account{}).

--- a/apps/aecore/src/aec_blocks.erl
+++ b/apps/aecore/src/aec_blocks.erl
@@ -1,7 +1,8 @@
 -module(aec_blocks).
 
 %% API
--export([height/1,
+-export([prev_hash/1,
+         height/1,
          trees/1,
          difficulty/1,
          set_nonce/2,
@@ -18,6 +19,9 @@
 -include("txs.hrl").
 
 -define(CURRENT_BLOCK_VERSION, 1).
+
+prev_hash(Block) ->
+    Block#block.prev_hash.
 
 height(Block) ->
     Block#block.height.

--- a/apps/aecore/src/aec_blocks.erl
+++ b/apps/aecore/src/aec_blocks.erl
@@ -8,17 +8,26 @@
          set_nonce/2,
          top/0,
          new/3,
-         to_header/1]).
+         to_header/1,
+         serialize_for_network/1,
+         deserialize_from_network/1,
+         hash_internal_representation/1]).
 
 -ifdef(TEST).
 -compile(export_all).
 -endif.
+
+-export_type([block_serialized_for_network/0,
+              block_deserialized_from_network/0]).
 
 -include("common.hrl").
 -include("blocks.hrl").
 -include("txs.hrl").
 
 -define(CURRENT_BLOCK_VERSION, 1).
+
+-type block_serialized_for_network() :: binary().
+-type block_deserialized_from_network() :: #block{trees :: DummyTrees::trees()}.
 
 prev_hash(Block) ->
     Block#block.prev_hash.
@@ -43,12 +52,12 @@ top() ->
 -spec new(block(), list(signed_tx()), trees()) -> {ok, block()} | {error, term()}.
 new(LastBlock, Txs, Trees0) ->
     LastBlockHeight = height(LastBlock),
-    LastBlockHeader = to_header(LastBlock),
+    {ok, LastBlockHeaderHash} = hash_internal_representation(LastBlock),
     Height = LastBlockHeight + 1,
     case aec_tx:apply_signed(Txs, Trees0, Height) of
         {ok, Trees} ->
             {ok, #block{height = Height,
-                        prev_hash = aec_sha256:hash(LastBlockHeader),
+                        prev_hash = LastBlockHeaderHash,
                         root_hash = aec_trees:all_trees_hash(Trees),
                         trees = Trees,
                         txs = Txs,
@@ -74,3 +83,23 @@ to_header(#block{height = Height,
             nonce = Nonce,
             time = Time,
             version = Version}.
+
+-spec serialize_for_network(BlockInternalRepresentation) ->
+                                   {ok, block_serialized_for_network()} when
+      BlockInternalRepresentation :: block()
+                                   | block_deserialized_from_network().
+serialize_for_network(B = #block{}) ->
+    %% TODO: Define serialization format.
+    DummyTrees = #trees{},
+    {ok, term_to_binary(B#block{trees = DummyTrees})}.
+
+-spec deserialize_from_network(block_serialized_for_network()) ->
+                                      {ok, block_deserialized_from_network()}.
+deserialize_from_network(B) when is_binary(B) ->
+    %% TODO: Define serialization format.
+    DummyTrees = #trees{},
+    {ok, #block{trees = DummyTrees} = binary_to_term(B)}.
+
+-spec hash_internal_representation(block()) -> {ok, block_header_hash()}.
+hash_internal_representation(B = #block{}) ->
+    aec_headers:hash_internal_representation(to_header(B)).

--- a/apps/aecore/src/aec_chain.erl
+++ b/apps/aecore/src/aec_chain.erl
@@ -1,0 +1,492 @@
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2017, Aeternity Anstalt
+%%% @doc Service holding the chain of block headers and blocks.
+%%%
+%%% @TODO Unit testing of unhappy paths.
+%%% @TODO Forced chain (fork).
+%%% @TODO Persistence.
+%%% @end
+%%%-------------------------------------------------------------------
+-module(aec_chain).
+
+-behaviour(gen_server).
+
+%% API
+-export([start_link/1,
+         stop/0]).
+-export([top_header/0,
+         top_block/0,
+         get_header_by_hash/1,
+         get_block_by_hash/1,
+         get_header_by_height/1,
+         get_block_by_height/1,
+         insert_header/1,
+         write_block/1]).
+%% TODO `force_insert_headers`: Insert the specified sequence of headers in the chain, potentially changing the top header in the chain.
+
+%% gen_server callbacks
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3]).
+
+-include("common.hrl").
+-include("blocks.hrl").
+
+-define(SERVER, ?MODULE).
+-define(DEFAULT_CALL_TIMEOUT, infinity). %% For synchronous persistence and for forced chain (fork).
+-define(TOP_HEADER, top_header).
+
+-record(top_state,
+        {top_header :: header(),
+         top_header_db :: dict:dict(
+                            ?TOP_HEADER, %% Only one key.
+                            block_header_hash()),
+         top_block :: aec_blocks:block_deserialized_from_network()}). %% Without state trees.
+-record(state,
+        {top :: #top_state{},
+         headers_db :: dict:dict(
+                         block_header_hash(),
+                         aec_headers:block_header_serialized_for_network()),
+         blocks_db :: dict:dict(
+                        block_header_hash(),
+                        aec_blocks:block_serialized_for_network())}). %% Without state trees.
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+start_link(GenesisBlock) ->
+    Args = [GenesisBlock],
+    gen_server:start_link({local, ?SERVER}, ?MODULE, Args, []).
+
+stop() ->
+    gen_server:stop(?SERVER).
+
+%% Returns the highest block header in the chain.
+top_header() ->
+    %% TODO Store top header in ETS table so not to require server state.
+    gen_server:call(?SERVER, {top_header},
+                    ?DEFAULT_CALL_TIMEOUT).
+
+%% Returns the highest known block in the chain.
+top_block() ->
+    %% TODO Store top block in ETS table so not to require server state.
+    gen_server:call(?SERVER, {top_block},
+                    ?DEFAULT_CALL_TIMEOUT).
+
+get_header_by_hash(HeaderHash) ->
+    gen_server:call(?SERVER, {get_header_by_hash, HeaderHash},
+                    ?DEFAULT_CALL_TIMEOUT).
+
+get_block_by_hash(HeaderHash) ->
+    gen_server:call(?SERVER, {get_block_by_hash, HeaderHash},
+                    ?DEFAULT_CALL_TIMEOUT).
+
+get_header_by_height(Height) ->
+    gen_server:call(?SERVER, {get_header_by_height, Height},
+                    ?DEFAULT_CALL_TIMEOUT).
+
+get_block_by_height(Height) ->
+    gen_server:call(?SERVER, {get_block_by_height, Height},
+                    ?DEFAULT_CALL_TIMEOUT).
+
+%% Insert in the chain the specified header if it is a successor of
+%% the top header in the chain.
+insert_header(Header) ->
+    gen_server:call(?SERVER, {insert_header, Header},
+                    ?DEFAULT_CALL_TIMEOUT).
+
+%% Store the specified block if its header is in the chain.
+write_block(Block) ->
+    gen_server:call(?SERVER, {write_block, Block},
+                    ?DEFAULT_CALL_TIMEOUT).
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+init(_Args = [GenesisBlock]) ->
+    process_flag(trap_exit, true),
+
+    %% Identify state of databases as before the start of this process.
+    %% TODO Consider persisted state.
+    TopHeaderDb = dict:new(),
+    HeadersDb = dict:new(),
+    BlocksDb = dict:new(),
+
+    %% Compute initial state of databases.
+    {ok, {NewTopHeaderDb, NewHeadersDb, NewBlocksDb}} =
+        do_init([GenesisBlock], TopHeaderDb, HeadersDb, BlocksDb),
+
+    %% Compute initial state of process.
+    {ok, TopHeaderHash} = top_header_db_get(NewTopHeaderDb, ?TOP_HEADER),
+    {ok, SerializedTopHeader} = headers_db_get(NewHeadersDb, TopHeaderHash),
+    {ok, TopHeader} = aec_headers:deserialize_from_network(SerializedTopHeader),
+    {ok, SerializedTopBlock} = blocks_db_get(NewBlocksDb, TopHeaderHash),
+    {ok, TopBlock} = aec_blocks:deserialize_from_network(SerializedTopBlock),
+    TopState = #top_state{top_header = TopHeader,
+                          top_header_db = NewTopHeaderDb,
+                          top_block = TopBlock},
+    State = #state{top = TopState,
+                   headers_db = NewHeadersDb,
+                   blocks_db = NewBlocksDb},
+    {ok, State}.
+
+handle_call({top_header}, _From, State) ->
+    Reply = {ok, State#state.top#top_state.top_header},
+    {reply, Reply, State};
+handle_call({top_block}, _From, State) ->
+    Reply = {ok, State#state.top#top_state.top_block},
+    {reply, Reply, State};
+handle_call({get_header_by_hash,
+             HeaderHash = <<_:?BLOCK_HEADER_HASH_BYTES/unit:8>>},
+            _From, State) ->
+    Reply = do_get_header_by_hash(HeaderHash, State#state.headers_db),
+    {reply, Reply, State};
+handle_call({get_block_by_hash,
+             HeaderHash = <<_:?BLOCK_HEADER_HASH_BYTES/unit:8>>},
+            _From, State) ->
+    Reply = do_get_block_by_hash(HeaderHash, State#state.blocks_db),
+    {reply, Reply, State};
+handle_call({get_header_by_height, Height}, _From, State)
+  when is_integer(Height), Height >= 0 ->
+    Reply = do_get_header_by_height(Height,
+                                    State#state.top#top_state.top_header,
+                                    State#state.headers_db),
+    {reply, Reply, State};
+handle_call({get_block_by_height, Height}, _From, State)
+  when is_integer(Height), Height >= 0 ->
+    Reply = do_get_block_by_height(Height,
+                                   State#state.top#top_state.top_header,
+                                   State#state.headers_db,
+                                   State#state.blocks_db),
+    {reply, Reply, State};
+handle_call({insert_header, Header}, _From, State) ->
+    case
+        do_insert_header(Header,
+                         State#state.top#top_state.top_header,
+                         State#state.top#top_state.top_header_db,
+                         State#state.headers_db)
+    of
+        {error, _Reason} = Reply ->
+            {reply, Reply, State};
+        {ok, {Reply, {NewTopHeaderDb, NewHeadersDb}}} ->
+            NewState =
+                State#state{
+                  top =
+                      State#state.top#top_state{top_header = Header,
+                                                top_header_db = NewTopHeaderDb},
+                  headers_db = NewHeadersDb},
+            {reply, Reply, NewState}
+    end;
+handle_call({write_block, Block}, _From, State) ->
+    case
+        do_write_block(Block,
+                       State#state.top#top_state.top_header,
+                       State#state.top#top_state.top_block,
+                       State#state.headers_db,
+                       State#state.blocks_db)
+    of
+        {error, _Reason} = Reply ->
+            {reply, Reply, State};
+        {ok, {Reply, {NewTopBlock, NewBlocksDb}}} ->
+            NewState =
+                State#state{
+                  top =
+                      State#state.top#top_state{top_block = NewTopBlock},
+                  blocks_db = NewBlocksDb},
+            {reply, Reply, NewState}
+    end;
+handle_call(Request, From, State) ->
+    lager:warning("Ignoring unknown call request from ~p: ~p", [From, Request]),
+    {noreply, State}.
+
+handle_cast(Msg, State) ->
+    lager:warning("Ignoring unknown cast message: ~p", [Msg]),
+    {noreply, State}.
+
+handle_info(Info, State) ->
+    lager:warning("Ignoring unknown info: ~p", [Info]),
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    %% TODO Close databases.
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+
+db_get(Db, K) ->
+    case dict:find(K, Db) of
+        {ok, V} ->
+            {ok, V};
+        error ->
+            {error, not_found}
+    end.
+
+db_put(Db, K, V) ->
+    {ok, _NewDb = dict:store(K, V, Db)}.
+
+top_header_db_get(Db, K = ?TOP_HEADER) ->
+    db_get(Db, K).
+
+top_header_db_put(Db, K = ?TOP_HEADER, V) ->
+    db_put(Db, K, V).
+
+headers_db_get(Db, K) ->
+    db_get(Db, K).
+
+headers_db_put(Db, K, V) ->
+    db_put(Db, K, V).
+
+blocks_db_get(Db, K) ->
+    db_get(Db, K).
+
+blocks_db_put(Db, K, V) ->
+    db_put(Db, K, V).
+
+do_init([GenesisBlock], TopHeaderDb, _HeadersDb, _BlocksDb) ->
+    %% Hardcode expectations on specified genesis block.
+    0 = aec_blocks:height(GenesisBlock),
+    <<_:?BLOCK_HEADER_HASH_BYTES/unit:8>> = aec_blocks:prev_hash(GenesisBlock),
+
+    %% Compute genesis serializations and hash.
+    {ok, SerializedGenesisBlock} =
+        aec_blocks:serialize_for_network(GenesisBlock),
+    {ok, SerializedGenesisHeader} =
+        aec_headers:serialize_for_network(
+          aec_blocks:to_header(GenesisBlock)),
+    {ok, GenesisHeaderHash} =
+        aec_headers:hash_network_serialization(
+          SerializedGenesisHeader),
+
+    %% Initialize databases.
+    {NewTopHeaderDb, NewHeadersDb, NewBlocksDb} =
+        case top_header_db_get(TopHeaderDb, ?TOP_HEADER) of
+            %% TODO Handle `{ok, TopHeaderHash}`.
+            {error, not_found} ->
+                %% Re-initialize the databases considering the
+                %% specified genesis block as the only element of the
+                %% chain.
+                %%
+                %% Discard top header database. There should be at
+                %% most one, key and that is absent, so the database
+                %% shall be empty. Discard it anyway.
+                TopHeaderDb1 = dict:new(),
+                %% Discard headers database.
+                HeadersDb1 = dict:new(),
+                %% Discard blocks database.
+                BlocksDb1 = dict:new(),
+                {ok, TopHeaderDb2} =
+                    top_header_db_put(TopHeaderDb1,
+                                      ?TOP_HEADER, GenesisHeaderHash),
+                {ok, HeadersDb2} =
+                    headers_db_put(HeadersDb1,
+                                   GenesisHeaderHash, SerializedGenesisHeader),
+                {ok, BlocksDb2} =
+                    blocks_db_put(BlocksDb1,
+                                  GenesisHeaderHash, SerializedGenesisBlock),
+                {TopHeaderDb2, HeadersDb2, BlocksDb2}
+        end,
+
+    %% Hardcode expectation on initialized databases: the chain leads
+    %% to the specified genesis block.
+    {ok, TopHeaderHash} = top_header_db_get(NewTopHeaderDb, ?TOP_HEADER),
+    {ok, SerializedGenesisHeader} =
+        do_find_genesis_header_from_header_hash(TopHeaderHash, NewHeadersDb),
+    %% Hardcode expectation on initialized databases: the specified
+    %% genesis block and its header are in the databases.
+    {ok, SerializedGenesisHeader} =
+        headers_db_get(NewHeadersDb, GenesisHeaderHash),
+    {ok, SerializedGenesisBlock} =
+        blocks_db_get(NewBlocksDb, GenesisHeaderHash),
+
+    {ok, {NewTopHeaderDb, NewHeadersDb, NewBlocksDb}}.
+
+do_find_genesis_header_from_header_hash(HeaderHash, HeadersDb) ->
+    {ok, SerializedHeader} = headers_db_get(HeadersDb, HeaderHash),
+    {ok, Header} = aec_headers:deserialize_from_network(SerializedHeader),
+    case aec_headers:height(Header) of
+        0 ->
+            {ok, SerializedHeader};
+        Height when is_integer(Height), Height > 0 ->
+            do_find_genesis_header_from_header_hash(
+              aec_headers:prev_hash(Header), Height - 1, HeadersDb)
+    end.
+
+do_find_genesis_header_from_header_hash(HeaderHash, Height = 0, HeadersDb) ->
+    {ok, SerializedHeader} = headers_db_get(HeadersDb, HeaderHash),
+    {ok, Header} = aec_headers:deserialize_from_network(SerializedHeader),
+    {Height, _} = {aec_headers:height(Header), Header},
+    {ok, SerializedHeader};
+do_find_genesis_header_from_header_hash(HeaderHash, Height, HeadersDb) ->
+    {ok, SerializedHeader} = headers_db_get(HeadersDb, HeaderHash),
+    {ok, Header} = aec_headers:deserialize_from_network(SerializedHeader),
+    {Height, _} = {aec_headers:height(Header), Header},
+    do_find_genesis_header_from_header_hash(
+      aec_headers:prev_hash(Header), Height - 1, HeadersDb).
+
+do_get_header_by_hash(HeaderHash, HeadersDb) ->
+    case headers_db_get(HeadersDb, HeaderHash) of
+        {ok, SerializedHeader} ->
+            {ok, _Header} =
+                aec_headers:deserialize_from_network(SerializedHeader);
+        {error, not_found} ->
+            {error, header_not_found}
+    end.
+
+do_get_block_by_hash(HeaderHash, BlocksDb) ->
+    case blocks_db_get(BlocksDb, HeaderHash) of
+        {ok, SerializedBlock} ->
+            {ok, _Block} = aec_blocks:deserialize_from_network(SerializedBlock);
+        {error, not_found} ->
+            {error, block_not_found}
+    end.
+
+do_get_header_by_height(Height, TopHeader, HeadersDb) ->
+    ChainHeight = aec_headers:height(TopHeader),
+    if
+        Height > ChainHeight ->
+            {error, {chain_too_short, {{chain_height, ChainHeight},
+                                       {top_header, TopHeader}
+                                      }
+                    }};
+        Height =:= ChainHeight ->
+            {ok, TopHeader};
+        Height < ChainHeight ->
+            do_get_past_header(ChainHeight - Height, TopHeader, HeadersDb)
+    end.
+
+do_get_past_header(Distance, CurrentHeader, HeadersDb)
+  when is_integer(Distance), Distance > 0 ->
+    PreviousHeaderHash = aec_headers:prev_hash(CurrentHeader),
+    {ok, SerializedPreviousHeader} = %% If not found, database is corrupt: fail.
+        headers_db_get(HeadersDb, PreviousHeaderHash),
+    {ok, PreviousHeader} =
+        aec_headers:deserialize_from_network(SerializedPreviousHeader),
+    case Distance of
+        1 ->
+            {ok, PreviousHeader};
+        _ ->
+            do_get_past_header(Distance - 1, PreviousHeader, HeadersDb)
+    end.
+
+do_get_block_by_height(Height, TopHeader, HeadersDb, BlocksDb) ->
+    case do_get_header_by_height(Height, TopHeader, HeadersDb) of
+        {error, {chain_too_short, _}} = Err ->
+            Err;
+        {ok, Header} ->
+            {ok, HeaderHash} = aec_headers:hash_internal_representation(Header),
+            case blocks_db_get(BlocksDb, HeaderHash) of
+                {ok, SerializedBlock} ->
+                    {ok, _Block} =
+                        aec_blocks:deserialize_from_network(SerializedBlock);
+                {error, not_found} ->
+                    {error, {block_not_found, {top_header, TopHeader}}}
+            end
+    end.
+
+do_insert_header(Header, TopHeader, TopHeaderDb, HeadersDb) ->
+    {ok, TopHeaderHash} = aec_headers:hash_internal_representation(TopHeader),
+    case aec_headers:prev_hash(Header) of
+        TopHeaderHash ->
+            TopHeaderHeight = aec_headers:height(TopHeader),
+            HeaderHeight = aec_headers:height(Header),
+            case {HeaderHeight, 1 + TopHeaderHeight} of
+                {HH, HH} ->
+                    %% Ensure header is stored, then update top. In
+                    %% this order so that, if execution stops after
+                    %% storing header, the top header hash still
+                    %% refers to a a chain.
+                    {ok, SerializedHeader} =
+                        aec_headers:serialize_for_network(Header),
+                    {ok, HeaderHash} =
+                        aec_headers:hash_network_serialization(SerializedHeader),
+                    {ok, NewHeadersDb} =
+                        headers_db_put(HeadersDb, HeaderHash, SerializedHeader),
+                    {ok, NewTopHeaderDb} =
+                        top_header_db_put(TopHeaderDb, ?TOP_HEADER, HeaderHash),
+                    {ok, {_Reply = ok, {NewTopHeaderDb, NewHeadersDb}}};
+                {HeaderHeight, _} when
+                      is_integer(HeaderHeight), HeaderHeight >= 0 ->
+                    {error, {height_inconsistent_with_previous_hash,
+                             {top_header, TopHeader}}}
+            end;
+        <<_:?BLOCK_HEADER_HASH_BYTES/unit:8>> ->
+            _Reply =
+                {error, {previous_hash_is_not_top, {top_header, TopHeader}}}
+    end.
+
+do_write_block(Block, TopHeader, TopBlock, HeadersDb, BlocksDb) ->
+    Header = aec_blocks:to_header(Block),
+    {ok, SerializedHeader} = aec_headers:serialize_for_network(Header),
+    {ok, HeaderHash} = aec_headers:hash_network_serialization(
+                         SerializedHeader),
+    case do_find_header_hash_in_chain(HeaderHash, TopHeader, HeadersDb) of
+        {error, not_found} ->
+            {error, {header_not_in_chain, {top_header, TopHeader}}};
+        ok ->
+            case blocks_db_get(BlocksDb, HeaderHash) of
+                {ok, SerializedBlock} ->
+                    {error, {block_already_stored, SerializedBlock}};
+                {error, not_found} ->
+                    %% Store block.
+                    {ok, SerializedBlock} =
+                        aec_blocks:serialize_for_network(Block),
+                    {ok, NewBlocksDb} =
+                        blocks_db_put(BlocksDb, HeaderHash, SerializedBlock),
+
+                    %% Determine new top block.
+                    %%
+                    %% There is no need to check the validity of the
+                    %% height of the block, because the block
+                    %% corresponds to a header already in the
+                    %% chain. The consistency of the height of the
+                    %% header was checked when inserting the header.
+                    BlockHeight = aec_headers:height(Header),
+                    TopBlockHeight = aec_blocks:height(TopBlock),
+                    NewTopBlock =
+                        if
+                            BlockHeight > TopBlockHeight ->
+                                %% Prefer the deserialized block to
+                                %% the initial one, in order not to
+                                %% keep track of state trees.
+                                {ok, DeserializedBlock} =
+                                    aec_blocks:deserialize_from_network(
+                                      SerializedBlock),
+                                DeserializedBlock;
+                            true ->
+                                TopBlock
+                        end,
+                    {ok, {_Reply = ok, {NewTopBlock, NewBlocksDb}}}
+            end
+    end.
+
+do_find_header_hash_in_chain(HeaderHashToFind, TopHeader, HeadersDb) ->
+    {ok, TopHeaderHash} = aec_headers:hash_internal_representation(TopHeader),
+    TopHeaderHeight = aec_headers:height(TopHeader),
+    if
+        HeaderHashToFind =:= TopHeaderHash ->
+            ok;
+        TopHeaderHeight =:= 0 ->
+            {error, not_found};
+        true ->
+            do_find_header_hash_in_chain_1(
+              HeaderHashToFind, aec_headers:prev_hash(TopHeader), HeadersDb)
+    end.
+
+do_find_header_hash_in_chain_1(HeaderHashToFind, HeaderHashToFind, _) ->
+    ok;
+do_find_header_hash_in_chain_1(HeaderHashToFind, HeaderHash, HeadersDb) ->
+    {ok, SerializedHeader} = headers_db_get(HeadersDb, HeaderHash),
+    {ok, Header} = aec_headers:deserialize_from_network(SerializedHeader),
+    case aec_headers:height(Header) of
+        0 ->
+            {error, not_found};
+        Height when is_integer(Height), Height > 0 ->
+            do_find_header_hash_in_chain_1(
+              HeaderHashToFind, aec_headers:prev_hash(Header), HeadersDb)
+    end.

--- a/apps/aecore/src/aec_headers.erl
+++ b/apps/aecore/src/aec_headers.erl
@@ -2,6 +2,7 @@
 
 %% API
 -export([prev_hash/1,
+         height/1,
          time_in_secs/1,
          get_by_height/1,
          get_by_hash/1]).
@@ -11,6 +12,9 @@
 
 prev_hash(Header) ->
     Header#header.prev_hash.
+
+height(Header) ->
+    Header#header.height.
 
 time_in_secs(Header) ->
     Time = Header#header.time,

--- a/apps/aecore/src/aec_headers.erl
+++ b/apps/aecore/src/aec_headers.erl
@@ -5,10 +5,18 @@
          height/1,
          time_in_secs/1,
          get_by_height/1,
-         get_by_hash/1]).
+         get_by_hash/1,
+         serialize_for_network/1,
+         deserialize_from_network/1,
+         hash_network_serialization/1,
+         hash_internal_representation/1]).
+
+-export_type([block_header_serialized_for_network/0]).
 
 -include("common.hrl").
 -include("blocks.hrl").
+
+-type block_header_serialized_for_network() :: binary().
 
 prev_hash(Header) ->
     Header#header.prev_hash.
@@ -29,3 +37,25 @@ get_by_hash(_Hash) ->
     %% TODO: Return block header by hash
     %% This may go to aec_blocks
     {ok, #header{}}.
+
+-spec serialize_for_network(header()) ->
+                                   {ok, block_header_serialized_for_network()}.
+serialize_for_network(H = #header{}) ->
+    %% TODO: Define serialization format.
+    {ok, term_to_binary(H)}.
+
+-spec deserialize_from_network(block_header_serialized_for_network()) ->
+                                      {ok, header()}.
+deserialize_from_network(H) when is_binary(H) ->
+    %% TODO: Define serialization format.
+    {ok, #header{} = binary_to_term(H)}.
+
+-spec hash_network_serialization(block_header_serialized_for_network()) ->
+                                        {ok, block_header_hash()}.
+hash_network_serialization(H) when is_binary(H) ->
+    {ok, aec_sha256:hash(H)}.
+
+-spec hash_internal_representation(header()) -> {ok, block_header_hash()}.
+hash_internal_representation(H = #header{}) ->
+    {ok, HH} = serialize_for_network(H),
+    hash_network_serialization(HH).

--- a/apps/aecore/test/aec_blocks_tests.erl
+++ b/apps/aecore/test/aec_blocks_tests.erl
@@ -18,7 +18,8 @@ new_block_test_() ->
              {ok, NewBlock} = ?TEST_MODULE:new(PrevBlock, [], #trees{}),
 
              ?assertEqual(12, ?TEST_MODULE:height(NewBlock)),
-             ?assertEqual(aec_sha256:hash(BlockHeader), NewBlock#block.prev_hash),
+             ?assertEqual(aec_sha256:hash(BlockHeader),
+                          ?TEST_MODULE:prev_hash(NewBlock)),
              ?assertEqual([], NewBlock#block.txs),
              ?assertEqual(17, NewBlock#block.difficulty),
              ?assertEqual(1, NewBlock#block.version)

--- a/apps/aecore/test/aec_blocks_tests.erl
+++ b/apps/aecore/test/aec_blocks_tests.erl
@@ -26,4 +26,20 @@ new_block_test_() ->
      end
     }.
 
+network_serialization_test() ->
+    Block = #block{trees = #trees{accounts = foo}},
+    {ok, SerializedBlock} = ?TEST_MODULE:serialize_for_network(Block),
+    {ok, DeserializedBlock} =
+        ?TEST_MODULE:deserialize_from_network(SerializedBlock),
+    ?assertEqual(Block#block{trees = #trees{}}, DeserializedBlock),
+    ?assertEqual({ok, SerializedBlock},
+                 ?TEST_MODULE:serialize_for_network(DeserializedBlock)).
+
+hash_test() ->
+    Block = #block{},
+    {ok, SerializedHeader} =
+        aec_headers:serialize_for_network(?TEST_MODULE:to_header(Block)),
+    ?assertEqual({ok, aec_sha256:hash(SerializedHeader)},
+                 ?TEST_MODULE:hash_internal_representation(Block)).
+
 -endif.

--- a/apps/aecore/test/aec_blocks_tests.erl
+++ b/apps/aecore/test/aec_blocks_tests.erl
@@ -17,7 +17,7 @@ new_block_test_() ->
 
              {ok, NewBlock} = ?TEST_MODULE:new(PrevBlock, [], #trees{}),
 
-             ?assertEqual(12, NewBlock#block.height),
+             ?assertEqual(12, ?TEST_MODULE:height(NewBlock)),
              ?assertEqual(aec_sha256:hash(BlockHeader), NewBlock#block.prev_hash),
              ?assertEqual([], NewBlock#block.txs),
              ?assertEqual(17, NewBlock#block.difficulty),

--- a/apps/aecore/test/aec_chain_tests.erl
+++ b/apps/aecore/test/aec_chain_tests.erl
@@ -1,0 +1,182 @@
+-module(aec_chain_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("common.hrl").
+-include("blocks.hrl").
+
+fake_genesis_block() ->
+    #block{height = 0, prev_hash = <<0:?BLOCK_HEADER_HASH_BYTES/unit:8>>}.
+
+genesis_test_() ->
+    {setup,
+     fun() -> {ok, Pid} = aec_chain:start_link(fake_genesis_block()), Pid end,
+     fun(_ChainPid) -> ok = aec_chain:stop() end,
+     fun() ->
+             GB = fake_genesis_block(),
+             ?assertEqual({ok, GB}, aec_chain:top_block()),
+             GH = aec_blocks:to_header(GB),
+             ?assertEqual({ok, GH}, aec_chain:top_header()),
+
+             ?assertEqual({ok, GH}, aec_chain:get_header_by_height(0)),
+             ?assertEqual({ok, GB}, aec_chain:get_block_by_height(0)),
+
+             {ok, GHH} = aec_blocks:hash_internal_representation(GB),
+             ?assertEqual({ok, GH}, aec_chain:get_header_by_hash(GHH)),
+             ?assertEqual({ok, GB}, aec_chain:get_block_by_hash(GHH))
+     end}.
+
+header_chain_test_() ->
+    {setup,
+     fun() -> {ok, Pid} = aec_chain:start_link(fake_genesis_block()), Pid end,
+     fun(_ChainPid) -> ok = aec_chain:stop() end,
+     fun() ->
+             %% Check chain is at genesis.
+             B0 = fake_genesis_block(),
+             BH0 = aec_blocks:to_header(B0),
+             ?assertEqual({ok, BH0}, aec_chain:top_header()),
+
+             %% Add a couple of headers - not blocks - to the chain.
+             {ok, B0H} = aec_blocks:hash_internal_representation(B0),
+             BH1 = #header{height = 1, prev_hash = B0H},
+             ?assertEqual(ok, aec_chain:insert_header(BH1)),
+             {ok, B1H} = aec_headers:hash_internal_representation(BH1),
+             BH2 = #header{height = 2, prev_hash = B1H},
+             ?assertEqual(ok, aec_chain:insert_header(BH2)),
+
+             %% Check highest header.
+             ?assertEqual({ok, BH2}, aec_chain:top_header()),
+             %% Check heighest known block - still genesis.
+             ?assertEqual({ok, B0}, aec_chain:top_block()),
+
+             %% Check by hash.
+             ?assertEqual({ok, BH0}, aec_chain:get_header_by_hash(B0H)),
+             ?assertEqual({ok, B0}, aec_chain:get_block_by_hash(B0H)),
+             ?assertEqual({ok, BH1}, aec_chain:get_header_by_hash(B1H)),
+             ?assertEqual({error, block_not_found},
+                          aec_chain:get_block_by_hash(B1H)),
+             {ok, B2H} = aec_headers:hash_internal_representation(BH2),
+             ?assertEqual({ok, BH2}, aec_chain:get_header_by_hash(B2H)),
+             ?assertEqual({error, block_not_found},
+                          aec_chain:get_block_by_hash(B2H)),
+
+             %% Check by height.
+             ?assertEqual({ok, BH0}, aec_chain:get_header_by_height(0)),
+             ?assertEqual({ok, B0}, aec_chain:get_block_by_height(0)),
+             ?assertEqual({ok, BH1}, aec_chain:get_header_by_height(1)),
+             ?assertEqual({error, {block_not_found, {top_header, BH2}
+                                  }}, aec_chain:get_block_by_height(1)),
+             ?assertEqual({ok, BH2}, aec_chain:get_header_by_height(2)),
+             ?assertEqual({error, {block_not_found, {top_header, BH2}
+                                  }}, aec_chain:get_block_by_height(2)),
+             ?assertEqual({error, {chain_too_short, {{chain_height, 2},
+                                                     {top_header, BH2}}
+                                  }}, aec_chain:get_header_by_height(3)),
+             ?assertEqual({error, {chain_too_short, {{chain_height, 2},
+                                                     {top_header, BH2}}
+                                  }}, aec_chain:get_block_by_height(3))
+     end}.
+
+block_chain_test_() ->
+    {foreach,
+     fun() -> {ok, Pid} = aec_chain:start_link(fake_genesis_block()), Pid end,
+     fun(_ChainPid) -> ok = aec_chain:stop() end,
+     [{"Build chain with genesis block plus 2 headers, then store block corresponding to top header",
+       fun() ->
+               %% Check chain is at genesis.
+               B0 = fake_genesis_block(),
+               BH0 = aec_blocks:to_header(B0),
+               ?assertEqual({ok, BH0}, aec_chain:top_header()),
+
+               %% Add a couple of headers - not blocks - to the chain.
+               {ok, B0H} = aec_blocks:hash_internal_representation(B0),
+               B1 = #block{height = 1, prev_hash = B0H},
+               BH1 = aec_blocks:to_header(B1),
+               ?assertEqual(ok, aec_chain:insert_header(BH1)),
+               {ok, B1H} = aec_headers:hash_internal_representation(BH1),
+               B2 = #block{height = 2, prev_hash = B1H},
+               BH2 = aec_blocks:to_header(B2),
+               ?assertEqual(ok, aec_chain:insert_header(BH2)),
+
+               %% Add one block corresponding to a header already in the chain.
+               ?assertEqual(ok, aec_chain:write_block(B2)),
+
+               %% Check highest header.
+               ?assertEqual({ok, BH2}, aec_chain:top_header()),
+               %% Check heighest known block.
+               ?assertEqual({ok, B2}, aec_chain:top_block()),
+
+               %% Check by hash.
+               ?assertEqual({ok, BH0}, aec_chain:get_header_by_hash(B0H)),
+               ?assertEqual({ok, B0}, aec_chain:get_block_by_hash(B0H)),
+               ?assertEqual({ok, BH1}, aec_chain:get_header_by_hash(B1H)),
+               ?assertEqual({error, block_not_found},
+                            aec_chain:get_block_by_hash(B1H)),
+               {ok, B2H} = aec_headers:hash_internal_representation(BH2),
+               ?assertEqual({ok, BH2}, aec_chain:get_header_by_hash(B2H)),
+               ?assertEqual({ok, B2}, aec_chain:get_block_by_hash(B2H)),
+
+               %% Check by height.
+               ?assertEqual({ok, BH0}, aec_chain:get_header_by_height(0)),
+               ?assertEqual({ok, B0}, aec_chain:get_block_by_height(0)),
+               ?assertEqual({ok, BH1}, aec_chain:get_header_by_height(1)),
+               ?assertEqual({error, {block_not_found, {top_header, BH2}
+                                    }}, aec_chain:get_block_by_height(1)),
+               ?assertEqual({ok, BH2}, aec_chain:get_header_by_height(2)),
+               ?assertEqual({ok, B2}, aec_chain:get_block_by_height(2)),
+               ?assertEqual({error, {chain_too_short, {{chain_height, 2},
+                                                       {top_header, BH2}}
+                                    }}, aec_chain:get_header_by_height(3)),
+               ?assertEqual({error, {chain_too_short, {{chain_height, 2},
+                                                       {top_header, BH2}}
+                                    }}, aec_chain:get_block_by_height(3))
+       end},
+     {"Build chain with genesis block plus 2 headers, then store block corresponding to header before top header",
+       fun() ->
+               %% Check chain is at genesis.
+               B0 = fake_genesis_block(),
+               BH0 = aec_blocks:to_header(B0),
+               ?assertEqual({ok, BH0}, aec_chain:top_header()),
+
+               %% Add a couple of headers - not blocks - to the chain.
+               {ok, B0H} = aec_blocks:hash_internal_representation(B0),
+               B1 = #block{height = 1, prev_hash = B0H},
+               BH1 = aec_blocks:to_header(B1),
+               ?assertEqual(ok, aec_chain:insert_header(BH1)),
+               {ok, B1H} = aec_headers:hash_internal_representation(BH1),
+               B2 = #block{height = 2, prev_hash = B1H},
+               BH2 = aec_blocks:to_header(B2),
+               ?assertEqual(ok, aec_chain:insert_header(BH2)),
+
+               %% Add one block corresponding to a header already in the chain.
+               ?assertEqual(ok, aec_chain:write_block(B1)),
+
+               %% Check highest header.
+               ?assertEqual({ok, BH2}, aec_chain:top_header()),
+               %% Check heighest known block.
+               ?assertEqual({ok, B1}, aec_chain:top_block()),
+
+               %% Check by hash.
+               ?assertEqual({ok, BH0}, aec_chain:get_header_by_hash(B0H)),
+               ?assertEqual({ok, B0}, aec_chain:get_block_by_hash(B0H)),
+               ?assertEqual({ok, BH1}, aec_chain:get_header_by_hash(B1H)),
+               ?assertEqual({ok, B1}, aec_chain:get_block_by_hash(B1H)),
+               {ok, B2H} = aec_headers:hash_internal_representation(BH2),
+               ?assertEqual({ok, BH2}, aec_chain:get_header_by_hash(B2H)),
+               ?assertEqual({error, block_not_found},
+                            aec_chain:get_block_by_hash(B2H)),
+
+               %% Check by height.
+               ?assertEqual({ok, BH0}, aec_chain:get_header_by_height(0)),
+               ?assertEqual({ok, B0}, aec_chain:get_block_by_height(0)),
+               ?assertEqual({ok, BH1}, aec_chain:get_header_by_height(1)),
+               ?assertEqual({ok, B1}, aec_chain:get_block_by_height(1)),
+               ?assertEqual({ok, BH2}, aec_chain:get_header_by_height(2)),
+               ?assertEqual({error, {block_not_found, {top_header, BH2}
+                                    }}, aec_chain:get_block_by_height(2)),
+               ?assertEqual({error, {chain_too_short, {{chain_height, 2},
+                                                       {top_header, BH2}}
+                                    }}, aec_chain:get_header_by_height(3)),
+               ?assertEqual({error, {chain_too_short, {{chain_height, 2},
+                                                       {top_header, BH2}}
+                                    }}, aec_chain:get_block_by_height(3))
+       end}]}.

--- a/apps/aecore/test/aec_headers_tests.erl
+++ b/apps/aecore/test/aec_headers_tests.erl
@@ -1,0 +1,12 @@
+-module(aec_headers_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-include("common.hrl").
+-include("blocks.hrl").
+
+-define(TEST_MODULE, aec_headers).
+
+getters_test() ->
+    BlockHeader = #header{height = 11},
+    ?assertEqual(11, ?TEST_MODULE:height(BlockHeader)).

--- a/apps/aecore/test/aec_headers_tests.erl
+++ b/apps/aecore/test/aec_headers_tests.erl
@@ -13,3 +13,21 @@ getters_test() ->
     ?assertEqual(11, ?TEST_MODULE:height(BlockHeader)),
     ?assertEqual(<<0:?BLOCK_HEADER_HASH_BYTES/unit:8>>,
                  ?TEST_MODULE:prev_hash(BlockHeader)).
+
+network_serialization_test() ->
+    Header = #header{},
+    {ok, SerializedHeader} = ?TEST_MODULE:serialize_for_network(Header),
+    {ok, DeserializedHeader} =
+        ?TEST_MODULE:deserialize_from_network(SerializedHeader),
+    ?assertEqual(Header, DeserializedHeader),
+    ?assertEqual({ok, SerializedHeader},
+                 ?TEST_MODULE:serialize_for_network(DeserializedHeader)).
+
+hash_test() ->
+    Header = #header{},
+    {ok, SerializedHeader} = ?TEST_MODULE:serialize_for_network(Header),
+    {ok, HeaderHash} =
+        ?TEST_MODULE:hash_network_serialization(SerializedHeader),
+    ?assertEqual({ok, HeaderHash},
+                 ?TEST_MODULE:hash_internal_representation(Header)),
+    ?assertEqual(aec_sha256:hash(SerializedHeader), HeaderHash).

--- a/apps/aecore/test/aec_headers_tests.erl
+++ b/apps/aecore/test/aec_headers_tests.erl
@@ -8,5 +8,8 @@
 -define(TEST_MODULE, aec_headers).
 
 getters_test() ->
-    BlockHeader = #header{height = 11},
-    ?assertEqual(11, ?TEST_MODULE:height(BlockHeader)).
+    BlockHeader = #header{height = 11,
+                          prev_hash = <<0:?BLOCK_HEADER_HASH_BYTES/unit:8>>},
+    ?assertEqual(11, ?TEST_MODULE:height(BlockHeader)),
+    ?assertEqual(<<0:?BLOCK_HEADER_HASH_BYTES/unit:8>>,
+                 ?TEST_MODULE:prev_hash(BlockHeader)).


### PR DESCRIPTION
@sennui This is a milestone towards GH-69 and I would appreciate your review.
* The service lacks support for changing tracked chain / fork, i.e. the service can only track a chain that grows one header at a time on the top. See comment on `force_insert_headers` for this missing implementation;
* The service has no persistence.

Depends on #90 (included in this PR). The only commit distinct for this PR is e67f91f.
