### PR TITLE
Gh 185 spend transaction

### DIFF
--- a/apps/aecore/include/txs.hrl
+++ b/apps/aecore/include/txs.hrl
@@ -7,8 +7,7 @@
 %% Basic transactions
 
 -record(coinbase_tx, {
-          account = <<>> :: pubkey(),
-          nonce = 0      :: non_neg_integer()}).
+          account = <<>> :: pubkey()}).
 -type(coinbase_tx() :: #coinbase_tx{}).
 
 -record(spend_tx, {

--- a/apps/aecore/include/txs.hrl
+++ b/apps/aecore/include/txs.hrl
@@ -11,8 +11,8 @@
 -type(coinbase_tx() :: #coinbase_tx{}).
 
 -record(spend_tx, {
-          from = <<>> :: pubkey(),
-          to = <<>>   :: pubkey(),
+          sender = <<>> :: pubkey(),
+          recipient = <<>> :: pubkey(),
           amount = 0  :: non_neg_integer(),
           fee = 0     :: non_neg_integer(),
           nonce = 0   :: non_neg_integer()}).

--- a/apps/aecore/src/aec_accounts.erl
+++ b/apps/aecore/src/aec_accounts.erl
@@ -7,6 +7,7 @@
          get_with_proof/2,
          put/2,
          earn/3,
+         spend/3,
          root_hash/1,
          verify_proof/3]).
 
@@ -48,6 +49,11 @@ put(Account, AccountsTree) ->
 
 earn(#account{balance = Balance0} = Account0, Amount, Height) ->
     {ok, Account0#account{balance = Balance0 + Amount,
+                          height = Height}}.
+
+spend(#account{balance = Balance0, nonce = Nonce} = Account0, Amount, Height) ->
+    {ok, Account0#account{balance = Balance0 - Amount,
+                          nonce = Nonce,
                           height = Height}}.
 
 root_hash(AccountsTree) ->

--- a/apps/aecore/src/aec_blocks.erl
+++ b/apps/aecore/src/aec_blocks.erl
@@ -218,7 +218,7 @@ hash_internal_representation(B = #block{}) ->
 validate(Block) ->
     Validators = [fun validate_coinbase_txs_count/1,
                   fun validate_txs_hash/1],
-    aeu_validation:run(Validators, Block).
+    aeu_validation:run(Validators, [Block]).
 
 -spec validate_coinbase_txs_count(block()) -> ok | {error, multiple_coinbase_txs}.
 validate_coinbase_txs_count(#block{txs = Txs}) ->

--- a/apps/aecore/src/aec_governance.erl
+++ b/apps/aecore/src/aec_governance.erl
@@ -4,7 +4,8 @@
 -export([recalculate_difficulty_frequency/0,
          expected_block_mine_rate/0,
          block_mine_reward/0,
-         max_txs_in_block/0]).
+         max_txs_in_block/0,
+         minimum_tx_fee/0]).
 
 -define(RECALCULATE_DIFFICULTY_FREQUENCY, 10).
 -define(EXPECTED_BLOCK_MINE_RATE, 300). %% 60secs * 5 = 300secs
@@ -26,3 +27,6 @@ block_mine_reward() ->
 max_txs_in_block() ->
     %% TODO Review considering block size and different size of signed transactions.
     10.
+
+minimum_tx_fee() ->
+    1.

--- a/apps/aecore/src/aec_headers.erl
+++ b/apps/aecore/src/aec_headers.erl
@@ -203,7 +203,7 @@ validate(Header) ->
     Validators = [fun validate_version/1,
                   fun validate_pow/1,
                   fun validate_time/1],
-    aeu_validation:run(Validators, Header).
+    aeu_validation:run(Validators, [Header]).
 
 -spec validate_version(header()) -> ok | {error, protocol_version_mismatch}.
 validate_version(#header{version = ?PROTOCOL_VERSION}) ->

--- a/apps/aecore/src/txs/aec_coinbase_tx.erl
+++ b/apps/aecore/src/txs/aec_coinbase_tx.erl
@@ -24,7 +24,7 @@ check(#coinbase_tx{account = AccountPubkey}, Trees0, Height) ->
     case aec_tx_common:ensure_account_at_height(AccountPubkey, Trees0, Height) of
         {ok, Trees} ->
             {ok, Trees};
-        {error, account_height_too_far} = Error ->
+        {error, account_height_too_big} = Error ->
             Error
     end.
 

--- a/apps/aecore/src/txs/aec_spend_tx.erl
+++ b/apps/aecore/src/txs/aec_spend_tx.erl
@@ -1,0 +1,158 @@
+-module(aec_spend_tx).
+
+%% API
+-export([new/2,
+         check/3,
+         process/3,
+         serialize/1,
+         deserialize/1,
+         type/0]).
+
+-behavior(aec_tx).
+
+-include("common.hrl").
+-include("trees.hrl").
+-include("txs.hrl").
+
+-spec new(map(), trees()) -> {ok, spend_tx()} | {error, sender_account_not_found}.
+new(#{sender := SenderPubkey,
+      recipient := RecipientPubkey,
+      amount := Amount,
+      fee := Fee}, Trees) ->
+    AccountsTrees = aec_trees:accounts(Trees),
+    case aec_accounts:get(SenderPubkey, AccountsTrees) of
+        {ok, #account{nonce = CurrentSenderNonce}} ->
+            {ok, #spend_tx{sender = SenderPubkey,
+                           recipient = RecipientPubkey,
+                           amount = Amount,
+                           fee = Fee,
+                           nonce = CurrentSenderNonce + 1}};
+        {error, notfound} ->
+            {error, sender_account_not_found}
+    end.
+
+-spec check(spend_tx(), trees(), height()) -> {ok, trees()} | {error, term()}.
+check(#spend_tx{recipient = RecipientPubkey} = SpendTx, Trees0, Height) ->
+    Checks = [fun check_tx_fee/3,
+              fun check_sender_account/3],
+    case aeu_validation:run(Checks, [SpendTx, Trees0, Height]) of
+        ok ->
+            case aec_tx_common:ensure_account_at_height(RecipientPubkey, Trees0, Height) of
+                {ok, Trees} ->
+                    {ok, Trees};
+                {error, account_height_too_big} ->
+                    {error, recipient_account_height_too_big}
+            end;
+        {error, _Reason} = Error ->
+            Error
+    end.
+
+-spec process(spend_tx(), trees(), height()) -> {ok, trees()}.
+process(#spend_tx{sender = SenderPubkey,
+                  recipient = RecipientPubkey,
+                  amount = Amount}, Trees0, Height) ->
+    AccountsTrees0 = aec_trees:accounts(Trees0),
+
+    {ok, SenderAccount0} = aec_accounts:get(SenderPubkey, AccountsTrees0),
+    {ok, RecipientAccount0} = aec_accounts:get(RecipientPubkey, AccountsTrees0),
+
+    {ok, SenderAccount} = aec_accounts:spend(SenderAccount0, Amount, Height),
+    {ok, RecipientAccount} = aec_accounts:earn(RecipientAccount0, Amount, Height),
+
+    {ok, AccountsTrees1} = aec_accounts:put(SenderAccount, AccountsTrees0),
+    {ok, AccountsTrees2} = aec_accounts:put(RecipientAccount, AccountsTrees1),
+
+    Trees = aec_trees:set_accounts(Trees0, AccountsTrees2),
+    {ok, Trees}.
+
+-define(SPEND_TX_TYPE, <<"spend">>).
+-define(SPEND_TX_VSN, 1).
+
+serialize(#spend_tx{sender = Sender,
+                    recipient = Recipient,
+                    amount = Amount,
+                    fee = Fee,
+                    nonce = Nonce}) ->
+    [#{<<"type">> => type()}, #{<<"vsn">> => version()},
+     #{<<"sender">> => Sender,
+       <<"recipient">> => Recipient,
+       <<"amount">> => Amount,
+       <<"fee">> => Fee,
+       <<"nonce">> => Nonce}].
+
+deserialize([#{<<"type">> := ?SPEND_TX_TYPE},
+             #{<<"vsn">>  := ?SPEND_TX_VSN},
+             #{<<"sender">> := Sender,
+               <<"recipient">> := Recipient,
+               <<"amount">> := Amount,
+               <<"fee">> := Fee,
+               <<"nonce">> := Nonce}]) ->
+    #spend_tx{sender = Sender,
+              recipient = Recipient,
+              amount = Amount,
+              fee = Fee,
+              nonce = Nonce}.
+
+-spec type() -> binary().
+type() ->
+    ?SPEND_TX_TYPE.
+
+version() ->
+    ?SPEND_TX_VSN.
+
+%% Internals
+
+-spec check_tx_fee(spend_tx(), trees(), height()) ->
+                          ok | {error, too_low_fee}.
+check_tx_fee(#spend_tx{fee = Fee}, _Trees, _Height) ->
+    case Fee >= aec_governance:minimum_tx_fee() of
+        true ->
+            ok;
+        false ->
+            {error, too_low_fee}
+    end.
+
+-spec check_sender_account(spend_tx(), trees(), height()) ->
+                                  ok | {error, term()}.
+check_sender_account(#spend_tx{sender = SenderPubkey} = SpendTx, Trees, Height) ->
+    AccountsTrees = aec_trees:accounts(Trees),
+    case aec_accounts:get(SenderPubkey, AccountsTrees) of
+        {ok, #account{} = Account} ->
+            Checks = [fun check_balance/3,
+                      fun check_nonce/3,
+                      fun check_height/3],
+            aeu_validation:run(Checks, [SpendTx, Account, Height]);
+        {error, notfound} ->
+            {error, sender_account_not_found}
+    end.
+
+-spec check_balance(spend_tx(), account(), height()) ->
+                           ok | {error, insufficient_funds}.
+check_balance(#spend_tx{amount = Amount, fee = Fee},
+              #account{balance = Balance}, _Height) ->
+    case Balance >= Amount + Fee of
+        true ->
+            ok;
+        false ->
+            {error, insufficient_funds}
+    end.
+
+-spec check_nonce(spend_tx(), account(), height()) ->
+                         ok | {error, account_nonce_too_high}.
+check_nonce(#spend_tx{nonce = TxNonce}, #account{nonce = SenderNonce}, _Height) ->
+    case TxNonce > SenderNonce of
+        true ->
+            ok;
+        false ->
+            {error, account_nonce_too_high}
+    end.
+
+-spec check_height(spend_tx(), account(), height()) ->
+                          ok | {error, account_height_too_big}.
+check_height(_SpendTx, #account{height = AccountCurrentHeight}, Height) ->
+    case AccountCurrentHeight =< Height of
+        true ->
+            ok;
+        false ->
+            {error, sender_account_height_too_big}
+    end.

--- a/apps/aecore/src/txs/aec_tx.erl
+++ b/apps/aecore/src/txs/aec_tx.erl
@@ -13,7 +13,7 @@
 %%%=============================================================================
 
 -callback new(Args :: map(), Trees :: trees()) ->
-    {ok, Tx :: term()}.
+    {ok, Tx :: term()} | {error, Reason :: term()}.
 
 -callback check(Tx :: term(), Trees :: trees(), Height :: non_neg_integer()) ->
     {ok, NewTrees :: trees()} | {error, Reason :: term()}.
@@ -21,9 +21,12 @@
 -callback process(Tx :: term(), Trees :: trees(), Height :: non_neg_integer()) ->
     {ok, NewTrees :: trees()}.
 
--callback serialize(Tx :: term()) -> map().
 
--callback deserialize(map()) -> Tx :: term().
+%% Relax type spec for now to have different spec in coinbase/spend
+-callback serialize(Tx :: term()) -> term().
+
+%% Relax type spec for now to have different spec in coinbase/spend
+-callback deserialize(term()) -> Tx :: term().
 
 -callback type() -> binary().
 
@@ -31,6 +34,8 @@
 %% API
 %%%=============================================================================
 
+fee(#coinbase_tx{}) ->
+    0;
 fee(#spend_tx{fee = F}) ->
     F.
 

--- a/apps/aecore/src/txs/aec_tx_common.erl
+++ b/apps/aecore/src/txs/aec_tx_common.erl
@@ -1,0 +1,26 @@
+-module(aec_tx_common).
+
+-export([ensure_account_at_height/3]).
+
+-include("common.hrl").
+-include("trees.hrl").
+
+-spec ensure_account_at_height(pubkey(), trees(), height()) ->
+                                   {ok, trees()} | {error, account_height_too_far}.
+ensure_account_at_height(AccountPubkey, Trees0, Height) ->
+    AccountsTrees0 = aec_trees:accounts(Trees0),
+    case aec_accounts:get(AccountPubkey, AccountsTrees0) of
+        {ok, #account{height = AccountCurrentHeight}} ->
+            case AccountCurrentHeight =< Height of
+                true ->
+                    {ok, Trees0};
+                false ->
+                    {error, account_height_too_far}
+            end;
+        {error, notfound} ->
+            %% Add newly referenced account (w/0 amount) to the state
+            Account = aec_accounts:new(AccountPubkey, 0, Height),
+            {ok, AccountsTrees} = aec_accounts:put(Account, AccountsTrees0),
+            Trees = aec_trees:set_accounts(Trees0, AccountsTrees),
+            {ok, Trees}
+    end.

--- a/apps/aecore/src/txs/aec_tx_common.erl
+++ b/apps/aecore/src/txs/aec_tx_common.erl
@@ -6,7 +6,7 @@
 -include("trees.hrl").
 
 -spec ensure_account_at_height(pubkey(), trees(), height()) ->
-                                   {ok, trees()} | {error, account_height_too_far}.
+                                   {ok, trees()} | {error, account_height_too_big}.
 ensure_account_at_height(AccountPubkey, Trees0, Height) ->
     AccountsTrees0 = aec_trees:accounts(Trees0),
     case aec_accounts:get(AccountPubkey, AccountsTrees0) of
@@ -15,7 +15,7 @@ ensure_account_at_height(AccountPubkey, Trees0, Height) ->
                 true ->
                     {ok, Trees0};
                 false ->
-                    {error, account_height_too_far}
+                    {error, account_height_too_big}
             end;
         {error, notfound} ->
             %% Add newly referenced account (w/0 amount) to the state

--- a/apps/aecore/src/txs/tx_dispatcher.erl
+++ b/apps/aecore/src/txs/tx_dispatcher.erl
@@ -1,8 +1,7 @@
 -module(tx_dispatcher).
 -export([handler/1,handler_by_type/1]).
 -type pubkey() :: binary().
--record(coinbase_tx,{account = <<>> :: pubkey(),
-                     nonce = 0 :: non_neg_integer()}).
+-record(coinbase_tx,{account = <<>> :: pubkey()}).
 handler(#coinbase_tx{}) ->
     aec_coinbase_tx.
 handler_by_type(<<"coinbase">>) ->

--- a/apps/aecore/src/txs/tx_dispatcher.erl
+++ b/apps/aecore/src/txs/tx_dispatcher.erl
@@ -1,8 +1,16 @@
 -module(tx_dispatcher).
--export([handler/1,handler_by_type/1]).
--type pubkey() :: binary().
--record(coinbase_tx,{account = <<>> :: pubkey()}).
+-export([handler/1,
+         handler_by_type/1]).
+
+-include("common.hrl").
+-include("txs.hrl").
+
 handler(#coinbase_tx{}) ->
-    aec_coinbase_tx.
+    aec_coinbase_tx;
+handler(#spend_tx{}) ->
+    aec_spend_tx.
+
 handler_by_type(<<"coinbase">>) ->
-    aec_coinbase_tx.
+    aec_coinbase_tx;
+handler_by_type(<<"spend">>) ->
+    aec_spend_tx.

--- a/apps/aecore/test/aec_blocks_tests.erl
+++ b/apps/aecore/test/aec_blocks_tests.erl
@@ -65,7 +65,7 @@ validate_test_() ->
      fun() ->
              SignedCoinbase = #signed_tx{data = #coinbase_tx{}},
              CorrectTxs = [SignedCoinbase],
-             MalformedTxs = [SignedCoinbase, #signed_tx{data = #coinbase_tx{nonce = 123}}],
+             MalformedTxs = [SignedCoinbase, #signed_tx{data = #coinbase_tx{account = <<"malformed_account">>}}],
              {ok, MalformedTree} = aec_txs_trees:new(MalformedTxs),
              {ok, MalformedRootHash} = aec_txs_trees:root_hash(MalformedTree),
              Block = #block{txs = CorrectTxs, txs_hash = MalformedRootHash},

--- a/apps/aecore/test/aec_coinbase_tx_tests.erl
+++ b/apps/aecore/test/aec_coinbase_tx_tests.erl
@@ -34,6 +34,14 @@ coinbase_tx_existing_account_test_() ->
                end}
       end,
       fun({PubKey, Trees0}) ->
+              {"Check coinbase trx with existing account, but with too high height",
+               fun() ->
+                       {ok, CoinbaseTx} = aec_coinbase_tx:new(#{account => PubKey}, Trees0),
+                       ?assertEqual({error, account_height_too_big},
+                                    aec_coinbase_tx:check(CoinbaseTx, Trees0, 3))
+               end}
+      end,
+      fun({PubKey, Trees0}) ->
               {"Process coinbase trx with existing account",
                fun() ->
                        {ok, CoinbaseTx} = aec_coinbase_tx:new(#{account => PubKey}, Trees0),

--- a/apps/aecore/test/aec_mining_tests.erl
+++ b/apps/aecore/test/aec_mining_tests.erl
@@ -59,8 +59,7 @@ mine_block_test_() ->
                  meck:expect(aec_tx, apply_signed, 3, {ok, Trees}),
                  meck:expect(aec_keys, pubkey, 0, {ok, ?TEST_PUB}),
                  meck:expect(aec_keys, sign, 1,
-                             {ok, #signed_tx{data = #coinbase_tx{account = <<"pubkey">>,
-                                                                 nonce = 1},
+                             {ok, #signed_tx{data = #coinbase_tx{account = <<"pubkey">>},
                                              signatures = [<<"sig1">>]}}),
 
                  {ok, BlockCandidate, InitialNonce, MaxNonce} = ?TEST_MODULE:create_block_candidate(),
@@ -80,8 +79,7 @@ mine_block_test_() ->
                  meck:expect(aec_tx, apply_signed, 3, {ok, Trees}),
                  meck:expect(aec_keys, pubkey, 0, {ok, ?TEST_PUB}),
                  meck:expect(aec_keys, sign, 1,
-                             {ok, #signed_tx{data = #coinbase_tx{account = <<"pubkey">>,
-                                                                 nonce = 1},
+                             {ok, #signed_tx{data = #coinbase_tx{account = <<"pubkey">>},
                                              signatures = [<<"sig1">>]}}),
 
                  {ok, BlockCandidate, InitialNonce, MaxNonce} = ?TEST_MODULE:create_block_candidate(),
@@ -99,8 +97,7 @@ mine_block_test_() ->
                  meck:expect(aec_tx, apply_signed, 3, {ok, Trees}),
                  meck:expect(aec_keys, pubkey, 0, {ok, ?TEST_PUB}),
                  meck:expect(aec_keys, sign, 1,
-                             {ok, #signed_tx{data = #coinbase_tx{account = <<"pubkey">>,
-                                                                 nonce = 1},
+                             {ok, #signed_tx{data = #coinbase_tx{account = <<"pubkey">>},
                                              signatures = [<<"sig1">>]}}),
 
                  {ok, BlockCandidate, InitialNonce, MaxNonce} = ?TEST_MODULE:create_block_candidate(),
@@ -113,8 +110,7 @@ mine_block_test_() ->
                 meck:expect(aec_tx, apply_signed, 3, {error, tx_failed}),
                 meck:expect(aec_keys, pubkey, 0, {ok, ?TEST_PUB}),
                 meck:expect(aec_keys, sign, 1,
-                            {ok, #signed_tx{data = #coinbase_tx{account = <<"pubkey">>,
-                                                                nonce = 1},
+                            {ok, #signed_tx{data = #coinbase_tx{account = <<"pubkey">>},
                                             signatures = [<<"sig1">>]}}),
                 ?assertEqual({error, tx_failed}, ?TEST_MODULE:create_block_candidate())
         end},
@@ -139,8 +135,7 @@ mine_block_test_() ->
                  meck:expect(aec_governance, expected_block_mine_rate, 0, 5),
                  meck:expect(aec_keys, pubkey, 0, {ok, ?TEST_PUB}),
                  meck:expect(aec_keys, sign, 1,
-                             {ok, #signed_tx{data = #coinbase_tx{account = <<"pubkey">>,
-                                                                 nonce = 1},
+                             {ok, #signed_tx{data = #coinbase_tx{account = <<"pubkey">>},
                                              signatures = [<<"sig1">>]}}),
 
                  {ok, BlockCandidate, InitialNonce, MaxNonce} = ?TEST_MODULE:create_block_candidate(),
@@ -188,8 +183,7 @@ mine_block_test_() ->
                  meck:expect(aec_governance, expected_block_mine_rate, 0, 100000),
                  meck:expect(aec_keys, pubkey, 0, {ok, ?TEST_PUB}),
                  meck:expect(aec_keys, sign, 1,
-                             {ok, #signed_tx{data = #coinbase_tx{account = <<"pubkey">>,
-                                                                 nonce = 1},
+                             {ok, #signed_tx{data = #coinbase_tx{account = <<"pubkey">>},
                                              signatures = [<<"sig1">>]}}),
 
                  {ok, BlockCandidate, InitialNonce, MaxNonce} = ?TEST_MODULE:create_block_candidate(),

--- a/apps/aecore/test/aec_spend_tx_tests.erl
+++ b/apps/aecore/test/aec_spend_tx_tests.erl
@@ -1,0 +1,99 @@
+-module(aec_spend_tx_tests).
+
+
+-include_lib("eunit/include/eunit.hrl").
+
+-include("common.hrl").
+-include("blocks.hrl").
+-include("txs.hrl").
+
+-define(TEST_MODULE, aec_spend_tx).
+
+-define(SENDER_PUBKEY, <<"sender_pubkey">>).
+-define(RECIPIENT_PUBKEY, <<"recipient_pubkey">>).
+
+check_test_() ->
+    [{"Tx fee lower than minimum fee defined in governance",
+      fun() ->
+              SpendTx = #spend_tx{fee = 0}, %% minimum governance fee = 1
+              ?assertEqual({error, too_low_fee},
+                           ?TEST_MODULE:check(SpendTx, #trees{}, 10))
+      end},
+     {"Sender account does not exist in state trees",
+      fun() ->
+              SpendTx = #spend_tx{fee = 10},
+              StateTree = create_state_tree(),
+              ?assertEqual({error, sender_account_not_found},
+                           ?TEST_MODULE:check(SpendTx, StateTree, 10))
+      end},
+     {"Sender account has insufficient funds to cover tx fee + amount",
+      fun() ->
+              SpendTx = #spend_tx{sender = ?SENDER_PUBKEY,
+                                  fee = 10,
+                                  amount = 50,
+                                  nonce = 12},
+
+              SenderAccount = #account{pubkey = ?SENDER_PUBKEY, balance = 55, nonce = 5, height = 10},
+              StateTree = create_state_tree_with_accounts([SenderAccount]),
+              ?assertEqual({error, insufficient_funds},
+                           ?TEST_MODULE:check(SpendTx, StateTree, 20))
+      end},
+     {"Sender account has nonce higher than tx nonce",
+      fun() ->
+              SpendTx = #spend_tx{sender = ?SENDER_PUBKEY,
+                                  fee = 10,
+                                  amount = 50,
+                                  nonce = 12},
+              AccountNonce = 15,
+              SenderAccount = #account{pubkey = ?SENDER_PUBKEY, balance = 100, nonce = AccountNonce, height = 10},
+              StateTree = create_state_tree_with_accounts([SenderAccount]),
+              ?assertEqual({error, account_nonce_too_high},
+                           ?TEST_MODULE:check(SpendTx, StateTree, 20))
+      end},
+     {"Sender account has height higher than tx height",
+      fun() ->
+              SpendTx = #spend_tx{sender = ?SENDER_PUBKEY,
+                                  fee = 10,
+                                  amount = 50,
+                                  nonce = 12},
+              AccountHeight = 100,
+              BlockHeight = 20,
+              SenderAccount = #account{pubkey = ?SENDER_PUBKEY, balance = 100, nonce = 10, height = AccountHeight},
+              StateTree = create_state_tree_with_accounts([SenderAccount]),
+              ?assertEqual({error, sender_account_height_too_big},
+                           ?TEST_MODULE:check(SpendTx, StateTree, BlockHeight))
+      end},
+     {"Recipient account has height higher than tx height",
+      fun() ->
+              SpendTx = #spend_tx{sender = ?SENDER_PUBKEY,
+                                  recipient = ?RECIPIENT_PUBKEY,
+                                  fee = 10,
+                                  amount = 50,
+                                  nonce = 12},
+              SenderAccountHeight = 10,
+              RecipientAccountHeight = 100,
+              BlockHeight = 20,
+              SenderAccount = #account{pubkey = ?SENDER_PUBKEY, balance = 100, nonce = 10, height = SenderAccountHeight},
+              RecipientAccount = #account{pubkey = ?RECIPIENT_PUBKEY, height = RecipientAccountHeight},
+              StateTree = create_state_tree_with_accounts([SenderAccount, RecipientAccount]),
+              ?assertEqual({error, recipient_account_height_too_big},
+                           ?TEST_MODULE:check(SpendTx, StateTree, BlockHeight))
+      end}].
+
+
+%% Internals
+
+create_state_tree() ->
+    {ok, AccountsTree} = aec_accounts:empty(),
+    StateTrees0 = #trees{},
+    aec_trees:set_accounts(StateTrees0, AccountsTree).
+
+create_state_tree_with_accounts(Accounts) ->
+    {ok, AccountsTree0} = aec_accounts:empty(),
+    AccountsTree1 = lists:foldl(
+                      fun(Account, Tree0) ->
+                              {ok, Tree} = aec_accounts:put(Account, Tree0),
+                              Tree
+                      end, AccountsTree0, Accounts),
+    StateTrees0 = #trees{},
+    aec_trees:set_accounts(StateTrees0, AccountsTree1).

--- a/apps/aecore/test/aec_tx_common_tests.erl
+++ b/apps/aecore/test/aec_tx_common_tests.erl
@@ -1,0 +1,64 @@
+-module(aec_tx_common_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-include("common.hrl").
+-include("trees.hrl").
+
+-define(TEST_MODULE, aec_tx_common).
+
+ensure_account_at_height_test_() ->
+    [{"Not existing account is created with 0 balance",
+      fun() ->
+              Trees0 = create_state_tree(),
+              AccountPubkey = <<"account_pubkey">>,
+              BlockHeight = 23,
+
+              {ok, Trees} = ?TEST_MODULE:ensure_account_at_height(AccountPubkey, Trees0, BlockHeight),
+
+              AccountsTree = aec_trees:accounts(Trees),
+              ExpectedAccount = #account{pubkey = AccountPubkey,
+                                         balance = 0,
+                                         height = BlockHeight},
+              ?assertEqual({ok, ExpectedAccount}, aec_accounts:get(AccountPubkey, AccountsTree))
+      end},
+     {"account_height_too_bit is returned on block height lower than current account height",
+      fun() ->
+              AccountPubkey = <<"account_pubkey">>,
+              AccountHeight = 25,
+              BlockHeight = 23,
+              Account = #account{pubkey = AccountPubkey,
+                                 balance = 777,
+                                 height = AccountHeight},
+              Trees = create_state_tree_with_account(Account),
+
+              ?assertEqual({error, account_height_too_big},
+                           ?TEST_MODULE:ensure_account_at_height(AccountPubkey, Trees, BlockHeight))
+      end},
+     {"Same unmodified state tree is returned when account is present",
+      fun() ->
+              AccountPubkey = <<"account_pubkey">>,
+              AccountHeight = 21,
+              BlockHeight = 23,
+              Account = #account{pubkey = AccountPubkey,
+                                 balance = 777,
+                                 height = AccountHeight},
+              Trees = create_state_tree_with_account(Account),
+
+              ?assertEqual({ok, Trees},
+                           ?TEST_MODULE:ensure_account_at_height(AccountPubkey, Trees, BlockHeight))
+      end}].
+
+
+%% Internals
+
+create_state_tree() ->
+    {ok, AccountsTree} = aec_accounts:empty(),
+    StateTrees0 = #trees{},
+    aec_trees:set_accounts(StateTrees0, AccountsTree).
+
+create_state_tree_with_account(Account) ->
+    {ok, AccountsTree0} = aec_accounts:empty(),
+    {ok, AccountsTree1} = aec_accounts:put(Account, AccountsTree0),
+    StateTrees0 = #trees{},
+    aec_trees:set_accounts(StateTrees0, AccountsTree1).

--- a/apps/aecore/test/aec_tx_pool_tests.erl
+++ b/apps/aecore/test/aec_tx_pool_tests.erl
@@ -144,7 +144,7 @@ all_test_() ->
       end}]}.
 
 a_signed_tx(Account, AccountNonce, Fee) ->
-    Tx = #spend_tx{from = Account, nonce = AccountNonce, fee = Fee},
+    Tx = #spend_tx{sender = Account, nonce = AccountNonce, fee = Fee},
     {ok, STx} = aec_keys:sign(Tx),
     STx.
 

--- a/apps/aehttp/priv/swagger.json
+++ b/apps/aehttp/priv/swagger.json
@@ -148,6 +148,12 @@
         "responses" : {
           "200" : {
             "description" : "successful operation"
+          },
+          "404" : {
+            "description" : "Block or header validation error",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
           }
         },
         "security" : [ ]
@@ -176,6 +182,36 @@
           },
           "404" : {
             "description" : "Account not found",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          }
+        },
+        "security" : [ ]
+      }
+    },
+    "/spend-tx" : {
+      "post" : {
+        "tags" : [ "external" ],
+        "description" : "Create spend transaction",
+        "operationId" : "PostSpendTx",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "in" : "body",
+          "name" : "body",
+          "description" : "Creates new spend transaction",
+          "required" : true,
+          "schema" : {
+            "$ref" : "#/definitions/SpendTx"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation"
+          },
+          "404" : {
+            "description" : "Spend transaction validation error",
             "schema" : {
               "$ref" : "#/definitions/Error"
             }
@@ -321,9 +357,25 @@
       "properties" : {
         "pubkey" : {
           "type" : "string"
+        }
+      }
+    },
+    "SpendTx" : {
+      "type" : "object",
+      "properties" : {
+        "sender_pubkey" : {
+          "type" : "string"
         },
-        "nonce" : {
-          "type" : "integer"
+        "recipient_pubkey" : {
+          "type" : "string"
+        },
+        "amount" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "fee" : {
+          "type" : "integer",
+          "format" : "int64"
         }
       }
     },

--- a/apps/aehttp/src/swagger/swagger_api.erl
+++ b/apps/aehttp/src/swagger/swagger_api.erl
@@ -42,6 +42,11 @@ request_params('PostBlock') ->
         'Block'
     ];
 
+request_params('PostSpendTx') ->
+    [
+        'SpendTx'
+    ];
+
 request_params(_) ->
     error(unknown_operation).
 
@@ -109,6 +114,15 @@ request_param_info('Ping', 'Ping') ->
     };
 
 request_param_info('PostBlock', 'Block') ->
+    #{
+        source =>   body,
+        rules => [
+            schema,
+            required
+        ]
+    };
+
+request_param_info('PostSpendTx', 'SpendTx') ->
     #{
         source =>   body,
         rules => [
@@ -185,6 +199,13 @@ validate_response('Ping', 404, Body, ValidatorState) ->
 
 validate_response('PostBlock', 200, Body, ValidatorState) ->
     validate_response_body('', '', Body, ValidatorState);
+validate_response('PostBlock', 400, Body, ValidatorState) ->
+    validate_response_body('Error', 'Error', Body, ValidatorState);
+
+validate_response('PostSpendTx', 200, Body, ValidatorState) ->
+    validate_response_body('', '', Body, ValidatorState);
+validate_response('PostSpendTx', 400, Body, ValidatorState) ->
+    validate_response_body('Error', 'Error', Body, ValidatorState);
 
 
 validate_response(_OperationID, _Code, _Body, _ValidatorState) ->

--- a/apps/aehttp/src/swagger/swagger_external_handler.erl
+++ b/apps/aehttp/src/swagger/swagger_external_handler.erl
@@ -101,6 +101,14 @@ allowed_methods(
 ) ->
     {[<<"POST">>], Req, State};
 
+allowed_methods(
+    Req,
+    State = #state{
+        operation_id = 'PostSpendTx'
+    }
+) ->
+    {[<<"POST">>], Req, State};
+
 allowed_methods(Req, State) ->
     {[], Req, State}.
 
