### PR TITLE
Added support for pre-configuring peers + peer aliases

### DIFF
--- a/apps/aecore/src/aec_sync.erl
+++ b/apps/aecore/src/aec_sync.erl
@@ -151,6 +151,8 @@ start_link() ->
     end.
 
 init([]) ->
+    Peers = application:get_env(aecore, peers, []),
+    [connect_peer(P) || P <- Peers],
     {ok, #state{}}.
 
 handle_call(subset_size, _From, #state{subset_size = Sz} = State) ->

--- a/apps/aehttp/src/aehttp_app.erl
+++ b/apps/aehttp/src/aehttp_app.erl
@@ -22,6 +22,7 @@
 start(_StartType, _StartArgs) ->
     {ok, Pid} = aehttp_sup:start_link(),
     ok = start_swagger_external(),
+    gproc:reg({n,l,{epoch, app, aehttp}}),
     {ok, Pid}.
 
 local_peer_uri() ->

--- a/config/dev2/sys.config
+++ b/config/dev2/sys.config
@@ -6,6 +6,7 @@
       {swagger_port_external, 3023}
   ]},
   {aecore, [
+      {peers, ["http://localhost:3013"]},
       {password, <<"secret">>}
     ]
   },

--- a/config/dev3/sys.config
+++ b/config/dev3/sys.config
@@ -8,6 +8,7 @@
   ]},
 
   {aecore, [
+      {peers, ["http://localhost:3013"]},
       {password, <<"secret">>}
     ]
   },


### PR DESCRIPTION
- Env var 'peers' in app 'aecore' can be a list of uris; these
  will be pinged at startup
- Peer aliases allow for the pinged and pinging peers to have
  different ideas of the uri (e.g. localhost vs full host name)

Ref. issue #40 