### PR TITLE
GH-109 Strongest chain

### DIFF
--- a/apps/aecore/include/blocks.hrl
+++ b/apps/aecore/include/blocks.hrl
@@ -1,6 +1,8 @@
 -include("trees.hrl").
 -include("pow.hrl").
 
+-define(GENESIS_HEIGHT, 0).
+
 -define(BLOCK_HEADER_HASH_BYTES, 32).
 
 -type(block_header_hash() :: <<_:(?BLOCK_HEADER_HASH_BYTES*8)>>).

--- a/apps/aecore/src/aec_chain.erl
+++ b/apps/aecore/src/aec_chain.erl
@@ -456,6 +456,10 @@ do_insert_header(Header, TopHeader, TopHeaderDb, HeadersDb) ->
                         aec_headers:serialize_for_network(Header),
                     {ok, HeaderHash} =
                         aec_headers:hash_network_serialization(SerializedHeader),
+                    %% As header is a successor of the current top, it
+                    %% should not be stored yet.  So store header
+                    %% without first checking that it is not yet
+                    %% stored.
                     {ok, NewHeadersDb} =
                         headers_db_put(HeadersDb, HeaderHash, SerializedHeader),
                     {ok, NewTopHeaderDb} =

--- a/apps/aecore/src/aec_chain.erl
+++ b/apps/aecore/src/aec_chain.erl
@@ -22,7 +22,8 @@
          get_header_by_height/1,
          get_block_by_height/1,
          insert_header/1,
-         write_block/1]).
+         write_block/1,
+         get_work_at_top/0]).
 %% TODO `force_insert_headers`: Insert the specified sequence of headers in the chain, potentially changing the top header in the chain.
 
 %% gen_server callbacks
@@ -42,25 +43,54 @@
         (is_integer(H) andalso (H > ?GENESIS_HEIGHT))
        ).
 
