### PR TITLE
Add persistence to chain, snapshots of state trees, transactions to pool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ apps/aecore/c_src/*.[1-9][0-9]o
 apps/aecore/c_src/cuckoo
 apps/aecore/priv/*.so
 apps/aecore/priv/keys
+.chain

--- a/apps/aecore/include/blocks.hrl
+++ b/apps/aecore/include/blocks.hrl
@@ -12,6 +12,10 @@
 
 -define(ACCEPTED_FUTURE_BLOCK_TIME_SHIFT, 30 * 60 * 1000). %% 30 min
 
+-define(STORAGE_TYPE_BLOCK,  0).
+-define(STORAGE_TYPE_HEADER, 1).
+-define(STORAGE_TYPE_STATE,  2).
+
 -type(block_header_hash() :: <<_:(?BLOCK_HEADER_HASH_BYTES*8)>>).
 -type(txs_hash() :: <<_:(?TXS_HASH_BYTES*8)>>).
 -type(state_hash() :: <<_:(?STATE_HASH_BYTES*8)>>).

--- a/apps/aecore/src/aec_chain_state.erl
+++ b/apps/aecore/src/aec_chain_state.erl
@@ -10,11 +10,15 @@
 -export([ difficulty_at_hash/2
         , difficulty_at_top_header/1
         , difficulty_at_top_block/1
+        , find_common_ancestor/3
         , get_block/2
         , get_header/2
+        , get_state_trees_for_persistance/1
         , insert_block/2
         , insert_header/2
         , new/0
+        , new/1
+        , new_from_persistance/2
         , top_block/1
         , top_block_hash/1
         , top_header/1
@@ -29,13 +33,29 @@
                     , 'state_db' => dict:dict()
                     , 'top_header_hash' => binary() | 'undefined'
                     , 'top_block_hash' => binary() | 'undefined'
+                    , 'max_snapshot_height' => pos_integer()
+                    , 'sparse_snapshots_interval' => pos_integer()
+                    , 'keep_all_snapshots_height' => pos_integer()
                     }).
 
--export_type([state/0]).
+-type(opts() :: #{ 'max_snapshot_height' := pos_integer()
+                 , 'sparse_snapshots_interval' := pos_integer()
+                 , 'keep_all_snapshots_height' := pos_integer()
+                 }).
+
+
+-export_type([ state/0
+             , opts/0
+             ]).
 
 -define(match_state(___S___), #{type := aec_chain_state, ___S___}).
 -define(assert_state(), #{type := aec_chain_state}).
 -define(internal_error(____E____), {aec_chain_state_error, ____E____}).
+
+%% TODO: These should be configs
+-define(MAX_SNAPSHOT_HEIGHT, 20).
+-define(SPARSE_SNAPSHOTS_INTERVAL, 5).
+-define(KEEP_ALL_SNAPSHOTS_HEIGHT, 4).
 
 %%%===================================================================
 %%% API
@@ -43,11 +63,25 @@
 
 -spec new() -> state().
 new() ->
+  new(default_opts()).
+
+-spec new(opts()) -> state().
+new(OptsIn) ->
+    Opts = maps:merge(default_opts(), OptsIn),
     #{ type => aec_chain_state
      , blocks_db => db_new()
      , top_header_hash => undefined
      , top_block_hash  => undefined
      , state_db => db_new()
+     , max_snapshot_height => maps:get(max_snapshot_height, Opts)
+     , sparse_snapshots_interval => maps:get(sparse_snapshots_interval, Opts)
+     , keep_all_snapshots_height => maps:get(keep_all_snapshots_height, Opts)
+     }.
+
+default_opts() ->
+    #{ max_snapshot_height => ?MAX_SNAPSHOT_HEIGHT
+     , sparse_snapshots_interval => ?SPARSE_SNAPSHOTS_INTERVAL
+     , keep_all_snapshots_height => ?KEEP_ALL_SNAPSHOTS_HEIGHT
      }.
 
 -spec top_header(state()) -> 'undefined' | #header{}.
@@ -117,6 +151,37 @@ difficulty_at_top_header(?assert_state() = State) ->
 difficulty_at_hash(Hash, ?assert_state() = State) ->
     total_difficulty_at_hash(Hash, State).
 
+-spec find_common_ancestor(binary(), binary(), state()) ->
+                                  {'ok', binary()} | {error, atom()}.
+find_common_ancestor(Hash1, Hash2, ?assert_state() = State) ->
+    case {blocks_db_find(Hash1, State), blocks_db_find(Hash2, State)} of
+        {{ok, Node1}, {ok, Node2}} ->
+            case find_fork_point(Node1, Node2, State) of
+                not_found -> {error, not_found};
+                {ok, ForkNode} -> {ok, hash(ForkNode)}
+            end;
+        _ -> {error, unknown_hash}
+    end.
+
+-spec get_state_trees_for_persistance(state())->[{Hash :: binary(), #trees{}}].
+get_state_trees_for_persistance(?assert_state() = State) ->
+    state_db_to_list(State).
+
+-spec new_from_persistance([#block{}|#header{}], [{Hash :: binary(), #trees{}}]) -> state().
+new_from_persistance(Chain, StateTreesList) ->
+    State = state_db_init_from_list(StateTreesList, new()),
+    NodeChain = [wrap_block_or_header(X) || X <- Chain],
+    State1 = blocks_db_init_from_list(NodeChain, State),
+    case find_top_hash_from_genesis_node(State1) of
+        not_found -> State1;
+        {ok, TopHash} ->
+            State2 = set_top_header_hash(TopHash, State1),
+            case find_top_block_from_top_header(State2) of
+                not_found -> State2;
+                {ok, Node} -> update_state_tree(Node, State2)
+            end
+    end.
+
 %%%===================================================================
 %%% Internal functions
 %%%===================================================================
@@ -154,19 +219,35 @@ node_difficulty(#node{difficulty = X}) -> X.
 
 node_is_block(#node{type = Type}) -> Type =:= block.
 
+node_root_hash(#node{type = header, content = X}) -> aec_headers:root_hash(X);
+node_root_hash(#node{type = block , content = X}) -> aec_blocks:root_hash(X).
+
+
+find_genesis_node(State) ->
+    case [X || X <- blocks_db_find_at_height(0, State),
+               node_is_genesis(X)] of
+        [] -> not_found;
+        [Genesis] -> {ok, Genesis}
+    end.
+
 node_is_genesis(Node) ->
     node_is_genesis_block(Node)
         orelse node_is_genesis_header(Node).
 
 node_is_genesis_header(Node) ->
     %% TODO: This is very blunt
-    (Node#node.type =:= header) andalso
-        (aec_block_genesis:genesis_header() =:= export_header(Node)).
+    (node_height(Node) =:= 0)
+        andalso (Node#node.type =:= header)
+        andalso (aec_block_genesis:genesis_header() =:= export_header(Node)).
 
 node_is_genesis_block(Node) ->
     %% TODO: This is very blunt
-    (Node#node.type =:= block) andalso
-        (aec_block_genesis:genesis_header() =:= export_header(Node)).
+    (node_height(Node) =:= 0)
+        andalso (Node#node.type =:= block)
+        andalso (aec_block_genesis:genesis_header() =:= export_header(Node)).
+
+wrap_block_or_header(#header{} = H) -> wrap_header(H);
+wrap_block_or_header(#block{}  = B) -> wrap_block(B).
 
 wrap_block(Block) ->
     {ok, Hash} = aec_blocks:hash_internal_representation(Block),
@@ -290,7 +371,7 @@ determine_chain_relation(Node, State) ->
                     TopNode = blocks_db_get(TopHash, State),
                     case find_fork_point(TopNode, Node, State) of
                         not_found -> off_chain;
-                        ForkNode -> {fork, ForkNode}
+                        {ok, ForkNode} -> {fork, ForkNode}
                     end
             end
     end.
@@ -310,7 +391,7 @@ find_fork_point(Node1, Node2, State) ->
     Height2 = node_height(Node2),
     find_fork_point(Node1, Height1, Node2, Height2, State).
 
-find_fork_point(Node, Height, Node, Height,_State) -> Node;
+find_fork_point(Node, Height, Node, Height,_State) -> {ok, Node};
 find_fork_point(_Node1, Height,_Node2, Height,_State) when Height =:= 0 ->
     not_found;
 find_fork_point(Node1, Height1, Node2, Height2, State) when Height1 > Height2,
@@ -331,6 +412,19 @@ find_fork_point(Node1, Height1, Node2, Height2, State) when Height2 >= Height2,
             NewHeight = node_height(NewNode),
             find_fork_point(Node1, Height1, NewNode, NewHeight, State)
     end.
+
+find_top_hash_from_genesis_node(State) ->
+    case find_genesis_node(State) of
+        not_found -> not_found;
+        {ok, Genesis} ->
+            case find_new_header_top_from_node(Genesis, State) of
+                [] -> not_found;
+                [TopHash] -> {ok, TopHash};
+                TopHashes ->
+                    {ok, determine_new_header_top_hash(TopHashes, State)}
+            end
+    end.
+
 
 find_new_header_top_from_node(Node, State) ->
     Height = node_height(Node),
@@ -370,53 +464,173 @@ genesis_state_tree(Node) ->
         true -> Trees
     end.
 
-%% Precondition: The header chain is assumed to have been updated
-%%               before this function is called, i.e., the choice
-%%               of main chain must have been made already.
-update_state_tree(#node{type = header} =_Node, State) ->
-    State;
-update_state_tree(#node{type = block} = Node, State) ->
-    Hash = Node#node.hash,
-    case get_prev_state_trees(Node, State) of
+%% Transitively compute the new state trees in the main chain
+%% starting from the node (which must be in the main chain).
+update_state_tree(Node, State) ->
+    case calculate_state_trees(Node, State) of
         error -> State;
-        {ok, Tree} ->
-            Txs = aec_blocks:txs(Node#node.content),
-            Height = aec_blocks:height(Node#node.content),
-            {ok, NewTrees} = aec_tx:apply_signed(Txs, Tree, Height),
-            State1 = state_db_put(Hash, NewTrees, State),
-            State2 = set_top_block_hash(Hash, State1),
-            case find_node_at_height_from_top_header(Height + 1, State2) of
-                {ok, NextNode} -> update_state_tree(NextNode, State2);
-                not_found -> State2
+        {stored,_Trees} ->
+            update_next_state_tree(Node, State);
+        {calculated, Trees} ->
+            RootHash = aec_trees:all_trees_hash(Trees),
+            Expected = node_root_hash(Node),
+            case RootHash =:= Expected of
+                true ->
+                    State1 = state_db_put(hash(Node), Trees, State),
+                    update_next_state_tree(Node, State1);
+                false ->
+                    internal_error({root_hash_mismatch, RootHash, Expected})
             end
     end.
 
-get_prev_state_trees(Node, State) ->
-    case node_is_genesis_block(Node) of
-        true -> {ok, genesis_state_tree(Node)};
-        false -> state_db_find(prev_hash(Node), State)
+update_next_state_tree(Node, State) ->
+    case find_successor_from_top_header(Node, State) of
+        {ok, NextNode} when NextNode#node.type =:= block ->
+            update_state_tree(NextNode, State);
+        {ok, NextNode} when NextNode#node.type =:= header ->
+            update_top_block_hash(hash(Node), State);
+        not_found ->
+            update_top_block_hash(hash(Node), State)
     end.
+
+%% Get the state tree if present, otherwise calculate it from the most
+%% recent previous tree if possible.
+calculate_state_trees(Node, State) ->
+    calculate_state_trees(Node, [], State).
+
+calculate_state_trees(#node{type = header},_Acc,_State) ->
+    %% If there is at least one header in the chain, we cannot
+    %% calculate the state of the block.
+    error;
+calculate_state_trees(Node, Acc, State) ->
+    IsGenesis = node_is_genesis_block(Node),
+    case state_db_find(hash(Node), State) of
+        {ok, Trees} when Acc =:= [] -> {stored, Trees};
+        {ok, Trees} -> {calculated, apply_node_transactions(Acc, Trees, State)};
+        error when IsGenesis  ->
+            Trees = genesis_state_tree(Node),
+            {calculated, apply_node_transactions([Node|Acc], Trees, State)};
+        error ->
+            case blocks_db_find(prev_hash(Node), State) of
+                error -> error;
+                {ok, Prev} -> calculate_state_trees(Prev, [Node|Acc], State)
+            end
+    end.
+
+update_top_block_hash(Hash, State) ->
+    case get_top_block_hash(State) =:= Hash of
+        true -> State;
+        false ->
+            State1 = set_top_block_hash(Hash, State),
+            garbage_collect_state_trees(State1)
+    end.
+
+apply_node_transactions([Node|Left], Trees, State) ->
+    Txs = aec_blocks:txs(Node#node.content),
+    Height = node_height(Node),
+    {ok, NewTrees} = aec_tx:apply_signed(Txs, Trees, Height),
+    apply_node_transactions(Left, NewTrees, State);
+apply_node_transactions([], Trees,_State) ->
+    Trees.
 
 is_node_in_main_chain(Node, State) ->
-    Height = node_height(Node),
-    case find_node_at_height_from_top_header(Height, State) of
-        not_found -> false;
-        {ok, Found} -> hash(Found) =:= hash(Node)
+    case get_top_header_hash(State) of
+        undefined -> false;
+        TopHash ->
+            TopNode = blocks_db_get(TopHash, State),
+            Height = node_height(Node),
+            case find_node_at_height(Height, TopNode, State) of
+                not_found -> false;
+                {ok, Found} -> hash(Found) =:= hash(Node)
+            end
     end.
 
-find_node_at_height_from_top_header(AtHeight, State) ->
+find_successor_from_top_header(Node, State) ->
+    Height = node_height(Node),
     TopHash = get_top_header_hash(State),
-    TopHeader = blocks_db_get(TopHash, State),
-    Height = node_height(TopHeader),
-    find_node_at_height(AtHeight, Height, TopHeader, State).
+    TopNode = blocks_db_get(TopHash, State),
+    find_node_at_height(Height + 1, TopNode, State).
 
-find_node_at_height(AtHeight, AtHeight, Node,_State) -> {ok, Node};
-find_node_at_height(AtHeight, Height, Node, State) when Height > AtHeight ->
-    PrevHash = prev_hash(Node),
-    Node1 = blocks_db_get(PrevHash, State),
-    find_node_at_height(AtHeight, Height - 1, Node1, State);
-find_node_at_height(AtHeight, Height,_Node,_State) when Height < AtHeight ->
-    not_found.
+find_node_at_height(AtHeight, Node, State) ->
+    Height = node_height(Node),
+    if
+        Height <   AtHeight -> not_found;
+        Height =:= AtHeight -> {ok, Node};
+        Height >   AtHeight ->
+            PrevNode = blocks_db_get(prev_hash(Node), State),
+            find_node_at_height(AtHeight, PrevNode, State)
+    end.
+
+find_top_block_from_top_header(State) ->
+    Hash = get_top_header_hash(State),
+    Node = blocks_db_get(Hash, State),
+    find_top_block_from_top_header(Node, State, not_found).
+
+find_top_block_from_top_header(Node, State, Candidate) ->
+    NewCandidate =
+        case node_is_block(Node) of
+            true when Candidate =:= not_found -> {ok, Node};
+            true -> Candidate;
+            false -> not_found
+        end,
+    case node_is_genesis(Node) of
+        true -> NewCandidate;
+        false ->
+            PrevNode = blocks_db_get(prev_hash(Node), State),
+            find_top_block_from_top_header(PrevNode, State, NewCandidate)
+    end.
+
+%%%-------------------------------------------------------------------
+%%% Garbage collection of state trees
+%%% -------------------------------------------------------------------
+%%% @doc Garbage collection strategy: Keep all snapshots from the
+%%% block top until ?KEEP_ALL_SNAPSHOTS_HEIGHT, then keep only
+%%% snapshots spaced with ?SPARSE_SNAPSHOTS_INTERVAL until
+%%% ?MAX_SNAPSHOT_HEIGHT.
+%%% TODO: The parameters should be configurable from the environment.
+
+garbage_collect_state_trees(State) ->
+    case get_top_block_hash(State) of
+        undefined -> State;
+        Hash when is_binary(Hash) ->
+            Node = blocks_db_get(Hash, State),
+            Keep = gc_collect(Node, 0, State, []),
+            gc_init(Keep, State)
+    end.
+
+gc_init(Nodes, State) ->
+    gc_init(Nodes, State, []).
+
+gc_init([], State, Acc) ->
+    state_db_init_from_list(Acc, State);
+gc_init([Node|Left], State, Acc) ->
+    case calculate_state_trees(Node, State) of
+        {stored, Trees} -> gc_init(Left, State, [{hash(Node), Trees}|Acc]);
+        {calculated, Trees} -> gc_init(Left, State, [{hash(Node), Trees}|Acc])
+    end.
+
+gc_collect(Node, HeightFromTop, State, Acc) ->
+    case node_height(Node) =:= 0 of
+        true  -> [Node|Acc];%% Always keep genesis if it falls into range
+        false ->
+            MaxHeight = maps:get(max_snapshot_height, State),
+            case HeightFromTop > MaxHeight of
+                true -> Acc;
+                false ->
+                    PrevNode = blocks_db_get(prev_hash(Node), State),
+                    Height = HeightFromTop + 1,
+                    case keep_state_snapshot(HeightFromTop, State) of
+                        true -> gc_collect(PrevNode, Height, State, [Node|Acc]);
+                        false -> gc_collect(PrevNode, Height, State, Acc)
+                    end
+            end
+    end.
+
+keep_state_snapshot(HeightFromTop, State) ->
+    KeepAll = maps:get(keep_all_snapshots_height, State),
+    Interval = maps:get(sparse_snapshots_interval, State),
+    (HeightFromTop < KeepAll)
+        orelse (((HeightFromTop - KeepAll) rem Interval) == 0).
 
 %%%-------------------------------------------------------------------
 %%% Internal interface for the blocks_db
@@ -440,6 +654,9 @@ db_find(Key, Store) ->
         error -> error
     end.
 
+db_to_list(Store) ->
+    dict:to_list(Store).
+
 blocks_db_put(#node{hash = Hash} = Node, State) ->
     DB = maps:get(blocks_db, State),
     State#{blocks_db => db_put(Hash, Node, DB)}.
@@ -460,8 +677,22 @@ blocks_db_find(Key, #{blocks_db := Store}) ->
 blocks_db_get(Key, #{blocks_db := Store}) ->
     db_get(Key, Store).
 
+blocks_db_init_from_list(List, State) ->
+    Fun = fun(Node, Acc) -> db_put(hash(Node), Node, Acc)end,
+    DB = lists:foldl(Fun, db_new(), List),
+    State#{blocks_db => DB}.
+
+
 state_db_put(Hash, Trees, #{state_db := DB} = State) ->
     State#{state_db => db_put(Hash, Trees, DB)}.
 
 state_db_find(Key, #{state_db := Store}) ->
     db_find(Key, Store).
+
+state_db_init_from_list(List, State) ->
+    Fun = fun({Key, Val}, Acc) -> db_put(Key, Val, Acc)end,
+    DB = lists:foldl(Fun, db_new(), List),
+    State#{state_db => DB}.
+
+state_db_to_list(#{state_db := DB} =_State) ->
+    db_to_list(DB).

--- a/apps/aecore/src/aec_chain_state.erl
+++ b/apps/aecore/src/aec_chain_state.erl
@@ -418,7 +418,6 @@ find_top_hash_from_genesis_node(State) ->
         not_found -> not_found;
         {ok, Genesis} ->
             case find_new_header_top_from_node(Genesis, State) of
-                [] -> not_found;
                 [TopHash] -> {ok, TopHash};
                 TopHashes ->
                     {ok, determine_new_header_top_hash(TopHashes, State)}

--- a/apps/aecore/src/aec_headers.erl
+++ b/apps/aecore/src/aec_headers.erl
@@ -89,7 +89,7 @@ serialize_for_store(H = #header{}) ->
     <<?STORAGE_TYPE_HEADER:8, Bin/binary>>.
 
 
-deserialize_from_store(<<?STORAGE_TYPE_HEADER, Bin>>) ->
+deserialize_from_store(<<?STORAGE_TYPE_HEADER, Bin/binary>>) ->
     case binary_to_term(Bin) of
         {?STORAGE_VERSION,
          Height,

--- a/apps/aecore/src/aec_headers.erl
+++ b/apps/aecore/src/aec_headers.erl
@@ -20,6 +20,7 @@
          hash_header/1,
          serialize_pow_evidence/1,
          deserialize_pow_evidence/1,
+         root_hash/1,
          validate/1]).
 
 -include("common.hrl").
@@ -41,6 +42,9 @@ target(Header) ->
 
 difficulty(Header) ->
     aec_pow:target_to_difficulty(target(Header)).
+
+root_hash(Header) ->
+    Header#header.root_hash.
 
 time_in_secs(Header) ->
     Time = Header#header.time,
@@ -69,23 +73,25 @@ serialize_to_map(H = #header{}) ->
       },
     {ok, Serialized}.
 
--define(STORAGEVERSION, 1).
+-define(STORAGE_VERSION, 1).
 serialize_for_store(H = #header{}) ->
-    term_to_binary({?STORAGEVERSION,
-                    height(H),
-                    prev_hash(H),
-                    H#header.root_hash,
-                    H#header.txs_hash,
-                    H#header.target,
-                    H#header.nonce,
-                    H#header.time,
-                    H#header.version,
-                    H#header.pow_evidence
-                   }, [{compressed,9}]).
+    Bin = term_to_binary({?STORAGE_VERSION,
+                          height(H),
+                          prev_hash(H),
+                          H#header.root_hash,
+                          H#header.txs_hash,
+                          H#header.target,
+                          H#header.nonce,
+                          H#header.time,
+                          H#header.version,
+                          H#header.pow_evidence
+                         }, [{compressed,9}]),
+    <<?STORAGE_TYPE_HEADER:8, Bin/binary>>.
 
-deserialize_from_store(Bin) ->
+
+deserialize_from_store(<<?STORAGE_TYPE_HEADER, Bin>>) ->
     case binary_to_term(Bin) of
-        {?STORAGEVERSION,
+        {?STORAGE_VERSION,
          Height,
          PrevHash,
          RootHash,
@@ -96,25 +102,29 @@ deserialize_from_store(Bin) ->
          Version,
          PowEvidence
         } ->
-            #header{
-               height = Height,
-               prev_hash = PrevHash,
-               root_hash = RootHash,
-               txs_hash = TxsHash,
-               target = Target,
-               nonce = Nonce,
-               time = Time,
-               version = Version,
-               pow_evidence = PowEvidence};
+            {ok,
+             #header{
+                height = Height,
+                prev_hash = PrevHash,
+                root_hash = RootHash,
+                txs_hash = TxsHash,
+                target = Target,
+                nonce = Nonce,
+                time = Time,
+                version = Version,
+                pow_evidence = PowEvidence}
+             };
         T when tuple_size(T) > 0 ->
             case element(1, T) of
-                I when is_integer(I), I > ?STORAGEVERSION ->
+                I when is_integer(I), I > ?STORAGE_VERSION ->
                     exit({future_storage_version, I, Bin});
                 %% Add handler of old version here when upgrading version.
-                I when is_integer(I), I < ?STORAGEVERSION ->
+                I when is_integer(I), I < ?STORAGE_VERSION ->
                     exit({old_forgotten_storage_version, I, Bin})
             end
-    end.
+    end;
+deserialize_from_store(_) -> false.
+
 
 
 -spec deserialize_from_network(binary()) -> {ok, header()}.

--- a/apps/aecore/src/aec_keys.erl
+++ b/apps/aecore/src/aec_keys.erl
@@ -26,7 +26,8 @@
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
          terminate/2, code_change/3]).
 
--export([new/1, open/1, set/3, sign/1, pubkey/0, delete/0]).
+-export([new/1, open/1, set/3, sign/1, pubkey/0, delete/0,
+         wait_for_pubkey/0]).
 
 -define(SERVER, ?MODULE).
 -define(PUB_SIZE, 65).
@@ -77,6 +78,18 @@ sign(Term) ->
 -spec pubkey() -> {ok, binary()} | {error, key_not_found}.
 pubkey() ->
     gen_server:call(?MODULE, pubkey).
+
+-spec wait_for_pubkey() -> {ok, binary()}.
+wait_for_pubkey() ->
+    wait_for_pubkey(1).
+
+wait_for_pubkey(Sleep) ->
+    case pubkey() of
+        {error, key_not_found} ->
+            timer:sleep(Sleep),
+            wait_for_pubkey(Sleep+10);
+        R -> R
+    end.
 
 -spec open(binary()) -> {ok, Password :: binary()} | {error, keys_not_loaded}.
 open(Password) ->

--- a/apps/aecore/src/aec_miner.erl
+++ b/apps/aecore/src/aec_miner.erl
@@ -5,17 +5,19 @@
 %%% @end
 %%%-------------------------------------------------------------------
 -module(aec_miner).
-
 -behaviour(gen_statem).
 
 %%------------------------------------------------------------------------------
 %% API
 %%------------------------------------------------------------------------------
 -export([start_link/0,
+         start_link/1,
          stop/0,
          resume/0,
          suspend/0,
-         get_balance/0]).
+         get_balance/0,
+         post_block/1
+        ]).
 
 %%------------------------------------------------------------------------------
 %% gen_statem callbacks
@@ -41,10 +43,15 @@
 -define(FETCH_NEW_TXS_FROM_POOL, true).
 
 -record(state, {block_candidate :: block() | undefined,
-                cycle_attempts_count = ?MINING_ATTEPTS_PER_CYCLE :: non_neg_integer(),
+                cycle_attempts_count =
+                    ?MINING_ATTEPTS_PER_CYCLE :: non_neg_integer(),
                 initial_cycle_nonce = 0 :: integer(),
                 max_block_candidate_nonce = 0 :: integer(),
-                fetch_new_txs_from_pool :: boolean()}).
+                fetch_new_txs_from_pool = ?FETCH_NEW_TXS_FROM_POOL:: boolean(),
+                miner = none :: pid() | none,
+                autostart = true :: boolean()
+               }
+       ).
 
 %%%===================================================================
 %%% API
@@ -56,6 +63,10 @@
 -spec start_link() -> {'ok', pid()} | {error | term()}.
 start_link() ->
     gen_statem:start_link({local, ?SERVER}, ?MODULE, [], []).
+
+-spec start_link(Options::list()) -> {'ok', pid()} | {error | term()}.
+start_link(Options) ->
+    gen_statem:start_link({local, ?SERVER}, ?MODULE, Options, []).
 
 %%------------------------------------------------------------------------------
 %% Stop the state machine
@@ -94,6 +105,13 @@ get_balance() ->
             {error, account_not_found}
     end.
 
+%%------------------------------------------------------------------------------
+%% Post a block
+%%------------------------------------------------------------------------------
+-spec post_block(block()) -> ok.
+post_block(Block) ->
+    gen_statem:cast(?SERVER, {post_block, Block}).
+
 %%%===================================================================
 %%% gen_statem callbacks
 %%%===================================================================
@@ -109,15 +127,60 @@ get_balance() ->
 %%                     {ok, StateName, State, Timeout} |
 %%                     ignore |
 %%                     {stop, StopReason}
+%% If an option in not provided in the application environment nor
+%% in the argument to the init function the default from the state
+%% record definition is used.
+%% If the application environment provides an option it overrides
+%% the default.
+%% If the call argument provides an option it overrides both the
+%% application environment and the default.
+%%
+%% The options are:
+%%
+%%
 %% @end
 %%--------------------------------------------------------------------
-init(_) ->
-    CycleAttemptsCount = application:get_env(aecore, mining_cycle_attempts_count, ?MINING_ATTEPTS_PER_CYCLE),
-    FetchNewTxsFromPool = application:get_env(aecore, fetch_new_txs_from_pool_during_mining, ?FETCH_NEW_TXS_FROM_POOL),
+init(Options) ->
+    DefaultState = #state{},
+    CycleAttemptsCount =
+        get_option(mining_cycle_attempts_count, DefaultState, Options),
+    FetchNewTxsFromPool =
+        get_option(fetch_new_txs_from_pool_during_mining, DefaultState, Options),
+    AutoStart = get_option(autostart,  DefaultState, Options),
+    State =
+        DefaultState#state{cycle_attempts_count = CycleAttemptsCount,
+                           fetch_new_txs_from_pool = FetchNewTxsFromPool,
+                           autostart = AutoStart
+                          },
+    AutoStart = start_if_auto(State),
+    Res =
+        if AutoStart ->
+                {ok, configure, State};
+           true ->
+                {ok, idle, State}
+        end,
+    epoch_mining:info("Miner process initilized ~p~n", [State]),
+    Res.
 
-    gen_statem:cast(?SERVER, create_block_candidate),
-    {ok, configure, #state{cycle_attempts_count = CycleAttemptsCount,
-                           fetch_new_txs_from_pool = FetchNewTxsFromPool}}.
+get_option(mining_cycle_attempts_count = Name, State, Options) ->
+    EnvVal = application:get_env(aecore, Name,
+                                 State#state.cycle_attempts_count),
+    option_override(Name, EnvVal, Options);
+get_option(fetch_new_txs_from_pool_during_mining = Name, State, Options) ->
+    EnvVal =
+        application:get_env(aecore, Name,
+                            State#state.fetch_new_txs_from_pool),
+    option_override(Name, EnvVal, Options);
+get_option(autostart = Name, State, Options) ->
+    EnvVal = application:get_env(aecore, Name,
+                                 State#state.autostart),
+    option_override(Name, EnvVal, Options).
+
+option_override(Name, Default, Options) ->
+    case proplists:lookup(Name, Options) of
+        {_, Value} -> Value;
+        none -> Default
+    end.
 
 %%--------------------------------------------------------------------
 %% @private
@@ -133,128 +196,263 @@ init(_) ->
 %%                   {next_state, NextStateName, NextState, [Actions]}
 %% @end
 %%--------------------------------------------------------------------
+
+%% -------------------------------------------------------------------
+%% State machine states
+%%           start
+%%           /   \     +-----------------+----+
+%%          /     \    |                 |    |
+%%         v  2 1  v   v                 v    |8
+%%       idle <-> configure -> wait_for_keys -+
+%%         ^      5,6| ^    5
+%%         |         v |4
+%%         +----- running <-+
+%%             2     |7     |
+%%                   +------+
+%%
+%% -------------------------------------------------------------------
+%% Events
+%%  1 call:start
+%%  2 call:suspend
+%%
+%%  3 cast:post_block Block
+%%  4 cast:miner_done Miner
+%%  5 cast:create_block_candidate
+%%  6 cast:bump_initial_cycle_nonce
+%%  7 cast:mine
+%%  8 cast:check_keys
+%% -------------------------------------------------------------------
+
+%% -------------------------------------------------------------------
+%% The Idle state
+%% -------------------------------------------------------------------
+%% Calls: start | suspend
 idle({call, From}, start, State) ->
     epoch_mining:info("Mining resumed by user.", []),
-    gen_statem:cast(?SERVER, create_block_candidate),
-    {next_state, configure, State, [{reply, From, ok}]};
+    {next_state, configure, State,
+     [{reply, From, ok}, candidate_event()]};
 idle({call, From}, suspend, State) ->
-    {next_state, idle, State, [{reply, From, {error, not_started}}]};
+    {keep_state, State, [{reply, From, ok}]};
 idle({call, From}, _Msg, State) ->
-    {next_state, idle, State, [{reply, From, {error, not_supported}}]};
-idle(_Type, _Msg, State) ->
-    {next_state, idle, State}.
+    {keep_state, State, [{reply, From, {error, not_supported}}]};
 
+%% Casts: post_block | miner_done | create_block_candidate |
+%%        bump_initial_cycle_nonce | mine | check_keys
+idle(cast, {post_block, Block}, State) ->
+    idle_post_block(Block, State);
+idle(cast, {miner_done, Miner}, #state{ miner = Miner } = State) ->
+    {next_state, configure, State#state{ miner = none }};
+idle(cast, {miner_done, Miner}, #state{ miner = OtherMiner } = State) ->
+    epoch_mining:error("Unknown miner finished: ~p~n", [Miner]),
+    {keep_state, State#state{ miner = OtherMiner }};
+idle(cast, create_block_candidate, State) ->
+    %% Wait for a resume.
+    {keep_state, State, [postpone]};
+idle(cast, bump_initial_cycle_nonce, State) ->
+    %% Wait for a resume.
+    {keep_state, State, [postpone]};
+idle(cast, mine, State) ->
+    %% Wait for a resume.
+    {keep_state, State, [postpone]};
+idle(cast, check_keys, State) ->
+    %% Wait for a resume.
+    {keep_state, State, [postpone]};
+%% Catchall, log & drop unwanted messages.
+idle(_Type, _Msg, State) ->
+    epoch_mining:error("Unknown event in idle: ~p:~p~n", [_Type,_Msg]),
+    {keep_state, State}.
+
+%% -------------------------------------------------------------------
+%% The Configure state
+%% -------------------------------------------------------------------
+%% Calls: start | suspend
 configure({call, From}, start, State) ->
-    {next_state, configure, State, [{reply, From, {error, already_started}}]};
+    {keep_state, State, [{reply, From, ok}]};
 configure({call, From}, suspend, State) ->
     epoch_mining:info("Mining suspended by user", []),
     {next_state, idle, State, [{reply, From, ok}]};
+
+%% Casts: post_block | miner_done | create_block_candidate |
+%%        bump_initial_cycle_nonce | mine | check_keys
+configure(cast, {post_block, Block}, State) ->
+    configure_post_block(Block, State);
+configure(cast, {miner_done, Miner}, #state{ miner = Miner } = State) ->
+    %% The current miner is done. Rmove it from the state.
+    {next_state, configure, State#state{ miner = none }};
+configure(cast, {miner_done, Miner}, #state{ miner = OtherMiner } = State) ->
+    epoch_mining:error("Unknown miner finished: ~p~n", [Miner]),
+    {keep_state, State#state{ miner = OtherMiner }};
 configure(cast, create_block_candidate, State) ->
     case aec_mining:create_block_candidate() of
         {ok, BlockCandidate, InitialNonce, MaxMiningNonce} ->
-            gen_statem:cast(?SERVER, mine),
-            {next_state, running, State#state{block_candidate = BlockCandidate,
-                                              initial_cycle_nonce = InitialNonce,
-                                              max_block_candidate_nonce = MaxMiningNonce}};
+            {next_state, running,
+             State#state{block_candidate = BlockCandidate,
+                         initial_cycle_nonce = InitialNonce,
+                         max_block_candidate_nonce = MaxMiningNonce},
+            [mine_event()]};
         {error, key_not_found} ->
             report_suspended(),
-            gen_statem:cast(?SERVER, check_keys),
-            {next_state, waiting_for_keys, State};
+            {next_state, waiting_for_keys, State,
+            [{next_event, cast, check_keys}]};
         {error, Reason} ->
             epoch_mining:error("Creation of block candidate failed: ~p", [Reason]),
-            gen_statem:cast(?SERVER, create_block_candidate),
-            {next_state, configure, State}
+            {next_state, configure, State,
+             [{next_event, cast, create_block_candidate}]}
     end;
-configure(cast, bump_initial_cycle_nonce, #state{fetch_new_txs_from_pool = true,
-                                                 block_candidate = BlockCandidate,
-                                                 cycle_attempts_count = CycleAttemptsCount,
-                                                 initial_cycle_nonce = InitialCycleNonce0} = State) ->
+configure(cast, bump_initial_cycle_nonce,
+          #state{fetch_new_txs_from_pool = true,
+                 block_candidate = BlockCandidate,
+                 cycle_attempts_count = CycleAttemptsCount,
+                 initial_cycle_nonce = InitialCycleNonce0} = State) ->
     case aec_mining:apply_new_txs(BlockCandidate) of
         {ok, BlockCandidate} ->
             %% No new txs applied to the block.
             %% Continue incrementing nonce, without block candidate modifications.
-            epoch_mining:info("No new txs available; continuing mining with bumped nonce"),
-            InitialCycleNonce = (InitialCycleNonce0 + CycleAttemptsCount) band 16#7fffffff,
-            gen_statem:cast(?SERVER, mine),
-            {next_state, running, State#state{initial_cycle_nonce = InitialCycleNonce}};
+            epoch_mining:info("No new txs available; "
+                              "continuing mining with bumped nonce"),
+            InitialCycleNonce =
+                (InitialCycleNonce0 + CycleAttemptsCount) band 16#7fffffff,
+            {next_state, running,
+             State#state{initial_cycle_nonce = InitialCycleNonce},
+             [mine_event()]
+            };
         {ok, NewBlockCandidate, InitialNonce, MaxMiningNonce} ->
             epoch_mining:info("New txs added for mining"),
-            gen_statem:cast(?SERVER, mine),
-            {next_state, running, State#state{block_candidate = NewBlockCandidate,
-                                              initial_cycle_nonce = InitialNonce,
-                                              max_block_candidate_nonce = MaxMiningNonce}};
+            {next_state, running,
+             State#state{block_candidate = NewBlockCandidate,
+                         initial_cycle_nonce = InitialNonce,
+                         max_block_candidate_nonce = MaxMiningNonce},
+             [mine_event()]};
         {error, key_not_found} ->
             report_suspended(),
-            gen_statem:cast(?SERVER, check_keys),
-            {next_state, waiting_for_keys, State};
+            {next_state, waiting_for_keys, State,
+             [{next_event, cast, check_keys}]};
         {error, Reason} ->
             epoch_mining:error("Application of new txs failed: ~p", [Reason]),
-            gen_statem:cast(?SERVER, bump_initial_cycle_nonce),
-            {next_state, configure, State}
+            {next_state, configure, State,
+            [{next_event, cast, bump_initial_cycle_nonce}]}
     end;
-configure(cast, bump_initial_cycle_nonce, #state{initial_cycle_nonce = InitialCycleNonce0,
-                                                 cycle_attempts_count = CycleAttemptsCount} = State) ->
-    InitialCycleNonce = (InitialCycleNonce0 + CycleAttemptsCount) band 16#7fffffff,
-    gen_statem:cast(?SERVER, mine),
-    {next_state, running, State#state{initial_cycle_nonce = InitialCycleNonce}};
-configure({call, From}, _Msg, State) ->
-    {next_state, configure, State, [{reply, From, {error, not_supported}}]};
+configure(cast, bump_initial_cycle_nonce,
+          #state{initial_cycle_nonce = InitialCycleNonce0,
+                 cycle_attempts_count = CycleAttemptsCount} = State) ->
+    InitialCycleNonce = (InitialCycleNonce0 + CycleAttemptsCount)
+        band 16#7fffffff,
+    {next_state, running,
+     State#state{initial_cycle_nonce = InitialCycleNonce},
+     [{next_event, cast, mine}]
+    };
+configure(cast, mine, State) ->
+    %% The mine message should come when running.
+    epoch_mining:error("Got mine event in configure state~n", []),
+    %% Keep the event and wait for a state transition.
+    {keep_state, State, [postpone]};
+configure(cast, check_keys, State) ->
+    %% The check_keys message should come when waiting.
+    epoch_mining:error("Got check_keys event in configure state~n", []),
+    %% Keep the event and wait for a state transition.
+    {keep_state, State, [postpone]};
 configure(_Type, _Msg, State) ->
-    {next_state, idle, State}.
+    %% log and drop unknown events.
+    epoch_mining:error("Unknown event in configure: ~p:~p~n", [_Type,_Msg]),
+    {keep_state, State}.
 
+%% -------------------------------------------------------------------
+%% The running state
+%% -------------------------------------------------------------------
+%% Calls: start | suspend
+running({call, From}, start, #state{ miner = none} = State) ->
+    epoch_mining:info("Mining resumed by user.", []),
+    {next_state, configure, State,
+     [{reply, From, ok},
+      {next_event, cast, create_block_candidate}]
+    };
 running({call, From}, start, State) ->
-    {next_state, running, State, [{reply, From, {error, already_started}}]};
+    {keep_state, State, [{reply, From, ok}]};
 running({call, From}, suspend, State) ->
     epoch_mining:info("Mining suspended by user.", []),
     {next_state, idle, State, [{reply, From, ok}]};
+
+%% Casts: post_block | miner_done | create_block_candidate |
+%%        bump_initial_cycle_nonce | mine | check_keys
+running(cast, {post_block, Block}, State) ->
+    running_post_block(Block, State);
+running(cast, {miner_done, Miner}, #state{ miner = Miner } = State) ->
+    {next_state, configure, State#state{ miner = none }};
+running(cast, {miner_done, Miner}, #state{ miner = OtherMiner } = State) ->
+    epoch_mining:error("Unknown miner finished: ~p~n", [Miner]),
+    {keep_state, State#state{ miner = OtherMiner }};
+running(cast, create_block_candidate, State) ->
+    {next_state, configure, State, [postpone]};
+running(cast, bump_initial_cycle_nonce, State) ->
+    {next_state, configure, State, [postpone]};
 running(cast, mine, #state{block_candidate = BlockCandidate,
                            cycle_attempts_count = CycleAttemptsCount,
                            initial_cycle_nonce = CurrentMiningNonce,
-                           max_block_candidate_nonce = MaxMiningNonce} = State) ->
-    case aec_mining:mine(BlockCandidate, CycleAttemptsCount, CurrentMiningNonce, MaxMiningNonce) of
-        {ok, Block} ->
-            ws_handler:broadcast(miner, mined_block, [{height,
-                                                       aec_blocks:height(Block)}]),
-            ok = save_mined_block(Block),
-            gen_statem:cast(?SERVER, create_block_candidate),
-            {next_state, configure, State};
-        {error, generation_count_exhausted} ->
-            try exometer:update([ae,epoch,aecore,mining,retries], 1)
-            catch error:_ -> ok end,
-            epoch_mining:info("Failed to mine block in ~p attempts, retrying.",
-                              [CycleAttemptsCount]),
-            gen_statem:cast(?SERVER, bump_initial_cycle_nonce),
-            {next_state, configure, State};
-        {error, nonce_range_exhausted} ->
-            try exometer:update([ae,epoch,aecore,mining,retries], 1)
-            catch error:_ -> ok end,
-            epoch_mining:info("Failed to mine block, nonce range exhausted; regenerating block candidate"),
-            gen_statem:cast(?SERVER, create_block_candidate),
-            {next_state, configure, State}
-    end;
-running({call, From}, _Msg, State) ->
-    {next_state, running, State, [{reply, From, {error, not_supported}}]};
-running(cast, _Msg, State) ->
-    {next_state, idle, State}.
+                           max_block_candidate_nonce = MaxMiningNonce,
+                           miner = none}
+        = State) ->
+    Miner = mine(BlockCandidate, CycleAttemptsCount,
+                 CurrentMiningNonce, MaxMiningNonce,
+                 State),
+    {keep_state, State#state{ miner = Miner }};
+running(cast, mine, #state{miner = _Other}= State) ->
+    %% Already started mining
+    %% (Future implementations could allow this, starting from new nonce.)
+    epoch_mining:info("Trying to start while mining: ~p~n", [_Other]),
+    {keep_state, State, [postpone]};
+running(cast, check_keys, State) ->
+    %% The check_keys message should come when waiting.
+    epoch_mining:error("Got check_keys event in running state~n", []),
+    %% Keep the event and wait for a state transition.
+    {keep_state, State, [postpone]};
+%% Catchall, log & drop unwanted messages.
+running(_Type, _Msg, State) ->
+    epoch_mining:error("Unknown event in running: ~p:~p~n", [_Type,_Msg]),
+    {keep_state, running, State}.
 
+%% -------------------------------------------------------------------
+%% The Waiting state
+%% -------------------------------------------------------------------
+%% Calls: start | suspend
+waiting_for_keys({call, From}, start, State) ->
+    {keep_state, State, [{reply, From, ok}]};
+waiting_for_keys({call, From}, suspend, State) ->
+    {next_state, idle, State, [{reply, From, ok}]};
+
+%% Casts: post_block | miner_done | create_block_candidate |
+%%        bump_initial_cycle_nonce | mine | check_keys
+waiting_for_keys(cast, {post_block, Block}, State) ->
+    waiting_post_block(Block, State);
+waiting_for_keys(cast, {miner_done, Miner}, #state{ miner = Miner } = State) ->
+    {keep_state, State#state{ miner = none }};
+waiting_for_keys(cast, {miner_done, Miner},
+                 #state{ miner = OtherMiner } = State) ->
+    epoch_mining:error("Unknown miner finished: ~p~n", [Miner]),
+    {keep_state, State#state{ miner = OtherMiner }};
+waiting_for_keys(cast, create_block_candidate, State) ->
+    {keep_state, State, [postpone]};
+waiting_for_keys(cast, bump_initial_cycle_nonce, State) ->
+    {keep_state, State, [postpone]};
+waiting_for_keys(cast, mine, State) ->
+    {keep_state, State, [postpone]};
 waiting_for_keys(cast, check_keys, State) ->
     timer:sleep(1000),
     case aec_keys:pubkey() of
         {ok, _Pubkey} ->
             epoch_mining:info("Key available, mining resumed.", []),
-            gen_statem:cast(?SERVER, create_block_candidate),
-            {next_state, configure, State};
+            {next_state, configure, State,
+             [candidate_event()]};
         {error, _} ->
             report_suspended(),
+            %% Add a new check_keys event to the *end* of the queue.
             gen_statem:cast(?SERVER, check_keys),
-            {next_state, waiting_for_keys, State}
+            {keep_state, State}
     end;
-waiting_for_keys({call, From}, resume, State) ->
-    {next_state, idle, State, [{reply, From, {error, already_started}}]};
-waiting_for_keys({call, From}, suspend, State) ->
-    {next_state, idle, State, [{reply, From, ok}]};
-waiting_for_keys(_, _, State) ->
-    {next_state, waiting_for_keys, State}.
+%% Catchall, log & drop unwanted messages.
+waiting_for_keys(_Type, _Msg, State) ->
+    epoch_mining:error("Unknown event in waiting: ~p:~p~n", [_Type,_Msg]),
+    {keep_state, State}.
+
 
 %%--------------------------------------------------------------------
 %% @private
@@ -289,6 +487,50 @@ callback_mode() ->
 %%% Internal functions
 %%%===================================================================
 
+mine(BlockCandidate, CycleAttemptsCount, CurrentMiningNonce, MaxMiningNonce,
+    State) ->
+    epoch_mining:info("Start mining~n", []),
+    %% Run the mining concurrently.
+    Miner =
+        spawn_link(fun () ->
+                           int_mine(BlockCandidate, CycleAttemptsCount,
+                                    CurrentMiningNonce, MaxMiningNonce,
+                                    State)
+                   end),
+    epoch_mining:info("Miner ~p~n", [Miner]),
+    Miner.
+
+int_mine(BlockCandidate, CycleAttemptsCount,
+         CurrentMiningNonce, MaxMiningNonce,
+         State) ->
+    Res = aec_mining:mine(BlockCandidate, CycleAttemptsCount,
+                          CurrentMiningNonce, MaxMiningNonce),
+    epoch_mining:info("Miner ~p finished with ~p ~n", [self(), Res]),
+
+    gen_statem:cast(?SERVER, {miner_done, self()}),
+    case Res of
+        {ok, Block} ->
+            ws_handler:broadcast(miner, mined_block, [{height,
+                                                       aec_blocks:height(Block)}]),
+            ok = save_mined_block(Block),
+            start_if_auto(State);
+        {error, generation_count_exhausted} ->
+            try exometer:update([ae,epoch,aecore,mining,retries], 1)
+            catch error:_ -> ok end,
+            epoch_mining:info("Failed to mine block in ~p attempts, retrying.",
+                              [CycleAttemptsCount]),
+            gen_statem:cast(?SERVER, bump_initial_cycle_nonce);
+        {error, nonce_range_exhausted} ->
+            try exometer:update([ae,epoch,aecore,mining,retries], 1)
+            catch error:_ -> ok end,
+            epoch_mining:info("Failed to mine block, "
+                              "nonce range exhausted; "
+                              "regenerating block candidate"),
+            gen_statem:cast(?SERVER, create_block_candidate)
+    end.
+
+
+
 -spec save_mined_block(block()) -> ok.
 save_mined_block(Block) ->
     Header = aec_blocks:to_header(Block),
@@ -313,5 +555,105 @@ save_mined_block(Block) ->
 report_suspended() ->
     epoch_mining:error("Mining suspended as no keys are avaiable for signing.", []).
 
+
+idle_post_block(Block, State) ->
+    case int_post_block(Block, State) of
+        new_top ->
+            start_if_auto(State),
+            {next_state, idle, State};
+        ok ->
+            {next_state, idle, State}
+    end.
+
+configure_post_block(Block, State) ->
+    case int_post_block(Block, State) of
+        new_top ->
+            start_if_auto(State),
+            {next_state, configure, State};
+        ok ->
+            {next_state, configure, State}
+    end.
+
+running_post_block(Block, State) ->
+    case int_post_block(Block, State) of
+        new_top ->
+            start_if_auto(State),
+            {next_state, configure, State};
+        ok ->
+            epoch_mining:info("Post block not on top of chain"),
+            {next_state, running, State}
+    end.
+
+waiting_post_block(Block, State) ->
+    int_post_block(Block, State),
+    {next_state, waiting_for_keys, State}.
+
+int_post_block(Block,_State) ->
+    epoch_mining:info("write_block: ~p", [Block]),
+    Header = aec_blocks:to_header(Block),
+    {ok, HH} = aec_headers:hash_header(Header),
+    case aec_chain:get_block_by_hash(HH) of
+        {ok, _Existing} ->
+            epoch_mining:debug("Aleady have block", []),
+            ok;
+        {error, _} ->
+            case {aec_headers:validate(Header), aec_blocks:validate(Block)} of
+                {ok, ok} ->
+                    case aec_chain:insert_header(Header) of
+                        ok ->
+                            %% Write block
+                            {ok, OldTop} = aec_chain:top(),
+                            Res = aec_chain:write_block(Block),
+                            epoch_mining:debug("write_block result: ~p", [Res]),
+                            {ok, NewTop} = aec_chain:top(),
+
+                            %% Gossip
+                            aec_sync:received_block(Block),
+
+                            %% Check if we have a new top block.
+                            if OldTop =:= NewTop -> ok;
+                               true ->
+                                    update_transactions(OldTop, NewTop),
+                                    new_top
+                            end;
+			{error, Reason} ->
+                            lager:debug("Couldn't insert header (~p)", [Reason]),
+                            ok
+                    end;
+                {{error, Reason}, _} ->
+                    lager:info("Malformed block posted to the node (~p)", [Reason]),
+                    error;
+                {ok, {error, Reason}} ->
+                    lager:info("Malformed block posted to the node (~p)", [Reason]),
+                    error
+            end
+    end.
+
+update_transactions(OldTop, NewTop) ->
+    Hash1 = block_to_hash(OldTop),
+    Hash2 = block_to_hash(NewTop),
+    {ok, Ancestor} = aec_chain:common_ancestor(Hash1, Hash2),
+    {ok, TransactionsOnOldChain} =
+        aec_chain:get_transactions_between(Hash1, Ancestor),
+    {ok, TransactionsOnNewChain} =
+        aec_chain:get_transactions_between(Hash2, Ancestor),
+    ok = aec_tx_pool:update(TransactionsOnNewChain, TransactionsOnOldChain),
+    ok.
+
+block_to_hash(Block) ->
+    Header = aec_blocks:to_header(Block),
+    {ok, Hash} = aec_headers:hash_header(Header),
+    Hash.
+
+start_if_auto(#state{autostart = true}) ->
+    gen_statem:cast(?SERVER, create_block_candidate),
+    true;
+start_if_auto(_) -> false.
+
 as_hex(S) ->
     [io_lib:format("~2.16.0b",[X]) || <<X:8>> <= S].
+
+candidate_event()     -> cast_event(create_block_candidate).
+mine_event()          -> cast_event(mine).
+cast_event(Msg)       -> next_event(cast, Msg).
+next_event(Type, Msg) -> {next_event, Type, Msg}.

--- a/apps/aecore/src/aec_persistence.erl
+++ b/apps/aecore/src/aec_persistence.erl
@@ -1,0 +1,325 @@
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2017, Aeternity Anstalt
+%%% @doc Service storing blocks (and state trees) to disc.
+%%%      (Might also store the transaction pool and peers in the future.)
+%%%
+%%%
+%%% @end
+%%%-------------------------------------------------------------------
+-module(aec_persistence).
+
+-behaviour(gen_server).
+
+
+-export([start_link/0,
+         start_link/1,
+         stop/0,
+         stop_and_clean/0]).
+
+%% API
+-export([get_chain/0,
+         get_block/1,
+         get_block_state/1,
+         get_header/1,
+         get_top_block/0,
+         get_top_header/0,
+         path/0,
+         sync/0,
+         write_block/1,
+         write_block_state/2,
+         write_header/1,
+         write_top_block/1,
+         write_top_header/1
+        ]).
+
+
+%% gen_server callbacks
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3]).
+
+-include("common.hrl").
+-include("blocks.hrl").
+
+-define(SERVER, ?MODULE).
+
+%%%===================================================================
+%%% API -  the main API for the server is in aec_chain.
+%%%===================================================================
+
+start_link() ->
+    Path =
+        case  application:get_env(db_path) of
+            {ok, DBPath} ->
+                filename:join(DBPath, ".chain");
+            _ ->
+                ".chain"
+        end,
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [Path], []).
+
+start_link(Path) ->
+    ChainPath = filename:join(Path, ".chain"),
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [ChainPath], []).
+
+stop() ->
+    gen_server:stop(?SERVER).
+
+%% WARNING to be used by tests. Deletes the whole DB before stoping.
+stop_and_clean() ->
+    Path = path(),
+    os:cmd("rm -rf " ++ Path),
+    stop().
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+-record(aecp_state, {path = ".chain"
+                    , blocks_db = ".chain/blocks"
+                    , top_header_hash = ".chain/top_header"
+                    , top_block_hash  = ".chain/top_block"
+                    , state_db = ".chain/states"}).
+
+init(_Args = [Path]) ->
+    init(init_state(Path));
+init(State) when is_record(State, aecp_state) ->
+    #aecp_state{path = Path} = State,
+    case file:list_dir(Path) of
+        {error, enoent} -> init_dir(State);
+        {ok,_Files} -> {ok, State}
+    end.
+
+init_state(Path) ->
+    _State = #aecp_state{path = Path
+                        , blocks_db       = filename:join(Path, "blocks")
+                        , top_header_hash = filename:join(Path, "top_header")
+                        , top_block_hash  = filename:join(Path, "top_block")
+                        , state_db        = filename:join(Path, "states")
+                        }.
+
+init_dir(#aecp_state{path = Path
+                    , blocks_db = Blocks
+                    , top_header_hash = Header
+                    , top_block_hash  = Block
+                    , state_db = States} = S) ->
+    case application:get_env(aecore, persist, false) of
+        true ->
+            ok = file:make_dir(Path),
+            ok = file:make_dir(Blocks),
+            ok = file:make_dir(States),
+            ok = file:write_file(Header,
+                                 term_to_binary(undefined, [compressed])),
+            ok = file:write_file(Block,
+                                 term_to_binary(undefined, [compressed])),
+            {ok, S};
+        false ->
+            {ok, S}
+    end.
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+sync() ->  gen_server:call(?SERVER, sync).
+path() ->  gen_server:call(?SERVER, path).
+get_chain() ->  gen_server:call(?SERVER, get_chain).
+write_block(Block) -> gen_server:call(?SERVER, {write_block, Block}).
+write_block_state(Hash, State) ->
+    gen_server:call(?SERVER, {write_block_state, Hash, State}).
+write_header(Header) ->
+    gen_server:call(?SERVER, {write_header, Header}).
+write_top_block(Hash) ->
+    gen_server:call(?SERVER, {write_top_block, Hash}).
+write_top_header(Hash) ->
+    gen_server:call(?SERVER, {write_top_header, Hash}).
+get_block(Hash) ->
+    gen_server:call(?SERVER, {get_block, Hash}).
+get_header(Hash) ->
+    gen_server:call(?SERVER, {get_header, Hash}).
+get_top_block() ->
+    gen_server:call(?SERVER, get_top_block).
+get_top_header()  ->
+    gen_server:call(?SERVER, get_top_header).
+get_block_state(Hash) ->
+    gen_server:call(?SERVER, {get_block_state, Hash}).
+
+%% State preserving functions
+handle_call(sync, _From, State) ->
+    %% Ensure that the persistense server has caught up with writing.
+    {reply, ok, State};
+handle_call(path, _From, #aecp_state{path = Path} = State) ->
+    %% Ensure that the persistense server has caught up with writing.
+    {reply, Path, State};
+handle_call(get_chain, _From, State) ->
+    Chain = int_get_chain(State),
+    {reply, Chain, State};
+handle_call({write_block, Block}, _From, State) ->
+    {reply, int_write_block(Block, State), State};
+handle_call({write_block_state, Hash, S}, _From, State) ->
+    {reply, int_write_block_state(Hash, S, State), State};
+handle_call({write_header, Header}, _From, State) ->
+    {reply, int_write_header(Header, State), State};
+handle_call({write_top_block, Hash}, _From, State) ->
+    {reply, int_write_top_block(Hash, State), State};
+handle_call({write_top_header, Hash}, _From, State) ->
+    {reply, int_write_top_header(Hash, State), State};
+handle_call({get_block, Hash}, _From, State) ->
+    {reply, int_get_block(Hash, State), State};
+handle_call({get_header, Hash}, _From, State) ->
+    {reply, int_get_header(Hash, State), State};
+handle_call(get_top_block, _From, State) ->
+    {reply, int_get_top_block(State), State};
+handle_call(get_top_header, _From, State) ->
+    {reply, int_get_top_header(State), State};
+handle_call({get_block_state, Hash}, _From, State) ->
+    {reply, int_get_block_state(Hash, State), State};
+
+handle_call(Request, From, State) ->
+    lager:warning("Unknown call request from ~p: ~p", [From, Request]),
+    {reply, {error, unknown_request}, State}.
+
+handle_cast(Msg, State) ->
+    lager:warning("Ignoring unknown cast message: ~p", [Msg]),
+    {noreply, State}.
+
+handle_info(Info, State) ->
+    lager:warning("Ignoring unknown info: ~p", [Info]),
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+
+int_write_block(Block, State) ->
+    Hash = hash(Block),
+    File = aec_blocks:serialize_for_store(Block),
+    write_block(Hash, File, State).
+
+int_write_header(Header, State) ->
+    Hash = hash(Header),
+    File = aec_headers:serialize_for_store(Header),
+    write_header(Hash, File, State).
+
+int_write_block_state(Hash, S, State) ->
+    File = serialize(S),
+    write_state(Hash, File, State).
+
+int_write_top_block(Hash, #aecp_state{top_block_hash = FileName}) ->
+    write(FileName, serialize(Hash)).
+
+int_write_top_header(Hash, #aecp_state{top_header_hash = FileName}) ->
+    write(FileName, serialize(Hash)).
+
+int_get_block(Hash, State) ->
+    FileName = block_filename(Hash, State),
+    {ok, Binary} = file:read_file(FileName),
+    {ok, Block} = aec_blocks:deserialize_from_store(Binary),
+    Block.
+
+int_get_header(Hash, State) ->
+    FileName = header_filename(Hash, State),
+    {ok, Binary} = file:read_file(FileName),
+    {ok, Header} = aec_headers:deserialize_from_store(Binary),
+    Header.
+
+
+int_get_top_block(#aecp_state{top_block_hash = FileName}) ->
+    {ok, Binary} = file:read_file(FileName),
+    deserialize(Binary).
+int_get_top_header(#aecp_state{top_header_hash = FileName}) ->
+    {ok, Binary} = file:read_file(FileName),
+    deserialize(Binary).
+int_get_block_state(Hash, State) ->
+    FileName = state_filename(Hash, State),
+    {ok, Binary} = file:read_file(FileName),
+    StateTrees = deserialize(Binary),
+    StateTrees.
+
+int_get_chain(#aecp_state{blocks_db = Path}) ->
+    ReadFun = fun(FileName, Acc) ->
+                      case get_block_or_header(FileName) of
+                          undefined -> Acc;
+                          Blob -> [Blob|Acc]
+                      end
+              end,
+    Chain = filelib:fold_files(Path, ".*", true, ReadFun, []),
+    Chain.
+
+get_block_or_header(FileName) ->
+    {ok, Binary} = file:read_file(FileName),
+    case aec_blocks:deserialize_from_store(Binary) of
+        {ok, Block} -> Block;
+        false ->
+            case aec_headers:deserialize_from_store(Binary) of
+                {ok, Header} -> Header;
+                false -> undefined
+            end
+    end.
+
+serialize(T) -> term_to_binary(T, [{compressed,9}]).
+deserialize(B) -> binary_to_term(B).
+
+write_block(Hash, Bin, State) ->
+    write(block_filename(Hash, State), Bin).
+
+write_header(Hash, Bin, State) ->
+    FileName = header_filename(Hash, State),
+    %% Don't overwrite a potential block file with header.
+    case filelib:is_file(FileName) of
+        true ->
+            ok;
+        false ->
+            write(header_filename(Hash, State), Bin)
+    end.
+
+write_state(Hash, Bin, State) ->
+    write(state_filename(Hash, State), Bin).
+
+hash(#block{} = B) ->
+    {ok, Hash} = aec_headers:hash_header(aec_blocks:to_header(B)),
+    Hash;
+hash(#header{} = H) ->
+    {ok, Hash} = aec_headers:hash_header(H),
+    Hash.
+
+header_filename(<<A:8,B:8,Hash/binary>>, #aecp_state{blocks_db = Path}) ->
+    mk_filename(Path, <<A, B>>, Hash).
+block_filename(<<A:8,B:8,Hash/binary>>, #aecp_state{blocks_db = Path}) ->
+    mk_filename(Path, <<A, B>>, Hash).
+state_filename(<<A:8,B:8,Hash/binary>>, #aecp_state{state_db = Path}) ->
+    mk_filename(Path, <<A, B>>, Hash).
+
+mk_filename(Path, DirBin, Hash) ->
+    Dir = to_hexstring(DirBin),
+    DirPath = filename:join(Path, Dir),
+    ok = ensure_dir_exists(DirPath),
+    filename:join(DirPath, to_hexstring(Hash)).
+
+write(FileName, Bin) ->
+    case application:get_env(aecore, persist, false) of
+        true ->
+            ok = file:write_file(FileName, Bin);
+        false ->
+            ok
+    end.
+
+ensure_dir_exists(Path) ->
+    case application:get_env(aecore, persist, false) of
+        true ->
+            case file:list_dir(Path) of
+                {error, enoent} ->
+                    ok = file:make_dir(Path);
+                {ok,_Files} -> ok
+            end;
+        false ->
+            ok
+    end.
+
+to_hexstring(L) when is_list(L) ->
+    [io_lib:format("~2.16.0B", [C]) || C <- L];
+to_hexstring(B) when is_binary(B) ->
+    [io_lib:format("~2.16.0B", [C]) || C <- binary_to_list(B)].

--- a/apps/aecore/src/aec_persistence.erl
+++ b/apps/aecore/src/aec_persistence.erl
@@ -319,7 +319,5 @@ ensure_dir_exists(Path) ->
             ok
     end.
 
-to_hexstring(L) when is_list(L) ->
-    [io_lib:format("~2.16.0B", [C]) || C <- L];
 to_hexstring(B) when is_binary(B) ->
     [io_lib:format("~2.16.0B", [C]) || C <- binary_to_list(B)].

--- a/apps/aecore/src/aec_trees.erl
+++ b/apps/aecore/src/aec_trees.erl
@@ -1,7 +1,7 @@
 -module(aec_trees).
 
 -include("common.hrl").
--include("trees.hrl").
+-include("blocks.hrl").
 
 %% API
 
@@ -26,8 +26,10 @@ all_trees_new() ->
 
 all_trees_hash(Trees) ->
     %% TODO Consider all state trees - not only accounts.
-    {ok, H} = aec_accounts:root_hash(accounts(Trees)),
-    H.
+    case aec_accounts:root_hash(accounts(Trees)) of
+      {ok, H} -> H;
+      {error, empty} -> <<0:?STATE_HASH_BYTES/unit:8>>
+    end.
 
 -spec accounts(trees()) -> tree().
 accounts(Trees) ->

--- a/apps/aecore/src/aecore_sup.erl
+++ b/apps/aecore/src/aecore_sup.erl
@@ -28,11 +28,11 @@ start_link() ->
 %%====================================================================
 
 init([]) ->
-    GB = aec_block_genesis:genesis_block_as_deserialized_from_network(),
     {ok, {{one_for_one, 5, 10}, [?CHILD(aec_peers, 5000, worker),
+                                 ?CHILD(aec_persistence, 5000, worker),
                                  ?CHILD(aec_tx_pool, 5000, worker),
-                                 ?CHILD(aec_chain, 5000, worker, [GB]),
+                                 ?CHILD(aec_chain, 5000, worker),
                                  ?CHILD(aec_keys, 5000, worker),
-				 ?CHILD(aec_sync, 5000, worker),
+                                 ?CHILD(aec_sync, 5000, worker),
                                  ?CHILD(aec_miner, 5000, worker)]
          }}.

--- a/apps/aecore/test/aec_chain_state_tests.erl
+++ b/apps/aecore/test/aec_chain_state_tests.erl
@@ -11,6 +11,11 @@
 -include("common.hrl").
 -include("blocks.hrl").
 
+-import(aec_test_utils,
+        [ extend_block_chain_by_difficulties_with_nonce_and_coinbase/3
+        , aec_keys_setup/0
+        , aec_keys_cleanup/1
+        ]).
 
 %%%===================================================================
 %%% Test cases
@@ -51,9 +56,102 @@ only_genesis_test_() ->
        end}
     ].
 
+gc_test_() ->
+    {foreach,
+     fun setup_meck_and_keys/0,
+     fun teardown_meck_and_keys/1,
+     [{gc_test_slogan(Length, Max, Interval, KeepAll)
+      , fun() ->
+                %% Generate blockchain and write it to the state.
+                BC = gen_block_chain(Length),
+                State1 = aec_chain_state:new(gc_opts(KeepAll, Max, Interval)),
+                State2 = write_blocks_to_chain(BC, State1),
+
+                %% Get the state trees that we would have persisted.
+                Trees = aec_chain_state:get_state_trees_for_persistance(State2),
+
+                %% Check that the top block hash is among the persisted.
+                TopHash = aec_chain_state:top_block_hash(State2),
+                ?assertMatch({TopHash, _}, lists:keyfind(TopHash, 1, Trees)),
+
+                %% Compute the hashes that always should be persisted...
+                KeepAllHashes =
+                    [block_hash(lists:nth(X, BC))
+                     || X <- lists:seq(Length - KeepAll + 1, Length)],
+                %% ...and check that they are indeed persisted.
+                ?assertEqual(lists:duplicate(length(KeepAllHashes), true),
+                             [lists:keymember(X, 1, Trees)
+                              || X <- KeepAllHashes]),
+
+                %% Compute the hashes that should be sparsely persisted...
+                KeepSparseHashes =
+                    [block_hash(lists:nth(X, BC))
+                     || X <- lists:seq(Length-KeepAll, Length-Max,-Interval)],
+                %% ...and check that they are indeed persisted.
+                ?assertEqual(lists:duplicate(length(KeepSparseHashes), true),
+                             [lists:keymember(X, 1, Trees)
+                              || X <- KeepSparseHashes]),
+
+                %% Check that we have have covered all the hashes that
+                %% we will persist (and that the hashes were unique).
+                HashSet = ordsets:from_list(KeepAllHashes ++ KeepSparseHashes),
+                ?assertEqual(ordsets:size(HashSet), length(Trees)),
+                ?assertEqual(ordsets:size(HashSet),
+                             length(KeepSparseHashes) + length(KeepAllHashes)),
+                ok
+        end}
+      || {Length, Max, Interval, KeepAll} <- gc_test_params()
+     ]}.
+
+gc_test_slogan(Length, Max, Interval, KeepAll) ->
+    S = io_lib:format("Create chain, test that only"
+                      " the intended snapshots are kept."
+                      " Length: ~w, Max: ~w, Interval: ~w, KeepAll: ~w",
+                      [Length, Max, Interval, KeepAll]),
+    lists:flatten(S).
+
+gc_test_params() ->
+    %% {Length, Max, Interval, KeepAll}
+    [ {15, 10, 5, 2}
+    , {4, 3, 1, 1}
+    , {100, 30, 10, 5}
+    ].
+
+
 %%%===================================================================
 %%% Internal functions
 %%%===================================================================
+
+setup_meck_and_keys() ->
+    aec_test_utils:mock_difficulty_as_target(),
+    aec_test_utils:aec_keys_setup().
+
+teardown_meck_and_keys(TmpDir) ->
+    aec_test_utils:unmock_difficulty_as_target(),
+    aec_test_utils:aec_keys_cleanup(TmpDir).
+
+write_blocks_to_chain([H|T], State) ->
+    {ok, State1} = aec_chain_state:insert_block(H, State),
+    write_blocks_to_chain(T, State1);
+write_blocks_to_chain([], State) ->
+    State.
+
+gc_opts(KeepAll, Max, Interval) ->
+    #{ max_snapshot_height => Max
+     , sparse_snapshots_interval => Interval
+     , keep_all_snapshots_height => KeepAll
+     }.
+
+gen_block_chain(Length) ->
+  gen_block_chain(Length, 1).
+
+gen_block_chain(Length, Difficulty) ->
+  gen_block_chain(Length, Difficulty, 111).
+
+gen_block_chain(Length, Difficulty, Nounce) ->
+  Ds = lists:duplicate(Length - 1, Difficulty),
+  G = genesis_block(),
+  [G|extend_block_chain_by_difficulties_with_nonce_and_coinbase(G, Ds, Nounce)].
 
 genesis_block() ->
     aec_block_genesis:genesis_block().

--- a/apps/aecore/test/aec_miner_tests.erl
+++ b/apps/aecore/test/aec_miner_tests.erl
@@ -12,8 +12,16 @@
 
 -include("common.hrl").
 -include("blocks.hrl").
+-include("txs.hrl").
 
 -define(TEST_MODULE, aec_miner).
+%%-define(DEBUG, true).
+
+-ifdef(DEBUG).
+-define(show_miner_state(), ?debugFmt("State ~p~n",[element(1,sys:get_state(?TEST_MODULE))])).
+-else.
+-define(show_miner_state(), ok).
+-endif.
 
 miner_test_() ->
     {foreach,
@@ -21,14 +29,15 @@ miner_test_() ->
              meck:new(aec_governance, [passthrough]),
              meck:expect(aec_governance, expected_block_mine_rate,
                          fun() ->
-                                 meck:passthrough([]) div 256
+                                 meck:passthrough([]) div 2560
                          end),
+             aec_test_utils:mock_time(),
              {ok, _} = aec_tx_pool:start_link(),
              {ok, _} = aec_chain:start_link(aec_block_genesis:genesis_block()),
              TmpKeysDir = mktempd(),
              ok = application:ensure_started(crypto),
              {ok, _} = aec_keys:start_link(["mypassword", TmpKeysDir]),
-             {ok, _} = ?TEST_MODULE:start_link(),
+             {ok, _} = ?TEST_MODULE:start_link([{autostart, true}]),
              TmpKeysDir
      end,
      fun(TmpKeysDir) ->
@@ -49,43 +58,79 @@ miner_test_() ->
              ok = file:del_dir(TmpKeysDir),
              ?assert(meck:validate(aec_governance)),
              meck:unload(aec_governance),
+             aec_test_utils:unmock_time(),
              file:delete(TmpKeysDir)
      end,
      [fun(_) ->
               {"Suspend and resume",
                fun() ->
+                       ?show_miner_state(),
                        ?assertEqual(ok, ?TEST_MODULE:suspend()),
+                       ?show_miner_state(),
                        ?assertEqual(ok, ?TEST_MODULE:resume()),
-                       ?assertEqual(ok, ?TEST_MODULE:suspend())
-               end}
+                       ?show_miner_state(),
+                       wait_for_running()
+               end} 
       end,
       fun(_) ->
               {"Resume twice",
                fun() ->
-                       ?assertEqual(ok, ?TEST_MODULE:suspend()),
+                       ?show_miner_state(),
                        ?assertEqual(ok, ?TEST_MODULE:resume()),
-                       ?assertEqual({error,already_started}, ?TEST_MODULE:resume()),
+                       ?show_miner_state(),
+                       ?assertEqual(ok, ?TEST_MODULE:suspend()),
+                       ?show_miner_state(),
+                       aec_test_utils:wait_for_it(
+                         fun() ->
+                                 {State, _} = sys:get_state(?TEST_MODULE),
+                                 (State =:= idle)
+                         end, true),
+                       ?assertEqual(ok, ?TEST_MODULE:resume()),
+                       ?show_miner_state(),
+                       ?TEST_MODULE:resume(),
+                       ?show_miner_state(),
+                       wait_for_running(),
                        ?assertEqual(ok, ?TEST_MODULE:suspend())
                end}
       end,
       fun(_) ->
               {"Suspend twice",
                fun() ->
+                       ?show_miner_state(),
+                       ?assertEqual(ok, ?TEST_MODULE:resume()),
                        ?assertEqual(ok, ?TEST_MODULE:suspend()),
-                       ?assertEqual({error,not_started}, ?TEST_MODULE:suspend())
+                       ?assertEqual(ok, ?TEST_MODULE:suspend()),
+                       ?show_miner_state()
                end}
       end,
       fun(_) ->
               {"Suspend in idle",
                fun() ->
+                       ?show_miner_state(),
+                       ?assertEqual(ok, ?TEST_MODULE:resume()),
                        ?assertEqual(ok, ?TEST_MODULE:suspend()),
-                       ?assertEqual({error,not_started}, ?TEST_MODULE:suspend())
+                       ?show_miner_state(),
+                       aec_test_utils:wait_for_it(
+                         fun() ->
+                                 {State, _} = sys:get_state(?TEST_MODULE),
+                                 State
+                         end, idle)
+                       %% ?show_miner_state(),
+
+                       %% ?assertEqual(ok, ?TEST_MODULE:suspend())
                end}
       end,
       fun(_) ->
-              {timeout, 60,
+              {timeout, 80,
                {"Run miner for a while",
                 fun() ->
+                        ?assertEqual(ok, ?TEST_MODULE:suspend()),
+                        aec_test_utils:wait_for_it(
+                          fun() ->
+                                  {State, _} = sys:get_state(?TEST_MODULE),
+                                  (State =:= idle)
+                          end, true),
+                       
                         meck:new(aec_chain, [passthrough]),
                         TestPid = self(),
                         meck:expect(
@@ -95,10 +140,21 @@ miner_test_() ->
                                   TestPid ! block_written_in_chain,
                                   Result
                           end),
+                        ?show_miner_state(),
+                        ?assertEqual(ok, ?TEST_MODULE:resume()),
+                        ?show_miner_state(),
+                        wait_for_running(),
+                        ?show_miner_state(),
                         receive block_written_in_chain -> ok end,
+                        ?show_miner_state(),
+                        aec_test_utils:wait_for_it(fun() ->
+                                            {ok, TopBlock} = aec_chain:top(),
+                                            aec_blocks:height(TopBlock) > 0
+                                    end,
+                                    true),
                         ?assertEqual(ok, ?TEST_MODULE:suspend()),
+                        ?show_miner_state(),
                         {ok, TopBlock} = aec_chain:top(),
-                        ?assertMatch(X when X > 0, aec_blocks:height(TopBlock)),
                         ?assertMatch(
                            Txs when is_list(Txs) andalso length(Txs) > 0,
                            aec_blocks:txs(TopBlock)),
@@ -110,26 +166,167 @@ miner_test_() ->
               }
       end,
       fun(_) ->
-              {"Remove keys while miner runs",
-               fun() ->
-                       {State1, _Data1} = sys:get_state(aec_miner),
-                       ?assertEqual(running, State1),
-                       ?assertEqual(ok, aec_keys:delete()),
-                       timer:sleep(1000),
-                       {State2, _Data2} = sys:get_state(aec_miner),
-                       ?assertEqual(waiting_for_keys, State2), %% XXX This assertion is fragile. Ticket GH-204 shall simplify this code path.
-                       ?assertNotEqual(error, aec_keys:new("mynewpassword")),
-                       timer:sleep(10),
-                       {State3, _Data3} = sys:get_state(aec_miner),
-                       ?assertEqual(configure, State3)
-               end}
+              {timeout, 60,
+               {"Remove keys while miner runs",
+                fun() ->
+                        ?show_miner_state(),
+                        ?assertEqual(ok, ?TEST_MODULE:resume()),
+                        ?show_miner_state(),
+                        wait_for_running(),
+                        ?show_miner_state(),
+                        ?assertEqual(ok, aec_keys:delete()),
+                        ?show_miner_state(),
+                        aec_test_utils:wait_for_it(
+                         fun () ->
+                                 ?show_miner_state(),
+                                 {MinerState, _Data1}
+                                     = sys:get_state(aec_miner),
+                                 MinerState
+                         end, waiting_for_keys),
+                        ?assertNotEqual(error, aec_keys:new("mynewpassword")),
+                        ?show_miner_state(),
+                        wait_for_running(),
+                        ?show_miner_state(),
+                        ok
+                end}
+              }
       end
      ]}.
+
+
+chain_test_() ->
+    {foreach,
+     fun() ->
+             meck:new(aec_governance, [passthrough]),
+             meck:expect(aec_governance, expected_block_mine_rate,
+                         fun() ->
+                                 meck:passthrough([]) div 2560
+                         end),
+             aec_test_utils:mock_time(),
+             {ok, _} = aec_tx_pool:start_link(),
+             {ok, _} = aec_chain:start_link(aec_block_genesis:genesis_block()),
+             TmpKeysDir = mktempd(),
+             ok = application:ensure_started(crypto),
+             {ok, _} = aec_keys:start_link(["mypassword", TmpKeysDir]),
+             {ok, _} = ?TEST_MODULE:start_link(),
+             meck:new(aec_headers, [passthrough]),
+             meck:new(aec_blocks, [passthrough]),
+             meck:expect(aec_headers, validate, fun(_) -> ok end),
+             meck:expect(aec_blocks, validate, fun(_) -> ok end),
+             TmpKeysDir
+     end,
+     fun(TmpKeysDir) ->
+             ok = ?TEST_MODULE:stop(),
+             ok = aec_keys:stop(),
+             ok = aec_chain:stop(),
+             ok = aec_tx_pool:stop(),
+             ok = application:stop(crypto),
+             {ok, KeyFiles} = file:list_dir(TmpKeysDir),
+             %% Expect two filenames - private and public keys.
+             [_KF1, _KF2] = KeyFiles,
+             lists:foreach(
+               fun(F) ->
+                       AbsF = filename:absname_join(TmpKeysDir, F),
+                       {ok, _} = {file:delete(AbsF), {F, AbsF}}
+               end,
+               KeyFiles),
+             ok = file:del_dir(TmpKeysDir),
+             aec_test_utils:unmock_time(),
+             ?assert(meck:validate(aec_governance)),
+             meck:unload(aec_governance),
+             meck:unload(aec_headers),
+             meck:unload(aec_blocks),
+             file:delete(TmpKeysDir)
+     end,
+     [
+      fun(_) ->
+              {"Start mining add a block.",
+               fun() ->
+                       GB = genesis_block(),
+                       %% Add a couple of blocks to the chain.
+                       {ok, B0H} = aec_blocks:hash_internal_representation(GB),
+                       B1  = #block{height = 1, prev_hash = B0H},
+                       B1H = block_hash(B1),
+                       B2  = #block{height = 2, prev_hash = B1H},
+                       BH2 = aec_blocks:to_header(B2),
+                       ?assertEqual(ok, ?TEST_MODULE:post_block(B1)),
+                       {State1, _Data1} = sys:get_state(aec_miner),
+                       ?assertEqual(configure, State1),
+                       ?assertEqual(ok, ?TEST_MODULE:post_block(B2)),
+                       aec_test_utils:wait_for_it(
+                         fun () -> aec_chain:top_header() end,
+                         {ok, BH2})
+               end}
+      end,
+      fun(_) ->
+              {"Switch to an alternative chain while mining.",
+               fun() ->
+                       Chain1 = build_a_chain_of_length(5),
+                       [?TEST_MODULE:post_block(B)
+                        || B <- Chain1],
+
+                       [_,_,_,B5] = Chain1,
+                       BH5 = aec_blocks:to_header(B5),
+                       aec_test_utils:wait_for_it(
+                         fun () -> aec_chain:top_header() end,
+                         {ok, BH5}),
+ 
+                       %% TODO: Add some transactions to the pool
+                       %% Let the miner mine one block
+
+                       Chain2 = build_a_chain_of_length(7),
+                       [?TEST_MODULE:post_block(B)
+                        || B <- Chain2],
+
+                       [_,_,_,_,_,B7] = Chain2,
+                       BH7 = aec_blocks:to_header(B7),
+                       aec_test_utils:wait_for_it(
+                         fun () -> aec_chain:top_header() end,
+                         {ok, BH7}),
+
+                       %% TODO: check the transaction pool
+                       ok
+               end
+              }
+      end
+     ]}.
+
+
+build_a_chain_of_length(N) ->
+    Hash = block_hash(genesis_block()),
+    build_a_chain_of_length(1, N, Hash, []).
+
+build_a_chain_of_length(N, N, _, Blocks) -> lists:reverse(Blocks);
+build_a_chain_of_length(N, Length, Parent, Blocks) ->
+    B  = #block{height = N,
+                prev_hash = Parent,
+                %% Mocked time
+                time = aeu_time:now_in_msecs(),
+                txs = [] %% TODO: Add some real transactions
+               },
+    Hash = block_hash(B),
+    build_a_chain_of_length(N+1, Length, Hash, [B|Blocks]).
+
+genesis_block() ->
+    aec_block_genesis:genesis_block().
+
+block_hash(B) ->
+    {ok, Hash} = aec_headers:hash_header(aec_blocks:to_header(B)),
+    Hash.
 
 mktempd() ->
     mktempd(os:type()).
 
 mktempd({unix, _}) ->
     lib:nonl(?cmd("mktemp -d")).
+
+wait_for_running() ->
+    aec_test_utils:wait_for_it(
+      fun() ->
+              {State, _} = sys:get_state(?TEST_MODULE),
+              (State =:= running)
+                  orelse
+                    (State =:= configure)
+      end, true).
 
 -endif.

--- a/apps/aecore/test/aec_persistence_tests.erl
+++ b/apps/aecore/test/aec_persistence_tests.erl
@@ -1,0 +1,215 @@
+-module(aec_persistence_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("common.hrl").
+-include("blocks.hrl").
+
+-define(compareBlockResults(B1, B2),
+        ?assertEqual(aec_blocks:serialize_for_network(B1),
+                     aec_blocks:serialize_for_network(B2))).
+
+-define(GENESIS_DIFFICULTY, 553713663.0).
+
+genesis_block() ->
+    aec_block_genesis:genesis_block().
+
+block_hash(B) ->
+    {ok, Hash} = aec_headers:hash_header(aec_blocks:to_header(B)),
+    Hash.
+
+header_hash(Header) ->
+    {ok, Hash} = aec_headers:hash_header(Header),
+    Hash.
+
+ts() -> integer_to_list(erlang:system_time()).
+
+init_persistence() ->
+    put('__persist__', application:get_env(aecore, persist, false)),
+    application:set_env(aecore, persist, true),
+    Path = ".test_" ++ ts(),
+    file:make_dir(Path),
+    {ok, _} = aec_persistence:start_link(Path),
+    Path.
+
+cleanup_persistence(Path) ->
+    Persist = get('__persist__'),
+    application:set_env(aecore, persist, Persist),
+    ok = aec_persistence:stop_and_clean(),
+    file:del_dir(Path),
+    ok.
+
+kill_and_restart_chain_server() ->
+    %% Stop server
+    ok = aec_chain:stop(),
+    %% check that it is dead.
+    dead =
+        try aec_chain:top()
+        catch exit:{noproc, _} -> dead
+        end,
+    %% Restart server
+    {ok, _} = aec_chain:start_link(),
+    server_up = wait_for_chain(),
+    ok.
+
+wait_for_chain() ->
+    case
+        try aec_chain:top()
+        catch exit:{noproc, _} -> dead
+        end
+    of
+        dead ->
+            timer:sleep(10),
+            wait_for_chain();
+        _ ->
+            server_up
+    end.
+
+write_test_() ->
+    {foreach,
+     fun() ->
+             init_persistence()
+     end,
+     fun(Path) ->
+             cleanup_persistence(Path)
+     end,
+     [{"Write a block to storage and read it back.",
+       fun() ->
+               GB = genesis_block(),
+               ok = aec_persistence:write_block(GB),
+               ok = aec_persistence:sync(),
+               Hash = block_hash(GB),
+
+               Block = aec_persistence:get_block(Hash),
+
+               %% Check block apart from state trees.
+               ?compareBlockResults(GB, Block),
+               ok
+       end}]}.
+
+write_chain_test_() ->
+    {foreach,
+     fun() ->
+             Path = init_persistence(),
+             {ok, _} = aec_chain:start_link(genesis_block()),
+             {Path, aec_test_utils:aec_keys_setup()}
+     end,
+     fun({Path, TmpDir}) ->
+             cleanup_persistence(Path),
+             aec_test_utils:aec_keys_cleanup(TmpDir),
+             ok = aec_chain:stop()
+     end,
+     [{"Write a block to chain and read it back.",
+       fun() ->
+               GB = genesis_block(),
+               ok = aec_persistence:write_block(GB),
+
+               Hash = block_hash(GB),
+
+               Block = aec_persistence:get_block(Hash),
+
+               %% Check block apart from state trees.
+               ?compareBlockResults(GB, Block),
+
+               %% Genesis should be top header
+               Header = aec_persistence:get_top_header(),
+               ?assertEqual(Header, Hash),
+
+               %% Genesis should be top block
+               TopBlockHash = aec_persistence:get_top_block(),
+               ?assertEqual(Header, TopBlockHash),
+
+               ok
+       end},
+      {"Build chain with genesis block plus 2 headers, then store block corresponding to top header",
+       fun() ->
+               [GB, B1, B2] = aec_test_utils:gen_block_chain(3),
+               %% Add a couple of headers - not blocks - to the chain.
+               BH1 = aec_blocks:to_header(B1),
+               ?assertEqual(ok, aec_chain:insert_header(BH1)),
+               BH2 = aec_blocks:to_header(B2),
+               ?assertEqual(ok, aec_chain:insert_header(BH2)),
+               aec_persistence:sync(),
+
+               GHash = block_hash(GB),
+
+               Block = aec_persistence:get_block(GHash),
+
+               %% Check block apart from state trees.
+               ?compareBlockResults(GB, Block),
+
+               %% BH2 should be top header
+               Header = aec_persistence:get_top_header(),
+               B2Hash = header_hash(BH2),
+               ?assertEqual(B2Hash, Header),
+
+               %% Genesis should be top block
+               TopBlockHash = aec_persistence:get_top_block(),
+               ?assertEqual(GHash, TopBlockHash),
+
+               %% Add one block corresponding to a header already in the chain.
+               ?assertEqual(ok, aec_chain:write_block(B2)),
+               aec_persistence:sync(),
+
+               %% GB should still be top block
+               NewTopBlockHash = aec_persistence:get_top_block(),
+               ?assertEqual(GHash, NewTopBlockHash),
+
+               %% Add missing block corresponding to a header already in the chain.
+               ?assertEqual(ok, aec_chain:write_block(B1)),
+               aec_persistence:sync(),
+               %% Now B2 should be the top block
+               LastTopBlockHash = aec_persistence:get_top_block(),
+               ?assertEqual(B2Hash, LastTopBlockHash),
+
+               ok
+       end}
+     ]}.
+
+
+restart_test_() ->
+    {foreach,
+     fun() ->
+             Path = init_persistence(),
+             {ok, _} = aec_chain:start_link(genesis_block()),
+             {Path, aec_test_utils:aec_keys_setup()}
+     end,
+     fun({Path, TmpDir}) ->
+             %% ok = aec_chain:stop(),
+             cleanup_persistence(Path),
+             aec_test_utils:aec_keys_cleanup(TmpDir)
+     end,
+     [{"Build chain, then kill server, check that chain is read back.",
+       fun() ->
+               [_GB, B1, B2] = aec_test_utils:gen_block_chain(3),
+               BH2 = aec_blocks:to_header(B2),
+               ?assertEqual(ok, aec_chain:write_block(B1)),
+               ?assertEqual(ok, aec_chain:write_block(B2)),
+               aec_persistence:sync(),
+               %% Now B2 should be the top block
+               TopBlockHash = aec_persistence:get_top_block(),
+               B2Hash = header_hash(BH2),
+               ?assertEqual(B2Hash, TopBlockHash),
+               {ok, ChainTop1} = aec_chain:top(),
+               ?compareBlockResults(B2, ChainTop1),
+
+               %% Check the state trees from persistence
+               ?assertEqual(aec_persistence:get_block_state(TopBlockHash),
+                            aec_blocks:trees(ChainTop1)),
+
+               %% Kill chain server
+               kill_and_restart_chain_server(),
+               aec_persistence:sync(),
+               NewTopBlockHash = aec_persistence:get_top_block(),
+               ?assertEqual(B2Hash, NewTopBlockHash),
+
+               {ok, ChainTop2} = aec_chain:top(),
+               ?compareBlockResults(B2, ChainTop2),
+
+               %% Compare the trees after restart
+               %% Check the state trees from persistence
+               ?assertEqual(aec_blocks:trees(ChainTop2),
+                            aec_blocks:trees(ChainTop1)),
+
+               ok
+       end}
+     ]}.

--- a/apps/aecore/test/aec_test_utils.erl
+++ b/apps/aecore/test/aec_test_utils.erl
@@ -1,0 +1,170 @@
+%%%=============================================================================
+%%% @copyright (C) 2017, Aeternity Anstalt
+%%% @doc
+%%%   Utils for (mocking tests).
+%%% @end
+%%%=============================================================================
+
+-module(aec_test_utils).
+
+-export([ mock_time/0
+        , unmock_time/0
+        , mock_difficulty_as_target/0
+        , unmock_difficulty_as_target/0
+        , wait_for_it/2
+        , extend_block_chain_by_difficulties_with_nonce_and_coinbase/3
+        , extend_block_chain_by_difficulties_with_nonce_and_coinbase/4
+        , aec_keys_setup/0
+        , aec_keys_cleanup/1
+        , gen_block_chain/1
+        ]).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("common.hrl").
+-include("blocks.hrl").
+
+-ifdef(DEBUG).
+-define(ifDebugFmt(Str, Args), ?debugFmt(Str, Args)).
+-else.
+-define(ifDebugFmt(Str, Args), ok).
+-endif.
+
+mock_time() ->
+    meck:new(aeu_time, [passthrough]),
+    TS = spawn(fun() -> receive F -> F(F, 1000) end end),
+    TS ! fun(F, T) ->
+                 receive {time, R, From}  -> From ! {R,T}
+                 end,
+                 F(F, T + 1000)
+         end,
+    GetTime = fun () -> TS ! {time, R = make_ref(), self()},
+                        receive {R, T} -> T end
+              end,
+
+    meck:expect(aeu_time, now_in_msecs,
+                fun() ->
+                        GetTime()
+                end),
+    ok.
+
+unmock_time() ->
+    meck:unload(aeu_time).
+
+wait_for_it(Fun, Value) ->
+    wait_for_it(Fun, Value, 0).
+
+wait_for_it(Fun, Value, Sleep) ->
+    case Fun() of
+        Value ->
+            Value;
+        _Other ->
+            ?ifDebugFmt("Waiting for ~p got ~p~n",[Value,_Other]),
+            timer:sleep(Sleep),
+            wait_for_it(Fun, Value, Sleep + 10)
+    end.
+
+%%%=============================================================================
+%%% Chain related util functions
+%%%=============================================================================
+
+%% @doc Meck difficulty as target. And startup keys server
+
+mock_difficulty_as_target() ->
+    meck:new(aec_headers, [passthrough]),
+    meck:new(aec_blocks, [passthrough]),
+    meck:expect(aec_headers, difficulty,
+                fun(#header{target = T}) when is_integer(T) -> float(T) end),
+    meck:expect(aec_blocks, difficulty,
+                fun(#block{target = T}) when is_integer(T) -> float(T) end).
+
+unmock_difficulty_as_target() ->
+    meck:unload(aec_headers),
+    meck:unload(aec_blocks).
+
+
+%% Generic blockchain with only coinbase transactions
+gen_block_chain(Length) when Length > 0 ->
+    {ok, MinerAccount} = aec_keys:wait_for_pubkey(),
+    gen_block_chain(Length, MinerAccount, []).
+
+gen_block_chain(0,_MinerAccount, Acc) -> lists:reverse(Acc);
+gen_block_chain(N, MinerAccount, []) ->
+    gen_block_chain(N - 1, MinerAccount, [aec_block_genesis:genesis_block()]);
+gen_block_chain(N, MinerAccount, [PreviousBlock|_] = Acc) ->
+    H = 1 + aec_blocks:height(PreviousBlock),
+    Trees = aec_blocks:trees(PreviousBlock),
+    Txs = [signed_coinbase_tx(MinerAccount, H)],
+    {ok, B} = aec_blocks:new(PreviousBlock, Txs, Trees),
+    gen_block_chain(N - 1, MinerAccount, [B|Acc]).
+
+extend_block_chain_by_difficulties_with_nonce_and_coinbase(
+  PreviousBlock,
+  Difficulties, Nonce) ->
+    {ok, MinerAccount} = aec_keys:wait_for_pubkey(),
+    extend_block_chain_by_difficulties_with_nonce_and_coinbase(
+      PreviousBlock, Difficulties, Nonce,
+      MinerAccount).
+
+extend_block_chain_by_difficulties_with_nonce_and_coinbase(
+  PreviousBlock,
+  Difficulties, Nonce,
+  MinerAccount) ->
+    [PreviousBlock | BlockChainExtension] =
+        lists:reverse(
+          lists:foldl(
+            fun(D, [PrevB | _] = BC) ->
+                    B = next_block_by_difficulty_with_nonce_and_coinbase(
+                          PrevB,
+                          D, Nonce,
+                          MinerAccount),
+                    [B | BC]
+            end,
+            [PreviousBlock],
+            Difficulties)),
+    BlockChainExtension.
+
+next_block_by_difficulty_with_nonce_and_coinbase(PreviousBlock,
+                                                 Difficulty, Nonce,
+                                                 MinerAccount) ->
+    H = 1 + aec_blocks:height(PreviousBlock),
+    Trees = aec_blocks:trees(PreviousBlock),
+    {ok, B} = aec_blocks:new(PreviousBlock, [signed_coinbase_tx(MinerAccount, H)], Trees),
+    B#block{ target = Difficulty
+           , nonce = Nonce
+           }.
+
+signed_coinbase_tx(Account, _AccountNonce) ->
+    {ok, Tx} = aec_coinbase_tx:new(#{account => Account},
+                                   unused_state_trees_argument),
+    {ok, STx} = aec_keys:sign(Tx),
+    STx.
+
+%%%=============================================================================
+%%% Key server setup/teardown
+%%%=============================================================================
+
+aec_keys_setup() ->
+    TmpKeysDir = mktempd(),
+    ok = application:ensure_started(crypto),
+    {ok, _} = aec_keys:start_link(["mypassword", TmpKeysDir]),
+    TmpKeysDir.
+
+aec_keys_cleanup(TmpKeysDir) ->
+    ok = aec_keys:stop(),
+    ok = application:stop(crypto),
+    {ok, KeyFiles} = file:list_dir(TmpKeysDir),
+    %% Expect two filenames - private and public keys.
+    [_KF1, _KF2] = KeyFiles,
+    lists:foreach(
+      fun(F) ->
+              AbsF = filename:absname_join(TmpKeysDir, F),
+              {ok, _} = {file:delete(AbsF), {F, AbsF}}
+      end,
+      KeyFiles),
+    ok = file:del_dir(TmpKeysDir).
+
+mktempd() ->
+    mktempd(os:type()).
+
+mktempd({unix, _}) ->
+    lib:nonl(?cmd("mktemp -d")).

--- a/apps/aehttp/src/aehttp_dispatch_ext.erl
+++ b/apps/aehttp/src/aehttp_dispatch_ext.erl
@@ -91,10 +91,8 @@ handle_request('PostBlock', Req, _Context) ->
     Header = aec_blocks:to_header(Block),
     {ok, HH} = aec_headers:hash_header(Header),
     lager:debug("'PostBlock'; header hash: ~p", [HH]),
-    case  aec_miner:post_block(Block) of
-        ok -> {200, [], #{}};
-        error -> {404, [], #{reason => <<"validation failed">>}}
-    end;
+    ok = aec_miner:post_block(Block),
+    {200, [], #{}};
 
 handle_request('GetAccountBalance', Req, _Context) ->
     Pubkey =

--- a/config/dev1/sys.config
+++ b/config/dev1/sys.config
@@ -16,7 +16,10 @@
                "http://localhost:3033"]},
       {password, <<"secret">>},
       {mining_cycle_attempts_count, 10},
-      {fetch_new_txs_from_pool_during_mining, true}
+      {fetch_new_txs_from_pool_during_mining, true},
+      {db_path, ""},
+      {persist, false},
+      {autostart, false}                                              
     ]
   },
 

--- a/config/dev2/sys.config
+++ b/config/dev2/sys.config
@@ -16,7 +16,10 @@
                "http://localhost:3033"]},
       {password, <<"secret">>},
       {mining_cycle_attempts_count, 10},
-      {fetch_new_txs_from_pool_during_mining, true}
+      {fetch_new_txs_from_pool_during_mining, true},
+      {db_path, ""},
+      {persist, false},
+      {autostart, false}                           
     ]
   },
 

--- a/config/dev3/sys.config
+++ b/config/dev3/sys.config
@@ -18,7 +18,10 @@
                "http://localhost:3023"]},
       {password, <<"secret">>},
       {mining_cycle_attempts_count, 10},
-      {fetch_new_txs_from_pool_during_mining, true}
+      {fetch_new_txs_from_pool_during_mining, true},
+      {db_path, ""},
+      {persist, false},
+      {autostart, false}                           
     ]
   },
 

--- a/config/sys.config
+++ b/config/sys.config
@@ -17,7 +17,9 @@
       {keys_dir, "/tmp/keys"},
       {password, <<"secret">>},
       {mining_cycle_attempts_count, 10},
-      {fetch_new_txs_from_pool_during_mining, true}
+      {fetch_new_txs_from_pool_during_mining, true},
+      {db_path, ""},
+      {persist, false}
     ]
   },
 
@@ -34,7 +36,7 @@
 
   {lager, [
       {handlers, [
-	  {lager_console_backend, [{level, none}]},
+          {lager_console_backend, [{level, none}]},
           {lager_file_backend,
             [{file, "log/epoch.log"}, {level, debug}, {size, 41943040}, {date, "$D0"}, {count, 10}]}
       ]},


### PR DESCRIPTION
Once again a huge PR. All these issues were so closely related so it made no sense splitting them up.

The aec_miner has been rewritten to make sure no messages are lost.

The block chain is persisted between node restarts if the sys config 'persist' is set to 'true'. This goes for both the blocks, headers and state trees.

When the top block changes through a 'post_block', all transactions are synced to the pool.

The test suites are somewhat more stable.

[Finishes #152471554 #152471640 #152471623 #152471670 #152471762 #152471598 ]