### PR TITLE
GH-117 Land initial websockets and GH-304 Python test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,11 +101,14 @@ test:
 venv-present:
 	@virtualenv -q $(PYTHON_DIR)
 
-nose-env: venv-present
+python-env: venv-present
 	@. $(PYTHON_BIN)/activate && $(PIP) -q install -r $(PYTHON_DIR)/requirements.txt 
 
 python-tests:
 	@$(NOSE) --nocapture -c $(PYTHON_TESTS)/nose.cfg $(PYTHON_TESTS)
+
+python-ws-test:
+	@$(PYTHON) $(PYTHON_TESTS)/ws_client.py --port 3014 --log INFO --handler ws_logic
 
 swagger: config/swagger.yaml
 	@swagger-codegen generate -i $< -l erlang-server -o $(SWTEMP)

--- a/apps/aecore/src/aec_miner.erl
+++ b/apps/aecore/src/aec_miner.erl
@@ -213,6 +213,8 @@ running(cast, mine, #state{block_candidate = BlockCandidate,
                            max_block_candidate_nonce = MaxMiningNonce} = State) ->
     case aec_mining:mine(BlockCandidate, CycleAttemptsCount, CurrentMiningNonce, MaxMiningNonce) of
         {ok, Block} ->
+            ws_handler:broadcast(miner, mined_block, [{height,
+                                                       aec_blocks:height(Block)}]),
             ok = save_mined_block(Block),
             gen_statem:cast(?SERVER, create_block_candidate),
             {next_state, configure, State};

--- a/apps/aehttp/src/aehttp.app.src
+++ b/apps/aehttp/src/aehttp.app.src
@@ -12,7 +12,9 @@
     jsx,
     lager,
     jesse,
-    aecore
+    aecore,
+    gproc,
+    poolboy
    ]},
   {env,[]},
   {modules, []},

--- a/apps/aehttp/src/aehttp_dispatch_ext.erl
+++ b/apps/aehttp/src/aehttp_dispatch_ext.erl
@@ -1,6 +1,7 @@
 -module(aehttp_dispatch_ext).
 
 -export([handle_request/3]).
+-export([cleanup_genesis/1]).
 
 -compile({parse_transform, lager_transform}).
 -include_lib("aecore/include/common.hrl").

--- a/apps/aehttp/src/ws_handler.erl
+++ b/apps/aehttp/src/ws_handler.erl
@@ -1,0 +1,66 @@
+-module(ws_handler).
+
+-behaviour(cowboy_websocket_handler).
+
+-export([init/3]).
+-export([websocket_init/3]).
+-export([websocket_handle/3]).
+-export([websocket_info/3]).
+-export([websocket_terminate/3]).
+-export([send_msg/4, broadcast/2, broadcast/3]).
+
+-define(GPROC_KEY, {p, l, {?MODULE, broadcast}}).
+
+init({tcp, http}, _Req, _Opts) ->
+    {upgrade, protocol, cowboy_websocket}.
+
+websocket_init(_TransportName, Req, _Opts) ->
+    case jobs:ask(ws_handlers_queue) of
+        {ok, JobId} ->
+            gproc:reg(?GPROC_KEY),
+            {ok, Req, JobId};
+        {error, rejected} ->
+            {shutdown, Req}
+    end.
+
+websocket_handle({text, MsgBin}, Req, State) ->
+    ws_task_worker:execute(MsgBin), %% async, pool
+    {ok, Req, State};
+websocket_handle(_Data, Req, State) ->
+    {ok, Req, State}.
+
+websocket_info({send, SenderName, Action, Payload}, Req, State) ->
+    MsgWithoutPayload = #{origin =>SenderName, action => Action},
+    EmptyPayload =
+        case Payload of
+            _ when is_list(Payload) ->
+                length(Payload) == 0;
+            _ when is_map(Payload) ->
+                maps:size(Payload) == 0
+        end,
+    Msg =
+        case EmptyPayload of
+            true ->
+                MsgWithoutPayload;
+            false ->
+                maps:put(payload, Payload, MsgWithoutPayload)
+        end,
+    {reply, {text, jsx:encode(Msg)}, Req, State};
+websocket_info(_Info, Req, State) ->
+    {ok, Req, State}.
+
+websocket_terminate(_Reason, _Req, JobId) ->
+    jobs:done(JobId),
+    ok.
+
+broadcast(SenderName, Action) ->
+    broadcast(SenderName, Action, []).
+broadcast(SenderName, Action, Payload) ->
+    try
+        gproc:send(?GPROC_KEY, {send, SenderName, Action, Payload})
+    catch error:badarg -> 
+        lager:info("ws_handler broadcasting when there is no client")
+    end.
+
+send_msg(WsPid, SenderName, Action, Payload) ->
+    WsPid ! {send, SenderName, Action, Payload}.

