### PR TITLE
GH-68 Add new txs to block while mining

### DIFF
--- a/apps/aecore/src/aec_pow_cuckoo.erl
+++ b/apps/aecore/src/aec_pow_cuckoo.erl
@@ -11,8 +11,8 @@
 
 -behaviour(aec_pow).
 
--export([generate/3,
-         generate/6,
+-export([generate/5,
+         generate/7,
          verify/4]).
 
 
@@ -58,21 +58,21 @@ init() ->
 %%  Very slow below 3 threads, not improving significantly above 5, let us take 5.
 %%------------------------------------------------------------------------------
 -spec generate(Data :: aec_sha256:hashable(), Target :: aec_pow:sci_int(),
-               Retries :: integer()) -> aec_pow:pow_result().
-generate(Data, Target, Retries) ->
-    Nonce = aec_pow:pick_nonce(),
-    generate(Data, Nonce, Target, 7, 5, Retries).
+               Retries :: integer(), Nonce :: integer(),
+               MaxNonce :: integer()) -> aec_pow:pow_result().
+generate(Data, Target, Retries, Nonce, MaxNonce) ->
+    generate(Data, Nonce, MaxNonce, Target, 7, 5, Retries).
 
 %%------------------------------------------------------------------------------
 %% Proof of Work generation, all params adjustable
 %%------------------------------------------------------------------------------
--spec generate(Data :: aec_sha256:hashable(), Nonce :: integer(),
+-spec generate(Data :: aec_sha256:hashable(), Nonce :: integer(), MaxNonce :: integer(),
                Target :: aec_pow:sci_int(), Trims :: integer(),
                Threads :: integer(), Retries :: integer()) ->
                       aec_pow:pow_result().
-generate(Data, Nonce, Target, Trims, Threads, Retries) ->
+generate(Data, Nonce, MaxNonce, Target, Trims, Threads, Retries) ->
     Hash = base64:encode_to_string(aec_sha256:hash(Data)),
-    generate_hashed(Hash, Nonce, Target, Trims, Threads, Retries).
+    generate_hashed(Hash, Nonce, MaxNonce, Target, Trims, Threads, Retries).
 
 %%------------------------------------------------------------------------------
 %% Proof of Work verification (with difficulty check)
@@ -96,23 +96,25 @@ verify(Data, Nonce, Evd, Target) when is_list(Evd) ->
 %%------------------------------------------------------------------------------
 %% Proof of Work generation: use the hash provided and try consecutive nonces
 %%------------------------------------------------------------------------------
-generate_hashed(_Hash, _Nonce, _Target, _Trims, _Threads, 0) ->
+generate_hashed(_Hash, _Nonce, _MaxNonce, _Target, _Trims, _Threads, 0) ->
     {error, generation_count_exhausted};
-generate_hashed(Hash, Nonce, Target, Trims, Threads, Retries) when Retries > 0 ->
+generate_hashed(_Hash, Nonce, Nonce, _Target, _Trims, _Threads, _Retries) ->
+    {error, nonce_range_exhausted};
+generate_hashed(Hash, Nonce, MaxNonce, Target, Trims, Threads, Retries) when Retries > 0 ->
     Nonce32 = Nonce band 16#7fffffff,
     case generate_single(Hash, Nonce32, Trims, Threads) of
         {error, no_solutions} ->
-            generate_hashed(Hash, Nonce + 1, Target, Trims, Threads, Retries - 1);
+            generate_hashed(Hash, Nonce32 + 1, MaxNonce, Target, Trims, Threads, Retries - 1);
         {ok, Soln} ->
             case test_target(Soln, Target) of
                 true ->
-                    {ok, {Nonce, Soln}};
+                    {ok, {Nonce32, Soln}};
                 false ->
                     NewNonce = case Nonce of
                                    16#7fffffff -> 0;
-                                   _ -> Nonce + 1
+                                   _ -> Nonce32 + 1
                                end,
-                    generate_hashed(Hash, NewNonce, Target, Trims, Threads, Retries - 1)
+                    generate_hashed(Hash, NewNonce, MaxNonce, Target, Trims, Threads, Retries - 1)
             end
     end.
 

--- a/apps/aecore/test/aec_miner_tests.erl
+++ b/apps/aecore/test/aec_miner_tests.erl
@@ -114,13 +114,16 @@ miner_test_() ->
       fun(_) ->
               {"Remove keys while miner runs",
                fun() ->
-                       ?assertEqual({running, {state}}, sys:get_state(aec_miner)),
+                       {State1, _Data1} = sys:get_state(aec_miner),
+                       ?assertEqual(running, State1),
                        ?assertEqual(ok, aec_keys:delete()),
-                       timer:sleep(100),
-                       ?assertEqual({waiting_for_keys, {state}}, sys:get_state(aec_miner)), %% XXX This assertion is fragile. Ticket GH-204 shall simplify this code path.
+                       timer:sleep(1000),
+                       {State2, _Data2} = sys:get_state(aec_miner),
+                       ?assertEqual(waiting_for_keys, State2), %% XXX This assertion is fragile. Ticket GH-204 shall simplify this code path.
                        ?assertNotEqual(error, aec_keys:new("mynewpassword")),
-                       timer:sleep(100),
-                       ?assertEqual({running, {state}}, sys:get_state(aec_miner))
+                       timer:sleep(10),
+                       {State3, _Data3} = sys:get_state(aec_miner),
+                       ?assertEqual(configure, State3)
                end}
       end
      ]}.

