### PR TITLE
make aeu_env & user config handl more modular

### DIFF
--- a/apps/aecore/src/aec_peers.erl
+++ b/apps/aecore/src/aec_peers.erl
@@ -26,6 +26,8 @@
          get_local_peer_uri/0,
          update_last_seen/1]).
 
+-export([check_env/0]).
+
 %% gen_server callbacks
 -export([start_link/0, init/1, handle_call/3, handle_cast/2,
          handle_info/2, terminate/2, code_change/3]).
@@ -193,6 +195,18 @@ get_local_peer_uri() ->
 -spec update_last_seen(uri()) -> ok.
 update_last_seen(Uri) ->
     gen_server:cast(?MODULE, {update_last_seen, uri(Uri), timestamp()}).
+
+%%------------------------------------------------------------------------------
+%% Check user-provided environment
+%%------------------------------------------------------------------------------
+check_env() ->
+    case aeu_env:user_config(<<"peers">>) of
+        {ok, Peers0} when is_list(Peers0) ->
+            Peers = [binary_to_list(P) || P <- Peers0],
+            application:set_env(aecore, peers, Peers);
+        undefined ->
+            ok
+    end.
 
 %%%=============================================================================
 %%% gen_server functions

--- a/apps/aecore/src/aecore.app.src
+++ b/apps/aecore/src/aecore.app.src
@@ -14,7 +14,13 @@
     msgpack
    ]},
   {env, [
-        {exometer_predefined, {script, "$PRIV_DIR/exometer_predefined.script"}}
+        {exometer_predefined, {script, "$PRIV_DIR/exometer_predefined.script"}},
+        {'$setup_hooks',
+         [
+          {normal, [
+                    {110, {aec_peers, check_env, []}}
+                   ]}
+         ]}
         ]},
   {modules, []},
 


### PR DESCRIPTION
[Finishes PT #152745563]

Adds `aeu_env:get_env/[2,3]` support for hierarchical keys, where for example in an env config:

```erlang
  { aehttp, [
      {swagger_port_external, 3013},
      {internal, [
          {swagger_port, 3113},
          {websocket, [ {port, 3114},
                        {handlers, 100},
                        {tasks, 200}
                      ]}
          ]}
```

one can call `aeu_env:get_env(aehttp, [internal, websocket, port], ?DEFAULT_PORT)`

Also, the contents of any `epoch.{yaml,json}` file is normalized and stored as an `aeutils` env, `'$user_config'`, which can be queried similarly using `aeu_env:user_config(Key)`, or `aeu_env:user_config(Key, Default)`.

Two ways to check the user config are illustrated:
* Add a setup hook (mode: 'normal', phaseno > 100) which checks user_config and if necessary updates the application env.
* Dynamically check the user config while checking the normal env (used in aehttp_app)