### PR TITLE
[WIP] Support upgrade in NIF library for Cuckoo miner

### DIFF
--- a/apps/aecore/c_src/aec_pow_cuckoo_nif.cpp
+++ b/apps/aecore/c_src/aec_pow_cuckoo_nif.cpp
@@ -97,7 +97,27 @@ static ErlNifFunc nif_funcs[] = {
   {"get_node_size",   0, get_node_size_nif,   0}
 };
 
-ERL_NIF_INIT(aec_pow_cuckoo, nif_funcs, NULL, NULL, NULL, NULL);
+static int on_load(ErlNifEnv* env, void** priv_data, ERL_NIF_TERM load_info) {
+  // *priv_data is documented to be initialized to NULL when this
+  // *function is called.
+
+  // No private data to initialize.
+  return 0;
+}
+
+static int on_upgrade(ErlNifEnv* env, void** priv_data, void** old_priv_data, ERL_NIF_TERM load_info) {
+  // *priv_data is initialized to NULL when this function is called.
+
+  // No private data to convert to a new version.
+  // *priv_data = *old_priv_data;
+  return 0;
+}
+
+static void on_unload(ErlNifEnv* env, void* priv_data) {
+  // Nothing to do.
+}
+
+ERL_NIF_INIT(aec_pow_cuckoo, nif_funcs, &on_load, NULL, &on_upgrade, &on_unload);
 
 ///=============================================================================
 /// Internal functions


### PR DESCRIPTION
Please refer to commit message for details.

----

Having fixed the NIF upgrade error, the [CI now fails with a new error](https://travis-ci.org/aeternity/epoch/jobs/295794988#L1321):
```
...
%%% aecore_sync_SUITE ==> start_first_node: OK

%%% aecore_sync_SUITE ==> mine_on_first (group two_nodes): FAILED

%%% aecore_sync_SUITE ==> {{badmatch,

     {badrpc,{'EXIT',{noproc,{gen_statem,call,[aec_miner,start,infinity]}}}}},

 [{aecore_sync_SUITE,mine_one_block,1,

      [{file,

           "/home/travis/build/aeternity/epoch/_build/test/lib/aecore/test/aecore_sync_SUITE.erl"},

       {line,195}]},

  {aecore_sync_SUITE,mine_on_first,1,

      [{file,

           "/home/travis/build/aeternity/epoch/_build/test/lib/aecore/test/aecore_sync_SUITE.erl"},

       {line,111}]},

  {test_server,ts_tc,3,[{file,"test_server.erl"},{line,1529}]},

  {test_server,run_test_case_eval1,6,[{file,"test_server.erl"},{line,1045}]},

  {test_server,run_test_case_eval,9,[{file,"test_server.erl"},{line,977}]}]}

%%% aecore_sync_SUITE ==> start_second_node: OK
...
```

Based on conversation with @uwiger , it may be related to one-shot mining. Cc @happi 

Also, this may be an intermittent test failure.