### PR TITLE
GH-188 Optimize CI jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: erlang
 otp_release:
   - 20.0.1
 before_install:
+  - if test osx = "${TRAVIS_OS_NAME:?}"; then export HOMEBREW_CACHE="$HOME/Library/Caches/Homebrew"; fi
   - if test osx = "${TRAVIS_OS_NAME:?}"; then brew update; fi
   - if test osx = "${TRAVIS_OS_NAME:?}"; then brew install erlang && export PATH="$(brew --prefix erlang)"/bin:"$PATH"; fi
   - erl -version
@@ -48,3 +49,4 @@ env:
 cache:
   directories:
     - $HOME/.cache/rebar3
+    - $HOME/Library/Caches/Homebrew

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,9 +42,7 @@ env:
   - JOB=test
   - JOB=dialyzer
   - JOB=xref
-  - JOB=start_local_rel
-  - JOB=start_prod_rel
-  - JOB=rocksdb_in_prod_rel
+  - JOB=check_rels
   - JOB=package
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,10 +34,6 @@ matrix:
       osx_image: xcode8.3 # [`xcode8.3` is Xcode 8.3.3 on OS X 10.12](https://docs.travis-ci.com/user/reference/osx#OS-X-Version)
       language: generic
       env: JOB=package
-    - os: osx
-      osx_image: xcode7.3 # [`xcode7.3` is Xcode 7.3.1 on OS X 10.11](https://docs.travis-ci.com/user/reference/osx#OS-X-Version)
-      language: generic
-      env: JOB=package
   allow_failures:
     - env: JOB=xref
   fast_finish: true

--- a/ci
+++ b/ci
@@ -40,17 +40,19 @@ case "${1:?}"-"${2:?}" in
         BuildDir="${3:?}"
         ( cd "${BuildDir:?}" && ./rebar3 xref; )
         ;;
-    script-start_local_rel)
+    script-check_rels)
         BuildDir="${3:?}"
-        ( cd "${BuildDir:?}" && make local-build && make local-start && until ./_build/local/rel/epoch/bin/epoch ping; do printf "."; sleep 1; done; ./_build/local/rel/epoch/bin/epoch eval 'ok = timer:sleep(5000).'; )
-        ;;
-    script-start_prod_rel)
-        BuildDir="${3:?}"
+        # Check `prod` release can be started and stays up for a few seconds.
+        # TODO Remove when some form of release test setup is hooked to CI.
         ( cd "${BuildDir:?}" && make prod-build && make prod-start && until ./_build/prod/rel/epoch/bin/epoch ping; do printf "."; sleep 1; done; ./_build/prod/rel/epoch/bin/epoch eval 'ok = timer:sleep(5000).'; )
-        ;;
-    script-rocksdb_in_prod_rel)
-        BuildDir="${3:?}"
-        ( cd "${BuildDir:?}" && make prod-build && make prod-start && until ./_build/prod/rel/epoch/bin/epoch ping; do printf "."; sleep 1; done; ./_build/prod/rel/epoch/bin/epoch eval 'Path = "/tmp/rocksdb.test", Options = [{create_if_missing, true}], {ok, Db} = rocksdb:open(Path, Options), not_found = rocksdb:get(Db, <<"my key">>, []), ok = rocksdb:put(Db, <<"my key">>, <<"my value">>, [{sync, true}]), {ok, <<"my value">>} = rocksdb:get(Db, <<"my key">>, []), ok = rocksdb:delete(Db, <<"my key">>, [{sync, true}]), not_found = rocksdb:get(Db, <<"my key">>, []), ok = rocksdb:close(Db).'; ) ## See https://gitlab.com/barrel-db/erlang-rocksdb/wikis/Getting-started
+        # Check `prod` release can use RocksDB - in order to check all moving parts.
+        # TODO Remove when codebase uses RocksDB and some form of release test setup is hooked to CI.
+        ( ./_build/prod/rel/epoch/bin/epoch eval 'Path = "/tmp/rocksdb.test", Options = [{create_if_missing, true}], {ok, Db} = rocksdb:open(Path, Options), not_found = rocksdb:get(Db, <<"my key">>, []), ok = rocksdb:put(Db, <<"my key">>, <<"my value">>, [{sync, true}]), {ok, <<"my value">>} = rocksdb:get(Db, <<"my key">>, []), ok = rocksdb:delete(Db, <<"my key">>, [{sync, true}]), not_found = rocksdb:get(Db, <<"my key">>, []), ok = rocksdb:close(Db).'; ) ## See https://gitlab.com/barrel-db/erlang-rocksdb/wikis/Getting-started
+        ( cd "${BuildDir:?}" && make prod-stop; )
+        # Check `local` release can be started and stays up for a few seconds.
+        # TODO Remove when acceptance tests are hooked to CI.
+        ( cd "${BuildDir:?}" && make local-build && make local-start && until ./_build/local/rel/epoch/bin/epoch ping; do printf "."; sleep 1; done; ./_build/local/rel/epoch/bin/epoch eval 'ok = timer:sleep(5000).'; )
+        ( cd "${BuildDir:?}" && make local-stop; )
         ;;
     script-package)
         BuildDir="${3:?}"
@@ -58,20 +60,10 @@ case "${1:?}"-"${2:?}" in
         Prefix=$(package_prefix "${TRAVIS_OS_NAME:?}")
         cp -p "${BuildDir:?}"/_build/prod/rel/epoch/epoch-0.1.0.tar.gz "${BuildDir:?}"/_build/prod/rel/epoch/"${Prefix:?}"-epoch-0.1.0.tar.gz
         ;;
-    after_failure-start_local_rel)
+    after_failure-check_rels)
         BuildDir="${3:?}"
-        ls -l "${BuildDir:?}"/_build/local/rel/epoch/log
-        for F in "${BuildDir:?}"/_build/local/rel/epoch/log/*; do echo "${F:?}"; cat "${F:?}"; echo; done
-        ;;
-    after_failure-start_prod_rel)
-        BuildDir="${3:?}"
-        ls -l "${BuildDir:?}"/_build/prod/rel/epoch/log
-        for F in "${BuildDir:?}"/_build/prod/rel/epoch/log/*; do echo "${F:?}"; cat "${F:?}"; echo; done
-        ;;
-    after_failure-rocksdb_in_prod_rel)
-        BuildDir="${3:?}"
-        ls -l "${BuildDir:?}"/_build/prod/rel/epoch/log
-        for F in "${BuildDir:?}"/_build/prod/rel/epoch/log/*; do echo "${F:?}"; cat "${F:?}"; echo; done
+        ls -l "${BuildDir:?}"/_build/{prod,local}/rel/epoch/log
+        for F in "${BuildDir:?}"/_build/{prod,local}/rel/epoch/log/*; do echo "${F:?}"; cat "${F:?}"; echo; done
         ;;
     after_failure-*)
         true


### PR DESCRIPTION
Closes GH-188.

* Deleting the old OSX job saves 1 Travis OSX worker and 10-15 minutes time;
* Caching Hombrew on the OSX job saves 1 minute;
* Merging the 3 similar release-checking jobs in 1 saves 2 Travis workers and 15-20 minutes.

I explored caching OTP and [I concluded it is not worth the effort](https://github.com/aeternity/epoch/issues/188#issuecomment-332168699).