@@ -201,6 +209,16 @@ valid_content_headers(
     Req0,
     State = #state{
         operation_id = 'PostBlock'
+    }
+) ->
+    Headers = [],
+    {Result, Req} = validate_headers(Headers, Req0),
+    {Result, Req, State};
+
+valid_content_headers(
+    Req0,
+    State = #state{
+        operation_id = 'PostSpendTx'
     }
 ) ->
     Headers = [],

--- a/apps/aehttp/src/swagger/swagger_router.erl
+++ b/apps/aehttp/src/swagger/swagger_router.erl
@@ -84,6 +84,11 @@ get_operations() ->
             path => "/v1/block",
             method => <<"POST">>,
             handler => 'swagger_external_handler'
+        },
+        'PostSpendTx' => #{
+            path => "/v1/spend-tx",
+            method => <<"POST">>,
+            handler => 'swagger_external_handler'
         }
     }.
 

--- a/apps/aeutils/src/aeu_validation.erl
+++ b/apps/aeutils/src/aeu_validation.erl
@@ -2,12 +2,12 @@
 
 -export([run/2]).
 
-run([], _Arg) ->
+run([], _Args) ->
     ok;
-run([F | Rest], Arg) ->
-    case F(Arg) of
+run([F | Rest], Args) ->
+    case apply(F, Args) of
         ok ->
