### PR TITLE
GH-120 Added missing exclusions to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ _build
 .idea
 config/*/sys.config
 config/sys.config
+priv
+c_src


### PR DESCRIPTION
This adds missing exclusions to .gitignore. See #120 