### PR TITLE
Stricter CI checks

### DIFF
--- a/apps/aecore/include/peers.hrl
+++ b/apps/aecore/include/peers.hrl
@@ -1,5 +1,7 @@
+-type uri() :: string().
+
 -record(peer, {
-          uri = ""          :: http_uri:uri(),
+          uri = ""          :: uri(),
           last_seen = 0     :: integer()}). % Erlang system time (POSIX time)
 
 

--- a/apps/aecore/src/aec_peers.erl
+++ b/apps/aecore/src/aec_peers.erl
@@ -35,7 +35,7 @@
 %%------------------------------------------------------------------------------
 %% Add peer by url or supplying full peer() record.
 %%------------------------------------------------------------------------------
--spec add(http_uri:uri() | peer()) -> ok.
+-spec add(uri() | peer()) -> ok.
 add(Peer) when is_record(Peer, peer) ->
     gen_server:cast(?MODULE, {add, Peer}),
     ok;
@@ -46,7 +46,7 @@ add(PeerUri) ->
 %%------------------------------------------------------------------------------
 %% Remove peer by url
 %%------------------------------------------------------------------------------
--spec remove(http_uri:uri()) -> ok.
+-spec remove(uri()) -> ok.
 remove(PeerUri) ->
     gen_server:cast(?MODULE, {remove, PeerUri}),
     ok.
@@ -56,7 +56,7 @@ remove(PeerUri) ->
 %% Normally returns {ok, Peer}
 %% If peer not found gives {error, "peer unknown"}
 %%------------------------------------------------------------------------------
--spec info(http_uri:uri()) -> get_peer_result().
+-spec info(uri()) -> get_peer_result().
 info(PeerUri) ->
     gen_server:call(?MODULE, {info, PeerUri}).
 
@@ -83,7 +83,7 @@ get_random() ->
 %%------------------------------------------------------------------------------
 %% Get url from IP and port. IP format: xxx.xxx.xxx.xxx
 %%------------------------------------------------------------------------------
--spec uri_from_ip_port(IP :: string(), Port :: number()) -> http_uri:uri().
+-spec uri_from_ip_port(IP :: string(), Port :: number()) -> uri().
 uri_from_ip_port(IP, Port) ->
     "http://" ++ IP ++ ":" ++ integer_to_list(Port) ++ "/".
 
@@ -147,9 +147,8 @@ code_change(_OldVsn, State, _Extra) ->
 %%% Internal functions
 %%%=============================================================================
 
--spec hash_uri(http_uri:uri()) -> binary().
+-spec hash_uri(uri()) -> binary().
 hash_uri(Uri) when is_list(Uri)->
-    hash_uri(list_to_binary(Uri));
-hash_uri(Uri) ->
-    Hash = crypto:hash(md4,Uri),  %TODO add some random for execution but constant salt, so people can't mess with uri-s to hide on our list.
-    <<Hash/binary, Uri/binary>>.
+    Binary = list_to_binary(Uri),
+    Hash = crypto:hash(md4,Binary),  %TODO add some random for execution but constant salt, so people can't mess with uri-s to hide on our list.
+    <<Hash/binary, Binary/binary>>.

--- a/rebar.config
+++ b/rebar.config
@@ -34,7 +34,8 @@
                    ]},
             {prod, [{relx, [{dev_mode, false},
                             {include_erts, true},
-                            {include_src, false}]}]
+                            {include_src, false}]},
+                    {erl_opts, [warnings_as_errors, true]}]
             }]
 }.
 

--- a/rebar.config
+++ b/rebar.config
@@ -44,3 +44,5 @@
 
 {post_hooks, [{"(linux|darwin)", clean, "make -C apps/aecore/c_src clean"}
              ]}.
+
+{dialyzer, [{warnings, [unknown]}]}.


### PR DESCRIPTION
This PR makes our checks stricter.
It bases on issues fixed in #116 and #74. Maybe we need even more checks?
Note: this won't pass tests with following dialyzer problems:
```
   0: Unknown type gb_trees:gb_tree/2 
   0: Unknown type http_uri:uri/0
```
First error is fixed in #116. Second waits for a fix.