### PR TITLE
Setup release packaging - for Ubuntu and OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,12 @@
+sudo: false
+dist: trusty
 language: erlang
 otp_release:
   - 20.0.1
 before_install:
+  - if test osx = "${TRAVIS_OS_NAME:?}"; then brew update; fi
+  - if test osx = "${TRAVIS_OS_NAME:?}"; then brew install erlang && export PATH="$(brew --prefix erlang)"/bin:"$PATH"; fi
+  - erl -version
   - ./ci before_install "${JOB:?}" "${TRAVIS_BUILD_DIR:?}"
 install:
   - ./ci install "${JOB:?}" "${TRAVIS_BUILD_DIR:?}"
@@ -9,8 +14,30 @@ script:
   - ./ci script "${JOB:?}" "${TRAVIS_BUILD_DIR:?}"
 after_failure:
   - ./ci after_failure "${JOB:?}" "${TRAVIS_BUILD_DIR:?}"
+deploy:
+  provider: releases
+  api_key:
+    # See https://docs.travis-ci.com/user/deployment/releases/#Authenticating-with-an-OAuth-token
+    secure: B4Yl81oyddyE2TQVmVggOgZFN3aZTIt5XjV4mQsy91ctqRxQskIa4nl+vLpNRDHMS+6P9cbEfWdYRXamrOm3PsPOm6KQcoekKbmHH45PdKhHkMbAiUxjXW/QTlufeEPs8ugplAv8anj/d2cb7D2mfzjP6PY1QIbCPbYJGGC0O/zeYHOUxwODyYZQzO6xsBQfOQdHwoT4D/2c1Oo6Mz31j8hxXXJZgXGtEoYjJnxZVHdU1Y7irs8CWlwW7pAjTjEs4cpBVCaM/3W2VQ1I/bW0ZGmZYv8g4Av3uBA6SypAXrqo1yzB2teOUPtxP/WvDzOl/wfZnLQH0u/6uaCt3/XInIYINY8F/Tck31rErPeCrV520WbGebG/ou2uzCHei9cl138doO8qemRf544nrCoSxz39gC2EMcl6PVH3mKpEnj8yLtXuqrfT36mKEzAILb0PQXNFD9Ccx48dGCVa86AZ2zxPnWO9s+veZN4/i9IjW+8sdTIekX96KkAadC/FmMMltbbKHnudEKh2wUujO1ra+OlF6GO7y5E0fEQ8/2C5uwnyMMFwrPAw6snf3pM7z8cEcC/KaqnqjGrOlQ1ze8Ra4NXuMNLwIqquQYxcBx6pJcGU+FavWTFflowzWlTmr5qHj5j3SoRmHqrjEezhHqDr/pvPZp4MNRuJMUOHtcNP4Y4=
+  file_glob: true
+  file: _build/prod/rel/epoch/*-epoch-0.1.0.tar.gz
+  skip_cleanup: true
+  on:
+    # See https://docs.travis-ci.com/user/deployment#Conditional-Releases-with-on%3A
+    repo: aeternity/epoch
+    tags: true
+    all_branches: true # Workaround for Travis - see https://github.com/travis-ci/travis-ci/issues/1675#issuecomment-37851765
+    condition: "${JOB:?} = package"
 matrix:
   include:
+    - os: osx
+      osx_image: xcode8.3 # [`xcode8.3` is Xcode 8.3.3 on OS X 10.12](https://docs.travis-ci.com/user/reference/osx#OS-X-Version)
+      language: generic
+      env: JOB=package
+    - os: osx
+      osx_image: xcode7.3 # [`xcode7.3` is Xcode 7.3.1 on OS X 10.11](https://docs.travis-ci.com/user/reference/osx#OS-X-Version)
+      language: generic
+      env: JOB=package
   allow_failures:
     - env: JOB=xref
   fast_finish: true
@@ -21,6 +48,7 @@ env:
   - JOB=start_local_rel
   - JOB=start_prod_rel
   - JOB=rocksdb_in_prod_rel
+  - JOB=package
 cache:
   directories:
     - $HOME/.cache/rebar3

--- a/ci
+++ b/ci
@@ -3,6 +3,19 @@
 set -ev # Ref https://docs.travis-ci.com/user/customizing-the-build/#Implementing-Complex-Build-Steps
 set -x
 
+
+package_prefix() {
+    case "${1:?}" in
+        linux)
+            echo "ubuntu"
+            ;;
+        osx)
+            echo "osx-$(sw_vers -productVersion)"
+            ;;
+    esac
+}
+
+
 case "${1:?}"-"${2:?}" in
     before_install-*)
         true
@@ -38,6 +51,12 @@ case "${1:?}"-"${2:?}" in
     script-rocksdb_in_prod_rel)
         BuildDir="${3:?}"
         ( cd "${BuildDir:?}" && make prod-build && make prod-start && until ./_build/prod/rel/epoch/bin/epoch ping; do printf "."; sleep 1; done; ./_build/prod/rel/epoch/bin/epoch eval 'Path = "/tmp/rocksdb.test", Options = [{create_if_missing, true}], {ok, Db} = rocksdb:open(Path, Options), not_found = rocksdb:get(Db, <<"my key">>, []), ok = rocksdb:put(Db, <<"my key">>, <<"my value">>, [{sync, true}]), {ok, <<"my value">>} = rocksdb:get(Db, <<"my key">>, []), ok = rocksdb:delete(Db, <<"my key">>, [{sync, true}]), not_found = rocksdb:get(Db, <<"my key">>, []), ok = rocksdb:close(Db).'; ) ## See https://gitlab.com/barrel-db/erlang-rocksdb/wikis/Getting-started
+        ;;
+    script-package)
+        BuildDir="${3:?}"
+        ( cd "${BuildDir:?}" && ./rebar3 as prod tar; )
+        Prefix=$(package_prefix "${TRAVIS_OS_NAME:?}")
+        cp -p "${BuildDir:?}"/_build/prod/rel/epoch/epoch-0.1.0.tar.gz "${BuildDir:?}"/_build/prod/rel/epoch/"${Prefix:?}"-epoch-0.1.0.tar.gz
         ;;
     after_failure-start_local_rel)
         BuildDir="${3:?}"


### PR DESCRIPTION
Closes GH-157.
Supersedes PR #166.

The release upload is triggered only on tags.

----

## Ubuntu package

The Ubuntu package can be tested on a VirtualBox machine setup as
following:
```
vagrant init ubuntu/trusty64
vagrant up
vagrant ssh
ls /vagrant
```

## OSX package

The OSX packages are two because an OSX package built with a recent
OSX / Xcode version does not work on an old OSX version.  OSX versions
10.12 and 10.11 are targeted.  Users with a non-standard path of the
OpenSSL installation, likely to be already advanced users, may find
difficulties in running the packaged software and may prefer building
from source as a developer.

## GitHub OAuth token

(Please refer to the commit message for details on how the token was generated.)