--- a/apps/aecore/test/aec_pow_cuckoo_tests.erl
+++ b/apps/aecore/test/aec_pow_cuckoo_tests.erl
@@ -14,42 +14,43 @@
 -define(TEST_MODULE, aec_pow_cuckoo).
 
 pow_test_() ->
-    {setup,
-     fun setup/0,
-     fun teardown/1,
-     [{"Fail if retry count is zero",
+    [{"Fail if retry count is zero",
+      fun() ->
+              ?assertEqual({error, generation_count_exhausted},
+                           ?TEST_MODULE:generate(<<"hello there">>, 5555, 0, 188, 0))
+      end},
+     {"Fail when max nonce is reached",
+      fun() ->
+              ?assertEqual({error, nonce_range_exhausted},
+                           ?TEST_MODULE:generate(<<"hello there">>, 5555, 10, 2, 4))
+      end},
+     {"Generate with a winning nonce and high target threshold, verify it",
+      {timeout, 60,
        fun() ->
-               ?assertEqual({error, generation_count_exhausted},
-                            ?TEST_MODULE:generate(<<"hello there">>, 5555, 0))
-       end},
-      {"Generate with a winning nonce and high target threshold, verify it",
-       {timeout, 60,
-        fun() ->
-                %% succeeds in a single step
-                {T1, Res} = timer:tc(?TEST_MODULE, generate,
-                                     [<<"wsffgujnjkqhduihsahswgdf">>, ?HIGHEST_TARGET_SCI, 100]),
-                ?debugFmt("~nReceived result ~p~nin ~p microsecs~n~n", [Res, T1]),
-                ?assertEqual(ok, element(1, Res)),
+               %% succeeds in a single step
+               {T1, Res} = timer:tc(?TEST_MODULE, generate,
+                                    [<<"wsffgujnjkqhduihsahswgdf">>, ?HIGHEST_TARGET_SCI, 100, 188, 0]),
+               ?debugFmt("~nReceived result ~p~nin ~p microsecs~n~n", [Res, T1]),
+               ?assertEqual(ok, element(1, Res)),
 
-                %% verify the beast
-                {ok, {Nonce, Soln}} = Res,
-                {T2, Res2} = timer:tc(?TEST_MODULE, verify,
-                                      [<<"wsffgujnjkqhduihsahswgdf">>, Nonce, Soln, ?HIGHEST_TARGET_SCI]),
-                ?debugFmt("~nVerified in ~p microsecs~n~n", [T2]),
-                ?assertEqual(true, Res2)
-        end}
-      },
-      {"Generate with a winning nonce but low difficulty, shall fail",
-       {timeout, 90,
-        fun() ->
-                %% Unlikely to succeed after 2 steps
-                Res = ?TEST_MODULE:generate(<<"wsffgujnjkqhduihsahswgdf">>, 16#01010000, 2),
-                ?debugFmt("Received result ~p~n", [Res]),
-                ?assertEqual({error, generation_count_exhausted}, Res)
-        end}
-      }
-     ]
-    }.
+               %% verify the beast
+               {ok, {Nonce, Soln}} = Res,
+               {T2, Res2} = timer:tc(?TEST_MODULE, verify,
+                                     [<<"wsffgujnjkqhduihsahswgdf">>, Nonce, Soln, ?HIGHEST_TARGET_SCI]),
+               ?debugFmt("~nVerified in ~p microsecs~n~n", [T2]),
+               ?assertEqual(true, Res2)
+       end}
+     },
+     {"Generate with a winning nonce but low difficulty, shall fail",
+      {timeout, 90,
+       fun() ->
+               %% Unlikely to succeed after 2 steps
+               Res = ?TEST_MODULE:generate(<<"wsffgujnjkqhduihsahswgdf">>, 16#01010000, 2, 188, 0),
+               ?debugFmt("Received result ~p~n", [Res]),
+               ?assertEqual({error, generation_count_exhausted}, Res)
+       end}
+     }
+    ].
 
 misc_test_() ->
     {setup,
@@ -72,14 +73,5 @@ misc_test_() ->
        end}
      ]
     }.
