### PR TITLE
GH-114 Ensure signed transaction includes transaction itself

### DIFF
--- a/apps/aecore/src/aec_keys.erl
+++ b/apps/aecore/src/aec_keys.erl
@@ -18,7 +18,9 @@
 -include("txs.hrl").
 
 %% API
--export([start_link/0]).
+-export([start_link/0,
+         start_link/1,
+         stop/0]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
@@ -56,7 +58,17 @@
 %% @end
 %%--------------------------------------------------------------------
 start_link() ->
-    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+    %% INFO: set the password to re-use keys between restarts
+    Password = application:get_env(aecore, password, undefined),
+    KeysDir = application:get_env(aecore, keys_dir, filename:join(code:root_dir(), "keys")),
+    Args = [Password, KeysDir],
+    start_link(Args).
+
+start_link(Args) ->
+    gen_server:start_link({local, ?SERVER}, ?MODULE, Args, []).
+
+stop() ->
+    gen_server:stop(?SERVER).
 
 -spec sign(term()) -> {ok, term()}.
 sign(Term) ->
@@ -96,17 +108,13 @@ delete() ->
 %%                     {stop, Reason}
 %% @end
 %%--------------------------------------------------------------------
-init([]) ->
+init([Password, KeysDir]) ->
     lager:info("Initializing keys manager"),
     %% TODO: consider moving the crypto config to config
     Algo = ecdsa,
     KeyType = ecdh,
     Digest = sha256,
     Curve = secp256k1,
-
-    %% INFO: set the password to re-use keys between restarts
-    Password = application:get_env(aecore, password, undefined),
-    KeysDir = application:get_env(aecore, keys_dir, filename:join(code:root_dir(), "keys")),
 
     %% Ensure there is directory for keys
     case filelib:is_dir(KeysDir) of
@@ -141,8 +149,8 @@ init([]) ->
 handle_call({sign, _}, _From, #state{priv=undefined} = State) ->
     {reply, {error, key_not_found}, State};
 handle_call({sign, Term}, _From, #state{priv=PrivKey, algo=Algo, digest=Digest, curve=Curve} = State) ->
-    Signed = crypto:sign(Algo, Digest, term_to_binary(Term),  [PrivKey, crypto:ec_curve(Curve)]),
-    {reply, {ok, #signed_tx{data = Signed, signatures = []}}, State};
+    Signature = crypto:sign(Algo, Digest, term_to_binary(Term),  [PrivKey, crypto:ec_curve(Curve)]), %% TODO Review transaction serialization.
+    {reply, {ok, #signed_tx{data = Term, signatures = [Signature]}}, State};
 
 handle_call(pubkey, _From, #state{pub=undefined} = State) ->
     {reply, {error, key_not_found}, State};

--- a/apps/aecore/test/aec_keys_tests.erl
+++ b/apps/aecore/test/aec_keys_tests.erl
@@ -13,7 +13,6 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-
 -define(TEST_PUB, <<4,130,41,165,13,201,185,26,2,151,146,68,56,108,22,242,94,157,95,191,140,86,
                     145,96,71,82,28,176,23,5,128,17,245,174,170,199,54,248,167,43,185,12,108,91,
                     107,188,126,242,98,36,211,79,105,50,16,124,227,93,228,142,83,163,126,167,206>>).
@@ -22,21 +21,34 @@
                      220,210,199,152,25,208,77,217,186,141,212>>).
 
 all_test_() ->
-    {setup,
-     fun setup/0,
-     fun teardown/1,
-     [{"Test if eunit is still broken and doesn't pick up sys.config",
-       fun() ->
-               ?assertEqual({error,key_not_found}, aec_keys:pubkey())
-       end}
-     ]
-    }.
+    {foreach,
+     fun() ->
+             TmpKeysDir = mktempd(),
+             ok = application:ensure_started(crypto),
+             {ok, _} = aec_keys:start_link(["mypassword", TmpKeysDir]),
+             TmpKeysDir
+     end,
+     fun(TmpKeysDir) ->
+             ok = aec_keys:stop(),
+             ok = application:stop(crypto),
+             file:delete(TmpKeysDir)
+     end,
+     [fun(TmpKeysDir) ->
+              [{"Sign coinbase transaction",
+                fun() ->
+                        {ok, PubKey} = aec_keys:pubkey(),
+                        {ok, Tx} =
+                            aec_coinbase_tx:new(#{account => PubKey},
+                                                unused_trees_argument),
+                        {ok, SignedTx} = aec_keys:sign(Tx),
+                        ?assertEqual(Tx, aec_tx_sign:data(SignedTx))
+                end}]
+      end]}.
 
-setup() ->
-    crypto:start(),
-    aec_keys:start_link().
+mktempd() ->
+    mktempd(os:type()).
 
-teardown(_) ->
-    crypto:stop().
+mktempd({unix, _}) ->
+    lib:nonl(?cmd("mktemp -d")).
 
 -endif.

--- a/apps/aecore/test/aec_keys_tests.erl
+++ b/apps/aecore/test/aec_keys_tests.erl
@@ -31,7 +31,16 @@ all_test_() ->
      fun(TmpKeysDir) ->
              ok = aec_keys:stop(),
              ok = application:stop(crypto),
-             file:delete(TmpKeysDir)
+             {ok, KeyFiles} = file:list_dir(TmpKeysDir),
+             %% Expect two filenames - private and public keys.
+             [KF1, KF2] = KeyFiles,
+             lists:foreach(
+               fun(F) ->
+                       AbsF = filename:absname_join(TmpKeysDir, F),
+                       {ok, _} = {file:delete(AbsF), {F, AbsF}}
+               end,
+               KeyFiles),
+             ok = file:del_dir(TmpKeysDir)
      end,
      [fun(TmpKeysDir) ->
               [{"Sign coinbase transaction",


### PR DESCRIPTION
See `aec_tx:apply_signed` for the expected return data of `aec_tx_sign:data/1`.

Also plant unit testing with aec_keys running.

----

I hit this mismatch in the content of the `#signed_tx.data` field while testing mining from genesis block in scope for GH-114.

I did not go as far as testing the verification of a signed transaction. Transaction verification is meant to be performed by `aec_tx_sign:verify` - that returns `ok` at the moment. See `aec_tx:apply_signed` for its invocation.