### PR TITLE
Wrap aecore EUnit tests as CT suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ before_install:
   - if test osx = "${TRAVIS_OS_NAME:?}"; then export HOMEBREW_CACHE="$HOME/Library/Caches/Homebrew"; fi
   - if test osx = "${TRAVIS_OS_NAME:?}"; then brew update; fi
   - if test osx = "${TRAVIS_OS_NAME:?}"; then brew install erlang && export PATH="$(brew --prefix erlang)"/bin:"$PATH"; fi
+  - if test osx = "${TRAVIS_OS_NAME:?}"; then brew install lynx && export PATH="$(brew --prefix lynx)"/bin:"$PATH"; fi
+  - if test linux = "${TRAVIS_OS_NAME:?}"; then sudo apt-get -y install lynx; fi
   - erl -version
   - epmd -daemon
   - ./ci before_install "${JOB:?}" "${TRAVIS_BUILD_DIR:?}"

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ dialyzer:
 	@./rebar3 dialyzer
 
 test:
-	@./rebar3 do eunit,ct
+	@./rebar3 do ct
 
 venv-present:
 	@virtualenv -q $(PYTHON_DIR)

--- a/apps/aecore/c_src/aec_pow_cuckoo_nif.cpp
+++ b/apps/aecore/c_src/aec_pow_cuckoo_nif.cpp
@@ -97,7 +97,27 @@ static ErlNifFunc nif_funcs[] = {
   {"get_node_size",   0, get_node_size_nif,   0}
 };
 
-ERL_NIF_INIT(aec_pow_cuckoo, nif_funcs, NULL, NULL, NULL, NULL);
+static int on_load(ErlNifEnv* env, void** priv_data, ERL_NIF_TERM load_info) {
+  // *priv_data is documented to be initialized to NULL when this
+  // *function is called.
+
+  // No private data to initialize.
+  return 0;
+}
+
+static int on_upgrade(ErlNifEnv* env, void** priv_data, void** old_priv_data, ERL_NIF_TERM load_info) {
+  // *priv_data is initialized to NULL when this function is called.
+
+  // No private data to convert to a new version.
+  // *priv_data = *old_priv_data;
+  return 0;
+}
+
+static void on_unload(ErlNifEnv* env, void* priv_data) {
+  // Nothing to do.
+}
+
+ERL_NIF_INIT(aec_pow_cuckoo, nif_funcs, &on_load, NULL, &on_upgrade, &on_unload);
 
 ///=============================================================================
 /// Internal functions

--- a/apps/aecore/test/aec_eunit_SUITE.erl
+++ b/apps/aecore/test/aec_eunit_SUITE.erl
@@ -1,0 +1,38 @@
+-module(aec_eunit_SUITE).
+
+-export([all/0, groups/0, suite/0,
+         init_per_suite/1, end_per_suite/1,
+         init_per_group/2, end_per_group/2,
+         init_per_testcase/2, end_per_testcase/2
+        ]).
+
+-include_lib("common_test/include/ct.hrl").
+-compile({parse_transform, ct_eunit_xform}).
+
+all() ->
+    [{group, eunit}].
+
+groups() ->
+    [].
+
+suite() ->
+    [].
+
+init_per_suite(Config) ->
+    eunit:start(),
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+init_per_group(_Grp, Config) ->
+    Config.
+
+end_per_group(_Grp, _Config) ->
+    ok.
+
+init_per_testcase(_TC, Config) ->
+    Config.
+
+end_per_testcase(_TC, _Config) ->
+    ok.

--- a/apps/aecore/test/ct_eunit_xform.erl
+++ b/apps/aecore/test/ct_eunit_xform.erl
@@ -29,7 +29,7 @@ parse_transform(Forms, Opts) ->
     parse_trans:optionally_pretty_print(Res, Opts, Ctxt),
     Res.
 