-
-setup() ->
-    ?debugFmt("Starting test ~p~n", [?MODULE]),
-    meck:new(aec_pow, [passthrough]),
-    meck:expect(aec_pow, pick_nonce, fun() -> 188 end).
-
-teardown(_) ->
-    meck:validate(aec_pow),
-    meck:unload(aec_pow).
 
 -endif.

--- a/apps/aecore/test/aec_pow_sha256_tests.erl
+++ b/apps/aecore/test/aec_pow_sha256_tests.erl
@@ -23,34 +23,34 @@ pow_test_() ->
            fun() ->
                    %% succeeds in a single step
                    ?assertEqual({error, generation_count_exhausted},
-                            ?TEST_MODULE:generate(<<"hello there">>, ?HIGHEST_TARGET_SCI, 0))
+                                ?TEST_MODULE:generate(<<"hello there">>, ?HIGHEST_TARGET_SCI, 0, 1, 0))
+           end},
+          {"Fail when max nonce is reached",
+           fun() ->
+                   ?assertEqual({error, nonce_range_exhausted},
+                                ?TEST_MODULE:generate(<<"hello there">>, 0, 10, 2, 4))
            end},
           {"Generate with very high target threshold",
            fun() ->
-               ?assertEqual(1, aec_pow:pick_nonce()),
                    %% succeeds in a single step
-                   {T1, Res} = timer:tc(?TEST_MODULE, generate, [<<"hello there">>, ?HIGHEST_TARGET_SCI, 1]),
-               ?debugFmt("~nReceived result ~p~nin ~p microsecs~n~n", [Res, T1]),
+                   {T1, Res} = timer:tc(?TEST_MODULE, generate, [<<"hello there">>, ?HIGHEST_TARGET_SCI, 1, 1, 0]),
+                   ?debugFmt("~nReceived result ~p~nin ~p microsecs~n~n", [Res, T1]),
                    ?assertEqual({ok, {1, no_value}}, Res),
 
                    %% verify
                    {T2, Res2} = timer:tc(?TEST_MODULE, verify,
                                          [<<"hello there">>, 1, no_value, ?HIGHEST_TARGET_SCI]),
                    ?debugFmt("~nVerified in ~p microsecs~n~n", [T2]),
-               ?assertEqual(true, Res2)
+                   ?assertEqual(true, Res2)
            end}
          ]
      end
     }.
 
 setup() ->
-    crypto:start(),
-    meck:new(aec_pow, [passthrough]),
-    meck:expect(aec_pow, pick_nonce, fun() -> 1 end).
+    crypto:start().
 
 teardown(_) ->