-            run(Rest, Arg);
+            run(Rest, Args);
         {error, _Reason} = Error ->
             Error
     end.

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -128,7 +128,7 @@ paths:
       responses:
         '200':
           description: successful operation
-        '400':
+        '404':
           description: Block or header validation error
           schema:
             $ref: '#/definitions/Error'
@@ -155,6 +155,31 @@ paths:
             $ref: '#/definitions/Balance'
         '404':
           description: Account not found
+          schema:
+            $ref: '#/definitions/Error'
+      security: []
+  /spend-tx:
+    post:
+      tags:
+        - external
+      operationId: PostSpendTx
+      description: 'Create spend transaction'
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: Creates new spend transaction
+          required: true
+          schema:
+            $ref: '#/definitions/SpendTx'
+      responses:
+        '200':
+          description: successful operation
+        '404':
+          description: Spend transaction validation error
           schema:
             $ref: '#/definitions/Error'
       security: []
@@ -253,8 +278,19 @@ definitions:
     properties:
       pubkey:
         type: string
-      nonce:
-        type: integer 
+  SpendTx:
+    type: object
+    properties:
+      sender_pubkey:
+        type: string
+      recipient_pubkey:
+        type: string
+      amount:
+        type: integer
+        format: int64
+      fee:
+        type: integer
+        format: int64
   SignedTx:
     type: object
     properties:
@@ -265,6 +301,7 @@ definitions:
         schema:
           oneOf:
             - $ref: '#/definitions/CoinbaseTx'
+            - $ref: '#/definitions/SpendTx'
       signatures:
         type: array
         items:


### PR DESCRIPTION
What is left:
* sign, put into the mempool and propagate to other peers transaction on `POST /spend-tx`
* change serialization to use msgpack, as it is done in https://github.com/aeternity/epoch/pull/310
* add sum of transaction fees to the miner's account when updating accounts state tree when creating/validating block candidate