--- a/apps/aehttp/src/ws_int_dispatch.erl
+++ b/apps/aehttp/src/ws_int_dispatch.erl
@@ -1,0 +1,56 @@
+-module(ws_int_dispatch).
+
+-export([execute/3]).
+
+-spec execute(Target :: atom(), Action :: atom(), Payload :: list() | map()) ->
+                    {ok, Origin :: atom(),
+                         Action :: atom(),
+                         Payload :: list() | map()} | {error, binary()}.
+execute(Target, Action, Payload) ->
+    case is_valid(Target, Action, Payload) of
+        {false, Reason} ->
+            {error, Reason};
+        true ->
+            case do_execute(Target, Action, Payload) of
+                {ok, _, _, _} = OK ->
+                    OK;
+                {error, _} = Err ->
+                    Err
+            end
+    end.
+
+-spec is_valid(Target :: atom(), Action :: atom(), Payload :: map()) ->
+                true | {false, ErrMsg :: binary}.
+is_valid(chain, get, #{<<"height">> := Height}) when Height < 0->
+    {false, <<"Invalid height">>};
+is_valid(_, _, _) ->
+    true.
+
+do_execute(chain, get, QueryPayload) ->
+    #{<<"type">> := Type} = QueryPayload,
+    {BlockFound, Query} =
+        case QueryPayload of
+            #{<<"height">> := Height} ->
+                {aec_chain:get_block_by_height(Height), {height, Height}};
+            #{<<"hash">> := Hash0} ->
+                Hash = base64:decode(Hash0),
+                {aec_chain:get_block_by_hash(Hash), {hash, Hash0}}
+        end,
+    case BlockFound of
+        {error, {ErrMsg, _Top}} ->
+            {error, ErrMsg};
+        {ok, Block} ->
+            Val0 =
+                  case Type of
+                      <<"header">> ->
+                          {ok, HH} = aec_headers:serialize_to_map(
+                              aec_blocks:to_header(Block)), 
+                          HH;
+                      <<"block">> ->
+                          aec_blocks:serialize_to_map(Block)
+                  end,
+            Val = aehttp_dispatch_ext:cleanup_genesis(Val0),
+            {ok, chain, requested_data, [{type, Type}, Query, {Type, Val}]} 
+    end;
+do_execute(_, _, _) -> % a catch all for a prettier error when action is missing
+    {error, <<"Missing action">>}.

--- a/apps/aehttp/src/ws_task_worker.erl
+++ b/apps/aehttp/src/ws_task_worker.erl
@@ -1,0 +1,51 @@
+-module(ws_task_worker).
+-behaviour(gen_server).
+-behaviour(poolboy_worker).
+
+-export([execute/1]).
+
+-export([start_link/1]).
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2,
+         code_change/3]).
+
+-record(state, {}).
+
+execute(Msg) ->
+    WsPid = self(),
+    spawn(fun() -> ws_task_worker_sup:spawn_child_for_msg(Msg, WsPid) end).
+
+start_link(Args) ->
+    gen_server:start_link(?MODULE, Args, []).
+
+init([ws_task_worker_args]) ->
+    {ok, #state{}}.
+
+handle_call({handle_msg, {MsgBin, WsPid}}, _From, #state{}=State) ->
+    #{<<"target">> := Target0,
+      <<"action">> := Action0} = Msg = jsx:decode(MsgBin, [return_maps]),
+    Payload = maps:get(<<"payload">>, Msg, []),
+    Target = binary_to_existing_atom(Target0, utf8),
+    Action = binary_to_existing_atom(Action0, utf8),
+    Response0 = ws_int_dispatch:execute(Target, Action, Payload),
+    case Response0 of
+        {error, ErrMsg} ->
+            lager:info("WS request with target ~p, action ~p and payload ~p failed with reason ~p",
+                       [Target, Action, Payload, ErrMsg]),
+            pass;
+        {ok, O, A, P} ->
+            ws_handler:send_msg(WsPid, O, A, P)
+    end,
+    {reply, ok, State}.
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, #state{}) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+

--- a/apps/aehttp/src/ws_task_worker_sup.erl
+++ b/apps/aehttp/src/ws_task_worker_sup.erl
@@ -1,0 +1,60 @@
+%%%-------------------------------------------------------------------
+%% @doc aehttp websocket task's worker supervisor 
+%% @end
+%%%-------------------------------------------------------------------
+
+-module(ws_task_worker_sup).
+
+-behaviour(supervisor).
+
+%% API
+-export([start_link/0]).
+
+%% Supervisor callbacks
+-export([init/1]).
+
+%% Execute message
+-export([spawn_child_for_msg/2]).
+
+-define(SERVER, ?MODULE).
+-define(POOL_NAME, ws_tasks_pool).
+
+%%====================================================================
+%% API functions
+%%====================================================================
+
+start_link() ->
+    supervisor:start_link({local, ?SERVER}, ?MODULE, []).
+
+%%====================================================================
+%% Supervisor callbacks
+%%====================================================================
+
+%% Child :: {Id,StartFunc,Restart,Shutdown,Type,Modules}
+init([]) ->
+    WsTasksPoolSize = pool_size(),
+    PoolBoySpec = poolboy:child_spec(?POOL_NAME,
+        [{name, {local, ?POOL_NAME}},
+          {worker_module, ws_task_worker},
+          {size, WsTasksPoolSize},
+          {max_overflow, WsTasksPoolSize * 2}],
+        [ws_task_worker_args]),
+    {ok, { {one_for_one, 10, 10}, [PoolBoySpec]} }.
+
+spawn_child_for_msg(Msg, WsPid) ->
+    poolboy:transaction(?POOL_NAME, fun(Worker) ->
+        gen_server:call(Worker, {handle_msg, {Msg, WsPid}})
+    end).
+
+
+%%====================================================================
+%% Internal functions
+%%====================================================================
+pool_size() ->
+    case application:get_env(aehttp, internal) of
+        {ok, InternalConfig} ->
+            WsConfig = proplists:get_value(websocket, InternalConfig),
+            proplists:get_value(tasks, WsConfig);
+        undefined ->
+            100
+    end.

--- a/config/dev1/sys.config
+++ b/config/dev1/sys.config
@@ -3,7 +3,13 @@
   ]},
 
   { aehttp, [
-      {swagger_port_external, 3013}
+      {swagger_port_external, 3013},
+      {internal, [
+          {websocket, [ {port, 3014},
+                        {handlers, 100},
+                        {tasks, 200}
+                      ]}
+          ]}
   ]},
   {aecore, [
       {peers, ["http://localhost:3023",
@@ -21,7 +27,11 @@
                        [{counter, [{limit, 10}]}
                        ]},
                       {producer, {aec_sync, sync_worker, []}}
-                     ]}
+                     ]},
+      {ws_task_workers, [{regulators,
+                      [{counter, [{limit, 100 }] }
+                      ]}
+                    ]}
      ]}
    ]},
 