-    meck:validate(aec_pow),
-    meck:unload(aec_pow),
     crypto:stop().
 
 -endif.

--- a/apps/aecore/test/aecore_sync_SUITE.erl
+++ b/apps/aecore/test/aecore_sync_SUITE.erl
@@ -371,18 +371,23 @@ miner_xform({function,L,running,3,Clauses}) ->
 miner_xform(_) ->
     continue.
 
-%% Remove all calls to gen_statem:cast(aec_miner, mine) from the
+%% Remove all calls to gen_statem:cast(aec_miner, create_block_candidate) from the
 %% 'running' state - i.e. don't automatically re-mine
 miner_xform_1({call,L,
                {remote,_,{atom,_,gen_statem},{atom,_,cast}},
-               [{atom,_,aec_miner},{atom,_,mine}]}) ->
+               [{atom,_,aec_miner},{atom,_,create_block_candidate}]}) ->
     {atom,L,ok};
 miner_xform_1({clause,_,[{tuple,_,[{atom,_,error},
                                    {atom,_,generation_count_exhausted}]}],
                _,_} = C) ->
     %% don't change next state to idle!
     C;
-miner_xform_1({tuple,L,[{atom,_,next_state},{atom,_,running},{var,_,S}]}) ->
+miner_xform_1({clause,_,[{tuple,_,[{atom,_,error},
+                                   {atom,_,nonce_range_exhausted}]}],
+               _,_} = C) ->
+    %% don't change next state to idle!
+    C;
+miner_xform_1({tuple,L,[{atom,_,next_state},{atom,_,configure},{var,_,S}]}) ->
     {tuple,L,[{atom,L,next_state},{atom,L,idle},{var,L,S}]};
 miner_xform_1(_) ->
     continue.

--- a/config/dev1/sys.config
+++ b/config/dev1/sys.config
@@ -8,7 +8,9 @@
   {aecore, [
       {peers, ["http://localhost:3023",
                "http://localhost:3033"]},
-      {password, <<"secret">>}
+      {password, <<"secret">>},
+      {mining_cycle_attempts_count, 10},
+      {fetch_new_txs_from_pool_during_mining, true}
     ]
   },
 

--- a/config/dev2/sys.config
+++ b/config/dev2/sys.config
@@ -8,7 +8,9 @@
   {aecore, [
       {peers, ["http://localhost:3013",
                "http://localhost:3033"]},
-      {password, <<"secret">>}
+      {password, <<"secret">>},
+      {mining_cycle_attempts_count, 10},
+      {fetch_new_txs_from_pool_during_mining, true}
     ]
   },
 

--- a/config/dev3/sys.config
+++ b/config/dev3/sys.config
@@ -10,7 +10,9 @@
   {aecore, [
       {peers, ["http://localhost:3013",
                "http://localhost:3023"]},
-      {password, <<"secret">>}
+      {password, <<"secret">>},
+      {mining_cycle_attempts_count, 10},
+      {fetch_new_txs_from_pool_during_mining, true}
     ]
   },
 

--- a/config/sys.config
+++ b/config/sys.config
@@ -9,13 +9,9 @@
 
   {aecore, [
       {keys_dir, "/tmp/keys"},
-      {password, <<"secret">>}
-    ]
-  },
-
-  {aecore, [
-      {keys_dir, "/tmp/keys"},
-      {password, <<"secret">>}
+      {password, <<"secret">>},
+      {mining_cycle_attempts_count, 10},
+      {fetch_new_txs_from_pool_during_mining, true}
     ]
   },
 


### PR DESCRIPTION
* Add `fetch_new_txs_from_pool_during_mining` param to `sys.config`
* Add `mining_cycle_attempts_count` param to `sys.config`
* Keep block candidate, which is being mined in `aec_miner`
* If `fetch_new_txs_from_pool_during_mining=false`, do not regenerate block candidate until nonce range is exhausted
* If `fetch_new_txs_from_pool_during_mining=true` and there are new txs in the pool, regenerate block candidate and restart mining