### PR TITLE
Report mining results to console, fixes #199

### DIFF
--- a/config/dev1/sys.config
+++ b/config/dev1/sys.config
@@ -15,6 +15,19 @@
           {lager_console_backend, [{level, none}]},
           {lager_file_backend,
             [{file, "log/epoch.log"}, {level, debug}, {size, 41943040}, {date, "$D0"}, {count, 10}]}
+      ]},
+      {extra_sinks, [
+           {epoch_mining_lager_event, [
+             {handlers, [
+               {lager_file_backend, [
+                  {file, "log/epoch_mining.log"},
+                  {level, info}
+               ]},
+               {lager_console_backend, [
+                  {level, info}
+               ]}
+             ]}
+           ]}
       ]}
   ]}
 ].

--- a/config/dev2/sys.config
+++ b/config/dev2/sys.config
@@ -15,6 +15,19 @@
           {lager_console_backend, [{level, none}]},
           {lager_file_backend,
             [{file, "log/epoch.log"}, {level, debug}, {size, 41943040}, {date, "$D0"}, {count, 10}]}
+      ]},
+      {extra_sinks, [
+           {epoch_mining_lager_event, [
+             {handlers, [
+               {lager_file_backend, [
+                  {file, "log/epoch_mining.log"},
+                  {level, info}
+               ]},
+               {lager_console_backend, [
+                  {level, info}
+               ]}
+             ]}
+           ]}
       ]}
   ]}
 ].

--- a/config/dev3/sys.config
+++ b/config/dev3/sys.config
@@ -17,6 +17,19 @@
           {lager_console_backend, [{level, none}]},
           {lager_file_backend,
             [{file, "log/epoch.log"}, {level, debug}, {size, 41943040}, {date, "$D0"}, {count, 10}]}
+      ]},
+      {extra_sinks, [
+           {epoch_mining_lager_event, [
+             {handlers, [
+               {lager_file_backend, [
+                  {file, "log/epoch_mining.log"},
+                  {level, info}
+               ]},
+               {lager_console_backend, [
+                  {level, info}
+               ]}
+             ]}
+           ]}
       ]}
   ]}
 ].

--- a/config/sys.config
+++ b/config/sys.config
@@ -24,6 +24,19 @@
 	  {lager_console_backend, [{level, none}]},
           {lager_file_backend,
             [{file, "log/epoch.log"}, {level, debug}, {size, 41943040}, {date, "$D0"}, {count, 10}]}
+      ]},
+      {extra_sinks, [
+           {epoch_mining_lager_event, [
+             {handlers, [
+               {lager_file_backend, [
+                  {file, "log/epoch_mining.log"},
+                  {level, info}
+               ]},
+               {lager_console_backend, [
+                  {level, info}
+               ]}
+             ]}
+           ]}
       ]}
   ]}
 ].

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,5 @@
-{erl_opts, [debug_info, {parse_transform, lager_transform}]}.
+{erl_opts, [debug_info, {parse_transform, lager_transform},
+            {lager_extra_sinks, [epoch_mining]}]}.
 {deps, [{lager, ".*", {git, "https://github.com/erlang-lager/lager.git", {tag, "3.5.1"}}},
         {gb_merkle_trees, {git, "https://github.com/aeternity/gb_merkle_trees.git", {ref, "4db7aad"}}},
         {rocksdb, "0.12.0"},


### PR DESCRIPTION
Sample output:

```shell
nonce 918184591: 7 trims completed  final load 48%
   4-cycle found at 0:61%
  14-cycle found at 4:82%
...
01:04:17.813 [info] Failed to mine block in 10 attempts, retrying.
initial load 3200%
...
01:04:34.635 [info] Block inserted: Height = 3
Hash = 6ba4225ffe5e9000dee18474a62493a08d9348e8d85ac7faed05422e0f8aaac7
initial load 3200%
```

The [info] messages above also end up in the log file `log/epoch_mining.log`, which currently contains only such mining results. The log corresponds to an extra lager sink: `epoch_mining_lager_event`, specified in the `sys.config`. The call to issue the events is `epoch_mining:info(Fmt, Args)` (see `aec_miner.erl`)