-xform({function,_,groups,0,_} = Form, AllMods) ->
+xform({function,_,groups,0,_}, AllMods) ->
     {done, {function,?LINE,groups,0,
             [{clause, ?LINE, [], [],
               [erl_parse:abstract(
@@ -43,8 +43,10 @@ xform(F, _) ->
 add_functions(AllMods) ->
     [{function,?LINE,M,1,
       [{clause,?LINE,[{var,?LINE,'_Config'}],[],
-        [{call,?LINE,{remote,?LINE,{atom,?LINE,eunit},{atom,?LINE,test}},
-          [{atom,?LINE,M}]}]
+        [{match, ?LINE,
+          {atom, ?LINE, ok},
+          {call,?LINE,{remote,?LINE,{atom,?LINE,eunit},{atom,?LINE,test}},
+          [{atom,?LINE,M}]}}]
        }]
      } || {M, _} <- AllMods].
 

--- a/apps/aecore/test/ct_eunit_xform.erl
+++ b/apps/aecore/test/ct_eunit_xform.erl
@@ -1,0 +1,90 @@
+-module(ct_eunit_xform).
+
+-export([parse_transform/2]).
+
+
+parse_transform(Forms, Opts) ->
+    Ctxt = parse_trans:initial_context(Forms, Opts),
+    [Mod] = [M || {attribute,_,module,M} <- Forms],
+    F = atom_to_list(Mod) ++ ".erl",
+    [Fullname|_] = [Fn || {attribute,_,file,{Fn,_}} <- Forms,
+                          filename:basename(Fn) == F],
+    Dir = filename:dirname(Fullname),
+    AllMods = all_mods(Dir),
+    NewForms =
+        parse_trans:plain_transform(fun(Form) ->
+                                            xform(Form, AllMods)
+                                    end, Forms),
+    Res = parse_trans:do_insert_forms(
+            above,
+            [{attribute,?LINE,pt_pp_src,true},
+             {attribute,?LINE,export,
+              [{M,1} || {M,_} <- AllMods]}],
+            parse_trans:do_insert_forms(
+              below,
+              add_functions(AllMods),
+              NewForms,
+              Ctxt),
+            Ctxt),
+    parse_trans:optionally_pretty_print(Res, Opts, Ctxt),
+    Res.
+
+xform({function,_,groups,0,_} = Form, AllMods) ->
+    {done, {function,?LINE,groups,0,
+            [{clause, ?LINE, [], [],
+              [erl_parse:abstract(
+                 [{eunit,
+                   [M || {M, _Fs} <- AllMods]}], [{line, ?LINE}])]}
+            ]}
+    };
+xform(F, _) ->
+    F.
+
+add_functions(AllMods) ->
+    [{function,?LINE,M,1,
+      [{clause,?LINE,[{var,?LINE,'_Config'}],[],
+        [{call,?LINE,{remote,?LINE,{atom,?LINE,eunit},{atom,?LINE,test}},
+          [{atom,?LINE,M}]}]
+       }]
+     } || {M, _} <- AllMods].
+
+all_mods(Dir) ->
+  filelib:fold_files(
+    Dir, ".*_tests\\.beam", false,
+    fun(F, Acc) ->
+            case get_eunit_tests(F) of
+                {ok, Mod, Tests} ->
+                    [{Mod, Tests}|Acc];
+                error ->
+                    Acc
+            end
+    end, []).
+
+get_eunit_tests(F) ->
+    case beam_lib:chunks(F, [imports, exports]) of
+        {ok, {Mod, Chunks}} ->
+            case lists:member({eunit, test, 1},
+                              proplists:get_value(imports, Chunks, [])) of
+                true ->
+                    Exports = proplists:get_value(exports, Chunks, []),
+                    case [F1 || {F1, 0} <- Exports,
+                                is_test_f(F1)] of
+                        [] ->
+                            error;
+                        [_|_] = Fs ->
+                            {ok, Mod, Fs}
+                    end;
+                false ->
+                    error
+            end;
+        _ ->
+            error
+    end.
+
+is_test_f(F) ->
+    case re:run(atom_to_list(F), ".+_test_?$", []) of
+        {match,_} ->
+            true;
+        nomatch ->
+            false
+    end.

--- a/ci
+++ b/ci
@@ -68,6 +68,14 @@ case "${1:?}"-"${2:?}" in
         for F in "${BuildDir:?}"/_build/{prod,local}/rel/epoch/log/*; do echo "${F:?}"; cat "${F:?}"; echo; done
         ;;
     after_failure-*)
-        true
+        BuildDir="${3:?}"
+        LogsDir="${BuildDir}/_build/test/logs"
+        lynx -dump ${LogsDir}/index.html
+        echo "logs/ct.latest.log\n"
+        cat ${LogsDir}/ct.latest.log
+        for f in `ls -1 ${LogsDir}/ct_run*/*.logs/run*/suite.log.html`; do echo \"\"; echo \"$f:\"; lynx -dump $f; done
+        for f in `ls ${BuildDir}/_build/dev*/rel/epoch/log/erlang.log.*`; do echo \"\"; echo \"$f:\"; echo \"\"; cat $f; done
+        for f in `ls ${BuildDir}/_build/dev*/rel/epoch/log/epoch.log`; do echo \"\"; echo \"$f:\"; echo \"\"; cat $f; done
+        for f in `ls ${BuildDir}/_build/dev*/rel/epoch/log/crash.log`; do echo \"\"; echo \"$f:\"; echo \"\"; cat $f; done
         ;;
 esac


### PR DESCRIPTION
A parse transform locates EUnit tests and fills in a Common Test skeleton suite.

This seems to fix some of the cleanup issues with EUnit, as well as give better overview of the outcome.

TODO: add some lines in `.travis.yml` to fetch CT info if the test fails. [This](https://github.com/GENIVI/rvi_core/blob/develop/.travis.yml) might serve as inspiration.