--- a/config/dev2/sys.config
+++ b/config/dev2/sys.config
@@ -3,7 +3,13 @@
   ]},
 
   { aehttp, [
-      {swagger_port_external, 3023}
+      {swagger_port_external, 3023},
+      {internal, [
+          {websocket, [ {port, 3024},
+                        {handlers, 100},
+                        {tasks, 200}
+                      ]}
+          ]}
   ]},
   {aecore, [
       {peers, ["http://localhost:3013",

--- a/config/dev3/sys.config
+++ b/config/dev3/sys.config
@@ -4,7 +4,13 @@
   ]},
 
   { aehttp, [
-      {swagger_port_external, 3033}
+      {swagger_port_external, 3033},
+      {internal, [
+          {websocket, [ {port, 3034},
+                        {handlers, 100},
+                        {tasks, 200}
+                      ]}
+          ]}
   ]},
 
   {aecore, [

--- a/config/sys.config
+++ b/config/sys.config
@@ -4,7 +4,13 @@
   ]},
 
   { aehttp, [
-      {swagger_port_external, 3013}
+      {swagger_port_external, 3013},
+      {internal, [
+          {websocket, [ {port, 3014},
+                        {handlers, 100},
+                        {tasks, 200}
+                      ]}
+          ]}
   ]},
 
   {aecore, [

--- a/py/requirements.txt
+++ b/py/requirements.txt
@@ -1,5 +1,9 @@
+certifi==2017.7.27.1
+chardet==3.0.4
+idna==2.5
 nose==1.3.7
-nose_xunitmp==0.4
+nose-xunitmp==0.4.0
 requests==2.18.1
-urllib3==1.21.1
 six==1.10.0
+urllib3==1.21.1
+websocket-client==0.44.0

--- a/py/tests/ws_client.py
+++ b/py/tests/ws_client.py
@@ -1,0 +1,129 @@
+import websocket
+import json
+import argparse
+import time
+import sys
+import logging
+import importlib
+
+MESSAGE_FUNCTIONS = {
+        }
+
+def error(msg):
+    logging.error("[ERROR] " + msg)
+
+def read_argv(argv):
+    global trace
+    parser = argparse.ArgumentParser(description='Websocket test')
+    parser.add_argument('--port', type=int, default=3014,
+                        help='Node\'s port number')
+    parser.add_argument('--log', type=str, default="INFO",
+                        help='Logging level')
+    parser.add_argument('--handler', type=str, default="ws-handler",
+                        help='Websocket logic handler module name')
+    args = parser.parse_args()
+    port = args.port
+    handler = args.handler
+    log_levels_dict= {"DEBUG": logging.DEBUG,
+                      "INFO": logging.INFO,
+                      "WARNING": logging.WARNING,
+                      "ERROR": logging.ERROR}
+    log_level_value = log_levels_dict.get(args.log, "INFO")
+    trace = False
+    if log_level_value == logging.DEBUG:
+        trace = True
+    logging.basicConfig(level=log_level_value, format='%(message)s', )
+    return (port, handler, trace)
+
+def parse_message(message_json):
+    message = json.loads(message_json)
+    status = message.get("status")
+    if status:
+        if status == "ok":
+            result = message.get("result")
+            if result:
+                logging.info("Request succeded with: " + str(result))
+            else:
+                logging.info("Request succeded")
+        if status == "error":
+            error("Request failed with: " + str(message["reason"]))
+        return None
+    action = message.get("action")
+    if action == None or not isinstance(action, basestring):
+        error("Invalid action")
+        return None
+    payload = message.get("payload", {})
+    origin = message.get("origin")
+    if origin == None or not isinstance(origin, basestring):
+        error("Invalid origin")
+        return None
+    origin_actions = MESSAGE_FUNCTIONS.get(origin)
+    if origin_actions == None:
+        error("Unknown origin " + origin)
+        return None
+    fun = origin_actions.get(action)
+    if fun == None:
+        error("Unknown action " + action + " for origin " + origin)
+        return None
+    return (fun, payload)
+
+
+## websocket
+def on_message(ws, message_json):
+    logging.debug("\n------------------------")
+    logging.debug("--- incoming message ---")
+    print(">> " + str(message_json))
+    act = parse_message(message_json)
+    if act != None:
+        (fun, payload) = act
+        fun(ws, payload)
+
+def ws_send(ws, target, action, payload={}):
+    if len(payload) > 0:
+        msg = {"target": target, "action": action, "payload": payload}
+    else:
+        msg = {"target": target, "action": action}
+    msg_json = json.dumps(msg)
+    logging.info("<< " + msg_json)
+    ws.send(msg_json)
+
+def on_error(ws, error):
+    print(error)
+
+def on_close(ws):
+    print("### closed ###")
+
+def on_open(ws):
+    print("### opened ###")
+    logging.info("Getting GenesisBlock")
+    get_block_by_height(ws, 0)
+    logging.info("Getting GenesisHeader")
+    get_header_by_height(ws, 0)
+
+
+## WS API functions
+def get_block_by_height(ws, height):
+    ws_send(ws, "chain", "get", {"type": "block", "height": height}) 
+
+def get_block_by_hash(ws, hash):
+    ws_send(ws, "chain", "get", {"type": "block", "hash": hash}) 
+
+def get_header_by_height(ws, height):
+    ws_send(ws, "chain", "get", {"type": "header", "height": height}) 
+
+def get_header_by_hash(ws, hash):
+    ws_send(ws, "chain", "get", {"type": "header", "hash": hash}) 
+
+
+
+if __name__ == "__main__":
+    port, handler, trace = read_argv(sys.argv)
+    logic = importlib.import_module(handler)
+    MESSAGE_FUNCTIONS = logic.actions()
+    websocket.enableTrace(trace)
+    ws = websocket.WebSocketApp("ws://127.0.0.1:" + str(port) + "/websocket",
+                              on_message = on_message,
+                              on_error = on_error,
+                              on_close = on_close)
+    ws.on_open = on_open
+    ws.run_forever()

--- a/py/tests/ws_logic.py
+++ b/py/tests/ws_logic.py
@@ -1,0 +1,22 @@
+import ws_client
+import logging
+
+def get_new_block(ws, payload):
+    ws_client.get_block_by_height(ws, payload["height"]) 
+
+def print_chain_data(ws, payload):
+    data_type = payload["type"]
+    value = payload[data_type]
+    search_key = "hash"
+    if payload["height"] != None:
+        search_key = "height"
+    logging.info("Recieved data for " + data_type + ", requested by its " +
+                search_key + " = " + str(payload[search_key]))
+    logging.info(str(value))
+
+def actions ():
+    return {
+        "chain": {  "requested_data": print_chain_data},
+        "miner": {  "mined_block": get_new_block}
+    }
+

--- a/rebar.config
+++ b/rebar.config
@@ -7,8 +7,9 @@
         {jsx, {git, "https://github.com/talentdeficit/jsx.git", {tag, "2.8.0"}}},
         {jesse, {git, "https://github.com/for-GET/jesse.git", {tag, "1.5.0-rc2"}}},
         {gproc, "0.6.1"},
-        {jobs, "0.7.0"},
-        {exometer_core, "1.5.2"}
+        {jobs, "0.7.1"},
+        {exometer_core, "1.5.2"},
+        {poolboy, "1.5.1"}
        ]}.
 
 {relx, [{release, { epoch, "version value comes from VERSION" },

--- a/rebar.lock
+++ b/rebar.lock
@@ -21,7 +21,7 @@
   {git,"https://github.com/for-GET/jesse.git",
        {ref,"dd40e210216bdab96549bcd105410c4d1d93d248"}},
   0},
- {<<"jobs">>,{pkg,<<"jobs">>,<<"0.7.0">>},0},
+ {<<"jobs">>,{pkg,<<"jobs">>,<<"0.7.1">>},0},
  {<<"jsx">>,
   {git,"https://github.com/talentdeficit/jsx.git",
        {ref,"3074d4865b3385a050badf7828ad31490d860df5"}},
@@ -31,6 +31,7 @@
        {ref,"c3970a99131c7c73de7eba3c2a569806fe47e40a"}},
   0},
  {<<"parse_trans">>,{pkg,<<"parse_trans">>,<<"3.0.0">>},1},
+ {<<"poolboy">>,{pkg,<<"poolboy">>,<<"1.5.1">>},0},
  {<<"ranch">>,
   {git,"https://github.com/ninenines/ranch.git",
        {ref,"adf1822defc2b7cfdc7aca112adabfa1d614043c"}},
@@ -49,8 +50,9 @@
  {<<"goldrush">>, <<"F06E5D5F1277DA5C413E84D5A2924174182FB108DABB39D5EC548B27424CD106">>},
  {<<"gproc">>, <<"4579663E5677970758A05D8F65D13C3E9814EC707AD51D8DCEF7294EDA1A730C">>},
  {<<"hut">>, <<"0089DF0FAA2827C605BBADA88153F24FFF5EA7A4BE32ECF0250A7FDC2719CAFB">>},
- {<<"jobs">>, <<"7259401F88CB7590B0BDF1270C01FAE02EC2510C1F41055302407C5EFDA74214">>},
+ {<<"jobs">>, <<"132E4BED856CE774B008B31C1AA809C17FA6C2C20BE03E010ACE273CA057A5DE">>},
  {<<"parse_trans">>, <<"9E96B1C9C3A0DF54E7B76F8F685D38BFA1EB21B31E042B1D1A5A70258E4DB1E3">>},
+ {<<"poolboy">>, <<"6B46163901CFD0A1B43D692657ED9D7E599853B3B21B95AE5AE0A777CF9B6CA8">>},
  {<<"rocksdb">>, <<"CD59EE3B6CB33D0AF8C17126AD055420AD2A625C5AE50913619D4FA1ADD85D54">>},
  {<<"setup">>, <<"738DB0685DC1741F45C6A9BF78478E0D5877F3D0876C0B50FD02F0210EDB5AA4">>}]}
 ].


### PR DESCRIPTION
## Messages envelope format
As discussed we will be using the ws for pushing events. We are not going to use it for blocking calls, calls that change the state of the node and etc - for these we'd be using a Swagger generated HTTP API 
### Node sending messages
Broadcasting a new event to all connected websocket clients is done via
```
ws_handler:broadcast(miner, mined_block, [{height, aec_blocks:height(Block)}]).
```
Which results in the following message being send to all ws clients:
```
{"action":"mined_block","origin":"miner","payload":{"height":1}}}
```
This event is currently sent when a new block is mined.

### Client sending messages
Client can send messages through the websocket though the HTTP API would be better suited for this.
If there is no hadneling of the request or there are wrong parameters - there is no response of the request.
Currently there are a couple of requests the server: get header/block by height/hash
Example for getting block with height 1
```
{"action": "get", "target": "chain", "payload": {"type": "block", "height": 1}}
```
Example server's reponse
```
{"action":"requested_data","origin":"chain","payload":{"type":"block","height":1,"block":{"height":1,"nonce":976235507,"pow":[1653605,10024768,10259664,10296433,14584092,18669246,18851946,19040263,19495264,22554524,22813452,25573089,44480753,45966973,47356778,49115947,51174450,51709247,61296826,64386492,64536410,65050643,67241735,68227517,74170775,81261966,82207712,85159905,87140585,89998612,94965092,104072660,104799138,106586019,108240970,109104623,113489287,116937181,117456709,118036804,124884325,127722495],"prev_hash":"u7RpHLzlIZ4qqp+nBVgbR+9BPIla9hcnCd3Xv/H4vUc=","state_hash":"+Gkio7NWSEgKvF+9z1S6bqGQUTVnST5209wUn3lCgdU=","target":553713663,"time":1509476094472,"transactions":[{"data":{"nonce":0,"pubkey":"BBIybDBucGc4MjyXIh/kE7+3/KmNDULPst6WPJbR5cdfzq/I6Zq4QtNf8+9MMVV/MHcPT6cIWznIk455992mAr4="},"signatures":["MEQCIBEP5+bhE2M1ob367qATDuXRJHOhUvPVbWYIjxjaRNq3AiA9geEKD2OcVad9Xik2ekfQZnDGBq7kch1yjnxlmrdqCQ=="],"type":"coinbase"}],"txs_hash":"4rsKBhDvN0nSmv2mtEPUuCgUu0Su4dEFc4J9QrfUB/0=","version":1}}}
```

## Python tests
### Setup
In order to run the tests, you have to prepare the virtenv
```
make python-env
```
There is a default python ws test that relies that you have already `local` node started (on port 3014). It POC and runs indefinetly. You can start it:
```
make python-ws-test
```
it actually runs a python script with default parameters and you can run it by hand with different ones
```
./py/bin/python ./py/tests/ws_client.py --port 3014 --log INFO --handler ws_logic
```
Whrere you can set port, log level (DEBUG, INFO, WARNING, ERROR) and handler. The handler itself is the interesting part and it implements the test's logic. Having the logic of the client separated from the client itself will be usefull for us to have sevral different and independent clients and we could use it for building test applications.
The current python test upgrades its connection to a websocket one, then fetches the Genesis Block and Genesis Header. After that it starts waiting for a new block to be mined. When an event for that is received - it get's the block by its height. Example output:
```
make python-ws-test 
### opened ###
Getting GenesisBlock
<< {"action": "get", "target": "chain", "payload": {"type": "block", "height": 0}}
Getting GenesisHeader
<< {"action": "get", "target": "chain", "payload": {"type": "header", "height": 0}}
>> {"action":"requested_data","origin":"chain","payload":{"type":"block","height":0,"block":{"height":0,"nonce":0,"target":553713663,"time":0,"version":1}}}
Recieved data for block, requested by its height = 0
{u'nonce': 0, u'time': 0, u'target': 553713663, u'version': 1, u'height': 0}
>> {"action":"requested_data","origin":"chain","payload":{"type":"header","height":0,"header":{"height":0,"nonce":0,"target":553713663,"time":0,"version":1}}}
Recieved data for header, requested by its height = 0
{u'nonce': 0, u'time': 0, u'target': 553713663, u'version': 1, u'height': 0}
>> {"action":"mined_block","origin":"miner","payload":{"height":1}}
<< {"action": "get", "target": "chain", "payload": {"type": "block", "height": 1}}
>> {"action":"requested_data","origin":"chain","payload":{"type":"block","height":1,"block":{"height":1,"nonce":976235507,"pow":[1653605,10024768,10259664,10296433,14584092,18669246,18851946,19040263,19495264,22554524,22813452,25573089,44480753,45966973,47356778,49115947,51174450,51709247,61296826,64386492,64536410,65050643,67241735,68227517,74170775,81261966,82207712,85159905,87140585,89998612,94965092,104072660,104799138,106586019,108240970,109104623,113489287,116937181,117456709,118036804,124884325,127722495],"prev_hash":"u7RpHLzlIZ4qqp+nBVgbR+9BPIla9hcnCd3Xv/H4vUc=","state_hash":"+Gkio7NWSEgKvF+9z1S6bqGQUTVnST5209wUn3lCgdU=","target":553713663,"time":1509476094472,"transactions":[{"data":{"nonce":0,"pubkey":"BBIybDBucGc4MjyXIh/kE7+3/KmNDULPst6WPJbR5cdfzq/I6Zq4QtNf8+9MMVV/MHcPT6cIWznIk455992mAr4="},"signatures":["MEQCIBEP5+bhE2M1ob367qATDuXRJHOhUvPVbWYIjxjaRNq3AiA9geEKD2OcVad9Xik2ekfQZnDGBq7kch1yjnxlmrdqCQ=="],"type":"coinbase"}],"txs_hash":"4rsKBhDvN0nSmv2mtEPUuCgUu0Su4dEFc4J9QrfUB/0=","version":1}}}
Recieved data for block, requested by its height = 1
{u'nonce': 976235507, u'target': 553713663, u'transactions': [{u'type': u'coinbase', u'signatures': [u'MEQCIBEP5+bhE2M1ob367qATDuXRJHOhUvPVbWYIjxjaRNq3AiA9geEKD2OcVad9Xik2ekfQZnDGBq7kch1yjnxlmrdqCQ=='], u'data': {u'nonce': 0, u'pubkey': u'BBIybDBucGc4MjyXIh/kE7+3/KmNDULPst6WPJbR5cdfzq/I6Zq4QtNf8+9MMVV/MHcPT6cIWznIk455992mAr4='}}], u'pow': [1653605, 10024768, 10259664, 10296433, 14584092, 18669246, 18851946, 19040263, 19495264, 22554524, 22813452, 25573089, 44480753, 45966973, 47356778, 49115947, 51174450, 51709247, 61296826, 64386492, 64536410, 65050643, 67241735, 68227517, 74170775, 81261966, 82207712, 85159905, 87140585, 89998612, 94965092, 104072660, 104799138, 106586019, 108240970, 109104623, 113489287, 116937181, 117456709, 118036804, 124884325, 127722495], u'time': 1509476094472, u'height': 1, u'version': 1, u'txs_hash': u'4rsKBhDvN0nSmv2mtEPUuCgUu0Su4dEFc4J9QrfUB/0=', u'prev_hash': u'u7RpHLzlIZ4qqp+nBVgbR+9BPIla9hcnCd3Xv/H4vUc=', u'state_hash': u'+Gkio7NWSEgKvF+9z1S6bqGQUTVnST5209wUn3lCgdU='}



```