### PR TITLE
Gh 150 mine continuously

### DIFF
--- a/apps/aecore/include/blocks.hrl
+++ b/apps/aecore/include/blocks.hrl
@@ -5,10 +5,11 @@
 -define(GENESIS_HEIGHT, 0).
 
 -define(BLOCK_HEADER_HASH_BYTES, 32).
--define(TXS_HASH_BYTES, 32). %% TODO Use this macro.
+-define(TXS_HASH_BYTES, 32).
 -define(STATE_HASH_BYTES, 32).
 
 -type(block_header_hash() :: <<_:(?BLOCK_HEADER_HASH_BYTES*8)>>).
+-type(txs_hash() :: <<_:(?TXS_HASH_BYTES*8)>>).
 -type(state_hash() :: <<_:(?STATE_HASH_BYTES*8)>>).
 
 -record(block, {
@@ -16,6 +17,7 @@
           prev_hash = <<0:?BLOCK_HEADER_HASH_BYTES/unit:8>> :: block_header_hash(),
           root_hash = <<0:?STATE_HASH_BYTES/unit:8>> :: state_hash(), % Hash of all state Merkle trees included in #block.trees
           trees = #trees{}        :: trees(),
+          txs_hash = <<0:?TXS_HASH_BYTES/unit:8>> :: txs_hash(),
           txs = []                :: list(),
           target = ?HIGHEST_TARGET_SCI :: aec_pow:sci_int(),
           nonce = 0               :: non_neg_integer(),
@@ -27,6 +29,7 @@
 -record(header, {
           height = 0              :: height(),
           prev_hash = <<0:?BLOCK_HEADER_HASH_BYTES/unit:8>> :: block_header_hash(),
+          txs_hash = <<0:?TXS_HASH_BYTES/unit:8>> :: txs_hash(),
           root_hash = <<>>        :: binary(),
           target = ?HIGHEST_TARGET_SCI :: aec_pow:sci_int(),
           nonce = 0               :: non_neg_integer(),

--- a/apps/aecore/src/aec_block_genesis.erl
+++ b/apps/aecore/src/aec_block_genesis.erl
@@ -35,7 +35,7 @@ genesis_header() ->
        version = ?GENESIS_VERSION,
        height = ?GENESIS_HEIGHT,
        prev_hash = <<0:?BLOCK_HEADER_HASH_BYTES/unit:8>>,
-       %% TODO txs_hash = <<0:?TXS_HASH_BYTES/unit:8>>,
+       txs_hash = <<0:?TXS_HASH_BYTES/unit:8>>,
        root_hash = <<0:?STATE_HASH_BYTES/unit:8>>,
        target = ?HIGHEST_TARGET_SCI,
        pow_evidence = no_value,
@@ -49,13 +49,13 @@ genesis_block_as_deserialized_from_network() ->
        version = H#header.version,
        height = H#header.height,
        prev_hash = H#header.prev_hash,
-       %% TODO txs_hash
+       txs_hash = H#header.txs_hash,
        root_hash = H#header.root_hash,
        target = H#header.target,
        pow_evidence = H#header.pow_evidence,
        nonce = H#header.nonce,
        time = H#header.time,
-       txs = [], %% TODO Review representation. See also txs_hash
+       txs = [],
        trees = _DummyTrees = #trees{}
       }.
 

--- a/apps/aecore/src/aec_blocks.erl
+++ b/apps/aecore/src/aec_blocks.erl
@@ -56,11 +56,13 @@ new(LastBlock, Txs, Trees0) ->
     Height = LastBlockHeight + 1,
     case aec_tx:apply_signed(Txs, Trees0, Height) of
         {ok, Trees} ->
+            {ok, TxsTree} = aec_txs_trees:new(Txs),
+            {ok, TxsRootHash} = aec_txs_trees:root_hash(TxsTree),
             {ok, #block{height = Height,
                         prev_hash = LastBlockHeaderHash,
                         root_hash = aec_trees:all_trees_hash(Trees),
                         trees = Trees,
-                        %% TODO Compute txs_hash based on Txs.
+                        txs_hash = TxsRootHash,
                         txs = Txs,
                         target = target(LastBlock),
                         time = aeu_time:now_in_msecs(),

--- a/apps/aecore/src/aec_blocks.erl
+++ b/apps/aecore/src/aec_blocks.erl
@@ -60,6 +60,7 @@ new(LastBlock, Txs, Trees0) ->
                         prev_hash = LastBlockHeaderHash,
                         root_hash = aec_trees:all_trees_hash(Trees),
                         trees = Trees,
+                        %% TODO Compute txs_hash based on Txs.
                         txs = Txs,
                         target = target(LastBlock),
                         time = aeu_time:now_in_msecs(),
@@ -71,6 +72,7 @@ new(LastBlock, Txs, Trees0) ->
 -spec to_header(block()) -> header().
 to_header(#block{height = Height,
                  prev_hash = PrevHash,
+                 txs_hash = TxsHash,
                  root_hash = RootHash,
                  target = Target,
                  nonce = Nonce,
@@ -79,6 +81,7 @@ to_header(#block{height = Height,
                  pow_evidence = Evd}) ->
     #header{height = Height,
             prev_hash = PrevHash,
+            txs_hash = TxsHash,
             root_hash = RootHash,
             target = Target,
             nonce = Nonce,

--- a/apps/aecore/src/aec_governance.erl
+++ b/apps/aecore/src/aec_governance.erl
@@ -2,10 +2,12 @@
 
 %% API
 -export([recalculate_difficulty_frequency/0,
-         expected_block_mine_rate/0]).
+         expected_block_mine_rate/0,
+         block_mine_reward/0]).
 
 -define(RECALCULATE_DIFFICULTY_FREQUENCY, 10).
 -define(EXPECTED_BLOCK_MINE_RATE, 300). %% 60secs * 5 = 300secs
+-define(BLOCK_MINE_REWARD, 10).
 
 
 recalculate_difficulty_frequency() ->
@@ -16,3 +18,6 @@ recalculate_difficulty_frequency() ->
 expected_block_mine_rate() ->
     %% Returned in seconds.
     ?EXPECTED_BLOCK_MINE_RATE.
+
+block_mine_reward() ->
+    ?BLOCK_MINE_REWARD.

--- a/apps/aecore/src/aec_miner.erl
+++ b/apps/aecore/src/aec_miner.erl
@@ -1,0 +1,199 @@
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2017, Aeternity Anstalt
+%%% @doc
+%%%    A continuous miner
+%%% @end
+%%%-------------------------------------------------------------------
+-module(aec_miner).
+
+-behaviour(gen_statem).
+
+%%------------------------------------------------------------------------------
+%% API
+%%------------------------------------------------------------------------------
+-export([start_link/0,
+         stop/0,
+         start_mining/0,
+         stop_mining/0,
+         get_balance/0]).
+
+%%------------------------------------------------------------------------------
+%% gen_statem callbacks
+%%------------------------------------------------------------------------------
+-export([init/1,
+         idle/3,
+         running/3,
+         terminate/3,
+         code_change/4,
+         callback_mode/0]).
+
+-include("common.hrl").
+-include("blocks.hrl").
+
+
+-define(SERVER, ?MODULE).
+
+-record(state, {}).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+%%------------------------------------------------------------------------------
+%% Start the state machine
+%%------------------------------------------------------------------------------
+-spec start_link() -> {'ok', pid()} | {error | term()}.
+start_link() ->
+    gen_statem:start_link({local, ?SERVER}, ?MODULE, [], []).
+
+%%------------------------------------------------------------------------------
+%% Stop the state machine
+%%------------------------------------------------------------------------------
+-spec  stop() -> 'ok'.
+stop() ->
+    gen_statem:stop(?SERVER).
+
+%%------------------------------------------------------------------------------
+%% Start mining
+%%------------------------------------------------------------------------------
+-spec start_mining() -> 'ok' | {'error' | term()}.
+start_mining() ->
+    gen_statem:call(?SERVER, start).
+
+%%------------------------------------------------------------------------------
+%% Stop mining
+%%------------------------------------------------------------------------------
+-spec stop_mining() -> 'ok' | {'error' | term()}.
+stop_mining() ->
+    gen_statem:call(?SERVER, stop).
+
+%%------------------------------------------------------------------------------
+%% Get the account balance
+%%------------------------------------------------------------------------------
+-spec get_balance() -> integer() | {'error', term()}.
+get_balance() ->
+    {ok, Pubkey} = aec_keys:pubkey(),
+    {ok, LastBlock} = aec_chain:top(),
+    Trees = aec_blocks:trees(LastBlock),
+    AccountsTree = aec_trees:accounts(Trees),
+    case aec_accounts:get(Pubkey, AccountsTree) of
+        {ok, #account{balance = B}} ->
+            B;
+        _ ->
+            {error, account_not_found}
+    end.
+
+%%%===================================================================
+%%% gen_statem callbacks
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Whenever a gen_statem is started using gen_statem:start/[3,4] or
+%% gen_statem:start_link/[3,4], this function is called by the new
+%% process to initialize.
+%%
+%% @spec init(Args) -> {ok, StateName, State} |
+%%                     {ok, StateName, State, Timeout} |
+%%                     ignore |
+%%                     {stop, StopReason}
+%% @end
+%%--------------------------------------------------------------------
+init(_) ->
+    {ok, _} = aec_chain:start_link(aec_block_genesis:genesis_block()),
+    {ok, idle, #state{}}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% There should be one instance of this function for each possible
+%% state name. Whenever a gen_statem receives an event sent using
+%% gen_statem:send_event/2, the instance of this function with the same
+%% name as the current state name StateName is called to handle
+%% the event. It is also called if a timeout occurs.
+%%
+%% @spec state_name(Type, Event, State) ->
+%%                   {next_state, NextStateName, NextState} |
+%%                   {next_state, NextStateName, NextState, [Actions]}
+%% @end
+%%--------------------------------------------------------------------
+idle({call, From}, start, State) ->
+    case aec_keys:pubkey() of
+        {ok, _Pubkey} ->
+            gen_statem:cast(?SERVER, mine),
+            {next_state, running, State, [{reply, From, ok}]};
+        {error, _} = Error ->
+            lager:error("Cannot start mining: ~p", [Error]),
+            {next_state, idle, State, [{reply, From, Error}]}
+    end;
+idle({call, From}, stop, State) ->
+    {next_state, idle, State, [{reply, From, {error, not_started}}]};
+idle({call, From}, _Msg, State) ->
+    {next_state, idle, State, [{reply, From, {error, not_supported}}]};
+idle(_Type, _Msg, State) ->
+    {next_state, idle, State}.
+
+running({call, From}, start, State) ->
+    {next_state, running, State, [{reply, From, {error, already_started}}]};
+running({call, From}, stop, State) ->
+    {ok, TopBlock} = aec_chain:top(),
+    Height = aec_blocks:height(TopBlock),
+    Bal = get_balance(),
+    lager:info("Mining finished at height ~p, balance ~p", [Height, Bal]),
+    {next_state, idle, State, [{reply, From, ok}]};
+running(cast, mine, State) ->
+    case aec_mining:mine(10) of
+        {ok, Block} ->
+            Header = aec_blocks:to_header(Block),
+            aec_chain:insert_header(Header),
+            aec_chain:write_block(Block),
+            gen_statem:cast(?SERVER, mine),
+            {next_state, running, State};
+        {error, generation_count_exhausted} ->
+            %% Needs more attempts, go on trying
+            gen_statem:cast(?SERVER, mine),
+            {next_state, running, State};
+        {error, Reason} ->
+            lager:error("Mining attempt failed with error: ~p", [Reason]),
+            gen_statem:cast(?SERVER, mine),
+            {next_state, running, State}
+    end;
+running({call, From}, _Msg, State) ->
+    {next_state, running, State, [{reply, From, {error, not_supported}}]};
+running(_Type, _Msg, State) ->
+    {next_state, idle, State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% This function is called by a gen_statem when it is about to
+%% terminate. It should be the opposite of Module:init/1 and do any
+%% necessary cleaning up. When it returns, the gen_statem terminates with
+%% Reason. The return value is ignored.
+%%
+%% @spec terminate(Reason, StateName, State) -> void()
+%% @end
+%%--------------------------------------------------------------------
+terminate(_Reason, _StateName, _State) ->
+    aec_chain:stop(),
+    ok.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Convert process state when code is changed
+%%
+%% @spec code_change(OldVsn, StateName, State, Extra) ->
+%%                   {ok, StateName, NewState}
+%% @end
+%%--------------------------------------------------------------------
+code_change(_OldVsn, StateName, State, _Extra) ->
+    {ok, StateName, State}.
+
+callback_mode() ->
+    state_functions.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================

--- a/apps/aecore/src/aec_pow_cuckoo.erl
+++ b/apps/aecore/src/aec_pow_cuckoo.erl
@@ -96,7 +96,8 @@ verify(Data, Nonce, Evd, Target) when is_list(Evd) ->
 generate_hashed(_Hash, _Nonce, _Target, _Trims, _Threads, 0) ->
     {error, generation_count_exhausted};
 generate_hashed(Hash, Nonce, Target, Trims, Threads, Retries) when Retries > 0 ->
-    case generate_single(Hash, Nonce, Trims, Threads) of
+    Nonce32 = Nonce band 16#7fffffff,
+    case generate_single(Hash, Nonce32, Trims, Threads) of
         {error, no_solutions} ->
             generate_hashed(Hash, Nonce + 1, Target, Trims, Threads, Retries - 1);
         {ok, Soln} ->

--- a/apps/aecore/src/aec_tx_sign.erl
+++ b/apps/aecore/src/aec_tx_sign.erl
@@ -3,6 +3,8 @@
 %% API
 -export([data/1,
          verify/1]).
+-export([serialize/1,
+         deserialize/1]).
 
 -include("common.hrl").
 -include("txs.hrl").
@@ -15,3 +17,16 @@ verify(failed_tx) ->
     {error, verification_failed};
 verify(_Tx) ->
     ok.
+
+%% TODO This is meant to be the deterministic canonical serialization.
+serialize(SignedTx = #signed_tx{data = Tx, signatures = [_]}) when
+      is_tuple(Tx) ->
+    term_to_binary(SignedTx).
+
+%% TODO This is meant to be the deserialization of the deterministic
+%% canonical serialization.
+deserialize(B) ->
+    case binary_to_term(B) of
+        #signed_tx{signatures = [_]} = SignedTx ->
+            SignedTx
+    end.

--- a/apps/aecore/src/aec_txs_trees.erl
+++ b/apps/aecore/src/aec_txs_trees.erl
@@ -1,0 +1,25 @@
+-module(aec_txs_trees).
+
+-export([new/1,
+         root_hash/1]).
+
+new(Txs = [_|_]) ->
+    {ok, EmptyTree} = aec_trees:new(),
+    TxsTree =
+        lists:foldl(
+          fun(SignedTx, TreeIn) ->
+                  {ok, TreeOut} = put_signed_tx(SignedTx, TreeIn),
+                  TreeOut
+          end,
+          EmptyTree,
+          Txs),
+    {ok, TxsTree}.
+
+put_signed_tx(SignedTx, TxsTree) ->
+    V = aec_tx_sign:serialize(SignedTx),
+    K = aec_sha256:hash(V),
+    {ok, _NewTxsTree} =
+        aec_trees:put(K, V, TxsTree).
+
+root_hash(TxsTree) ->
+    aec_trees:root_hash(TxsTree).

--- a/apps/aecore/src/aecore_sup.erl
+++ b/apps/aecore/src/aecore_sup.erl
@@ -25,6 +25,7 @@ start_link() ->
 
 init([]) ->
     {ok, {{one_for_one, 5, 10}, [?CHILD(aec_peers, 5000, worker),
-                                 ?CHILD(aec_keys, 5000, worker)]
+                                 ?CHILD(aec_keys, 5000, worker),
+                                 ?CHILD(aec_miner, 5000, worker)]
          }}.
 

--- a/apps/aecore/src/txs/aec_coinbase_tx.erl
+++ b/apps/aecore/src/txs/aec_coinbase_tx.erl
@@ -11,7 +11,6 @@
 -include("trees.hrl").
 -include("txs.hrl").
 
--define(BLOCK_MINE_REWARD, 10). %% To be set in governance
 
 -spec new(map(), trees()) -> {ok, coinbase_tx()}.
 new(#{account := AccountPubkey}, _Trees) ->
@@ -36,7 +35,8 @@ process(#coinbase_tx{account = AccountPubkey}, Trees0, Height) ->
     AccountsTrees0 = aec_trees:accounts(Trees0),
     case aec_accounts:get(AccountPubkey, AccountsTrees0) of
         {ok, Account0} ->
-            {ok, Account} = aec_accounts:earn(Account0, ?BLOCK_MINE_REWARD, Height),
+            Reward = aec_governance:block_mine_reward(),
+            {ok, Account} = aec_accounts:earn(Account0, Reward, Height),
             {ok, AccountsTrees} = aec_accounts:put(Account, AccountsTrees0),
             Trees = aec_trees:set_accounts(Trees0, AccountsTrees),
             {ok, Trees};

--- a/apps/aecore/test/aec_blocks_tests.erl
+++ b/apps/aecore/test/aec_blocks_tests.erl
@@ -12,11 +12,20 @@
 new_block_test_() ->
     {setup,
      fun() ->
+             meck:new(aec_txs_trees, [passthrough]),
              meck:new(aec_trees, [passthrough]),
+             meck:expect(aec_txs_trees, new, 1, {ok, fake_txs_tree}),
+             meck:expect(
+               aec_txs_trees, root_hash,
+               fun(fake_txs_tree) ->
+                       {ok, <<"fake_txs_tree_hash">>}
+               end),
              meck:expect(aec_trees, all_trees_hash, 1, <<>>)
      end,
      fun(_) ->
+             ?assert(meck:validate(aec_txs_trees)),
              ?assert(meck:validate(aec_trees)),
+             meck:unload(aec_txs_trees),
              meck:unload(aec_trees)
      end,
      {"Generate new block with given txs and 0 nonce",
@@ -29,6 +38,7 @@ new_block_test_() ->
               ?assertEqual(12, ?TEST_MODULE:height(NewBlock)),
               ?assertEqual(aec_sha256:hash(BlockHeader),
                            ?TEST_MODULE:prev_hash(NewBlock)),
+              ?assertEqual(<<"fake_txs_tree_hash">>, NewBlock#block.txs_hash),
               ?assertEqual([], NewBlock#block.txs),
               ?assertEqual(17, NewBlock#block.target),
               ?assertEqual(1, NewBlock#block.version)

--- a/apps/aecore/test/aec_coinbase_tx_tests.erl
+++ b/apps/aecore/test/aec_coinbase_tx_tests.erl
@@ -73,7 +73,7 @@ create_coinbase_tx_no_account_test() ->
                                     aec_accounts:get(PubKey, AccountsTrees))
                end}
       end,
-      fun({PubKey, Trees0, CoinbaseTx}) ->
+      fun({_PubKey, Trees0, CoinbaseTx}) ->
               {"Process coinbase trx without existing account in state: shall fail",
                ?assertEqual({error, account_not_found}, aec_coinbase_tx:process(CoinbaseTx, Trees0, 9))}
       end

--- a/apps/aecore/test/aec_keys_tests.erl
+++ b/apps/aecore/test/aec_keys_tests.erl
@@ -33,7 +33,7 @@ all_test_() ->
              ok = application:stop(crypto),
              {ok, KeyFiles} = file:list_dir(TmpKeysDir),
              %% Expect two filenames - private and public keys.
-             [KF1, KF2] = KeyFiles,
+             [_KF1, _KF2] = KeyFiles,
              lists:foreach(
                fun(F) ->
                        AbsF = filename:absname_join(TmpKeysDir, F),
@@ -42,7 +42,7 @@ all_test_() ->
                KeyFiles),
              ok = file:del_dir(TmpKeysDir)
      end,
-     [fun(TmpKeysDir) ->
+     [fun(_) ->
               [{"Sign coinbase transaction",
                 fun() ->
                         {ok, PubKey} = aec_keys:pubkey(),

--- a/apps/aecore/test/aec_miner_tests.erl
+++ b/apps/aecore/test/aec_miner_tests.erl
@@ -1,0 +1,119 @@
+%%%=============================================================================
+%%% @copyright (C) 2017, Aeternity Anstalt
+%%% @doc
+%%%   Unit tests for the aec_miner
+%%% @end
+%%%=============================================================================
+-module(aec_miner_tests).
+
+-ifdef(TEST).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-include("common.hrl").
+-include("blocks.hrl").
+
+-define(TEST_MODULE, aec_miner).
+
+miner_test_() ->
+    {foreach,
+     fun() ->
+             meck:new(aec_chain, [passthrough]),
+             meck:new(aeu_time, [passthrough]),
+             meck:new(aec_governance, [passthrough]),
+             meck:expect(
+               aec_chain, top,
+               fun() ->
+                       %% TODO Remove this workaround once
+                       %% `aec_chain:top/0` returns state trees.
+                       {ok, B} = meck:passthrough([]),
+                       {ok, B#block{trees = (aec_block_genesis:genesis_block())#block.trees}}
+               end),
+             %% As unit test run with speeded-up PoW, difficulty calculation may fail as
+             %% block timestamps are rounded to seconds. Use millisecs here.
+             meck:expect(aeu_time, msecs_to_secs, fun(Ms) -> Ms end),
+             meck:expect(aec_governance, expected_block_mine_rate,
+                         fun() ->
+                                 meck:passthrough([])
+                         end),
+             TmpKeysDir = mktempd(),
+             ok = application:ensure_started(crypto),
+             {ok, _} = aec_keys:start_link(["mypassword", TmpKeysDir]),
+             {ok, _} = ?TEST_MODULE:start_link(),
+             TmpKeysDir
+     end,
+     fun(TmpKeysDir) ->
+             ok = ?TEST_MODULE:stop(),
+             ok = aec_keys:stop(),
+             ok = application:stop(crypto),
+             {ok, KeyFiles} = file:list_dir(TmpKeysDir),
+             %% Expect two filenames - private and public keys.
+             [_KF1, _KF2] = KeyFiles,
+             lists:foreach(
+               fun(F) ->
+                       AbsF = filename:absname_join(TmpKeysDir, F),
+                       {ok, _} = {file:delete(AbsF), {F, AbsF}}
+               end,
+               KeyFiles),
+             ok = file:del_dir(TmpKeysDir),
+             ?assert(meck:validate(aec_chain)),
+             ?assert(meck:validate(aec_governance)),
+             ?assert(meck:validate(aeu_time)),
+             meck:unload(aec_governance),
+             meck:unload(aeu_time),
+             meck:unload(aec_chain),
+             file:delete(TmpKeysDir)
+     end,
+     [fun(_) ->
+             [{"Start and stop",
+               fun() ->
+                       ?assertEqual(ok, ?TEST_MODULE:start_mining()),
+                       ?assertEqual(ok, ?TEST_MODULE:stop_mining()),
+                       ?assertEqual(ok, ?TEST_MODULE:start_mining()),
+                       ?assertEqual(ok, ?TEST_MODULE:stop_mining())
+               end}
+             ]
+      end,
+      fun(_) ->
+              [{"Start twice",
+               fun() ->
+                       ?assertEqual(ok, ?TEST_MODULE:start_mining()),
+                       ?assertEqual({error,already_started}, ?TEST_MODULE:start_mining()),
+                       ?assertEqual(ok, ?TEST_MODULE:stop_mining())
+               end},
+              {"Stop twice",
+               fun() ->
+                       ?assertEqual(ok, ?TEST_MODULE:start_mining()),
+                       ?assertEqual(ok, ?TEST_MODULE:stop_mining()),
+                       ?assertEqual({error,not_started}, ?TEST_MODULE:stop_mining())
+               end},
+              {"Stop in idle",
+               fun() ->
+                       ?assertEqual({error,not_started}, ?TEST_MODULE:stop_mining())
+               end},
+              {timeout, 60,
+               {"Run miner for a while",
+                fun() ->
+                        ?assertEqual(ok, ?TEST_MODULE:start_mining()),
+                        timer:sleep(20000),
+                        ?assertEqual(ok, ?TEST_MODULE:stop_mining()),
+                        {ok, TopBlock} = aec_chain:top(),
+                        ?debugFmt("reached height ~p~n", [aec_blocks:height(TopBlock)]),
+                        ?assert(aec_blocks:height(TopBlock) > 0),
+                        ?debugFmt("reached balance ~p~n", [?TEST_MODULE:get_balance()]),
+                        ?assertEqual(1, length(TopBlock#block.txs)),
+                        ?assertMatch(<<H:?TXS_HASH_BYTES/unit:8>> when H > 0,
+                                                                       TopBlock#block.txs_hash)
+                end}
+              }
+             ]
+      end
+     ]}.
+
+mktempd() ->
+    mktempd(os:type()).
+
+mktempd({unix, _}) ->
+    lib:nonl(?cmd("mktemp -d")).
+
+-endif.

--- a/apps/aecore/test/aec_mining_tests.erl
+++ b/apps/aecore/test/aec_mining_tests.erl
@@ -56,7 +56,7 @@ mine_block_test_() ->
                  meck:expect(aec_pow, pick_nonce, 0, 1),
                  meck:expect(aec_tx, apply_signed, 3, {ok, Trees}),
                  meck:expect(aec_keys, pubkey, 0, {ok, ?TEST_PUB}),
-                 meck:expect(aec_keys, sign, 1, {ok, #signed_tx{data = <<"123">>}}),
+                 meck:expect(aec_keys, sign, 1, {ok, #signed_tx{data = {<<"123">>}, signatures = [sig1]}}),
 
                  {ok, Block} = ?TEST_MODULE:mine(400),
 
@@ -73,7 +73,7 @@ mine_block_test_() ->
                  meck:expect(aec_pow, pick_nonce, 0, 1),
                  meck:expect(aec_tx, apply_signed, 3, {ok, Trees}),
                  meck:expect(aec_keys, pubkey, 0, {ok, ?TEST_PUB}),
-                 meck:expect(aec_keys, sign, 1, {ok, #signed_tx{data = <<"123">>}}),
+                 meck:expect(aec_keys, sign, 1, {ok, #signed_tx{data = {<<"123">>}, signatures = [sig1]}}),
 
                  ?assertEqual({error, generation_count_exhausted}, ?TEST_MODULE:mine())
          end}},
@@ -83,7 +83,7 @@ mine_block_test_() ->
                 meck:expect(aec_chain, top, 0, {ok, #block{}}),
                 meck:expect(aec_tx, apply_signed, 3, {error, tx_failed}),
                 meck:expect(aec_keys, pubkey, 0, {ok, ?TEST_PUB}),
-                meck:expect(aec_keys, sign, 1, {ok, #signed_tx{data = <<"123">>}}),
+                meck:expect(aec_keys, sign, 1, {ok, #signed_tx{data = {<<"123">>}, signatures = [sig1]}}),
                 ?assertEqual({error, tx_failed}, ?TEST_MODULE:mine())
         end},
        {timeout, 60,
@@ -106,7 +106,7 @@ mine_block_test_() ->
                  meck:expect(aec_governance, recalculate_difficulty_frequency, 0, 10),
                  meck:expect(aec_governance, expected_block_mine_rate, 0, 5),
                  meck:expect(aec_keys, pubkey, 0, {ok, ?TEST_PUB}),
-                 meck:expect(aec_keys, sign, 1, {ok, #signed_tx{data = <<"123">>}}),
+                 meck:expect(aec_keys, sign, 1, {ok, #signed_tx{data = {<<"123">>}, signatures = [sig1]}}),
 
                  {ok, Block} = ?TEST_MODULE:mine(),
 
@@ -151,7 +151,7 @@ mine_block_test_() ->
                  meck:expect(aec_governance, recalculate_difficulty_frequency, 0, 10),
                  meck:expect(aec_governance, expected_block_mine_rate, 0, 100000),
                  meck:expect(aec_keys, pubkey, 0, {ok, ?TEST_PUB}),
-                 meck:expect(aec_keys, sign, 1, {ok, #signed_tx{data = <<"123">>}}),
+                 meck:expect(aec_keys, sign, 1, {ok, #signed_tx{data = {<<"123">>}, signatures = [sig1]}}),
 
                  {ok, Block} = ?TEST_MODULE:mine(400),
 
@@ -224,7 +224,9 @@ mine_block_from_genesis_test_() ->
                 fun() ->
                         {ok, Block} = ?TEST_MODULE:mine(),
                         ?assertEqual(1, aec_blocks:height(Block)),
-                        ?assertEqual(1, length(Block#block.txs))
+                        ?assertEqual(1, length(Block#block.txs)),
+                        ?assertMatch(<<H:?TXS_HASH_BYTES/unit:8>> when H > 0,
+                                     Block#block.txs_hash)
                 end}]
       end} || PoWMod <- PoWModules].
 

--- a/apps/aecore/test/aec_mining_tests.erl
+++ b/apps/aecore/test/aec_mining_tests.erl
@@ -58,7 +58,7 @@ mine_block_test_() ->
                  meck:expect(aec_keys, pubkey, 0, {ok, ?TEST_PUB}),
                  meck:expect(aec_keys, sign, 1, {ok, #signed_tx{data = <<"123">>}}),
 
-                 {ok, Block} = ?TEST_MODULE:mine(),
+                 {ok, Block} = ?TEST_MODULE:mine(400),
 
                  ?assertEqual(1, Block#block.height),
                  ?assertEqual(1, length(Block#block.txs))
@@ -153,7 +153,7 @@ mine_block_test_() ->
                  meck:expect(aec_keys, pubkey, 0, {ok, ?TEST_PUB}),
                  meck:expect(aec_keys, sign, 1, {ok, #signed_tx{data = <<"123">>}}),
 
-                 {ok, Block} = ?TEST_MODULE:mine(),
+                 {ok, Block} = ?TEST_MODULE:mine(400),
 
                  ?assertEqual(200, Block#block.height),
                  case PoWMod of

--- a/apps/aecore/test/aec_mining_tests.erl
+++ b/apps/aecore/test/aec_mining_tests.erl
@@ -108,7 +108,7 @@ mine_block_test_() ->
                  meck:expect(aec_keys, pubkey, 0, {ok, ?TEST_PUB}),
                  meck:expect(aec_keys, sign, 1, {ok, #signed_tx{data = {<<"123">>}, signatures = [sig1]}}),
 
-                 {ok, Block} = ?TEST_MODULE:mine(),
+                 {ok, Block} = ?TEST_MODULE:mine(400),
 
                  ?assertEqual(30, Block#block.height),
                  case PoWMod of
@@ -193,7 +193,7 @@ mine_block_from_genesis_test_() ->
                 end),
               meck:expect(aec_pow, pow_module, 0, PoWMod),
               meck:expect(aec_pow, pick_nonce, 0, 1),
-              {ok, Pid} = aec_chain:start_link(aec_block_genesis:genesis_block()),
+              {ok, _} = aec_chain:start_link(aec_block_genesis:genesis_block()),
               TmpKeysDir = mktempd(),
               ok = application:ensure_started(crypto),
               {ok, _} = aec_keys:start_link(["mypassword", TmpKeysDir]),
@@ -204,7 +204,7 @@ mine_block_from_genesis_test_() ->
               ok = application:stop(crypto),
               {ok, KeyFiles} = file:list_dir(TmpKeysDir),
               %% Expect two filenames - private and public keys.
-              [KF1, KF2] = KeyFiles,
+              [_KF1, _KF2] = KeyFiles,
               lists:foreach(
                 fun(F) ->
                         AbsF = filename:absname_join(TmpKeysDir, F),
@@ -219,10 +219,10 @@ mine_block_from_genesis_test_() ->
               meck:unload(aec_chain),
               file:delete(TmpKeysDir)
       end,
-      fun(TmpKeysDir) ->
+      fun(_) ->
               [{"Find a new block (PoW module " ++ atom_to_list(PoWMod) ++ ")",
                 fun() ->
-                        {ok, Block} = ?TEST_MODULE:mine(),
+                        {ok, Block} = ?TEST_MODULE:mine(400),
                         ?assertEqual(1, aec_blocks:height(Block)),
                         ?assertEqual(1, length(Block#block.txs)),
                         ?assertMatch(<<H:?TXS_HASH_BYTES/unit:8>> when H > 0,


### PR DESCRIPTION
Built on top of PR #146. 

The miner state machine is started by the supervisor. Currently crashes when actual mining is started by the user until state trees are properly added to the block. Its unit test contains a workaround for this, needs to be removed when problem fixed.
Includes minor unit test fixes.
Closes #150 