### PR TITLE
Use add_and_ping_peers() (corrected) at startup; implemented re-pings

### DIFF
--- a/apps/aecore/include/peers.hrl
+++ b/apps/aecore/include/peers.hrl
@@ -1,6 +1,9 @@
 -record(peer, {
           uri = ""          :: http_uri:uri(),
-          last_seen = 0     :: integer()}). % Erlang system time (POSIX time)
+          last_seen = 0     :: integer(), % Erlang system time (POSIX time)
+          last_pings = []   :: [integer()], % Erlang system time
+          ping_tref         :: reference() | undefined
+         }).
 
 
 -type peer() :: #peer{}.

--- a/apps/aecore/src/aec_peers.erl
+++ b/apps/aecore/src/aec_peers.erl
@@ -199,10 +199,10 @@ update_last_seen(Uri) ->
 %%%=============================================================================
 
 -record(state, {peers :: gb_trees:tree(binary(),peer()),
-                aliases :: gb_trees:tree(uri(), binary()),
+                aliases :: gb_trees:tree(uri(), uri()),
                 local_peer_uri :: uri(),
-                local_peer_host :: string(),
-                local_peer_port :: integer()}).
+                local_peer_host :: string() | undefined,
+                local_peer_port :: integer() | undefined}).
 
 start_link() ->
     gen_server:start_link({local, ?MODULE} ,?MODULE, ok, []).

--- a/apps/aecore/src/aec_sync.erl
+++ b/apps/aecore/src/aec_sync.erl
@@ -165,7 +165,7 @@ start_link() ->
 
 init([]) ->
     Peers = application:get_env(aecore, peers, []),
-    [connect_peer(P) || P <- Peers],
+    aec_peers:add_and_ping_peers(Peers),
     {ok, #state{}}.
 
 handle_call(subset_size, _From, #state{subset_size = Sz} = State) ->

--- a/apps/aecore/test/aec_peers_tests.erl
+++ b/apps/aecore/test/aec_peers_tests.erl
@@ -47,9 +47,40 @@ all_test_() ->
       {"Uri_from_ip_port",
        fun() ->
                ?assertEqual("http://123.123.123.123:1337/", aec_peers:uri_from_ip_port("123.123.123.123", 1337))
+       end},
+      {"Remove all",
+       fun do_remove_all/0},
+      {"Add peer",
+       fun() ->
+               ok = aec_peers:add("http://localhost:800", false),
+               ["http://localhost:800/"] =
+                   [aec_peers:uri(P) || P <- aec_peers:all()]
+       end},
+      {"Register source",
+       fun() ->
+               ok = aec_peers:register_source("http://somenode:800",
+                                              "http://localhost:800"),
+               {ok, P} = aec_peers:info("http://localhost:800"),
+               "http://somenode:800/" = aec_peers:uri(P)
+       end},
+      {"Get random N",
+       fun() ->
+               do_remove_all(),
+               Base = "http://localhost:",
+               [ok = aec_peers:add(Base ++ integer_to_list(N))
+                || N <- lists:seq(900,910)],
+               L1 = aec_peers:get_random(5),
+               5 = length(L1)
        end}
+
      ]
     }.
+
+do_remove_all() ->
+    [aec_peers:remove(P) || P <- aec_peers:all()],
+    [] = aec_peers:all(),
+    ok.
+
 
 setup() ->
     crypto:start(),

--- a/apps/aehttp/src/aehttp_dispatch_ext.erl
+++ b/apps/aehttp/src/aehttp_dispatch_ext.erl
@@ -20,11 +20,12 @@ handle_request('Ping', #{'Ping' := PingObj}, _Context) ->
         ok ->
             Source = maps:get(<<"source">>, PingObj),
             aec_peers:update_last_seen(Source),
+            TheirPeers = maps:get(<<"peers">>, PingObj, []),
+            aec_peers:add_and_ping_peers(TheirPeers),
             Ok = LocalPingObj#{<<"pong">> => <<"pong">>},
             Share = maps:get(<<"share">>, PingObj),
             Res = case mk_num(Share) of
                       N when is_integer(N), N > 0 ->
-                          TheirPeers = maps:get(<<"peers">>, PingObj, []),
                           Peers = aec_peers:get_random(N, [Source|TheirPeers]),
                           PeerUris = [iolist_to_binary(aec_peers:uri(P))
                                       || P <- Peers],

--- a/apps/aeutils/test/aeu_requests_tests.erl
+++ b/apps/aeutils/test/aeu_requests_tests.erl
@@ -14,24 +14,17 @@ all_test_() ->
     {setup,
      fun setup/0,
      fun teardown/1,
-     [{"Ping the peer",
-       fun() ->
-               {ok, Peer}=aec_peers:get_random(),
-               "http://localhost:8043/"=aec_peers:uri(Peer),
-               {ok, #{<<"pong">> := <<"pong">>}} = aeu_requests:ping(Peer)
-       end}
-     ]
+     []
     }.
 
 setup() ->
-    inets:start(),
-    application:ensure_all_started(aehttp),
-    aec_peers:start_link(),
-    aec_peers:add("http://localhost:8043/", false).
+    ok = application:ensure_started(inets),
+    {ok, Apps} = application:ensure_all_started(aehttp),
+    Apps.
 
-teardown(_) ->
-    aec_peers:remove("http://localhost:8043/"),
-    ok = application:stop(aehttp),
-    ok = application:stop(aecore),
-    inets:stop().
+teardown(Apps) ->
+    [ok = application:stop(A) || A <- lists:reverse(Apps)],
+    ok = application:stop(inets).
+
+
 -endif.


### PR DESCRIPTION
The aec_sync module would ping preconfigured peers one at a time.
This, combined with a lack of re-pings, could lead to an incomplete
discovery. Now, all preconfigured peers are first added to the peers
database, then pings are initiated.

The aec_peers server now sets re-ping timers for peers, using a
backoff algorithm if the ping failed (starting from MIN, then
increasing the wait in a sort-of-fibonacci sequence, up to MAX ms).
The MIN and MAX can be configured using the env var
{aecore, ping_interval_limits, {Min, Max}}, where Max >= Min, and
both values are in milliseconds. Default: {3000, 60000}.

If the ping succeeds, a re-ping is scheduled in MAX ms.