### PR TITLE
Fix NIF Makefile: create priv dir if not present

### DIFF
--- a/apps/aecore/c_src/Makefile
+++ b/apps/aecore/c_src/Makefile
@@ -130,6 +130,9 @@ deps: $(LIBDIR)
 $(LIBDIR):
 	git clone https://github.com/tromp/cuckoo.git
 
+$(PRIV_DIR):
+	mkdir -p $(PRIV_DIR)
+
 $(CUCKOO_SRCS): $(LIBDIR)
 
 $(CUCKOO_OBJECTS): $(CUCKOO_SRCS)


### PR DESCRIPTION
Fixes a bug introduced in PR #175 