### PR TITLE
GH-109 Fix type warning `Unknown type gb_trees:gb_tree/2`

### DIFF
--- a/apps/aecore/src/aec_peers.erl
+++ b/apps/aecore/src/aec_peers.erl
@@ -91,7 +91,7 @@ uri_from_ip_port(IP, Port) ->
 %%% gen_server functions
 %%%=============================================================================
 
--record(state, {peers :: gb_trees:gb_tree(binary(),peer())}).
+-record(state, {peers :: gb_trees:tree(binary(),peer())}).
 
 start_link() ->
     gen_server:start_link({local, ?MODULE} ,?MODULE, ok, []).


### PR DESCRIPTION
Please refer to commit message for details.

Warning identified while working on GH-109.