### PR TITLE
GH-17 Add received header and block validation

### DIFF
--- a/apps/aecore/include/blocks.hrl
+++ b/apps/aecore/include/blocks.hrl
@@ -1,12 +1,16 @@
 -include("trees.hrl").
 -include("pow.hrl").
 
+-define(PROTOCOL_VERSION, 1).
+
 -define(GENESIS_VERSION, 1).
 -define(GENESIS_HEIGHT, 0).
 
 -define(BLOCK_HEADER_HASH_BYTES, 32).
 -define(TXS_HASH_BYTES, 32).
 -define(STATE_HASH_BYTES, 32).
+
+-define(ACCEPTED_FUTURE_BLOCK_TIME_SHIFT, 30 * 60 * 1000). %% 30 min
 
 -type(block_header_hash() :: <<_:(?BLOCK_HEADER_HASH_BYTES*8)>>).
 -type(txs_hash() :: <<_:(?TXS_HASH_BYTES*8)>>).
@@ -22,7 +26,7 @@
           target = ?HIGHEST_TARGET_SCI :: aec_pow:sci_int(),
           nonce = 0               :: non_neg_integer(),
           time = 0                :: non_neg_integer(),
-          version = 0             :: non_neg_integer(),
+          version = ?PROTOCOL_VERSION :: non_neg_integer(),
           pow_evidence = no_value :: aec_pow:pow_evidence()}).
 -type(block() :: #block{}).
 
@@ -34,7 +38,7 @@
           target = ?HIGHEST_TARGET_SCI :: aec_pow:sci_int(),
           nonce = 0               :: non_neg_integer(),
           time = 0                :: non_neg_integer(),
-          version = 0             :: non_neg_integer(),
+          version = ?PROTOCOL_VERSION :: non_neg_integer(),
           pow_evidence = no_value :: aec_pow:pow_evidence()}).
 -type(header() :: #header{}).
 

--- a/apps/aecore/test/aec_headers_tests.erl
+++ b/apps/aecore/test/aec_headers_tests.erl
@@ -26,3 +26,35 @@ network_serialization_test() ->
 hash_test() ->
     Header = #header{},
     {ok, _HeaderHash} = ?TEST_MODULE:hash_header(Header).
+
+validate_test_() ->
+    {foreach,
+     fun() ->
+             meck:new(aec_pow_cuckoo, [passthrough]),
+             meck:new(aeu_time, [passthrough])
+     end,
+     fun(_) ->
+             meck:unload(aec_pow_cuckoo),
+             meck:unload(aeu_time)
+     end,
+     [fun() ->
+              Header = #header{version = 736},
+              ?assertEqual({error, protocol_version_mismatch}, ?TEST_MODULE:validate(Header))
+      end,
+      fun() ->
+              meck:expect(aec_pow_cuckoo, verify, 4, false),
+              Header = #header{},
+              ?assertEqual({error, incorrect_pow}, ?TEST_MODULE:validate(Header))
+      end,
+      fun() ->
+              meck:expect(aec_pow_cuckoo, verify, 4, true),
+              NowTime = 7592837461,
+              meck:expect(aeu_time, now_in_msecs, 0, NowTime),
+              Header = #header{time = 2 * NowTime},
+              ?assertEqual({error, block_from_the_future}, ?TEST_MODULE:validate(Header))
+      end,
+      fun() ->
+              meck:expect(aec_pow_cuckoo, verify, 4, true),
+              Header = #header{},
+              ?assertEqual(ok, ?TEST_MODULE:validate(Header))
+      end]}.

--- a/apps/aeutils/src/aeu_validation.erl
+++ b/apps/aeutils/src/aeu_validation.erl
@@ -1,0 +1,13 @@
+-module(aeu_validation).
+
+-export([run/2]).
+
+run([], _Arg) ->
+    ok;
+run([F | Rest], Arg) ->
+    case F(Arg) of
+        ok ->
+            run(Rest, Arg);
+        {error, _Reason} = Error ->
+            Error
+    end.

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -128,6 +128,10 @@ paths:
       responses:
         '200':
           description: successful operation
+        '400':
+          description: Block or header validation error
+          schema:
+            $ref: '#/definitions/Error'
       security: []
   /account/balance:
     get:


### PR DESCRIPTION
* This does not include "state digest" listed out in https://github.com/aeternity/epoch/issues/17, as state is transformed only whenever a block is appended to the chain, hence we cannot do that when receiving a block (e.g. block may land in a pool to wait for its predecessors in the chain)
* `aec_headers:validate(Header)` and `aec_blocks:validate(Block)` are hooked up into `aehttp_dispatch_ext.erl`, but are planned to be moved from it whenever logic is moved out of the http dispatcher
* Closes https://github.com/aeternity/epoch/issues/60
