### PR TITLE
Remove outdated comment

### DIFF
--- a/apps/aehttp/src/aehttp_dispatch_int.erl
+++ b/apps/aehttp/src/aehttp_dispatch_int.erl
@@ -25,8 +25,6 @@ handle_request('PostSpendTx', #{'SpendTx' := SpendTxObj}, _Context) ->
                             nonce => Nonce}),
                     {ok, SignedTx} = aec_keys:sign(SpendTx),
                     ok = aec_tx_pool:push(SignedTx),
-                    %% TODO: send to peers via external API
-                    %% To be done when POST /tx is implemented
                     {200, [], #{}};
                 {error, account_not_found} ->
                     %% Account was not found in state trees


### PR DESCRIPTION
I think there is nothing to be done here.

When a tx is pushed into the mempool, it is not already present there and signature verification passes, the tx is published to other peers already using `aec_events:publish/2` API.

https://github.com/aeternity/epoch/blob/master/apps/aecore/src/aec_tx_pool.erl#L204

/cc @uwiger 