### PR TITLE
GH-111 Coinbase trx with account creation

### DIFF
--- a/apps/aecore/include/txs.hrl
+++ b/apps/aecore/include/txs.hrl
@@ -103,3 +103,7 @@
           fee = 0         :: non_neg_integer(),
           nonce = 0       :: non_neg_integer()}).
 -type(oracle_close_tx() :: #oracle_close_tx{}).
+
+-type tx() :: coinbase_tx() | spend_tx() | channel_new_tx() | channel_grow_tx() |
+             channel_team_close_tx() | channel_solo_close_tx() | channel_slash_tx() |
+             channel_timeout_tx() | oracle_new_tx() | oracle_close_tx().

--- a/apps/aecore/src/aec_accounts.erl
+++ b/apps/aecore/src/aec_accounts.erl
@@ -2,6 +2,7 @@
 
 %% API
 -export([empty/0,
+         new/3,
          get/2,
          get_with_proof/2,
          put/2,
@@ -14,6 +15,9 @@
 
 empty() ->
     {ok, _AccountsTree} = aec_trees:new().
+
+new(Pubkey, Balance, Height) ->
+    #account{pubkey = Pubkey, balance = Balance, height = Height}.
 
 get(Pubkey, AccountsTree) ->
     case aec_trees:get(Pubkey, AccountsTree) of

--- a/apps/aecore/src/txs/aec_coinbase_tx.erl
+++ b/apps/aecore/src/txs/aec_coinbase_tx.erl
@@ -1,7 +1,9 @@
 -module(aec_coinbase_tx).
 
 %% API
--export([new/2, run/3]).
+-export([new/2,
+         check/3,
+         process/3]).
 
 -behavior(aec_tx).
 
@@ -15,13 +17,29 @@
 new(#{account := AccountPubkey}, _Trees) ->
     {ok, #coinbase_tx{account = AccountPubkey}}.
 
--spec run(coinbase_tx(), trees(), non_neg_integer()) -> {ok, trees()} | {error, term()}.
-run(#coinbase_tx{account = AccountPubkey}, Trees0, Height) ->
+-spec check(coinbase_tx(), trees(), non_neg_integer()) -> {ok, trees()} | {error, term()}.
+check(#coinbase_tx{account = AccountPubkey}, Trees0, Height) ->
     AccountsTrees0 = aec_trees:accounts(Trees0),
-    {ok, Account0} = aec_accounts:get(AccountPubkey, AccountsTrees0),
+    case aec_accounts:get(AccountPubkey, AccountsTrees0) of
+        {ok, _Account} ->
+            {ok, Trees0};
+        {error, notfound} ->
+            %% Add newly referenced account (w/0 amount) to the state
+            Account = aec_accounts:new(AccountPubkey, 0, Height),
+            {ok, AccountsTrees} = aec_accounts:put(Account, AccountsTrees0),
+            Trees = aec_trees:set_accounts(Trees0, AccountsTrees),
+            {ok, Trees}
+    end.
 
-    {ok, Account} = aec_accounts:earn(Account0, ?BLOCK_MINE_REWARD, Height),
-
-    {ok, AccountsTrees} = aec_accounts:put(Account, AccountsTrees0),
-    Trees = aec_trees:set_accounts(Trees0, AccountsTrees),
-    {ok, Trees}.
+-spec process(coinbase_tx(), trees(), non_neg_integer()) -> {ok, trees()} | {error, term()}.
+process(#coinbase_tx{account = AccountPubkey}, Trees0, Height) ->
+    AccountsTrees0 = aec_trees:accounts(Trees0),
+    case aec_accounts:get(AccountPubkey, AccountsTrees0) of
+        {ok, Account0} ->
+            {ok, Account} = aec_accounts:earn(Account0, ?BLOCK_MINE_REWARD, Height),
+            {ok, AccountsTrees} = aec_accounts:put(Account, AccountsTrees0),
+            Trees = aec_trees:set_accounts(Trees0, AccountsTrees),
+            {ok, Trees};
+        {error, notfound} ->
+            {error, account_not_found}
+    end.

--- a/apps/aecore/src/txs/aec_tx.erl
+++ b/apps/aecore/src/txs/aec_tx.erl
@@ -6,15 +6,23 @@
 -include("trees.hrl").
 -include("txs.hrl").
 
-%% aec_tx behavior callbacks
+
+%%%=============================================================================
+%%% aec_tx behavior callbacks
+%%%=============================================================================
 
 -callback new(Args :: map(), Trees :: trees()) ->
     {ok, Tx :: term()}.
 
--callback run(Tx :: term(), Trees :: trees(), Height :: non_neg_integer()) ->
+-callback check(Tx :: term(), Trees :: trees(), Height :: non_neg_integer()) ->
     {ok, NewTrees :: trees()} | {error, Reason :: term()}.
 
+-callback process(Tx :: term(), Trees :: trees(), Height :: non_neg_integer()) ->
+    {ok, NewTrees :: trees()} | {error, Reason :: term()}.
+
+%%%%=============================================================================
 %% API
+%%%=============================================================================
 
 -spec apply_signed(list(signed_tx()), trees(), non_neg_integer()) -> {ok, trees()} | {error, term()}.
 apply_signed([], Trees, _Height) ->
@@ -23,9 +31,14 @@ apply_signed([SignedTx | Rest], Trees0, Height) ->
     case aec_tx_sign:verify(SignedTx) of
         ok ->
             Tx = aec_tx_sign:data(SignedTx),
-            case apply_single(Tx, Trees0, Height) of
-                {ok, Trees} ->
-                    apply_signed(Rest, Trees, Height);
+            case check_single(Tx, Trees0, Height) of
+                {ok, Trees1} ->
+                    case process_single(Tx, Trees1, Height) of
+                        {ok, Trees2} ->
+                            apply_signed(Rest, Trees2, Height);
+                        {error, _Reason} = Error ->
+                            Error
+                    end;
                 {error, _Reason} = Error ->
                     Error
             end;
@@ -34,10 +47,24 @@ apply_signed([SignedTx | Rest], Trees0, Height) ->
     end.
 
 
-%% Internal functions
+%%%=============================================================================
+%%% Internal functions
+%%%=============================================================================
 
--spec apply_single(coinbase_tx(), trees(), non_neg_integer()) -> {ok, trees()} | {error, term()}.
-apply_single(#coinbase_tx{} = Tx, Trees, Height) ->
-    aec_coinbase_tx:run(Tx, Trees, Height);
-apply_single(_Other, _Trees_, _Height) ->
+%%------------------------------------------------------------------------------
+%% Check transaction. Prepare state tree: e.g., create newly referenced account
+%%------------------------------------------------------------------------------
+-spec check_single(tx(), trees(), non_neg_integer()) -> {ok, trees()} | {error, term()}.
+check_single(#coinbase_tx{} = Tx, Trees, Height) ->
+    aec_coinbase_tx:check(Tx, Trees, Height);
+check_single(_Other, _Trees_, _Height) ->
+    {error, not_implemented}.
+
+%%------------------------------------------------------------------------------
+%% Process the transaction. Accounts must already be present in the state tree
+%%------------------------------------------------------------------------------
+-spec process_single(tx(), trees(), non_neg_integer()) -> {ok, trees()} | {error, term()}.
+process_single(#coinbase_tx{} = Tx, Trees, Height) ->
+    aec_coinbase_tx:process(Tx, Trees, Height);
+process_single(_Other, _Trees_, _Height) ->
     {error, not_implemented}.

--- a/apps/aecore/test/aec_coinbase_tx_tests.erl
+++ b/apps/aecore/test/aec_coinbase_tx_tests.erl
@@ -5,31 +5,96 @@
 -include_lib("eunit/include/eunit.hrl").
 
 -include("common.hrl").
--include("trees.hrl").
+-include("blocks.hrl").
 
 -define(TEST_MODULE, aec_coinbase_tx).
 
-create_coinbase_tx_test() ->
-    PubKey = <<"my_pubkey">>,
-    Account0 = #account{pubkey = PubKey,
-        balance = 23,
-        height = 6},
-    Trees0 = create_state_tree_with_account(Account0),
 
-    {ok, CoinbaseTx} = aec_coinbase_tx:new(#{account => PubKey}, Trees0),
-    {ok, Trees} = aec_coinbase_tx:run(CoinbaseTx, Trees0, 9),
+%%%=============================================================================
+%%% Tests
+%%%=============================================================================
 
-    AccountsTree = aec_trees:accounts(Trees),
-    {ok, Account} = aec_accounts:get(PubKey, AccountsTree),
-    ?assertEqual(PubKey, Account#account.pubkey),
-    ?assertEqual(23 + 10, Account#account.balance), %% block reward = 10
-    ?assertEqual(9, Account#account.height).
+coinbase_tx_existing_account_test_() ->
+    {foreach,
+     fun() ->
+             PubKey = <<"my_pubkey">>,
+             Account0 = #account{pubkey = PubKey,
+                                 balance = 23,
+                                 height = 6},
+             {PubKey, create_state_tree_with_account(Account0)}
+     end,
+     fun(_) ->
+             ok
+     end,
+     [fun({PubKey, Trees0}) ->
+              {"Check coinbase trx with existing account: shall not change state",
+               fun() ->
+                       {ok, CoinbaseTx} = aec_coinbase_tx:new(#{account => PubKey}, Trees0),
+                       ?assertEqual({ok, Trees0}, aec_coinbase_tx:check(CoinbaseTx, Trees0, 9))
+               end}
+      end,
+      fun({PubKey, Trees0}) ->
+              {"Process coinbase trx with existing account",
+               fun() ->
+                       {ok, CoinbaseTx} = aec_coinbase_tx:new(#{account => PubKey}, Trees0),
+                       {ok, Trees} = aec_coinbase_tx:process(CoinbaseTx, Trees0, 9),
 
+                       AccountsTree = aec_trees:accounts(Trees),
+                       {ok, Account} = aec_accounts:get(PubKey, AccountsTree),
+                       ?assertEqual(PubKey, Account#account.pubkey),
+                       ?assertEqual(23 + 10, Account#account.balance), %% block reward = 10
+                       ?assertEqual(9, Account#account.height)
+               end}
+      end
+     ]
+    }.
+
+create_coinbase_tx_no_account_test() ->
+    {foreach,
+     fun() ->
+             PubKey = <<"my_pubkey">>,
+             Trees0 = create_state_tree(),
+             {ok, CoinbaseTx} = aec_coinbase_tx:new(#{account => PubKey}, Trees0),
+             {PubKey, Trees0, CoinbaseTx}
+     end,
+     fun(_) ->
+             ok
+     end,
+     [fun({PubKey, Trees0, CoinbaseTx}) ->
+              {"Check coinbase trx without existing account in state: shall create account",
+               fun() ->
+                       {Succ, Trees} = aec_coinbase_tx:check(CoinbaseTx, Trees0, 9),
+                       ?assertEqual(ok, Succ),
+                       AccountsTrees = aec_trees:accounts(Trees),
+                       ?assertEqual({ok, #account{pubkey = PubKey,
+                                                  balance = 0,
+                                                  nonce = 0,
+                                                  height = 9}},
+                                    aec_accounts:get(PubKey, AccountsTrees))
+               end}
+      end,
+      fun({PubKey, Trees0, CoinbaseTx}) ->
+              {"Process coinbase trx without existing account in state: shall fail",
+               ?assertEqual({error, account_not_found}, aec_coinbase_tx:process(CoinbaseTx, Trees0, 9))}
+      end
+     ]
+    }.
+
+
+%%%=============================================================================
+%%% Internal functions
+%%%=============================================================================
+
+create_state_tree() ->
+    {ok, AccountsTree} = aec_accounts:empty(),
+    StateTrees0 = #trees{},
+    aec_trees:set_accounts(StateTrees0, AccountsTree).
 
 create_state_tree_with_account(Account) ->
     {ok, AccountsTree0} = aec_accounts:empty(),
     {ok, AccountsTree1} = aec_accounts:put(Account, AccountsTree0),
     StateTrees0 = #trees{},
     aec_trees:set_accounts(StateTrees0, AccountsTree1).
+
 
 -endif.


### PR DESCRIPTION
Add a 'check' call to aec_tx behaviour that may check the applicability of the transaction. For coinbase transactions, it creates the relevant account in the state tree if not yet present.

The previous 'run' call is renamed to 'process'. This call fails for coinbase transactions if the corresponding account is not present in the state tree.

Related to issue #111, updates PR #133 