### PR TITLE
GH-114 Plant transactions hash for genesis block

### DIFF
--- a/apps/aecore/include/blocks.hrl
+++ b/apps/aecore/include/blocks.hrl
@@ -5,10 +5,11 @@
 -define(GENESIS_HEIGHT, 0).
 
 -define(BLOCK_HEADER_HASH_BYTES, 32).
--define(TXS_HASH_BYTES, 32). %% TODO Use this macro.
+-define(TXS_HASH_BYTES, 32).
 -define(STATE_HASH_BYTES, 32).
 
 -type(block_header_hash() :: <<_:(?BLOCK_HEADER_HASH_BYTES*8)>>).
+-type(txs_hash() :: <<_:(?TXS_HASH_BYTES*8)>>).
 -type(state_hash() :: <<_:(?STATE_HASH_BYTES*8)>>).
 
 -record(block, {
@@ -16,6 +17,7 @@
           prev_hash = <<0:?BLOCK_HEADER_HASH_BYTES/unit:8>> :: block_header_hash(),
           root_hash = <<0:?STATE_HASH_BYTES/unit:8>> :: state_hash(), % Hash of all state Merkle trees included in #block.trees
           trees = #trees{}        :: trees(),
+          txs_hash = <<0:?TXS_HASH_BYTES/unit:8>> :: txs_hash(),
           txs = []                :: list(),
           target = ?HIGHEST_TARGET_SCI :: aec_pow:sci_int(),
           nonce = 0               :: non_neg_integer(),
@@ -27,6 +29,7 @@
 -record(header, {
           height = 0              :: height(),
           prev_hash = <<0:?BLOCK_HEADER_HASH_BYTES/unit:8>> :: block_header_hash(),
+          txs_hash = <<0:?TXS_HASH_BYTES/unit:8>> :: txs_hash(),
           root_hash = <<>>        :: binary(),
           target = ?HIGHEST_TARGET_SCI :: aec_pow:sci_int(),
           nonce = 0               :: non_neg_integer(),

--- a/apps/aecore/src/aec_block_genesis.erl
+++ b/apps/aecore/src/aec_block_genesis.erl
@@ -35,7 +35,7 @@ genesis_header() ->
        version = ?GENESIS_VERSION,
        height = ?GENESIS_HEIGHT,
        prev_hash = <<0:?BLOCK_HEADER_HASH_BYTES/unit:8>>,
-       %% TODO txs_hash = <<0:?TXS_HASH_BYTES/unit:8>>,
+       txs_hash = <<0:?TXS_HASH_BYTES/unit:8>>,
        root_hash = <<0:?STATE_HASH_BYTES/unit:8>>,
        target = ?HIGHEST_TARGET_SCI,
        pow_evidence = no_value,
@@ -49,13 +49,13 @@ genesis_block_as_deserialized_from_network() ->
        version = H#header.version,
        height = H#header.height,
        prev_hash = H#header.prev_hash,
-       %% TODO txs_hash
+       txs_hash = H#header.txs_hash,
        root_hash = H#header.root_hash,
        target = H#header.target,
        pow_evidence = H#header.pow_evidence,
        nonce = H#header.nonce,
        time = H#header.time,
-       txs = [], %% TODO Review representation. See also txs_hash
+       txs = [],
        trees = _DummyTrees = #trees{}
       }.
 

--- a/apps/aecore/src/aec_blocks.erl
+++ b/apps/aecore/src/aec_blocks.erl
@@ -60,6 +60,7 @@ new(LastBlock, Txs, Trees0) ->
                         prev_hash = LastBlockHeaderHash,
                         root_hash = aec_trees:all_trees_hash(Trees),
                         trees = Trees,
+                        %% TODO Compute txs_hash based on Txs.
                         txs = Txs,
                         target = target(LastBlock),
                         time = aeu_time:now_in_msecs(),
@@ -71,6 +72,7 @@ new(LastBlock, Txs, Trees0) ->
 -spec to_header(block()) -> header().
 to_header(#block{height = Height,
                  prev_hash = PrevHash,
+                 txs_hash = TxsHash,
                  root_hash = RootHash,
                  target = Target,
                  nonce = Nonce,
@@ -79,6 +81,7 @@ to_header(#block{height = Height,
                  pow_evidence = Evd}) ->
     #header{height = Height,
             prev_hash = PrevHash,
+            txs_hash = TxsHash,
             root_hash = RootHash,
             target = Target,
             nonce = Nonce,

--- a/apps/aecore/test/aec_mining_tests.erl
+++ b/apps/aecore/test/aec_mining_tests.erl
@@ -58,7 +58,7 @@ mine_block_test_() ->
                  meck:expect(aec_keys, pubkey, 0, {ok, ?TEST_PUB}),
                  meck:expect(aec_keys, sign, 1, {ok, #signed_tx{data = <<"123">>}}),
 
-                 {ok, Block} = ?TEST_MODULE:mine(),
+                 {ok, Block} = ?TEST_MODULE:mine(400),
 
                  ?assertEqual(1, Block#block.height),
                  ?assertEqual(1, length(Block#block.txs))
@@ -153,7 +153,7 @@ mine_block_test_() ->
                  meck:expect(aec_keys, pubkey, 0, {ok, ?TEST_PUB}),
                  meck:expect(aec_keys, sign, 1, {ok, #signed_tx{data = <<"123">>}}),
 
-                 {ok, Block} = ?TEST_MODULE:mine(),
+                 {ok, Block} = ?TEST_MODULE:mine(400),
 
                  ?assertEqual(200, Block#block.height),
                  case PoWMod of


### PR DESCRIPTION
These are the minimal "transactions hash"-related changes in scope for GH-114. @akorosmezey This does not code the computation of the root hash when there are transactions, in scope for GH-111.

For context, please see wiki page https://github.com/aeternity/epoch/wiki/Block-Header and comment at the top of `aec_block_genesis` module.