### PR TITLE
GH-16 Plant transaction fee getter - for mempool

### DIFF
--- a/apps/aecore/include/common.hrl
+++ b/apps/aecore/include/common.hrl
@@ -1,2 +1,3 @@
 -type(height() :: non_neg_integer()).
 -type(pubkey() :: binary()).
+-type(account_nonce() :: non_neg_integer()).

--- a/apps/aecore/include/trees.hrl
+++ b/apps/aecore/include/trees.hrl
@@ -7,6 +7,6 @@
 -record(account, {
           pubkey = <<>>  :: pubkey(),
           balance = 0    :: non_neg_integer(),
-          nonce = 0      :: non_neg_integer(),
+          nonce = 0      :: account_nonce(),
           height = 0     :: height()}).
 -type(account() :: #account{}).

--- a/apps/aecore/include/txs.hrl
+++ b/apps/aecore/include/txs.hrl
@@ -1,3 +1,5 @@
+-type(fee() :: non_neg_integer()).
+
 -record(signed_tx, {
           data            :: term(),
           signatures = [] :: list(binary())}).
@@ -8,15 +10,15 @@
 
 -record(coinbase_tx, {
           account = <<>> :: pubkey(),
-          nonce = 0      :: non_neg_integer()}).
+          nonce = 0      :: account_nonce()}).
 -type(coinbase_tx() :: #coinbase_tx{}).
 
 -record(spend_tx, {
           from = <<>> :: pubkey(),
           to = <<>>   :: pubkey(),
           amount = 0  :: non_neg_integer(),
-          fee = 0     :: non_neg_integer(),
-          nonce = 0   :: non_neg_integer()}).
+          fee = 0     :: fee(),
+          nonce = 0   :: account_nonce()}).
 -type(spend_tx() :: #spend_tx{}).
 
 
@@ -28,8 +30,8 @@
           account2 = <<>> :: pubkey(),
           amount1 = 0     :: non_neg_integer(),
           amount2 = 0     :: non_neg_integer(),
-          fee = 0         :: non_neg_integer(),
-          nonce = 0       :: non_neg_integer(),
+          fee = 0         :: fee(),
+          nonce = 0       :: account_nonce(),
           delay = 0       :: non_neg_integer()}).
 -type(channel_new_tx() :: #channel_new_tx{}).
 
@@ -39,8 +41,8 @@
           account2 = <<>> :: pubkey(),
           amount1 = 0     :: non_neg_integer(),
           amount2 = 0     :: non_neg_integer(),
-          fee = 0         :: non_neg_integer(),
-          nonce = 0       :: non_neg_integer(),
+          fee = 0         :: fee(),
+          nonce = 0       :: account_nonce(),
           delay = 0       :: non_neg_integer()}).
 -type(channel_grow_tx() :: #channel_grow_tx{}).
 
@@ -49,29 +51,29 @@
           account1 = <<>> :: pubkey(),
           account2 = <<>> :: pubkey(),
           amount = 0      :: non_neg_integer(),
-          fee = 0         :: non_neg_integer(),
-          nonce = 0       :: non_neg_integer()}).
+          fee = 0         :: fee(),
+          nonce = 0       :: account_nonce()}).
 -type(channel_team_close_tx() :: #channel_team_close_tx{}).
 
 -record(channel_solo_close_tx, {
           id = 0         :: non_neg_integer(),
           account = <<>> :: pubkey(),
-          fee = 0        :: non_neg_integer(),
-          nonce = 0      :: non_neg_integer()}).
+          fee = 0        :: fee(),
+          nonce = 0      :: account_nonce()}).
 -type(channel_solo_close_tx() :: #channel_solo_close_tx{}).
 
 -record(channel_slash_tx, {
           id = 0         :: non_neg_integer(),
           account = <<>> :: pubkey(),
-          fee = 0        :: non_neg_integer(),
-          nonce = 0      :: non_neg_integer()}).
+          fee = 0        :: fee(),
+          nonce = 0      :: account_nonce()}).
 -type(channel_slash_tx() :: #channel_slash_tx{}).
 
 -record(channel_timeout_tx, {
           id = 0         :: non_neg_integer(),
           account = <<>> :: pubkey(),
-          fee = 0        :: non_neg_integer(),
-          nonce = 0      :: non_neg_integer()}).
+          fee = 0        :: fee(),
+          nonce = 0      :: account_nonce()}).
 -type(channel_timeout_tx() :: #channel_timeout_tx{}).
 
 
@@ -85,23 +87,23 @@
           question = <<>> :: binary(),
           difficulty = 0  :: non_neg_integer(),
           start_date = 0  :: integer(),
-          fee = 0         :: non_neg_integer(),
-          nonce = 0       :: non_neg_integer()}).
+          fee = 0         :: fee(),
+          nonce = 0       :: account_nonce()}).
 -type(oracle_new_tx() :: #oracle_new_tx{}).
 
 -record(oracle_bet_tx, {
           id = 0          :: non_neg_integer(),
           account = <<>>  :: pubkey(),
           bet             :: oracle_bet(),
-          fee = 0         :: non_neg_integer(),
-          nonce = 0       :: non_neg_integer()}).
+          fee = 0         :: fee(),
+          nonce = 0       :: account_nonce()}).
 -type(oracle_bet_tx() :: #oracle_bet_tx{}).
 
 -record(oracle_close_tx, {
           id = 0          :: non_neg_integer(),
           account = <<>>  :: pubkey(),
-          fee = 0         :: non_neg_integer(),
-          nonce = 0       :: non_neg_integer()}).
+          fee = 0         :: fee(),
+          nonce = 0       :: account_nonce()}).
 -type(oracle_close_tx() :: #oracle_close_tx{}).
 
 -type tx() :: coinbase_tx() | spend_tx() | channel_new_tx() | channel_grow_tx() |

--- a/apps/aecore/src/txs/aec_coinbase_tx.erl
+++ b/apps/aecore/src/txs/aec_coinbase_tx.erl
@@ -2,6 +2,8 @@
 
 %% API
 -export([new/2,
+         initiating_account/1,
+         initiating_account_nonce/1,
          check/3,
          process/3]).
 
@@ -14,7 +16,16 @@
 
 -spec new(map(), trees()) -> {ok, coinbase_tx()}.
 new(#{account := AccountPubkey}, _Trees) ->
+    %% TODO Populate nonce in coinbase tx with the nonce value that
+    %% succeeds the nonce in the account as per specified state
+    %% account tree.
     {ok, #coinbase_tx{account = AccountPubkey}}.
+
+initiating_account(Tx) ->
+    Tx#coinbase_tx.account.
+
+initiating_account_nonce(Tx) ->
+    Tx#coinbase_tx.nonce.
 
 -spec check(coinbase_tx(), trees(), non_neg_integer()) -> {ok, trees()} | {error, term()}.
 check(#coinbase_tx{account = AccountPubkey}, Trees0, Height) ->
@@ -35,6 +46,9 @@ process(#coinbase_tx{account = AccountPubkey}, Trees0, Height) ->
     AccountsTrees0 = aec_trees:accounts(Trees0),
     case aec_accounts:get(AccountPubkey, AccountsTrees0) of
         {ok, Account0} ->
+            %% TODO Check that nonce in coinbase tx is strictly
+            %% greater than nonce in account.  This may need to be
+            %% checked in the `check` function.
             Reward = aec_governance:block_mine_reward(),
             {ok, Account} = aec_accounts:earn(Account0, Reward, Height),
             {ok, AccountsTrees} = aec_accounts:put(Account, AccountsTrees0),

--- a/apps/aecore/test/aec_coinbase_tx_tests.erl
+++ b/apps/aecore/test/aec_coinbase_tx_tests.erl
@@ -80,6 +80,22 @@ create_coinbase_tx_no_account_test() ->
      ]
     }.
 
+getters_test_() ->
+    [{"Coinbase tx has initiating account and related nonce",
+      fun() ->
+              A = <<"a pubkey">>,
+              {ok, Tx} = aec_coinbase_tx:new(#{account => A},
+                                             unused_state_trees_argument),
+              ?assertEqual(A, aec_tx:initiating_account(Tx)),
+              ?assertEqual(0, aec_tx:initiating_account_nonce(Tx)) %% TODO Review when coinbase tx `new` considers nonce from account state tree.
+      end},
+     {"Coinbase tx does not have fee",
+      fun() ->
+              {ok, Tx} = aec_coinbase_tx:new(#{account => <<"a pubkey">>},
+                                             unused_state_trees_argument),
+              ?assertEqual({error, {no_fee_for_tx_type, coinbase}},
+                           aec_tx:fee(Tx))
+      end}].
 
 %%%=============================================================================
 %%% Internal functions


### PR DESCRIPTION
For GH-16 I need to fetch the transaction fee in a generic manner. Hence I propose getters and types for the fee, and in the meantime also for the other attributes common to the (non-signed) transaction. Please refer to commit message for details.

I tried to keep this not too invasive in order to limit conflicts on concurrent developments, e.g. PR #216 and ticket GH-185, but I may make it even less invasive by only coding `aec_tx:fee/1` for the time being.