+-define(IS_WORK(W), (is_float(W) andalso (W > 0.0))). %% For guard.
+
+-define(IS_CHAIN_HEADER(H), %% For guard.
+        (is_record(H, chain_header)
+         andalso is_record(element(#chain_header.h, H), header)
+         andalso ?IS_WORK(element(#chain_header.td, H))
+        )
+       ).
+
 -define(TOP_HEADER, top_header).
 
 -record(top_state,
-        {top_header :: header(),
+        {top_header :: headers_db_value(),
          top_header_db :: top_header_db(),
          top_block :: aec_blocks:block_deserialized_from_network()}). %% Without state trees.
 -record(state, {top :: #top_state{},
                 headers_db :: headers_db(),
                 blocks_db :: blocks_db()}).
 
--type top_header_db() :: dict:dict(
-                           ?TOP_HEADER, %% Only one key.
-                           block_header_hash()).
--type headers_db() :: dict:dict(
-                        block_header_hash(),
-                        aec_headers:block_header_serialized_for_network()).
--type blocks_db() :: dict:dict(
-                       block_header_hash(),
-                       aec_blocks:block_serialized_for_network()). %% Without state trees.
+-record(chain_header, {
+          %% Assumption: The internal representation of the block
+          %% header is the same as the block header deserialized from
+          %% the network, e.g. does not contain extra information.
+          h :: header(),
+          %% Total difficulty i.e. amount of work done from genesis to
+          %% this block header.
+          td :: work()}).
+
+-type work() :: float(). %% TODO: Move to PoW-related module.
+
+-type chain_header() :: #chain_header{}.
+
+-type top_header_db_key() :: ?TOP_HEADER. %% Only one key.
+-type top_header_db_value() :: block_header_hash().
+-type top_header_db() :: dict:dict(top_header_db_key(), top_header_db_value()).
+
+-type headers_db_key() :: block_header_hash().
+-type headers_db_value() :: chain_header().
+-type headers_db() :: dict:dict(headers_db_key(), headers_db_value()).
+
+-type blocks_db_key() :: block_header_hash().
+-type blocks_db_value() ::
+        aec_blocks:block_serialized_for_network(). %% Without state trees.
+-type blocks_db() :: dict:dict(blocks_db_key(), blocks_db_value()).
+
+-type db_handle() :: dict:dict().
+-type db_key() :: binary().
+-type db_value() :: binary().
 
 %%%===================================================================
 %%% API
@@ -84,7 +114,7 @@ top() ->
     {ok, BlockWithStateTrees}.
 
 %% Returns the highest block header in the chain.
--spec top_header() -> {ok, header()}.
+-spec top_header() -> do_top_header_reply().
 top_header() ->
     %% TODO Store top header in ETS table so not to require server state.
     gen_server:call(?SERVER, {top_header},
@@ -94,7 +124,7 @@ top_header() ->
 %%
 %% The highest known block may be lower than the highest block header
 %% in the chain as returned by `top_header/0`.
--spec top_block() -> {ok, aec_blocks:block_deserialized_from_network()}.
+-spec top_block() -> do_top_block_reply().
 top_block() ->
     %% TODO Store top block in ETS table so not to require server state.
     gen_server:call(?SERVER, {top_block},
@@ -135,6 +165,11 @@ write_block(Block) ->
     gen_server:call(?SERVER, {write_block, Block},
                     ?DEFAULT_CALL_TIMEOUT).
 
+-spec get_work_at_top() -> do_get_work_at_top_reply().
+get_work_at_top() ->
+    gen_server:call(?SERVER, {get_work_at_top},
+                    ?DEFAULT_CALL_TIMEOUT).
+
 %%%===================================================================
 %%% gen_server callbacks
 %%%===================================================================
@@ -154,8 +189,7 @@ init(_Args = [GenesisBlock]) ->
 
     %% Compute initial state of process.
     {ok, TopHeaderHash} = top_header_db_get(NewTopHeaderDb, ?TOP_HEADER),
-    {ok, SerializedTopHeader} = headers_db_get(NewHeadersDb, TopHeaderHash),
-    {ok, TopHeader} = aec_headers:deserialize_from_network(SerializedTopHeader),
+    {ok, TopHeader} = headers_db_get(NewHeadersDb, TopHeaderHash),
     {ok, SerializedTopBlock} = blocks_db_get(NewBlocksDb, TopHeaderHash),
     {ok, TopBlock} = aec_blocks:deserialize_from_network(SerializedTopBlock),
     TopState = #top_state{top_header = TopHeader,
@@ -167,10 +201,10 @@ init(_Args = [GenesisBlock]) ->
     {ok, State}.
 
 handle_call({top_header}, _From, State) ->
-    Reply = {ok, State#state.top#top_state.top_header},
+    Reply = do_top_header(State#state.top#top_state.top_header),
     {reply, Reply, State};
 handle_call({top_block}, _From, State) ->
-    Reply = {ok, State#state.top#top_state.top_block},
+    Reply = do_top_block(State#state.top#top_state.top_block),
     {reply, Reply, State};
 handle_call({get_header_by_hash,
              HeaderHash = <<_:?BLOCK_HEADER_HASH_BYTES/unit:8>>},
@@ -208,12 +242,13 @@ handle_call({insert_header, Header}, _From, State) ->
     of
         {error, _Reason} = Reply ->
             {reply, Reply, State};
-        {ok, {Reply, {NewTopHeaderDb, NewHeadersDb}}} ->
+        {ok, {Reply, {NewTopHeader, NewTopHeaderDb, NewHeadersDb}}} ->
             NewState =
                 State#state{
                   top =
-                      State#state.top#top_state{top_header = Header,
-                                                top_header_db = NewTopHeaderDb},
+                      State#state.top#top_state{
+                                    top_header = NewTopHeader,
+                                    top_header_db = NewTopHeaderDb},
                   headers_db = NewHeadersDb},
             {reply, Reply, NewState}
     end;
@@ -235,6 +270,9 @@ handle_call({write_block, Block}, _From, State) ->
                   blocks_db = NewBlocksDb},
             {reply, Reply, NewState}
     end;
+handle_call({get_work_at_top}, _From, State) ->
+    Reply = do_get_work_at_top(State#state.top#top_state.top_header),
+    {reply, Reply, State};
 handle_call(Request, From, State) ->
     lager:warning("Ignoring unknown call request from ~p: ~p", [From, Request]),
     {noreply, State}.
@@ -258,6 +296,18 @@ code_change(_OldVsn, State, _Extra) ->
 %%% Internal functions
 %%%===================================================================
 
+-spec header_difficulty(header()) -> work().
+header_difficulty(Header) ->
+    aec_headers:difficulty(Header).
+
+chain_header_serialize(H) when ?IS_CHAIN_HEADER(H) ->
+    term_to_binary(H).
+
+chain_header_deserialize(B) when is_binary(B) ->
+    case binary_to_term(B) of H when ?IS_CHAIN_HEADER(H) -> H end.
+
+-type db_get_return(Value) :: {ok, Value} | {error, not_found}.
+-spec db_get(db_handle(), db_key()) -> db_get_return(db_value()).
 db_get(Db, K) ->
     case dict:find(K, Db) of
         {ok, V} ->
@@ -266,43 +316,77 @@ db_get(Db, K) ->
             {error, not_found}
     end.
 
+-type db_put_return() :: {ok, NewDb::db_handle()}.
+-spec db_put(db_handle(), db_key(), db_value()) -> db_put_return().
 db_put(Db, K, V) ->
-    {ok, _NewDb = dict:store(K, V, Db)}.
+    {ok, dict:store(K, V, Db)}.
 
+-spec top_header_db_get(db_handle(), top_header_db_key()) ->
+                               db_get_return(top_header_db_value()).
 top_header_db_get(Db, K = ?TOP_HEADER) ->
-    db_get(Db, K).
+    db_get(Db, atom_to_binary(K, latin1)).
 
+-spec top_header_db_put(db_handle(), top_header_db_key(), top_header_db_value()
+                       ) -> db_put_return().
 top_header_db_put(Db, K = ?TOP_HEADER, V) ->
-    db_put(Db, K, V).
+    db_put(Db, atom_to_binary(K, latin1), V).
 
+-spec headers_db_get(db_handle(), headers_db_key()) ->
+                            db_get_return(headers_db_value()).
 headers_db_get(Db, K) ->
-    db_get(Db, K).
+    case db_get(Db, K) of
+        {error, not_found} = Err ->
+            Err;
+        {ok, V} ->
+            {ok, chain_header_deserialize(V)}
+    end.
 
+-spec headers_db_put(db_handle(), headers_db_key(), headers_db_value()) ->
+                            db_put_return().
 headers_db_put(Db, K, V) ->
-    db_put(Db, K, V).
+    db_put(Db, K, chain_header_serialize(V)).
 
+-spec blocks_db_get(db_handle(), blocks_db_key()) ->
+                           db_get_return(blocks_db_value()).
 blocks_db_get(Db, K) ->
     db_get(Db, K).
 
+-spec blocks_db_put(db_handle(), blocks_db_key(), blocks_db_value()) ->
+                           db_put_return().
 blocks_db_put(Db, K, V) ->
     db_put(Db, K, V).
 
-do_init([GenesisBlock], TopHeaderDb, _HeadersDb, _BlocksDb) ->
+do_init([GenesisBlock], TopHeaderDb, HeadersDb, BlocksDb) ->
     %% Hardcode expectations on specified genesis block.
-    ?GENESIS_HEIGHT = aec_blocks:height(GenesisBlock),
-    <<_:?BLOCK_HEADER_HASH_BYTES/unit:8>> = aec_blocks:prev_hash(GenesisBlock),
+    ok = do_init_check_genesis_block(GenesisBlock),
 
-    %% Compute genesis serializations and hash.
     {ok, SerializedGenesisBlock} =
         aec_blocks:serialize_for_network(GenesisBlock),
-    {ok, SerializedGenesisHeader} =
-        aec_headers:serialize_for_network(
-          aec_blocks:to_header(GenesisBlock)),
+    GenesisHeader = aec_blocks:to_header(GenesisBlock),
     {ok, GenesisHeaderHash} =
-        aec_headers:hash_network_serialization(
-          SerializedGenesisHeader),
+        aec_headers:hash_internal_representation(GenesisHeader),
 
     %% Initialize databases.
+    {ok, {NewTopHeaderDb, NewHeadersDb, NewBlocksDb}} =
+        do_init_initialize_dbs(
+          GenesisHeaderHash, GenesisHeader, SerializedGenesisBlock,
+          TopHeaderDb, HeadersDb, BlocksDb),
+    %% Hardcode expectation on initialized databases.
+    ok = do_init_check_dbs(
+           GenesisHeaderHash, GenesisHeader, SerializedGenesisBlock,
+           NewTopHeaderDb, NewHeadersDb, NewBlocksDb),
+
+    {ok, {NewTopHeaderDb, NewHeadersDb, NewBlocksDb}}.
+
+do_init_check_genesis_block(GenesisBlock) ->
+    ?GENESIS_HEIGHT = aec_blocks:height(GenesisBlock),
+    <<_:?BLOCK_HEADER_HASH_BYTES/unit:8>> = aec_blocks:prev_hash(GenesisBlock),
+    Difficulty = header_difficulty(aec_blocks:to_header(GenesisBlock)),
+    {true, _} = {?IS_WORK(Difficulty), Difficulty},
+    ok.
+
+do_init_initialize_dbs(GenesisHeaderHash, GenesisHeader, SerializedGenesisBlock,
+                       TopHeaderDb, _HeadersDb, _BlocksDb) ->
     {NewTopHeaderDb, NewHeadersDb, NewBlocksDb} =
         case top_header_db_get(TopHeaderDb, ?TOP_HEADER) of
             %% TODO Handle `{ok, TopHeaderHash}`.
@@ -323,34 +407,38 @@ do_init([GenesisBlock], TopHeaderDb, _HeadersDb, _BlocksDb) ->
                     top_header_db_put(TopHeaderDb1,
                                       ?TOP_HEADER, GenesisHeaderHash),
                 {ok, HeadersDb2} =
-                    headers_db_put(HeadersDb1,
-                                   GenesisHeaderHash, SerializedGenesisHeader),
+                    headers_db_put(
+                      HeadersDb1,
+                      GenesisHeaderHash,
+                      #chain_header{
+                         h = GenesisHeader,
+                         td = header_difficulty(GenesisHeader)}),
                 {ok, BlocksDb2} =
                     blocks_db_put(BlocksDb1,
                                   GenesisHeaderHash, SerializedGenesisBlock),
                 {TopHeaderDb2, HeadersDb2, BlocksDb2}
         end,
-
-    %% Hardcode expectation on initialized databases: the chain leads
-    %% to the specified genesis block.
-    {ok, TopHeaderHash} = top_header_db_get(NewTopHeaderDb, ?TOP_HEADER),
-    {ok, SerializedGenesisHeader} =
-        do_find_genesis_header_from_header_hash(TopHeaderHash, NewHeadersDb),
-    %% Hardcode expectation on initialized databases: the specified
-    %% genesis block and its header are in the databases.
-    {ok, SerializedGenesisHeader} =
-        headers_db_get(NewHeadersDb, GenesisHeaderHash),
-    {ok, SerializedGenesisBlock} =
-        blocks_db_get(NewBlocksDb, GenesisHeaderHash),
-
     {ok, {NewTopHeaderDb, NewHeadersDb, NewBlocksDb}}.
 
+do_init_check_dbs(GenesisHeaderHash, GenesisHeader, SerializedGenesisBlock,
+                  TopHeaderDb, HeadersDb, BlocksDb) ->
+    %% Hardcode expectation on initialized databases: the chain leads
+    %% to the specified genesis block.
+    {ok, TopHeaderHash} = top_header_db_get(TopHeaderDb, ?TOP_HEADER),
+    {ok, GenesisHeader} =
+        do_find_genesis_header_from_header_hash(TopHeaderHash, HeadersDb),
+    %% Hardcode expectation on initialized databases: the specified
+    %% genesis block and its header are in the databases.
+    {ok, #chain_header{h = GenesisHeader}} =
+        headers_db_get(HeadersDb, GenesisHeaderHash),
+    {ok, SerializedGenesisBlock} = blocks_db_get(BlocksDb, GenesisHeaderHash),
+    ok.
+
 do_find_genesis_header_from_header_hash(HeaderHash, HeadersDb) ->
-    {ok, SerializedHeader} = headers_db_get(HeadersDb, HeaderHash),
-    {ok, Header} = aec_headers:deserialize_from_network(SerializedHeader),
+    {ok, #chain_header{h = Header}} = headers_db_get(HeadersDb, HeaderHash),
     case aec_headers:height(Header) of
         ?GENESIS_HEIGHT ->
-            {ok, SerializedHeader};
+            {ok, Header};
         Height when ?IS_HEIGHT_AFTER_GENESIS(Height) ->
             do_find_genesis_header_from_header_hash(
               aec_headers:prev_hash(Header), Height - 1, HeadersDb)
@@ -358,74 +446,82 @@ do_find_genesis_header_from_header_hash(HeaderHash, HeadersDb) ->
 
 do_find_genesis_header_from_header_hash(HeaderHash, Height = ?GENESIS_HEIGHT,
                                         HeadersDb) ->
-    {ok, SerializedHeader} = headers_db_get(HeadersDb, HeaderHash),
-    {ok, Header} = aec_headers:deserialize_from_network(SerializedHeader),
+    {ok, #chain_header{h = Header}} = headers_db_get(HeadersDb, HeaderHash),
     {Height, _} = {aec_headers:height(Header), Header},
-    {ok, SerializedHeader};
+    {ok, Header};
 do_find_genesis_header_from_header_hash(HeaderHash, Height, HeadersDb) ->
-    {ok, SerializedHeader} = headers_db_get(HeadersDb, HeaderHash),
-    {ok, Header} = aec_headers:deserialize_from_network(SerializedHeader),
+    {ok, #chain_header{h = Header}} = headers_db_get(HeadersDb, HeaderHash),
     {Height, _} = {aec_headers:height(Header), Header},
     do_find_genesis_header_from_header_hash(
       aec_headers:prev_hash(Header), Height - 1, HeadersDb).
 
+-type do_top_header_reply() :: {ok, header()}.
+-spec do_top_header(chain_header()) -> do_top_header_reply().
+do_top_header(TopHeader) ->
+    {ok, TopHeader#chain_header.h}.
+
+-type do_top_block_reply() ::
+        {ok, aec_blocks:block_deserialized_from_network()}.
+-spec do_top_block(aec_blocks:block_deserialized_from_network()) ->
+                          do_top_block_reply().
+do_top_block(TopBlock) ->
+    {ok, TopBlock}.
+
 -type do_get_header_by_hash_reply() ::
         {ok, header()} |
         {error, Reason::{header_not_found, {top_header, header()}}}.
--spec do_get_header_by_hash(block_header_hash(), header(), headers_db()) ->
+-spec do_get_header_by_hash(block_header_hash(),
+                            chain_header(), headers_db()) ->
                                    do_get_header_by_hash_reply().
 do_get_header_by_hash(HeaderHash, TopHeader, HeadersDb) ->
     case headers_db_get(HeadersDb, HeaderHash) of
-        {ok, SerializedHeader} ->
-            {ok, _Header} =
-                aec_headers:deserialize_from_network(SerializedHeader);
+        {ok, #chain_header{h = Header}} ->
+            {ok, Header};
         {error, not_found} ->
-            {error, {header_not_found, {top_header, TopHeader}}}
+            {error, {header_not_found, {top_header, TopHeader#chain_header.h}}}
     end.
 
 -type do_get_block_by_hash_reply() ::
         {ok, header()} |
         {error, Reason::{block_not_found, {top_header, header()}}}.
--spec do_get_block_by_hash(block_header_hash(), header(), blocks_db()) ->
+-spec do_get_block_by_hash(block_header_hash(), chain_header(), blocks_db()) ->
                                   do_get_block_by_hash_reply().
 do_get_block_by_hash(HeaderHash, TopHeader, BlocksDb) ->
     case blocks_db_get(BlocksDb, HeaderHash) of
         {ok, SerializedBlock} ->
             {ok, _Block} = aec_blocks:deserialize_from_network(SerializedBlock);
         {error, not_found} ->
-            {error, {block_not_found, {top_header, TopHeader}}}
+            {error, {block_not_found, {top_header, TopHeader#chain_header.h}}}
     end.
 
 -type do_get_header_by_height_reply() ::
         {ok, header()} |
         {error, Reason::{chain_too_short, {{chain_height, height()},
                                            {top_header, header()}}}}.
--spec do_get_header_by_height(height(), header(), headers_db()) ->
+-spec do_get_header_by_height(height(), chain_header(), headers_db()) ->
                                      do_get_header_by_height_reply().
 do_get_header_by_height(Height, TopHeader, HeadersDb) ->
-    ChainHeight = aec_headers:height(TopHeader),
+    ChainHeight = aec_headers:height(TopHeader#chain_header.h),
     if
         Height > ChainHeight ->
             {error, {chain_too_short, {{chain_height, ChainHeight},
-                                       {top_header, TopHeader}
+                                       {top_header, TopHeader#chain_header.h}
                                       }
                     }};
         Height =:= ChainHeight ->
-            {ok, TopHeader};
+            {ok, TopHeader#chain_header.h};
         Height < ChainHeight ->
             do_get_past_header(ChainHeight - Height, TopHeader, HeadersDb)
     end.
 
 do_get_past_header(Distance, CurrentHeader, HeadersDb)
   when is_integer(Distance), Distance > 0 ->
-    PreviousHeaderHash = aec_headers:prev_hash(CurrentHeader),
-    {ok, SerializedPreviousHeader} = %% If not found, database is corrupt: fail.
+    PreviousHeaderHash = aec_headers:prev_hash(CurrentHeader#chain_header.h),
+    {ok, PreviousHeader} = %% If not found, database is corrupt: fail.
         headers_db_get(HeadersDb, PreviousHeaderHash),
-    {ok, PreviousHeader} =
-        aec_headers:deserialize_from_network(SerializedPreviousHeader),
     case Distance of
         1 ->
-            {ok, PreviousHeader};
+            {ok, PreviousHeader#chain_header.h};
         _ ->
             do_get_past_header(Distance - 1, PreviousHeader, HeadersDb)
     end.
@@ -436,7 +532,8 @@ do_get_past_header(Distance, CurrentHeader, HeadersDb)
                                            {top_header, header()}}} |
                         {block_not_found, {top_header, header()}}
         }.
--spec do_get_block_by_height(height(), header(), headers_db(), blocks_db()) ->
+-spec do_get_block_by_height(height(),
+                             chain_header(), headers_db(), blocks_db()) ->
                                     do_get_block_by_height_reply().
 do_get_block_by_height(Height, TopHeader, HeadersDb, BlocksDb) ->
     case do_get_header_by_height(Height, TopHeader, HeadersDb) of
@@ -449,7 +546,8 @@ do_get_block_by_height(Height, TopHeader, HeadersDb, BlocksDb) ->
                     {ok, _Block} =
                         aec_blocks:deserialize_from_network(SerializedBlock);
                 {error, not_found} ->
-                    {error, {block_not_found, {top_header, TopHeader}}}
+                    {error, {block_not_found, {top_header,
+                                               TopHeader#chain_header.h}}}
             end
     end.
 
@@ -459,42 +557,54 @@ do_get_block_by_height(Height, TopHeader, HeadersDb, BlocksDb) ->
                         {height_inconsistent_with_previous_hash, {top_header,
                                                                   header()}}
         }.
--spec do_insert_header(header(), header(), top_header_db(), headers_db()) ->
+-spec do_insert_header(header(),
+                       chain_header(), top_header_db(), headers_db()) ->
                               do_insert_header_reply_error() |
                               {ok, {do_insert_header_reply_ok(), NewState}} when
-      NewState :: {top_header_db(), headers_db()}.
+      NewState :: {chain_header(), top_header_db(), headers_db()}.
 do_insert_header(Header, TopHeader, TopHeaderDb, HeadersDb) ->
-    {ok, TopHeaderHash} = aec_headers:hash_internal_representation(TopHeader),
-    case aec_headers:prev_hash(Header) of
-        TopHeaderHash ->
-            TopHeaderHeight = aec_headers:height(TopHeader),
-            HeaderHeight = aec_headers:height(Header),
-            case {HeaderHeight, 1 + TopHeaderHeight} of
-                {HH, HH} ->
-                    %% Ensure header is stored, then update top. In
-                    %% this order so that, if execution stops after
-                    %% storing header, the top header hash still
-                    %% refers to a a chain.
-                    {ok, SerializedHeader} =
-                        aec_headers:serialize_for_network(Header),
-                    {ok, HeaderHash} =
-                        aec_headers:hash_network_serialization(SerializedHeader),
-                    %% As header is a successor of the current top, it
-                    %% should not be stored yet.  So store header
-                    %% without first checking that it is not yet
-                    %% stored.
-                    {ok, NewHeadersDb} =
-                        headers_db_put(HeadersDb, HeaderHash, SerializedHeader),
-                    {ok, NewTopHeaderDb} =
-                        top_header_db_put(TopHeaderDb, ?TOP_HEADER, HeaderHash),
-                    {ok, {_Reply = ok, {NewTopHeaderDb, NewHeadersDb}}};
-                {HeaderHeight, _} when ?IS_HEIGHT(HeaderHeight) ->
-                    {error, {height_inconsistent_with_previous_hash,
-                             {top_header, TopHeader}}}
-            end;
-        <<_:?BLOCK_HEADER_HASH_BYTES/unit:8>> ->
+    HeaderDifficulty = header_difficulty(Header),
+    %% Hardcode expectation on block header difficulty: a valid
+    %% internal representation of block header will always comply.
+    %% Check this explicitly in this manner in order to speed up
+    %% investigation in case of failure in unit tests, and not to
+    %% cause Dialyzer warnings.
+    {true, _} = {?IS_WORK(HeaderDifficulty), {bad_difficulty,
+                                              HeaderDifficulty}},
+    {ok, TopHeaderHash = <<_:?BLOCK_HEADER_HASH_BYTES/unit:8>>} =
+        aec_headers:hash_internal_representation(TopHeader#chain_header.h),
+    HeaderPreviousHash = <<_:?BLOCK_HEADER_HASH_BYTES/unit:8>> =
+        aec_headers:prev_hash(Header),
+    TopHeaderHeight = aec_headers:height(TopHeader#chain_header.h),
+    ExpectedHeaderHeight = 1 + TopHeaderHeight,
+    HeaderHeight = aec_headers:height(Header),
+    if
+        HeaderPreviousHash =/= TopHeaderHash ->
             _Reply =
-                {error, {previous_hash_is_not_top, {top_header, TopHeader}}}
+                {error, {previous_hash_is_not_top, {top_header,
+                                                    TopHeader#chain_header.h}}};
+        HeaderHeight =/= ExpectedHeaderHeight ->
+            _Reply =
+                {error, {height_inconsistent_with_previous_hash,
+                         {top_header, TopHeader#chain_header.h}}};
+        true ->
+            NewTopHeader =
+                #chain_header{
+                   h = Header,
+                   td = TopHeader#chain_header.td + HeaderDifficulty},
+            %% Ensure header is stored, then update top. In this order
+            %% so that, if execution stops after storing header, the
+            %% top header hash still refers to a a chain.
+            {ok, HeaderHash} = aec_headers:hash_internal_representation(Header),
+            %% As header is a successor of the current top, it should
+            %% not be stored yet.  So store header without first
+            %% checking that it is not yet stored.
+            {ok, NewHeadersDb} =
+                headers_db_put(HeadersDb, HeaderHash, NewTopHeader),
+            {ok, NewTopHeaderDb} =
+                top_header_db_put(TopHeaderDb, ?TOP_HEADER, HeaderHash),
+            {ok, {_Reply = ok,
+                  {NewTopHeader, NewTopHeaderDb, NewHeadersDb}}}
     end.
 
 -type do_write_block_argument() ::
@@ -505,19 +615,19 @@ do_insert_header(Header, TopHeader, TopHeaderDb, HeadersDb) ->
                         {block_already_stored, aec_blocks:block_serialized_for_network()}
         }.
 -spec do_write_block(do_write_block_argument(),
-                     header(), aec_blocks:block_deserialized_from_network(),
+                     chain_header(),
+                     aec_blocks:block_deserialized_from_network(),
                      headers_db(), blocks_db()) ->
                             do_write_block_reply_error() |
                             {ok, {do_write_block_reply_ok(), NewState}} when
       NewState :: {aec_blocks:block_deserialized_from_network(), blocks_db()}.
 do_write_block(Block, TopHeader, TopBlock, HeadersDb, BlocksDb) ->
     Header = aec_blocks:to_header(Block),
-    {ok, SerializedHeader} = aec_headers:serialize_for_network(Header),
-    {ok, HeaderHash} = aec_headers:hash_network_serialization(
-                         SerializedHeader),
+    {ok, HeaderHash} = aec_headers:hash_internal_representation(Header),
     case do_find_header_hash_in_chain(HeaderHash, TopHeader, HeadersDb) of
         {error, not_found} ->
-            {error, {header_not_in_chain, {top_header, TopHeader}}};
+            {error, {header_not_in_chain, {top_header,
+                                           TopHeader#chain_header.h}}};
         ok ->
             case blocks_db_get(BlocksDb, HeaderHash) of
                 {ok, SerializedBlock} ->
@@ -556,8 +666,9 @@ do_write_block(Block, TopHeader, TopBlock, HeadersDb, BlocksDb) ->
     end.
 
 do_find_header_hash_in_chain(HeaderHashToFind, TopHeader, HeadersDb) ->
-    {ok, TopHeaderHash} = aec_headers:hash_internal_representation(TopHeader),
-    TopHeaderHeight = aec_headers:height(TopHeader),
+    {ok, TopHeaderHash} =
+        aec_headers:hash_internal_representation(TopHeader#chain_header.h),
+    TopHeaderHeight = aec_headers:height(TopHeader#chain_header.h),
     if
         HeaderHashToFind =:= TopHeaderHash ->
             ok;
@@ -565,14 +676,15 @@ do_find_header_hash_in_chain(HeaderHashToFind, TopHeader, HeadersDb) ->
             {error, not_found};
         true ->
             do_find_header_hash_in_chain_1(
-              HeaderHashToFind, aec_headers:prev_hash(TopHeader), HeadersDb)
+              HeaderHashToFind,
+              aec_headers:prev_hash(TopHeader#chain_header.h),
+              HeadersDb)
     end.
 
 do_find_header_hash_in_chain_1(HeaderHashToFind, HeaderHashToFind, _) ->
     ok;
 do_find_header_hash_in_chain_1(HeaderHashToFind, HeaderHash, HeadersDb) ->
-    {ok, SerializedHeader} = headers_db_get(HeadersDb, HeaderHash),
-    {ok, Header} = aec_headers:deserialize_from_network(SerializedHeader),
+    {ok, #chain_header{h = Header}} = headers_db_get(HeadersDb, HeaderHash),
     case aec_headers:height(Header) of
         ?GENESIS_HEIGHT ->
             {error, not_found};
@@ -580,3 +692,9 @@ do_find_header_hash_in_chain_1(HeaderHashToFind, HeaderHash, HeadersDb) ->
             do_find_header_hash_in_chain_1(
               HeaderHashToFind, aec_headers:prev_hash(Header), HeadersDb)
     end.
+
+-type do_get_work_at_top_reply() ::
+        {ok, {WorkAtTop::work(), {top_header, header()}}}.
+-spec do_get_work_at_top(chain_header()) -> do_get_work_at_top_reply().
+do_get_work_at_top(TopHeader) ->
+    {ok, {TopHeader#chain_header.td, {top_header, TopHeader#chain_header.h}}}.

--- a/apps/aecore/src/aec_chain.erl
+++ b/apps/aecore/src/aec_chain.erl
@@ -67,7 +67,7 @@ stop() ->
 
 %% Returns the highest known block in the chain with its state trees.
 %%
-%% The heighest known block may be lower than the highest block header
+%% The highest known block may be lower than the highest block header
 %% in the chain as returned by `top_header/0`.
 -spec top() -> {ok, block()}.
 top() ->
@@ -84,7 +84,7 @@ top_header() ->
 
 %% Returns the highest known block in the chain.
 %%
-%% The heighest known block may be lower than the highest block header
+%% The highest known block may be lower than the highest block header
 %% in the chain as returned by `top_header/0`.
 -spec top_block() -> {ok, aec_blocks:block_deserialized_from_network()}.
 top_block() ->

--- a/apps/aecore/src/aec_chain.erl
+++ b/apps/aecore/src/aec_chain.erl
@@ -1,9 +1,11 @@
 %%%-------------------------------------------------------------------
 %%% @copyright (C) 2017, Aeternity Anstalt
-%%% @doc Service holding the chain of block headers and blocks.
+%%% @doc Service holding the longest chain of block headers and blocks.
+%%%
+%%% The longest chain is determined according to the amount of work
+%%% done on the chain.
 %%%
 %%% @TODO Unit testing of unhappy paths.
-%%% @TODO Forced chain (fork).
 %%% @TODO Persistence.
 %%% @end
 %%%-------------------------------------------------------------------
@@ -23,8 +25,10 @@
          get_block_by_height/1,
          insert_header/1,
          write_block/1,
-         get_work_at_top/0]).
-%% TODO `force_insert_headers`: Insert the specified sequence of headers in the chain, potentially changing the top header in the chain.
+         get_work_at_top/0,
+         get_work_by_hash_and_at_top/1,
+         has_more_work/1,
+         force_insert_headers/1]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
@@ -74,6 +78,11 @@
 -type work() :: float(). %% TODO: Move to PoW-related module.
 
 -type chain_header() :: #chain_header{}.
+
+-type header_chain() :: header_chain_from_genesis()
+                      | header_chain_without_genesis().
+-type header_chain_from_genesis() :: [header(), ...]. %% First element is genesis.
+-type header_chain_without_genesis() :: [header(), ...]. %% First element has lowest height.
 
 -type top_header_db_key() :: ?TOP_HEADER. %% Only one key.
 -type top_header_db_value() :: block_header_hash().
@@ -170,6 +179,78 @@ get_work_at_top() ->
     gen_server:call(?SERVER, {get_work_at_top},
                     ?DEFAULT_CALL_TIMEOUT).
 
+-spec get_work_by_hash_and_at_top(block_header_hash()) ->
+                                         do_get_work_by_hash_and_at_top_reply().
+get_work_by_hash_and_at_top(HeaderHash) ->
+    gen_server:call(?SERVER, {get_work_by_hash_and_at_top, HeaderHash},
+                    ?DEFAULT_CALL_TIMEOUT).
+
+-spec has_more_work(header_chain()) ->
+                           {ok, {boolean(), {{{top_chain_work, work()},
+                                              {alt_chain_work, work()}},
+                                             {top_header, header()}}}} |
+                           {error, Reason} when
+      Reason :: {no_common_ancestor, {top_header, header()}}
+              | {different_genesis, {genesis_header, header()}}.
+has_more_work(HeaderChain = [LowerHeader | _]) ->
+    %% This function does not guarantee that the specified list of
+    %% headers is a chain, i.e. it does not check fields height and
+    %% previous hash in each header in relation to the previous
+    %% header.
+    case aec_headers:height(LowerHeader) of
+        ?GENESIS_HEIGHT ->
+            %% The specified chain is a chain complete from genesis.
+            %% Check that the genesis is the expected one.
+            {ok, GenesisHeader} = get_header_by_height(0),
+            if
+                LowerHeader =/= GenesisHeader ->
+                    {error, {different_genesis, {genesis_header,
+                                                 GenesisHeader}}};
+                true ->
+                    %% The specified chain does not require retrieving
+                    %% any ancestor for computing the total work in
+                    %% it.
+                    {ok, AltChainWork} = work_in_header_chain(HeaderChain),
+                    %% Retrieve the total work in the longest chain.
+                    {ok, {TopChainWork, {top_header, TopHeader}}} =
+                        get_work_at_top(),
+                    {ok, {'work_op_>'(AltChainWork, TopChainWork),
+                          {{{top_chain_work, TopChainWork},
+                            {alt_chain_work, AltChainWork}},
+                           {top_header, TopHeader}}}}
+            end;
+        LowerHeaderHeight when ?IS_HEIGHT_AFTER_GENESIS(LowerHeaderHeight) ->
+            %% The specified chain does not start from genesis.
+            %% Attempt to retrieve work of higher missing ancestor and
+            %% work of top, so to compare work of top against work of
+            %% specified chain.
+            LowerHeaderPreviousHash = aec_headers:prev_hash(LowerHeader),
+            case get_work_by_hash_and_at_top(LowerHeaderPreviousHash) of
+                {error, {header_not_found, {top_header, TopHeader}}} ->
+                    {error, {no_common_ancestor, {top_header, TopHeader}}};
+                {ok, {{{work_at_hash, WorkBeforeLowerHeader},
+                       {work_at_top, TopChainWork}},
+                      {top_header, TopHeader}}} ->
+                    {ok, WorkFromLowerHeader} =
+                        work_in_header_chain(HeaderChain),
+                    AltChainWork =
+                        'work_op_+'(WorkBeforeLowerHeader, WorkFromLowerHeader),
+                    {ok, {'work_op_>'(AltChainWork, TopChainWork),
+                          {{{top_chain_work, TopChainWork},
+                            {alt_chain_work, AltChainWork}},
+                           {top_header, TopHeader}}}}
+            end
+    end.
+
+%% Insert the specified sequence of headers in the chain, changing the
+%% top header in the chain.
+-spec force_insert_headers(header_chain()) ->
+                                  do_force_insert_headers_reply_ok() |
+                                  do_force_insert_headers_reply_error().
+force_insert_headers(HeaderChain) ->
+    gen_server:call(?SERVER, {force_insert_headers, HeaderChain},
+                    ?DEFAULT_CALL_TIMEOUT).
+
 %%%===================================================================
 %%% gen_server callbacks
 %%%===================================================================
@@ -190,8 +271,9 @@ init(_Args = [GenesisBlock]) ->
     %% Compute initial state of process.
     {ok, TopHeaderHash} = top_header_db_get(NewTopHeaderDb, ?TOP_HEADER),
     {ok, TopHeader} = headers_db_get(NewHeadersDb, TopHeaderHash),
-    {ok, SerializedTopBlock} = blocks_db_get(NewBlocksDb, TopHeaderHash),
-    {ok, TopBlock} = aec_blocks:deserialize_from_network(SerializedTopBlock),
+    {ok, TopBlock} =
+        do_find_highest_block_from_header_hash(TopHeaderHash,
+                                               NewHeadersDb, NewBlocksDb),
     TopState = #top_state{top_header = TopHeader,
                           top_header_db = NewTopHeaderDb,
                           top_block = TopBlock},
@@ -273,6 +355,37 @@ handle_call({write_block, Block}, _From, State) ->
 handle_call({get_work_at_top}, _From, State) ->
     Reply = do_get_work_at_top(State#state.top#top_state.top_header),
     {reply, Reply, State};
+handle_call({get_work_by_hash_and_at_top,
+             HeaderHash = <<_:?BLOCK_HEADER_HASH_BYTES/unit:8>>},
+            _From, State) ->
+    Reply = do_get_work_by_hash_and_at_top(HeaderHash,
+                                           State#state.top#top_state.top_header,
+                                           State#state.headers_db),
+    {reply, Reply, State};
+handle_call({force_insert_headers, HeaderChain = [_|_]}, _From, State) ->
+    case
+        do_force_insert_headers(HeaderChain,
+                                State#state.top#top_state.top_header,
+                                State#state.top#top_state.top_block,
+                                State#state.top#top_state.top_header_db,
+                                State#state.headers_db,
+                                State#state.blocks_db)
+    of
+        {error, _Reason} = Reply ->
+            {reply, Reply, State};
+        {ok, {Reply, {NewTopHeader, NewTopBlock,
+                      NewTopHeaderDb, NewHeadersDb, NewBlocksDb}}} ->
+            NewState =
+                State#state{
+                  top =
+                      State#state.top#top_state{
+                                    top_header = NewTopHeader,
+                                    top_header_db = NewTopHeaderDb,
+                                    top_block = NewTopBlock},
+                  headers_db = NewHeadersDb,
+                  blocks_db = NewBlocksDb},
+            {reply, Reply, NewState}
+    end;
 handle_call(Request, From, State) ->
     lager:warning("Ignoring unknown call request from ~p: ~p", [From, Request]),
     {noreply, State}.
@@ -300,6 +413,90 @@ code_change(_OldVsn, State, _Extra) ->
 header_difficulty(Header) ->
     aec_headers:difficulty(Header).
 
+-spec 'work_op_>'(work(), work()) -> boolean().
+'work_op_>'(A, B) when ?IS_WORK(A), ?IS_WORK(B) ->
+    A > B.
+
+-spec 'work_op_+'(work(), work()) -> work().
+'work_op_+'(A, B) when ?IS_WORK(A), ?IS_WORK(B) ->
+    A + B.
+
+-spec work_in_header_chain(header_chain()) -> {ok, work()}.
+work_in_header_chain([Header]) ->
+    case header_difficulty(Header) of
+        W when ?IS_WORK(W) ->
+            {ok, W}
+    end;
+work_in_header_chain([LowerHeader | OtherHeaders]) ->
+    LowerHeaderWork = header_difficulty(LowerHeader),
+    {ok, OtherHeadersWork} = work_in_header_chain(OtherHeaders),
+    {ok, 'work_op_+'(LowerHeaderWork, OtherHeadersWork)}.
+
+-spec header_chain_with_work(work(), header_chain_without_genesis()) ->
+                                    [chain_header(), ...].
+header_chain_with_work(WorkBeforeLowerHeader, HeaderChain) ->
+    {_, ReversedHeaderChainWithWork} =
+        lists:foldl(
+          fun(H, {W, RHCW}) ->
+                  D = header_difficulty(H),
+                  HH = #chain_header{h = H, td = 'work_op_+'(W, D)},
+                  {HH#chain_header.td, [HH | RHCW]}
+          end,
+          {WorkBeforeLowerHeader, []},
+          HeaderChain),
+    lists:reverse(ReversedHeaderChainWithWork).
+
+-type is_header_chain_return_error() ::
+        {error, Reason::{inconsistent_previous_hash, term()} |
+                        {height_inconsistent_with_previous_height, term()}
+        }.
+-spec is_header_chain(header_chain()) -> ok | is_header_chain_return_error().
+is_header_chain([LowestHeader | OtherHeaders]) ->
+    {ok, LowestHeaderHash} =
+        aec_headers:hash_internal_representation(LowestHeader),
+    is_header_chain_1(LowestHeaderHash, aec_headers:height(LowestHeader),
+                      OtherHeaders).
+
+is_header_chain_1(<<_:?BLOCK_HEADER_HASH_BYTES/unit:8>>, PreviousHeight, [])
+  when ?IS_HEIGHT(PreviousHeight) ->
+    ok;
+is_header_chain_1(PreviousHash = <<_:?BLOCK_HEADER_HASH_BYTES/unit:8>>,
+                  PreviousHeight,
+                  [LowestHeader | OtherHeaders])
+  when ?IS_HEIGHT(PreviousHeight) ->
+    LowestHeaderPrevHash = aec_headers:prev_hash(LowestHeader),
+    ExpectedHeight = 1 + PreviousHeight,
+    LowestHeaderHeight = aec_headers:height(LowestHeader),
+    if
+        LowestHeaderPrevHash =/= PreviousHash ->
+            {error, {inconsistent_previous_hash,
+                     {{actual_previous_hash, LowestHeaderPrevHash},
+                      {expected_previous_hash, PreviousHash}}}};
+        LowestHeaderHeight =/= ExpectedHeight ->
+            {error, {height_inconsistent_with_previous_height,
+                     {{actual_height, LowestHeaderHeight},
+                      {expected_height, {ExpectedHeight}},
+                      {previous_hash, LowestHeaderPrevHash}}}};
+        true ->
+            {ok, LowestHeaderHash} =
+                aec_headers:hash_internal_representation(LowestHeader),
+            is_header_chain_1(
+              LowestHeaderHash, aec_headers:height(LowestHeader),
+              OtherHeaders)
+    end.
+
+-spec is_header_chain_included(header_chain(), chain_header(), headers_db()) ->
+                                      boolean().
+is_header_chain_included(HeaderChain, TopHeader, HeadersDb) ->
+    {ok, HeaderChainHash} =
+        aec_headers:hash_internal_representation(lists:last(HeaderChain)),
+    case do_find_header_hash_in_chain(HeaderChainHash, TopHeader, HeadersDb) of
+        ok ->
+            true;
+        {error, not_found} ->
+            false
+    end.
+
 chain_header_serialize(H) when ?IS_CHAIN_HEADER(H) ->
     term_to_binary(H).
 
@@ -320,6 +517,11 @@ db_get(Db, K) ->
 -spec db_put(db_handle(), db_key(), db_value()) -> db_put_return().
 db_put(Db, K, V) ->
     {ok, dict:store(K, V, Db)}.
+
+-type db_delete_return() :: {ok, NewDb::db_handle()}.
+-spec db_delete(db_handle(), db_key()) -> db_delete_return().
+db_delete(Db, K) ->
+    {ok, dict:erase(K, Db)}.
 
 -spec top_header_db_get(db_handle(), top_header_db_key()) ->
                                db_get_return(top_header_db_value()).
@@ -346,6 +548,11 @@ headers_db_get(Db, K) ->
 headers_db_put(Db, K, V) ->
     db_put(Db, K, chain_header_serialize(V)).
 
+-spec headers_db_delete(db_handle(), headers_db_key()) ->
+                               db_delete_return().
+headers_db_delete(Db, K) ->
+    db_delete(Db, K).
+
 -spec blocks_db_get(db_handle(), blocks_db_key()) ->
                            db_get_return(blocks_db_value()).
 blocks_db_get(Db, K) ->
@@ -355,6 +562,11 @@ blocks_db_get(Db, K) ->
                            db_put_return().
 blocks_db_put(Db, K, V) ->
     db_put(Db, K, V).
+
+-spec blocks_db_delete(db_handle(), blocks_db_key()) ->
+                              db_delete_return().
+blocks_db_delete(Db, K) ->
+    db_delete(Db, K).
 
 do_init([GenesisBlock], TopHeaderDb, HeadersDb, BlocksDb) ->
     %% Hardcode expectations on specified genesis block.
@@ -454,6 +666,20 @@ do_find_genesis_header_from_header_hash(HeaderHash, Height, HeadersDb) ->
     {Height, _} = {aec_headers:height(Header), Header},
     do_find_genesis_header_from_header_hash(
       aec_headers:prev_hash(Header), Height - 1, HeadersDb).
+
+do_find_highest_block_from_header_hash(HeaderHash, HeadersDb, BlocksDb) ->
+    case blocks_db_get(BlocksDb, HeaderHash) of
+        {ok, SerializedBlock} ->
+            {ok, _Block} =
+                aec_blocks:deserialize_from_network(SerializedBlock);
+        {error, not_found} ->
+            {ok, #chain_header{h = Header}} =
+                headers_db_get(HeadersDb, HeaderHash),
+            %% Assumption: The specified header hash leads to genesis.
+            %% Assumption: At least the genesis block is present.
+            do_find_highest_block_from_header_hash(
+              aec_headers:prev_hash(Header), HeadersDb, BlocksDb)
+    end.
 
 -type do_top_header_reply() :: {ok, header()}.
 -spec do_top_header(chain_header()) -> do_top_header_reply().
@@ -591,7 +817,8 @@ do_insert_header(Header, TopHeader, TopHeaderDb, HeadersDb) ->
             NewTopHeader =
                 #chain_header{
                    h = Header,
-                   td = TopHeader#chain_header.td + HeaderDifficulty},
+                   td = 'work_op_+'(TopHeader#chain_header.td,
+                                    HeaderDifficulty)},
             %% Ensure header is stored, then update top. In this order
             %% so that, if execution stops after storing header, the
             %% top header hash still refers to a a chain.
@@ -698,3 +925,272 @@ do_find_header_hash_in_chain_1(HeaderHashToFind, HeaderHash, HeadersDb) ->
 -spec do_get_work_at_top(chain_header()) -> do_get_work_at_top_reply().
 do_get_work_at_top(TopHeader) ->
     {ok, {TopHeader#chain_header.td, {top_header, TopHeader#chain_header.h}}}.
+
+-type do_get_work_by_hash_and_at_top_reply() ::
+        {ok, {ResultInfo::{{work_at_hash, work()},
+                           {work_at_top, work()}},
+              ResultContext::{top_header, header()}}} |
+        {error, Reason::{header_not_found, {top_header, header()}}}.
+-spec do_get_work_by_hash_and_at_top(block_header_hash(),
+                                     chain_header(), headers_db()
+                                    ) -> do_get_work_by_hash_and_at_top_reply().
+do_get_work_by_hash_and_at_top(HeaderHash, TopHeader, HeadersDb) ->
+    case headers_db_get(HeadersDb, HeaderHash) of
+        {error, not_found} ->
+            {error, {header_not_found, {top_header, TopHeader#chain_header.h}}};
+        {ok, #chain_header{td = WorkAtHash}} ->
+            {ok, {{{work_at_hash, WorkAtHash},
+                   {work_at_top, TopHeader#chain_header.td}},
+                  {top_header, TopHeader#chain_header.h}}}
+    end.
+
+-type do_force_insert_headers_reply_ok() :: {ok, {{old_top_header, header()},
+                                                  {new_top_header, header()}}}.
+-type do_force_insert_headers_reply_error() ::
+        is_header_chain_return_error() |
+        {error, Reason::{header_chain_already_included, term()} |
+                        {no_common_ancestor, term()}
+        }.
+-spec do_force_insert_headers(
+        header_chain(),
+        chain_header(), aec_blocks:block_deserialized_from_network(),
+        top_header_db(), headers_db(), blocks_db()
+       ) -> do_force_insert_headers_reply_error() |
+            {ok, {do_force_insert_headers_reply_ok(), NewState}} when
+      NewState :: {chain_header(), aec_blocks:block_deserialized_from_network(),
+                   top_header_db(), headers_db(), blocks_db()}.
+do_force_insert_headers(HeaderChain,
+                        TopHeader, TopBlock,
+                        TopHeaderDb, HeadersDb, BlocksDb) ->
+    case is_header_chain(HeaderChain) of
+        {error, _Reason} = Err ->
+            _Reply = Err;
+        ok ->
+            case is_header_chain_included(HeaderChain, TopHeader, HeadersDb) of
+                true ->
+                    _Reply =
+                        {error, {header_chain_already_included,
+                                 {top_header, TopHeader#chain_header.h}}};
+                false -> %% At least part of the chain is not included.
+                    case
+                        do_find_highest_common_ancestor(HeaderChain,
+                                                        TopHeader, HeadersDb)
+                    of
+                        {error, no_common_ancestor} ->
+                            _Reply =
+                                {error,
+                                 {no_common_ancestor,
+                                  {top_header, TopHeader#chain_header.h}}};
+                        {ok, {{highest_common_ancestor,
+                               HighestCommonAncestor},
+                              {not_included_header_chain,
+                               RelevantHeaderChainPortion =
+                                   [LowestRelevantHeader | _]}}} ->
+                            %% Hardcode expectation that lowest header
+                            %% of relevant portion of the specified
+                            %% header chain is not genesis, as it has
+                            %% at least a predecessor (the highest
+                            %% common ancestor).
+                            case aec_headers:height(LowestRelevantHeader) of
+                                H when ?IS_HEIGHT_AFTER_GENESIS(H) ->
+                                    do_force_insert_headers_1(
+                                      RelevantHeaderChainPortion,
+                                      HighestCommonAncestor,
+                                      TopHeader, TopBlock,
+                                      TopHeaderDb, HeadersDb, BlocksDb)
+                            end
+                    end
+            end
+    end.
+
+-spec do_force_insert_headers_1(
+        header_chain_without_genesis(),
+        chain_header(),
+        chain_header(), aec_blocks:block_deserialized_from_network(),
+        top_header_db(), headers_db(), blocks_db()
+       ) -> {ok, {do_force_insert_headers_reply_ok(), NewState}} when
+      NewState :: {chain_header(), aec_blocks:block_deserialized_from_network(),
+                   top_header_db(), headers_db(), blocks_db()}.
+do_force_insert_headers_1(HeaderChain = [_|_], %% Above common ancestor.
+                          CommonAncestor,
+                          OldTopHeader, _TopBlock,
+                          TopHeaderDb, HeadersDb, BlocksDb) ->
+    HeaderChainWithWork =
+        header_chain_with_work(CommonAncestor#chain_header.td, HeaderChain),
+    NewTopHeader = lists:last(HeaderChainWithWork),
+    {ok, NewTopHeaderHash} =
+        aec_headers:hash_internal_representation(NewTopHeader#chain_header.h),
+    {ok, CommonAncestorHash} =
+        aec_headers:hash_internal_representation(CommonAncestor#chain_header.h),
+    %% Ensure headers above common ancestor are stored, then update
+    %% top, then delete unused blocks (in old chain above highest
+    %% common ancestor), then delete unused headers (in old chain
+    %% above highest common ancestor). In this order so that, if
+    %% execution stops, the top header hash still refers to a chain,
+    %% and each block has its header stored.
+    %%
+    %% As the headers belong to a distinct chain than the current top,
+    %% they should not be stored yet.  So store each header without
+    %% first checking that it is not yet stored.
+    HeadersDbWithNewHeaders =
+        lists:foldl(
+          fun(H, HsDb) ->
+                  {ok, HH} =
+                      aec_headers:hash_internal_representation(
+                        H#chain_header.h),
+                  {ok, NewHsDb} = headers_db_put(HsDb, HH, H),
+                  NewHsDb
+          end,
+          HeadersDb,
+          HeaderChainWithWork),
+    {ok, NewTopHeaderDb} =
+        top_header_db_put(TopHeaderDb, ?TOP_HEADER, NewTopHeaderHash),
+    {ok, {NewHeadersDb, NewBlocksDb}} =
+        do_delete_headers_and_blocks_from_header_to_header_hash(
+          OldTopHeader, %% To delete.
+          CommonAncestorHash, %% Not to delete.
+          HeadersDbWithNewHeaders, BlocksDb),
+    {ok, NewTopBlock} =
+        do_find_highest_block_from_header_hash(NewTopHeaderHash,
+                                               NewHeadersDb, NewBlocksDb),
+    {ok, {_Reply = {ok, {{old_top_header, OldTopHeader#chain_header.h},
+                         {new_top_header, NewTopHeader#chain_header.h}}},
+          {NewTopHeader, NewTopBlock,
+           NewTopHeaderDb, NewHeadersDb, NewBlocksDb}}}.
+
+do_delete_headers_and_blocks_from_header_to_header_hash(
+  HighIncludedHeader, LowExcludedHeaderHash,
+  HeadersDb, BlocksDb) ->
+    {ok, HighIncludedHeaderHash} =
+        aec_headers:hash_internal_representation(
+          HighIncludedHeader#chain_header.h),
+    {ok, NewBlocksDb} = blocks_db_delete(BlocksDb, HighIncludedHeaderHash),
+    {ok, NewHeadersDb} = headers_db_delete(HeadersDb, HighIncludedHeaderHash),
+    case aec_headers:prev_hash(HighIncludedHeader#chain_header.h) of
+        LowExcludedHeaderHash ->
+            {ok, {NewHeadersDb, NewBlocksDb}};
+        PrevHeaderHash ->
+            {ok, PrevHeader} = headers_db_get(HeadersDb, PrevHeaderHash),
+            do_delete_headers_and_blocks_from_header_to_header_hash(
+              PrevHeader, LowExcludedHeaderHash,
+              NewHeadersDb, NewBlocksDb)
+    end.
+
+-spec do_find_highest_common_ancestor(
+        header_chain(), %% At least part of the first chain must be not included...
+        chain_header(), headers_db() %% ... in the second chain.
+       ) -> {ok, {{highest_common_ancestor, chain_header()},
+                  {not_included_header_chain, header_chain_without_genesis()}}
+            } |
+            {error, no_common_ancestor}.
+do_find_highest_common_ancestor(HC, TopHeader, HeadersDb) ->
+    %% The highest common ancestor cannot be higher than the minimum
+    %% height of the two chains.
+    [HighestHCHeader | ReversedHCRest] = lists:reverse(HC),
+    HCHeight = aec_headers:height(HighestHCHeader),
+    TopHeight = aec_headers:height(TopHeader#chain_header.h),
+    if
+        HCHeight =< TopHeight ->
+            %% Hardcode expectation on at least part of the chain
+            %% being not included.  Compare block headers at highest
+            %% common height.
+            {ok, H} = do_get_header_by_height(HCHeight, TopHeader, HeadersDb),
+            case
+                {aec_headers:hash_internal_representation(HighestHCHeader),
+                 aec_headers:hash_internal_representation(H)}
+            of
+                {{ok, HighestHCHeaderHash}, {ok, HH}}
+                  when HighestHCHeaderHash =/= HH ->
+                    ok
+            end,
+            do_find_highest_common_ancestor_1(
+              {aec_headers:prev_hash(HighestHCHeader),
+               aec_headers:height(HighestHCHeader),
+               ReversedHCRest},
+              {aec_headers:prev_hash(H), aec_headers:height(H), HeadersDb},
+              _NotIncludedHCAcc0 = [HighestHCHeader]);
+        HCHeight > TopHeight ->
+            %% Being higher, of course at least part of the chain is
+            %% not included.
+            {ok, TopHeaderHash} = aec_headers:hash_internal_representation(
+                                    TopHeader#chain_header.h),
+            do_find_highest_common_ancestor_2(
+              {aec_headers:prev_hash(HighestHCHeader),
+               aec_headers:height(HighestHCHeader),
+               ReversedHCRest},
+              {TopHeaderHash,
+               1 + aec_headers:height(TopHeader#chain_header.h),
+               HeadersDb},
+              _NotIncludedHCAcc0 = [HighestHCHeader])
+    end.
+
+%% The first specified chain may be without genesis. The second
+%% specified chain arrives at genesis. The two specified chains may
+%% refer to distinct genesis block headers.
+-spec do_find_highest_common_ancestor_1(
+        FirstChain::term(), SecondChain::term(),
+        NotIncludedHeaderChainAccumulator::header_chain()) -> term().
+do_find_highest_common_ancestor_1({_, H, []}, {_, H = ?GENESIS_HEIGHT, _}, _) ->
+    %% Distinct genesis block headers.
+    {error, no_common_ancestor};
+do_find_highest_common_ancestor_1({HCPrevHash, H, []}, {HCPrevHash, H, HeadersDb}, NotIncludedHC)
+  when ?IS_HEIGHT_AFTER_GENESIS(H) ->
+    %% The first chain is without genesis.
+    %%
+    %% The highest common ancestor is the header that is not in the
+    %% first chain, but that is the previous header of the lowest
+    %% header in the first chain.
+    {ok, Header2} = headers_db_get(HeadersDb, HCPrevHash),
+    {ok, {{highest_common_ancestor, Header2},
+          {not_included_header_chain, NotIncludedHC}}};
+do_find_highest_common_ancestor_1({_, H, []}, {_, H, _}, _)
+  when ?IS_HEIGHT_AFTER_GENESIS(H) ->
+    %% The first chain is without genesis.
+    %%
+    %% No known common ancestors - not even the previous header of the
+    %% lowest header in the first chain.
+    {error, no_common_ancestor};
+do_find_highest_common_ancestor_1({HCPrevHash, H, [HighestHCHeader | _]}, {HCPrevHash, H, HeadersDb}, NotIncludedHC)
+  when ?IS_HEIGHT_AFTER_GENESIS(H) ->
+    %% The highest common ancestor is the identified header, in the
+    %% first chain.
+    %%
+    %% Hardcode expectation that the ancestor is the same in both chains.
+    {ok, Header2 = #chain_header{h = HighestHCHeader}} =
+        headers_db_get(HeadersDb, HCPrevHash),
+    {ok, {{highest_common_ancestor, Header2},
+          {not_included_header_chain, NotIncludedHC}}};
+do_find_highest_common_ancestor_1({_, H, [HighestHCHeader | HCRest]}, {PrevHash, H, HeadersDb}, NotIncludedHC)
+  when ?IS_HEIGHT_AFTER_GENESIS(H) ->
+    %% Still looking for the highest common ancestor.  Go down both
+    %% chains.
+    {ok, #chain_header{h = Header2}} = headers_db_get(HeadersDb, PrevHash),
+    do_find_highest_common_ancestor_1(
+      {aec_headers:prev_hash(HighestHCHeader),
+       aec_headers:height(HighestHCHeader),
+       HCRest},
+      {aec_headers:prev_hash(Header2), aec_headers:height(Header2), HeadersDb},
+      [HighestHCHeader | NotIncludedHC]).
+
+-spec do_find_highest_common_ancestor_2(
+        FirstChain::term(), SecondChain::term(),
+        NotIncludedHeaderChainAccumulator::header_chain()) -> term().
+do_find_highest_common_ancestor_2({_, H1, [HighestHCHeader | HCRest]}, C2 = {_, H2, _}, NotIncludedHC)
+  when ?IS_HEIGHT(H1), ?IS_HEIGHT(H2), H1 > H2 ->
+    %% Still higher on first chain than on second chain.  Go down
+    %% first chain.
+    do_find_highest_common_ancestor_2(
+      {aec_headers:prev_hash(HighestHCHeader),
+       aec_headers:height(HighestHCHeader),
+       HCRest},
+      C2,
+      [HighestHCHeader | NotIncludedHC]
+     );
+do_find_highest_common_ancestor_2({_, H1, []}, {_, H2, _}, _)
+  when ?IS_HEIGHT(H1), ?IS_HEIGHT(H2), H1 > H2 ->
+    %% No known common ancestors.
+    {error, no_common_ancestor};
+do_find_highest_common_ancestor_2(C1 = {_, H, _}, C2 = {_, H, _}, NotIncludedHC)
+  when ?IS_HEIGHT(H) ->
+    %% The two chains have a block at the same height.  Reuse other function.
+    do_find_highest_common_ancestor_1(C1, C2, NotIncludedHC).

--- a/apps/aecore/src/aec_chain.erl
+++ b/apps/aecore/src/aec_chain.erl
@@ -358,7 +358,7 @@ do_find_genesis_header_from_header_hash(HeaderHash, Height, HeadersDb) ->
 
 -type do_get_header_by_hash_reply() ::
         {ok, header()} |
-        {error, Reason::{header_not_found, Details::{top_header, header()}}}.
+        {error, Reason::{header_not_found, {top_header, header()}}}.
 -spec do_get_header_by_hash(block_header_hash(), header(), headers_db()) ->
                                    do_get_header_by_hash_reply().
 do_get_header_by_hash(HeaderHash, TopHeader, HeadersDb) ->
@@ -372,7 +372,7 @@ do_get_header_by_hash(HeaderHash, TopHeader, HeadersDb) ->
 
 -type do_get_block_by_hash_reply() ::
         {ok, header()} |
-        {error, Reason::{block_not_found, Details::{top_header, header()}}}.
+        {error, Reason::{block_not_found, {top_header, header()}}}.
 -spec do_get_block_by_hash(block_header_hash(), header(), blocks_db()) ->
                                   do_get_block_by_hash_reply().
 do_get_block_by_hash(HeaderHash, TopHeader, BlocksDb) ->
@@ -385,8 +385,8 @@ do_get_block_by_hash(HeaderHash, TopHeader, BlocksDb) ->
 
 -type do_get_header_by_height_reply() ::
         {ok, header()} |
-        {error, Reason::{chain_too_short, Details::{{chain_height, height()},
-                                                    {top_header, header()}}}}.
+        {error, Reason::{chain_too_short, {{chain_height, height()},
+                                           {top_header, header()}}}}.
 -spec do_get_header_by_height(height(), header(), headers_db()) ->
                                      do_get_header_by_height_reply().
 do_get_header_by_height(Height, TopHeader, HeadersDb) ->
@@ -419,8 +419,8 @@ do_get_past_header(Distance, CurrentHeader, HeadersDb)
 
 -type do_get_block_by_height_reply() ::
         {ok, block()} |
-        {error, Reason::{chain_too_short, Details::{{chain_height, height()},
-                                                    {top_header, header()}}} |
+        {error, Reason::{chain_too_short, {{chain_height, height()},
+                                           {top_header, header()}}} |
                         {block_not_found, {top_header, header()}}
         }.
 -spec do_get_block_by_height(height(), header(), headers_db(), blocks_db()) ->

--- a/apps/aecore/src/aec_headers.erl
+++ b/apps/aecore/src/aec_headers.erl
@@ -3,6 +3,7 @@
 %% API
 -export([prev_hash/1,
          height/1,
+         nonce/1,
          target/1,
          difficulty/1,
          time_in_secs/1,
@@ -23,6 +24,9 @@ prev_hash(Header) ->
 
 height(Header) ->
     Header#header.height.
+
+nonce(Header) ->
+    Header#header.nonce.
 
 target(Header) ->
     Header#header.target.

--- a/apps/aecore/src/aec_headers.erl
+++ b/apps/aecore/src/aec_headers.erl
@@ -3,6 +3,8 @@
 %% API
 -export([prev_hash/1,
          height/1,
+         target/1,
+         difficulty/1,
          time_in_secs/1,
          serialize_for_network/1,
          deserialize_from_network/1,
@@ -21,6 +23,12 @@ prev_hash(Header) ->
 
 height(Header) ->
     Header#header.height.
+
+target(Header) ->
+    Header#header.target.
+
+difficulty(Header) ->
+    aec_pow:target_to_difficulty(target(Header)).
 
 time_in_secs(Header) ->
     Time = Header#header.time,

--- a/apps/aecore/test/aec_chain_tests.erl
+++ b/apps/aecore/test/aec_chain_tests.erl
@@ -51,6 +51,9 @@ header_chain_test_() ->
              BH0 = aec_blocks:to_header(B0),
              ?assertEqual({ok, BH0}, aec_chain:top_header()),
 
+             %% Check height of genesis - for readability of the test.
+             0 = aec_headers:height(BH0),
+
              %% Add a couple of headers - not blocks - to the chain.
              {ok, B0H} = aec_blocks:hash_internal_representation(B0),
              BH1 = #header{height = 1, prev_hash = B0H},
@@ -103,6 +106,9 @@ block_chain_test_() ->
                BH0 = aec_blocks:to_header(B0),
                ?assertEqual({ok, BH0}, aec_chain:top_header()),
 
+               %% Check height of genesis - for readability of the test.
+               0 = aec_headers:height(BH0),
+
                %% Add a couple of headers - not blocks - to the chain.
                {ok, B0H} = aec_blocks:hash_internal_representation(B0),
                B1 = #block{height = 1, prev_hash = B0H},
@@ -152,6 +158,9 @@ block_chain_test_() ->
                B0 = fake_genesis_block(),
                BH0 = aec_blocks:to_header(B0),
                ?assertEqual({ok, BH0}, aec_chain:top_header()),
+
+               %% Check height of genesis - for readability of the test.
+               0 = aec_headers:height(BH0),
 
                %% Add a couple of headers - not blocks - to the chain.
                {ok, B0H} = aec_blocks:hash_internal_representation(B0),
@@ -208,6 +217,9 @@ unhappy_paths_test_() ->
                B0 = fake_genesis_block(),
                BH0 = aec_blocks:to_header(B0),
                ?assertEqual({ok, BH0}, aec_chain:top_header()),
+
+               %% Check height of genesis - for readability of the test.
+               0 = aec_headers:height(BH0),
 
                %% Add a header to the chain.
                {ok, B0H} = aec_blocks:hash_internal_representation(B0),

--- a/apps/aecore/test/aec_chain_tests.erl
+++ b/apps/aecore/test/aec_chain_tests.erl
@@ -210,7 +210,8 @@ block_chain_test_() ->
 fake_genesis_block_with_difficulty() ->
     #block{height = 0,
            prev_hash = <<0:?BLOCK_HEADER_HASH_BYTES/unit:8>>,
-           target = 1}. %% Field used as if it were difficulty for ease of testing.
+           target = 1, %% Field used as if it were difficulty for ease of testing.
+           nonce = 0}.
 
 get_work_at_top_test_() ->
     {foreach,
@@ -293,4 +294,633 @@ unhappy_paths_test_() ->
                %% Attempt to get by hash header not added to chain.
                ?assertEqual({error, {header_not_found, {top_header, BH1}}},
                             aec_chain:get_header_by_hash(B2H))
+       end}]}.
+
+generate_block_chain_by_difficulties_with_nonce(
+  GenesisBlock, [GenesisDifficulty | OtherDifficulties], Nonce) ->
+    %% Check height of genesis - for readability.
+    0 = aec_blocks:height(GenesisBlock),
+    %% Check difficulty of genesis - for readability.
+    {GD, GD} = {float(GenesisDifficulty), aec_blocks:difficulty(GenesisBlock)},
+    lists:reverse(
+      lists:foldl(
+        fun(D, [PrevB | _] = BC) ->
+                {ok, PrevHH} = aec_blocks:hash_internal_representation(PrevB),
+                B = #block{height = 1 + aec_blocks:height(PrevB),
+                           prev_hash = PrevHH,
+                           target = D,
+                           nonce = Nonce},
+                [B | BC]
+        end,
+        [GenesisBlock],
+        OtherDifficulties)).
+
+header_chain_from_block_chain(BC) ->
+    lists:map(fun aec_blocks:to_header/1, BC).
+
+longest_header_chain_test_() ->
+    {foreach,
+     fun() ->
+             meck:new(aec_headers, [passthrough]),
+             meck:new(aec_blocks, [passthrough]),
+             meck:expect(
+               aec_headers, difficulty,
+               fun(#header{target = T}) when is_integer(T) -> float(T) end),
+             meck:expect(
+               aec_blocks, difficulty,
+               fun(#block{target = T}) when is_integer(T) -> float(T) end),
+             {ok, Pid} = aec_chain:start_link(
+                           fake_genesis_block_with_difficulty()),
+             Pid
+     end,
+     fun(_ChainPid) ->
+             ok = aec_chain:stop(),
+             ?assert(meck:validate(aec_blocks)),
+             ?assert(meck:validate(aec_headers)),
+             meck:unload(aec_blocks),
+             meck:unload(aec_headers)
+     end,
+     [{"The alternative header chain has a different genesis hence its amount of work cannot be compared",
+       fun() ->
+               %% Check chain is at genesis.
+               B0 = fake_genesis_block_with_difficulty(),
+               BH0 = aec_blocks:to_header(B0),
+               ?assertEqual({ok, BH0}, aec_chain:top_header()),
+
+               %% Check height of genesis - for readability of the test.
+               0 = aec_headers:height(BH0),
+               %% Check nonce of genesis - for readability of the test.
+               0 = aec_headers:nonce(BH0),
+
+               %% Generate the alternative header chain from a
+               %% different genesis.
+               HA0 = BH0#header{nonce = 1},
+               {ok, HA0H} = aec_headers:hash_internal_representation(HA0),
+               HA1 = #header{height = 1, prev_hash = HA0H},
+               AltHC = [HA0, HA1],
+
+               %% Attempt to determine chain with more work -
+               %% specifying full header chain.
+               ?assertEqual({error, {different_genesis, {genesis_header, BH0}}},
+                            aec_chain:has_more_work(AltHC)),
+               %% Attempt to determine chain with more work -
+               %% specifying header chain removing old ancestors.
+               ?assertEqual({error, {no_common_ancestor, {top_header, BH0}}},
+                            aec_chain:has_more_work(
+                              [HA1] = lists:nthtail(1, AltHC))),
+
+               %% Check top.
+               ?assertEqual({ok, BH0}, aec_chain:top_header())
+       end},
+      {"The alternative header chain does not have more work - case alternative chain is less high",
+       fun() ->
+               %% Generate the two header chains.
+               B0 = fake_genesis_block_with_difficulty(),
+               MainBC = [B0, _, _] = generate_block_chain_by_difficulties_with_nonce(B0, [1, 2, 2], 111),
+               AltBC = [B0, _] = generate_block_chain_by_difficulties_with_nonce(B0, [1, 3], 222),
+               MainHC = [H0, _, HM2] = header_chain_from_block_chain(MainBC),
+               AltHC = [H0, _] = header_chain_from_block_chain(AltBC),
+
+               %% Check chain is at genesis.
+               ?assertEqual({ok, H0}, aec_chain:top_header()),
+
+               %% Insert the main chain.
+               lists:foreach(
+                 fun(H) -> ok = aec_chain:insert_header(H) end,
+                 lists:nthtail(1, MainHC)),
+
+               %% Check top is main chain.
+               ?assertEqual({ok, HM2}, aec_chain:top_header()),
+
+               %% Determine chain with more work - specifying full
+               %% header chain.
+               ?assertEqual({ok, {false, {{{top_chain_work, 5.0},
+                                           {alt_chain_work, 4.0}},
+                                          {top_header, HM2}}}},
+                            aec_chain:has_more_work(AltHC)),
+               %% Attempt to determine chain with more work -
+               %% specifying header chain removing old ancestors.
+               ?assertEqual({ok, {false, {{{top_chain_work, 5.0},
+                                           {alt_chain_work, 4.0}},
+                                          {top_header, HM2}}}},
+                            aec_chain:has_more_work(lists:nthtail(1, AltHC))),
+
+               %% Give up updating chain because existing chain has more work.
+               ok
+       end},
+      {"The alternative header chain does not have more work - case alternative chain is higher",
+       fun() ->
+               %% Generate the two header chains.
+               B0 = fake_genesis_block_with_difficulty(),
+               MainBC = [B0, _] = generate_block_chain_by_difficulties_with_nonce(B0, [1, 3], 111),
+               AltBC = [B0, _, _] = generate_block_chain_by_difficulties_with_nonce(B0, [1, 1, 1], 222),
+               MainHC = [H0, HM1] = header_chain_from_block_chain(MainBC),
+               AltHC = [H0, _, _] = header_chain_from_block_chain(AltBC),
+
+               %% Check chain is at genesis.
+               ?assertEqual({ok, H0}, aec_chain:top_header()),
+
+               %% Insert the main chain.
+               lists:foreach(
+                 fun(H) -> ok = aec_chain:insert_header(H) end,
+                 lists:nthtail(1, MainHC)),
+
+               %% Check top is main chain.
+               ?assertEqual({ok, HM1}, aec_chain:top_header()),
+
+               %% Determine chain with more work - specifying full
+               %% header chain.
+               ?assertEqual({ok, {false, {{{top_chain_work, 4.0},
+                                           {alt_chain_work, 3.0}},
+                                          {top_header, HM1}}}},
+                            aec_chain:has_more_work(AltHC)),
+               %% Attempt to determine chain with more work -
+               %% specifying header chain removing old ancestors.
+               ?assertEqual({ok, {false, {{{top_chain_work, 4.0},
+                                           {alt_chain_work, 3.0}},
+                                          {top_header, HM1}}}},
+                            aec_chain:has_more_work(lists:nthtail(1, AltHC))),
+
+               %% Give up updating chain because existing chain has more work.
+               ok
+       end},
+      {"The alternative chain has the same amount of work, hence is to be ignored because received later",
+       fun() ->
+               %% Generate the two header chains.
+               B0 = fake_genesis_block_with_difficulty(),
+               MainBC = [B0, _] = generate_block_chain_by_difficulties_with_nonce(B0, [1, 2], 111),
+               AltBC = [B0, _, _] = generate_block_chain_by_difficulties_with_nonce(B0, [1, 1, 1], 222),
+               MainHC = [H0, HM1] = header_chain_from_block_chain(MainBC),
+               AltHC = [H0, _, _] = header_chain_from_block_chain(AltBC),
+
+               %% Check chain is at genesis.
+               ?assertEqual({ok, H0}, aec_chain:top_header()),
+
+               %% Insert the main chain.
+               lists:foreach(
+                 fun(H) -> ok = aec_chain:insert_header(H) end,
+                 lists:nthtail(1, MainHC)),
+
+               %% Check top is main chain.
+               ?assertEqual({ok, HM1}, aec_chain:top_header()),
+
+               %% Attempt to determine chain with more work -
+               %% specifying full header chain.
+               ?assertEqual({ok, {false, {{{top_chain_work, 3.0},
+                                           {alt_chain_work, 3.0}},
+                                          {top_header, HM1}}}},
+                            aec_chain:has_more_work(AltHC)),
+               %% Attempt to determine chain with more work -
+               %% specifying header chain removing old ancestors.
+               ?assertEqual({ok, {false, {{{top_chain_work, 3.0},
+                                           {alt_chain_work, 3.0}},
+                                          {top_header, HM1}}}},
+                            aec_chain:has_more_work(lists:nthtail(1, AltHC))),
+
+               %% Give up updating chain because existing chain has same work.
+               ok
+       end},
+      {"The alternative header chain has more work - case alternative chain is higher. Force chain excluding genesis.",
+       fun() ->
+               %% Generate the two header chains.
+               B0 = fake_genesis_block_with_difficulty(),
+               MainBC = [B0, _] = generate_block_chain_by_difficulties_with_nonce(B0, [1, 2], 111),
+               AltBC = [B0, _, _, _] = generate_block_chain_by_difficulties_with_nonce(B0, [1, 1, 1, 1], 222),
+               MainHC = [H0, HM1] = header_chain_from_block_chain(MainBC),
+               AltHC = [H0, _, _, HA3] = header_chain_from_block_chain(AltBC),
+
+               %% Check chain is at genesis.
+               ?assertEqual({ok, H0}, aec_chain:top_header()),
+
+               %% Insert the main chain.
+               lists:foreach(
+                 fun(H) -> ok = aec_chain:insert_header(H) end,
+                 lists:nthtail(1, MainHC)),
+
+               %% Check top is main chain.
+               ?assertEqual({ok, HM1}, aec_chain:top_header()),
+
+               %% Determine chain with more work - specifying full
+               %% header chain.
+               ?assertEqual({ok, {true, {{{top_chain_work, 3.0},
+                                          {alt_chain_work, 4.0}},
+                                         {top_header, HM1}}}},
+                            aec_chain:has_more_work(AltHC)),
+               %% Attempt to determine chain with more work -
+               %% specifying header chain removing old ancestors.
+               ?assertEqual({ok, {true, {{{top_chain_work, 3.0},
+                                          {alt_chain_work, 4.0}},
+                                         {top_header, HM1}}}},
+                            aec_chain:has_more_work(lists:nthtail(1, AltHC))),
+
+               %% Update chain because existing chain has less work.
+               ?assertEqual({ok, {{old_top_header, HM1},
+                                  {new_top_header, HA3}}},
+                            aec_chain:force_insert_headers(
+                              lists:nthtail(1, AltHC))),
+
+               %% Check top changed.
+               ?assertEqual({ok, HA3}, aec_chain:top_header()),
+
+               %% Check that headers in previous chain cannot be
+               %% retrieved by hash; i.e. chain service minimizes used
+               %% storage while exposing consistent view of chain.
+               lists:foreach(
+                 fun(H) ->
+                         {ok, HH} = aec_headers:hash_internal_representation(H),
+                         ?assertEqual({error, {header_not_found,
+                                               {top_header, HA3}}},
+                                      aec_chain:get_header_by_hash(HH))
+                 end,
+                 lists:nthtail(1, MainHC))
+       end},
+      {"The alternative header chain has more work - case alternative chain is higher. Force chain including genesis.",
+       fun() ->
+               %% Generate the two header chains.
+               B0 = fake_genesis_block_with_difficulty(),
+               MainBC = [B0, _] = generate_block_chain_by_difficulties_with_nonce(B0, [1, 2], 111),
+               AltBC = [B0, _, _, _] = generate_block_chain_by_difficulties_with_nonce(B0, [1, 1, 1, 1], 222),
+               MainHC = [H0, HM1] = header_chain_from_block_chain(MainBC),
+               AltHC = [H0, _, _, HA3] = header_chain_from_block_chain(AltBC),
+
+               %% Check chain is at genesis.
+               ?assertEqual({ok, H0}, aec_chain:top_header()),
+
+               %% Insert the main chain.
+               lists:foreach(
+                 fun(H) -> ok = aec_chain:insert_header(H) end,
+                 lists:nthtail(1, MainHC)),
+
+               %% Check top is main chain.
+               ?assertEqual({ok, HM1}, aec_chain:top_header()),
+
+               %% Determine chain with more work - specifying full
+               %% header chain.
+               ?assertEqual({ok, {true, {{{top_chain_work, 3.0},
+                                          {alt_chain_work, 4.0}},
+                                         {top_header, HM1}}}},
+                            aec_chain:has_more_work(AltHC)),
+               %% Attempt to determine chain with more work -
+               %% specifying header chain removing old ancestors.
+               ?assertEqual({ok, {true, {{{top_chain_work, 3.0},
+                                          {alt_chain_work, 4.0}},
+                                         {top_header, HM1}}}},
+                            aec_chain:has_more_work(lists:nthtail(1, AltHC))),
+
+               %% Update chain because existing chain has less work.
+               ?assertEqual({ok, {{old_top_header, HM1},
+                                  {new_top_header, HA3}}},
+                            aec_chain:force_insert_headers(AltHC)),
+
+               %% Check top changed.
+               ?assertEqual({ok, HA3}, aec_chain:top_header()),
+
+               %% Check that headers in previous chain cannot be
+               %% retrieved by hash; i.e. chain service minimizes used
+               %% storage while exposing consistent view of chain.
+               lists:foreach(
+                 fun(H) ->
+                         {ok, HH} = aec_headers:hash_internal_representation(H),
+                         ?assertEqual({error, {header_not_found,
+                                               {top_header, HA3}}},
+                                      aec_chain:get_header_by_hash(HH))
+                 end,
+                 lists:nthtail(1, MainHC))
+       end},
+      {"The alternative header chain has more work - case alternative chain is less high",
+       fun() ->
+               %% Generate the two header chains.
+               B0 = fake_genesis_block_with_difficulty(),
+               MainBC = [B0, _, _] = generate_block_chain_by_difficulties_with_nonce(B0, [1, 1, 1], 111),
+               AltBC = [B0, _] = generate_block_chain_by_difficulties_with_nonce(B0, [1, 3], 222),
+               MainHC = [H0, _, HM2] = header_chain_from_block_chain(MainBC),
+               AltHC = [H0, HA1] = header_chain_from_block_chain(AltBC),
+
+               %% Check chain is at genesis.
+               ?assertEqual({ok, H0}, aec_chain:top_header()),
+
+               %% Insert the main chain.
+               lists:foreach(
+                 fun(H) -> ok = aec_chain:insert_header(H) end,
+                 lists:nthtail(1, MainHC)),
+
+               %% Check top is main chain.
+               ?assertEqual({ok, HM2}, aec_chain:top_header()),
+
+               %% Determine chain with more work - specifying full
+               %% header chain.
+               ?assertEqual({ok, {true, {{{top_chain_work, 3.0},
+                                          {alt_chain_work, 4.0}},
+                                         {top_header, HM2}}}},
+                            aec_chain:has_more_work(AltHC)),
+               %% Attempt to determine chain with more work -
+               %% specifying header chain removing old ancestors.
+               ?assertEqual({ok, {true, {{{top_chain_work, 3.0},
+                                          {alt_chain_work, 4.0}},
+                                         {top_header, HM2}}}},
+                            aec_chain:has_more_work(lists:nthtail(1, AltHC))),
+
+               %% Update chain because existing chain has less work.
+               ?assertEqual({ok, {{old_top_header, HM2},
+                                  {new_top_header, HA1}}},
+                            aec_chain:force_insert_headers(AltHC)),
+
+               %% Check top changed.
+               ?assertEqual({ok, HA1}, aec_chain:top_header()),
+
+               %% Check that headers in previous chain cannot be
+               %% retrieved by hash; i.e. chain service minimizes used
+               %% storage while exposing consistent view of chain.
+               lists:foreach(
+                 fun(H) ->
+                         {ok, HH} = aec_headers:hash_internal_representation(H),
+                         ?assertEqual({error, {header_not_found,
+                                               {top_header, HA1}}},
+                                      aec_chain:get_header_by_hash(HH))
+                 end,
+                 lists:nthtail(1, MainHC))
+       end},
+      {"The alternative header chain has more work, but results in sub-optimal choice because of concurrent insertion",
+       fun() ->
+               %% This test has the main aim of clarifying design of
+               %% whether chain service shall reject forcing chain
+               %% with less work.
+
+               %% Generate the two header chains.
+               B0 = fake_genesis_block_with_difficulty(),
+               MainBC = [B0, _, _, _] = generate_block_chain_by_difficulties_with_nonce(B0, [1, 1, 1, 2], 111),
+               AltBC = [B0, _] = generate_block_chain_by_difficulties_with_nonce(B0, [1, 3], 222),
+               _MainHC = [H0, HM1, HM2, HM3] = header_chain_from_block_chain(MainBC),
+               InitialMainHC = [H0, HM1, HM2],
+               AltHC = [H0, HA1] = header_chain_from_block_chain(AltBC),
+
+               %% Check chain is at genesis.
+               ?assertEqual({ok, H0}, aec_chain:top_header()),
+
+               %% Insert the initial part of the main chain.
+               lists:foreach(
+                 fun(H) -> ok = aec_chain:insert_header(H) end,
+                 lists:nthtail(1, InitialMainHC)),
+               ?assertEqual({ok, HM2}, aec_chain:top_header()),
+
+               %% Determine chain with more work.
+               ?assertEqual({ok, {true, {{{top_chain_work, 3.0},
+                                          {alt_chain_work, 4.0}},
+                                         {top_header, HM2}}}},
+                            aec_chain:has_more_work(AltHC)),
+
+               %% Decide to update chain because existing chain has
+               %% less work.
+
+               %% Concurrent actor increases amount of work in tracked
+               %% chain.
+               ok = aec_chain:insert_header(HM3),
+               ?assertEqual({ok, HM3}, aec_chain:top_header()),
+
+               %% Based on past - now obsolete - decision, update
+               %% chain.  Chain tracked in chain service is
+               %% sub-optimal.
+               ?assertEqual({ok, {{old_top_header, HM3},
+                                  {new_top_header, HA1}}},
+                            aec_chain:force_insert_headers(AltHC)),
+               ?assertEqual({ok, HA1}, aec_chain:top_header())
+       end}]}.
+
+longest_block_chain_test_() ->
+    {foreach,
+     fun() ->
+             meck:new(aec_headers, [passthrough]),
+             meck:new(aec_blocks, [passthrough]),
+             meck:expect(
+               aec_headers, difficulty,
+               fun(#header{target = T}) when is_integer(T) -> float(T) end),
+             meck:expect(
+               aec_blocks, difficulty,
+               fun(#block{target = T}) when is_integer(T) -> float(T) end),
+             {ok, Pid} = aec_chain:start_link(
+                           fake_genesis_block_with_difficulty()),
+             Pid
+     end,
+     fun(_ChainPid) ->
+             ok = aec_chain:stop(),
+             ?assert(meck:validate(aec_blocks)),
+             ?assert(meck:validate(aec_headers)),
+             meck:unload(aec_blocks),
+             meck:unload(aec_headers)
+     end,
+     [{"The alternative block chain has more work - case alternative chain with all blocks",
+       fun() ->
+               %% Generate the two block chains.
+               B0 = fake_genesis_block_with_difficulty(),
+               MainBC = [B0, _, B2] = generate_block_chain_by_difficulties_with_nonce(B0, [1, 1, 1], 111),
+               AltBC = [B0, _, _, BA3] = generate_block_chain_by_difficulties_with_nonce(B0, [1, 1, 1, 1], 222),
+               MainHC = [H0, _, HM2] = header_chain_from_block_chain(MainBC),
+               AltHC = [H0, _, _, HA3] = header_chain_from_block_chain(AltBC),
+
+               %% Check chain is at genesis.
+               ?assertEqual({ok, H0}, aec_chain:top_header()),
+               ?assertEqual({ok, B0}, aec_chain:top_block()),
+
+               %% Insert the main header chain...
+               lists:foreach(
+                 fun(H) -> ok = aec_chain:insert_header(H) end,
+                 lists:nthtail(1, MainHC)),
+               %% ... and a block corresponding to a header already in
+               %% the chain.
+               ?assertEqual(ok, aec_chain:write_block(B2)),
+
+               %% Check top is main chain.
+               ?assertEqual({ok, HM2}, aec_chain:top_header()),
+               ?assertEqual({ok, B2}, aec_chain:top_block()),
+
+               %% Determine chain with more work - specifying full
+               %% header chain.
+               ?assertEqual({ok, {true, {{{top_chain_work, 3.0},
+                                          {alt_chain_work, 4.0}},
+                                         {top_header, HM2}}}},
+                            aec_chain:has_more_work(AltHC)),
+               %% Attempt to determine chain with more work -
+               %% specifying header chain removing old ancestors.
+               ?assertEqual({ok, {true, {{{top_chain_work, 3.0},
+                                          {alt_chain_work, 4.0}},
+                                         {top_header, HM2}}}},
+                            aec_chain:has_more_work(lists:nthtail(1, AltHC))),
+
+               %% Update header chain because existing chain has less
+               %% work.
+               ?assertEqual({ok, {{old_top_header, HM2},
+                                  {new_top_header, HA3}}},
+                            aec_chain:force_insert_headers(AltHC)),
+
+               %% Check top changed.
+               ?assertEqual({ok, HA3}, aec_chain:top_header()),
+               ?assertEqual({ok, B0}, aec_chain:top_block()),
+
+               %% Insert all blocks for new chain.
+               lists:foreach(
+                 fun(B) -> ?assertEqual(ok, aec_chain:write_block(B)) end,
+                 lists:nthtail(1, AltBC)),
+
+               %% Check top block changed.
+               ?assertEqual({ok, HA3}, aec_chain:top_header()),
+               ?assertEqual({ok, BA3}, aec_chain:top_block()),
+
+               %% Check that headers and blocks in previous chain
+               %% cannot be retrieved by hash; i.e. chain service
+               %% minimizes used storage while exposing consistent
+               %% view of chain."
+               lists:foreach(
+                 fun(H) ->
+                         {ok, HH} = aec_headers:hash_internal_representation(H),
+                         ?assertEqual({error, {header_not_found,
+                                               {top_header, HA3}}},
+                                      aec_chain:get_header_by_hash(HH)),
+                         ?assertEqual({error, {block_not_found,
+                                               {top_header, HA3}}},
+                                      aec_chain:get_block_by_hash(HH))
+                 end,
+                 lists:nthtail(1, MainHC))
+       end},
+      {"The alternative block chain has more work - case alternative chain with only block corresponding to top header",
+       fun() ->
+               %% Generate the two block chains.
+               B0 = fake_genesis_block_with_difficulty(),
+               MainBC = [B0, _, B2] = generate_block_chain_by_difficulties_with_nonce(B0, [1, 1, 1], 111),
+               AltBC = [B0, _, _, BA3] = generate_block_chain_by_difficulties_with_nonce(B0, [1, 1, 1, 1], 222),
+               MainHC = [H0, _, HM2] = header_chain_from_block_chain(MainBC),
+               AltHC = [H0, _, _, HA3] = header_chain_from_block_chain(AltBC),
+
+               %% Check chain is at genesis.
+               ?assertEqual({ok, H0}, aec_chain:top_header()),
+               ?assertEqual({ok, B0}, aec_chain:top_block()),
+
+               %% Insert the main header chain...
+               lists:foreach(
+                 fun(H) -> ok = aec_chain:insert_header(H) end,
+                 lists:nthtail(1, MainHC)),
+               %% ... and a block corresponding to a header already in
+               %% the chain.
+               ?assertEqual(ok, aec_chain:write_block(B2)),
+
+               %% Check top is main chain.
+               ?assertEqual({ok, HM2}, aec_chain:top_header()),
+               ?assertEqual({ok, B2}, aec_chain:top_block()),
+
+               %% Determine chain with more work - specifying full
+               %% header chain.
+               ?assertEqual({ok, {true, {{{top_chain_work, 3.0},
+                                          {alt_chain_work, 4.0}},
+                                         {top_header, HM2}}}},
+                            aec_chain:has_more_work(AltHC)),
+               %% Attempt to determine chain with more work -
+               %% specifying header chain removing old ancestors.
+               ?assertEqual({ok, {true, {{{top_chain_work, 3.0},
+                                          {alt_chain_work, 4.0}},
+                                         {top_header, HM2}}}},
+                            aec_chain:has_more_work(lists:nthtail(1, AltHC))),
+
+               %% Update header chain because existing chain has less
+               %% work.
+               ?assertEqual({ok, {{old_top_header, HM2},
+                                  {new_top_header, HA3}}},
+                            aec_chain:force_insert_headers(AltHC)),
+
+               %% Check top changed.
+               ?assertEqual({ok, HA3}, aec_chain:top_header()),
+               ?assertEqual({ok, B0}, aec_chain:top_block()),
+
+               %% Insert only block corresponding to top header.
+               ?assertEqual(ok, aec_chain:write_block(BA3)),
+
+               %% Check top block changed.
+               ?assertEqual({ok, HA3}, aec_chain:top_header()),
+               ?assertEqual({ok, BA3}, aec_chain:top_block()),
+
+               %% Check that headers and blocks in previous chain
+               %% cannot be retrieved by hash; i.e. chain service
+               %% minimizes used storage while exposing consistent
+               %% view of chain."
+               lists:foreach(
+                 fun(H) ->
+                         {ok, HH} = aec_headers:hash_internal_representation(H),
+                         ?assertEqual({error, {header_not_found,
+                                               {top_header, HA3}}},
+                                      aec_chain:get_header_by_hash(HH)),
+                         ?assertEqual({error, {block_not_found,
+                                               {top_header, HA3}}},
+                                      aec_chain:get_block_by_hash(HH))
+                 end,
+                 lists:nthtail(1, MainHC))
+       end},
+      {"The alternative block chain has more work - case alternative chain with only block corresponding to header before top header",
+       fun() ->
+               %% Generate the two block chains.
+               B0 = fake_genesis_block_with_difficulty(),
+               MainBC = [B0, _, B2] = generate_block_chain_by_difficulties_with_nonce(B0, [1, 1, 1], 111),
+               AltBC = [B0, _, BA2, _] = generate_block_chain_by_difficulties_with_nonce(B0, [1, 1, 1, 1], 222),
+               MainHC = [H0, _, HM2] = header_chain_from_block_chain(MainBC),
+               AltHC = [H0, _, _, HA3] = header_chain_from_block_chain(AltBC),
+
+               %% Check chain is at genesis.
+               ?assertEqual({ok, H0}, aec_chain:top_header()),
+               ?assertEqual({ok, B0}, aec_chain:top_block()),
+
+               %% Insert the main header chain...
+               lists:foreach(
+                 fun(H) -> ok = aec_chain:insert_header(H) end,
+                 lists:nthtail(1, MainHC)),
+               %% ... and a block corresponding to a header already in
+               %% the chain.
+               ?assertEqual(ok, aec_chain:write_block(B2)),
+
+               %% Check top is main chain.
+               ?assertEqual({ok, HM2}, aec_chain:top_header()),
+               ?assertEqual({ok, B2}, aec_chain:top_block()),
+
+               %% Determine chain with more work - specifying full
+               %% header chain.
+               ?assertEqual({ok, {true, {{{top_chain_work, 3.0},
+                                          {alt_chain_work, 4.0}},
+                                         {top_header, HM2}}}},
+                            aec_chain:has_more_work(AltHC)),
+               %% Attempt to determine chain with more work -
+               %% specifying header chain removing old ancestors.
+               ?assertEqual({ok, {true, {{{top_chain_work, 3.0},
+                                          {alt_chain_work, 4.0}},
+                                         {top_header, HM2}}}},
+                            aec_chain:has_more_work(lists:nthtail(1, AltHC))),
+
+               %% Update header chain because existing chain has less
+               %% work.
+               ?assertEqual({ok, {{old_top_header, HM2},
+                                  {new_top_header, HA3}}},
+                            aec_chain:force_insert_headers(AltHC)),
+
+               %% Check top changed.
+               ?assertEqual({ok, HA3}, aec_chain:top_header()),
+               ?assertEqual({ok, B0}, aec_chain:top_block()),
+
+               %% Insert only block corresponding to header before top
+               %% header.
+               ?assertEqual(ok, aec_chain:write_block(BA2)),
+
+               %% Check top block changed.
+               ?assertEqual({ok, HA3}, aec_chain:top_header()),
+               ?assertEqual({ok, BA2}, aec_chain:top_block()),
+
+               %% Check that headers and blocks in previous chain
+               %% cannot be retrieved by hash; i.e. chain service
+               %% minimizes used storage while exposing consistent
+               %% view of chain."
+               lists:foreach(
+                 fun(H) ->
+                         {ok, HH} = aec_headers:hash_internal_representation(H),
+                         ?assertEqual({error, {header_not_found,
+                                               {top_header, HA3}}},
+                                      aec_chain:get_header_by_hash(HH)),
+                         ?assertEqual({error, {block_not_found,
+                                               {top_header, HA3}}},
+                                      aec_chain:get_block_by_hash(HH))
+                 end,
+                 lists:nthtail(1, MainHC))
        end}]}.

--- a/apps/aecore/test/aec_chain_tests.erl
+++ b/apps/aecore/test/aec_chain_tests.erl
@@ -739,7 +739,7 @@ longest_header_chain_test_() ->
                  end,
                  lists:nthtail(1, MainHC))
        end},
-      {"The alternative header chain has more work, but results in sub-optimal choice because of concurrent insertion",
+      {"The alternative chain initially has more work, but concurrent insertion in chain service makes it not have more work any longer. I.e. concurrent insertions in the chain service do not result in sub-optimal choice.",
        fun() ->
                %% This test has the main aim of clarifying design of
                %% whether chain service shall reject forcing chain
@@ -751,7 +751,7 @@ longest_header_chain_test_() ->
                AltBC = [B0, _] = generate_block_chain_by_difficulties_with_nonce(B0, [1, 3], 222),
                _MainHC = [H0, HM1, HM2, HM3] = header_chain_from_block_chain(MainBC),
                InitialMainHC = [H0, HM1, HM2],
-               AltHC = [H0, HA1] = header_chain_from_block_chain(AltBC),
+               AltHC = [H0, _] = header_chain_from_block_chain(AltBC),
 
                %% Check chain is at genesis.
                ?assertEqual({ok, H0}, aec_chain:top_header()),
@@ -777,12 +777,13 @@ longest_header_chain_test_() ->
                ?assertEqual({ok, HM3}, aec_chain:top_header()),
 
                %% Based on past - now obsolete - decision, update
-               %% chain.  Chain tracked in chain service is
-               %% sub-optimal.
-               ?assertEqual({ok, {{old_top_header, HM3},
-                                  {new_top_header, HA1}}},
+               %% chain.  Chain service rejects.
+               ?assertEqual({error, {chain_does_not_have_more_work,
+                                     {{{top_chain_work, 5.0},
+                                       {alt_chain_work, 4.0}},
+                                      {top_header, HM3}}}},
                             aec_chain:force_insert_headers(AltHC)),
-               ?assertEqual({ok, HA1}, aec_chain:top_header())
+               ?assertEqual({ok, HM3}, aec_chain:top_header())
        end}]}.
 
 longest_block_chain_test_() ->

--- a/apps/aecore/test/aec_chain_tests.erl
+++ b/apps/aecore/test/aec_chain_tests.erl
@@ -294,6 +294,105 @@ unhappy_paths_test_() ->
                %% Attempt to get by hash header not added to chain.
                ?assertEqual({error, {header_not_found, {top_header, BH1}}},
                             aec_chain:get_header_by_hash(B2H))
+       end},
+      {"Insert header meant to be successor of top header - case wrong previous hash",
+       fun() ->
+               %% Check chain is at genesis.
+               B0 = fake_genesis_block(),
+               BH0 = aec_blocks:to_header(B0),
+               ?assertEqual({ok, BH0}, aec_chain:top_header()),
+
+               %% Check height of genesis - for readability of the test.
+               0 = aec_headers:height(BH0),
+
+               %% Attempts to add to the chain at genesis header with
+               %% inconsistent previous header fail.
+               ?assertEqual({error, {previous_hash_is_not_top,
+                                     {top_header, BH0}}},
+                            aec_chain:insert_header(BH0)), %% Genesis again.
+               ?assertEqual({ok, BH0}, aec_chain:top_header()),
+               {ok, B0H} = aec_blocks:hash_internal_representation(B0),
+               BH1 = #header{height = 1, prev_hash = B0H},
+               {ok, B1H} = aec_headers:hash_internal_representation(BH1),
+               BH2 = #header{height = 2, prev_hash = B1H},
+               ?assertEqual({error, {previous_hash_is_not_top,
+                                     {top_header, BH0}}},
+                            aec_chain:insert_header(BH2)), %% Too far ahead.
+               ?assertEqual({ok, BH0}, aec_chain:top_header()),
+
+               %% Add a header to the chain.
+               ?assertEqual(ok, aec_chain:insert_header(BH1)),
+               ?assertEqual({ok, BH1}, aec_chain:top_header()),
+
+               %% Attempts to add to chain of two blocks with
+               %% inconsistent previous header fail.
+               {ok, B2H} = aec_headers:hash_internal_representation(BH2),
+               BH3 = #header{height = 3, prev_hash = B2H},
+               ?assertEqual({error, {previous_hash_is_not_top,
+                                     {top_header, BH1}}},
+                            aec_chain:insert_header(BH3)), %% Too far ahead.
+               ?assertEqual({ok, BH1}, aec_chain:top_header()),
+               ?assertEqual({error, {previous_hash_is_not_top,
+                                     {top_header, BH1}}},
+                            aec_chain:insert_header(BH0)), %% Genesis again.
+               ?assertEqual({ok, BH1}, aec_chain:top_header()),
+               ?assertEqual({error, {previous_hash_is_not_top,
+                                     {top_header, BH1}}},
+                            aec_chain:insert_header(BH1)), %% Block 1 again.
+               ?assertEqual({ok, BH1}, aec_chain:top_header()),
+               ?assertEqual({error, {previous_hash_is_not_top,
+                                     {top_header, BH1}}},
+                            aec_chain:insert_header(
+                              #header{height = 2, prev_hash = B0H})), %% Previous hash to to 2 block headers ago.
+               ?assertEqual({ok, BH1}, aec_chain:top_header())
+       end},
+      {"Insert header meant to be successor of top header - case correct previous hash but wrong height",
+       fun() ->
+               %% Check chain is at genesis.
+               B0 = fake_genesis_block(),
+               BH0 = aec_blocks:to_header(B0),
+               ?assertEqual({ok, BH0}, aec_chain:top_header()),
+
+               %% Check height of genesis - for readability of the test.
+               0 = aec_headers:height(BH0),
+
+               %% Attempts to add to the chain at genesis header with
+               %% inconsistent height fail.
+               {ok, B0H} = aec_blocks:hash_internal_representation(B0),
+               ?assertEqual({error, {height_inconsistent_with_previous_hash,
+                                     {top_header, BH0}}},
+                            aec_chain:insert_header(
+                              #header{height = 2, prev_hash = B0H})),
+               ?assertEqual({ok, BH0}, aec_chain:top_header()),
+               ?assertEqual({error, {height_inconsistent_with_previous_hash,
+                                     {top_header, BH0}}},
+                            aec_chain:insert_header(
+                              #header{height = 0, prev_hash = B0H})),
+               ?assertEqual({ok, BH0}, aec_chain:top_header()),
+
+               %% Add a header to the chain.
+               BH1 = #header{height = 1, prev_hash = B0H},
+               ?assertEqual(ok, aec_chain:insert_header(BH1)),
+               ?assertEqual({ok, BH1}, aec_chain:top_header()),
+
+               %% Attempts to add to chain of two blocks with
+               %% inconsistent height fail.
+               {ok, B1H} = aec_headers:hash_internal_representation(BH1),
+               ?assertEqual({error, {height_inconsistent_with_previous_hash,
+                                     {top_header, BH1}}},
+                            aec_chain:insert_header(
+                              #header{height = 3, prev_hash = B1H})),
+               ?assertEqual({ok, BH1}, aec_chain:top_header()),
+               ?assertEqual({error, {height_inconsistent_with_previous_hash,
+                                     {top_header, BH1}}},
+                            aec_chain:insert_header(
+                              #header{height = 1, prev_hash = B1H})),
+               ?assertEqual({ok, BH1}, aec_chain:top_header()),
+               ?assertEqual({error, {height_inconsistent_with_previous_hash,
+                                     {top_header, BH1}}},
+                            aec_chain:insert_header(
+                              #header{height = 0, prev_hash = B1H})),
+               ?assertEqual({ok, BH1}, aec_chain:top_header())
        end}]}.
 
 generate_block_chain_by_difficulties_with_nonce(


### PR DESCRIPTION
Closes GH-109.
Supersedes PRs #127 #128 #129.

This is PR #129 rebased on master.

@sennui @akorosmezey I mocked `aec_headers:difficulty/1` and `aec_blocks:difficulty/1` for minimizing effort. More effort was needed in order to assert expected difficulty and work within tolerance (e.g. `0.001`) because of scientific notation to/from integer conversion and floating point arithmetic.