### PR TITLE
GH-218 Clarify name of difficulty-related aec_chain functions

### DIFF
--- a/apps/aecore/src/aec_chain.erl
+++ b/apps/aecore/src/aec_chain.erl
@@ -32,7 +32,7 @@
          get_block_by_height/1,
          insert_header/1,
          write_block/1,
-         get_total_difficulty_of_top/0,
+         get_total_difficulty/0,
          get_total_difficulty_by_hash/1,
          get_total_difficulty_by_hash_and_of_top/1,
          has_more_work/1,
@@ -186,9 +186,9 @@ write_block(Block) ->
 
 %% Returns the amount of work done on the chain i.e. the total
 %% difficulty of the top header.
--spec get_total_difficulty_of_top() -> do_get_total_difficulty_of_top_reply().
-get_total_difficulty_of_top() ->
-    gen_server:call(?SERVER, {get_total_difficulty_of_top},
+-spec get_total_difficulty() -> do_get_total_difficulty_reply().
+get_total_difficulty() ->
+    gen_server:call(?SERVER, {get_total_difficulty},
                     ?DEFAULT_CALL_TIMEOUT).
 
 %% Returns the total difficulty of the specified header.
@@ -238,7 +238,7 @@ has_more_work(HeaderChain = [LowerHeader | _]) ->
                     {ok, AltChainWork} = work_in_header_chain(HeaderChain),
                     %% Retrieve the total work in the longest chain.
                     {ok, {TopChainWork, {top_header, TopHeader}}} =
-                        get_total_difficulty_of_top(),
+                        get_total_difficulty(),
                     {ok, {'work_op_>'(AltChainWork, TopChainWork),
                           {{{top_chain_work, TopChainWork},
                             {alt_chain_work, AltChainWork}},
@@ -382,9 +382,8 @@ handle_call({write_block, Block}, _From, State) ->
                   blocks_db = NewBlocksDb},
             {reply, Reply, NewState}
     end;
-handle_call({get_total_difficulty_of_top}, _From, State) ->
-    Reply =
-        do_get_total_difficulty_of_top(State#state.top#top_state.top_header),
+handle_call({get_total_difficulty}, _From, State) ->
+    Reply = do_get_total_difficulty(State#state.top#top_state.top_header),
     {reply, Reply, State};
 handle_call({get_total_difficulty_by_hash,
              HeaderHash = <<_:?BLOCK_HEADER_HASH_BYTES/unit:8>>},
@@ -967,11 +966,11 @@ do_find_header_hash_in_chain_internal_1(
               HeaderHashToFind, aec_headers:prev_hash(Header), HeadersDb)
     end.
 
--type do_get_total_difficulty_of_top_reply() ::
+-type do_get_total_difficulty_reply() ::
         {ok, {WorkAtTop::work(), {top_header, header()}}}.
--spec do_get_total_difficulty_of_top(
-        chain_header()) -> do_get_total_difficulty_of_top_reply().
-do_get_total_difficulty_of_top(TopHeader) ->
+-spec do_get_total_difficulty(
+        chain_header()) -> do_get_total_difficulty_reply().
+do_get_total_difficulty(TopHeader) ->
     {ok, {TopHeader#chain_header.td, {top_header, TopHeader#chain_header.h}}}.
 
 -type do_get_total_difficulty_by_hash_reply() ::

--- a/apps/aecore/test/aec_chain_tests.erl
+++ b/apps/aecore/test/aec_chain_tests.erl
@@ -248,7 +248,7 @@ get_work_test_() ->
 
                %% Check work of chain at top.
                ?assertEqual({ok, {1.0, {top_header, BH0}}},
-                            aec_chain:get_total_difficulty_of_top()),
+                            aec_chain:get_total_difficulty()),
                {ok, B0H} = aec_blocks:hash_internal_representation(B0),
                ?assertEqual({ok, {1.0, {top_header, BH0}}},
                             aec_chain:get_total_difficulty_by_hash(B0H))
@@ -273,7 +273,7 @@ get_work_test_() ->
 
                %% Check work of chain at top.
                ?assertEqual({ok, {8.0, {top_header, BH2}}},
-                            aec_chain:get_total_difficulty_of_top()),
+                            aec_chain:get_total_difficulty()),
 
                %% Check work at each header in the chain.
                {ok, B2H} = aec_headers:hash_header(BH2),

--- a/apps/aecore/test/aec_chain_tests.erl
+++ b/apps/aecore/test/aec_chain_tests.erl
@@ -248,7 +248,10 @@ get_work_test_() ->
 
                %% Check work of chain at top.
                ?assertEqual({ok, {1.0, {top_header, BH0}}},
-                            aec_chain:get_total_difficulty_of_top())
+                            aec_chain:get_total_difficulty_of_top()),
+               {ok, B0H} = aec_blocks:hash_internal_representation(B0),
+               ?assertEqual({ok, {1.0, {top_header, BH0}}},
+                            aec_chain:get_total_difficulty_by_hash(B0H))
        end},
       {"Get work in chain of genesis block plus 2 headers",
        fun() ->
@@ -270,7 +273,16 @@ get_work_test_() ->
 
                %% Check work of chain at top.
                ?assertEqual({ok, {8.0, {top_header, BH2}}},
-                            aec_chain:get_total_difficulty_of_top())
+                            aec_chain:get_total_difficulty_of_top()),
+
+               %% Check work at each header in the chain.
+               {ok, B2H} = aec_headers:hash_header(BH2),
+               ?assertEqual({ok, {8.0, {top_header, BH2}}},
+                            aec_chain:get_total_difficulty_by_hash(B2H)),
+               ?assertEqual({ok, {3.0, {top_header, BH2}}},
+                            aec_chain:get_total_difficulty_by_hash(B1H)),
+               ?assertEqual({ok, {1.0, {top_header, BH2}}},
+                            aec_chain:get_total_difficulty_by_hash(B0H))
        end}]}.
 
 %% Cover unhappy paths not covered in any other tests.

--- a/apps/aecore/test/aec_chain_tests.erl
+++ b/apps/aecore/test/aec_chain_tests.erl
@@ -218,7 +218,7 @@ fake_genesis_block_with_difficulty() ->
     GB = aec_block_genesis:genesis_block_as_deserialized_from_network(),
     GB#block{target = 1}. %% Field used as if it were difficulty for ease of testing.
 
-get_work_at_top_test_() ->
+get_work_test_() ->
     {foreach,
      fun() ->
              meck:new(aec_headers, [passthrough]),
@@ -248,7 +248,7 @@ get_work_at_top_test_() ->
 
                %% Check work of chain at top.
                ?assertEqual({ok, {1.0, {top_header, BH0}}},
-                            aec_chain:get_work_at_top())
+                            aec_chain:get_total_difficulty_of_top())
        end},
       {"Get work in chain of genesis block plus 2 headers",
        fun() ->
@@ -270,7 +270,7 @@ get_work_at_top_test_() ->
 
                %% Check work of chain at top.
                ?assertEqual({ok, {8.0, {top_header, BH2}}},
-                            aec_chain:get_work_at_top())
+                            aec_chain:get_total_difficulty_of_top())
        end}]}.
 
 %% Cover unhappy paths not covered in any other tests.


### PR DESCRIPTION
Closes GH-218.

I did not add function to get total difficulty at height as I think that clients needing the total difficulty want to a refer to a specific chain, and requesting by height does not guarantee that (after a stronger chain is forced, header at same height as before may be a distinct header).