### PR TITLE
 PT-152711960-stabilize-eunit-tests 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,9 @@ dialyzer:
 test:
 	@./rebar3 do ct
 
+eunit:
+	@./rebar3 do eunit
+
 venv-present:
 	@virtualenv -q $(PYTHON_DIR)
 

--- a/apps/aecore/test/aec_keys_tests.erl
+++ b/apps/aecore/test/aec_keys_tests.erl
@@ -13,34 +13,13 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
--define(TEST_PUB, <<4,130,41,165,13,201,185,26,2,151,146,68,56,108,22,242,94,157,95,191,140,86,
-                    145,96,71,82,28,176,23,5,128,17,245,174,170,199,54,248,167,43,185,12,108,91,
-                    107,188,126,242,98,36,211,79,105,50,16,124,227,93,228,142,83,163,126,167,206>>).
-
--define(TEST_PRIV, <<116,214,52,147,205,225,149,14,95,228,19,253,76,49,82,53,18,39,12,254,53,
-                     220,210,199,152,25,208,77,217,186,141,212>>).
-
 all_test_() ->
     {foreach,
      fun() ->
-             TmpKeysDir = mktempd(),
-             ok = application:ensure_started(crypto),
-             {ok, _} = aec_keys:start_link(["mypassword", TmpKeysDir]),
-             TmpKeysDir
+             aec_test_utils:aec_keys_setup()
      end,
      fun(TmpKeysDir) ->
-             ok = aec_keys:stop(),
-             ok = application:stop(crypto),
-             {ok, KeyFiles} = file:list_dir(TmpKeysDir),
-             %% Expect two filenames - private and public keys.
-             [_KF1, _KF2] = KeyFiles,
-             lists:foreach(
-               fun(F) ->
-                       AbsF = filename:absname_join(TmpKeysDir, F),
-                       {ok, _} = {file:delete(AbsF), {F, AbsF}}
-               end,
-               KeyFiles),
-             ok = file:del_dir(TmpKeysDir)
+             aec_test_utils:aec_keys_cleanup(TmpKeysDir)
      end,
      [fun(_) ->
               [{"Sign coinbase transaction",
@@ -82,11 +61,4 @@ all_test_() ->
                         ?assertEqual(false, ValidPair)
                 end}]
       end]}.
-
-mktempd() ->
-    mktempd(os:type()).
-
-mktempd({unix, _}) ->
-    lib:nonl(?cmd("mktemp -d")).
-
 -endif.

--- a/apps/aecore/test/aec_miner_tests.erl
+++ b/apps/aecore/test/aec_miner_tests.erl
@@ -36,7 +36,6 @@ miner_test_() ->
              TmpKeysDir = aec_test_utils:aec_keys_setup(),
              {ok, _} = aec_tx_pool:start_link(),
              {ok, _} = aec_chain:start_link(aec_block_genesis:genesis_block()),
-             ok = application:ensure_started(crypto),
              {ok, _} = ?TEST_MODULE:start_link([{autostart, true}]),
              TmpKeysDir
      end,
@@ -45,20 +44,10 @@ miner_test_() ->
              ok = aec_chain:stop(),
              ok = aec_tx_pool:stop(),
              ok = application:stop(gproc),
-             aec_test_utils:aec_keys_cleanup(TmpKeysDir),
-             %% {ok, KeyFiles} = file:list_dir(TmpKeysDir),
-             %% %% Expect two filenames - private and public keys.
-             %% [_KF1, _KF2] = KeyFiles,
-             %% lists:foreach(
-             %%   fun(F) ->
-             %%           AbsF = filename:absname_join(TmpKeysDir, F),
-             %%           {ok, _} = {file:delete(AbsF), {F, AbsF}}
-             %%   end,
-             %%   KeyFiles),
              ?assert(meck:validate(aec_governance)),
              meck:unload(aec_governance),
              aec_test_utils:unmock_time(),
-             file:delete(TmpKeysDir)
+             aec_test_utils:aec_keys_cleanup(TmpKeysDir)
      end,
      [fun(_) ->
               {"Suspend and resume",
@@ -219,22 +208,11 @@ chain_test_() ->
              ok = aec_tx_pool:stop(),
              aec_test_utils:aec_keys_cleanup(TmpKeysDir),
              ok = application:stop(gproc),
-             %% Expect two filenames - private and public keys.
-
-             %% [_KF1, _KF2] = KeyFiles,
-             %% lists:foreach(
-             %%   fun(F) ->
-             %%           AbsF = filename:absname_join(TmpKeysDir, F),
-             %%           {ok, _} = {file:delete(AbsF), {F, AbsF}}
-             %%   end,
-             %%   KeyFiles),
-             %% ok = file:del_dir(TmpKeysDir),
              aec_test_utils:unmock_time(),
              ?assert(meck:validate(aec_governance)),
              meck:unload(aec_governance),
              meck:unload(aec_headers),
-             meck:unload(aec_blocks),
-             file:delete(TmpKeysDir)
+             meck:unload(aec_blocks)
      end,
      [
       fun(_) ->
@@ -284,9 +262,6 @@ chain_test_() ->
               }
       end
      ]}.
-
-genesis_block() ->
-    aec_block_genesis:genesis_block().
 
 block_hash(B) ->
     {ok, Hash} = aec_headers:hash_header(aec_blocks:to_header(B)),

--- a/apps/aecore/test/aec_mining_tests.erl
+++ b/apps/aecore/test/aec_mining_tests.erl
@@ -211,25 +211,12 @@ mine_block_from_genesis_test_() ->
               meck:expect(aec_pow, pow_module, 0, PoWMod),
               meck:expect(aec_pow, pick_nonces, 0, {1, 400}),
               {ok, _} = aec_tx_pool:start_link(),
+              TmpKeysDir = aec_test_utils:aec_keys_setup(),
               {ok, _} = aec_chain:start_link(aec_block_genesis:genesis_block()),
-              TmpKeysDir = mktempd(),
-              ok = application:ensure_started(crypto),
-              {ok, _} = aec_keys:start_link(["mypassword", TmpKeysDir]),
               TmpKeysDir
       end,
       fun(TmpKeysDir) ->
-              ok = aec_keys:stop(),
-              ok = application:stop(crypto),
-              {ok, KeyFiles} = file:list_dir(TmpKeysDir),
-              %% Expect two filenames - private and public keys.
-              [_KF1, _KF2] = KeyFiles,
-              lists:foreach(
-                fun(F) ->
-                        AbsF = filename:absname_join(TmpKeysDir, F),
-                        {ok, _} = {file:delete(AbsF), {F, AbsF}}
-                end,
-                KeyFiles),
-              ok = file:del_dir(TmpKeysDir),
+              ok = aec_test_utils:aec_keys_cleanup(TmpKeysDir),
               ok = aec_chain:stop(),
               ok = aec_tx_pool:stop(),
               ?assert(meck:validate(aec_pow)),
@@ -250,11 +237,5 @@ mine_block_from_genesis_test_() ->
                  end}}
               ]
       end} || PoWMod <- PoWModules].
-
-mktempd() ->
-    mktempd(os:type()).
-
-mktempd({unix, _}) ->
-    lib:nonl(?cmd("mktemp -d")).
 
 -endif.

--- a/apps/aecore/test/aec_test_utils.erl
+++ b/apps/aecore/test/aec_test_utils.erl
@@ -146,6 +146,7 @@ aec_keys_setup() ->
     TmpKeysDir = mktempd(),
     ok = application:ensure_started(crypto),
     {ok, _} = aec_keys:start_link(["mypassword", TmpKeysDir]),
+    wait_for_it(fun() -> whereis(aec_keys) =/= undefined end, true),
     TmpKeysDir.
 
 aec_keys_cleanup(TmpKeysDir) ->


### PR DESCRIPTION
Add make target for only running eunit tests

Use common code to setup and cleanup key server

Wait for aec_keys to start before proceeding

Use proper constructors for blocks and headers