### PR TITLE
Tests that result in lager errors should not pass

### DIFF
--- a/apps/aecore/test/aec_eunit_SUITE.erl
+++ b/apps/aecore/test/aec_eunit_SUITE.erl
@@ -32,6 +32,7 @@ end_per_group(_Grp, _Config) ->
     ok.
 
 init_per_testcase(_TC, Config) ->
+    lager_common_test_backend:bounce(error),
     Apps = application:which_applications(),
     Names = registered(),
     [{running_apps, Apps},
@@ -42,13 +43,15 @@ end_per_testcase(_TC, Config) ->
     Names0 = ?config(regnames, Config),
     Apps = application:which_applications(),
     Names = registered() -- [cover_server, timer_server],
-    case {(Apps -- Apps0), Names -- Names0} of
-      {[], []} -> 
+    case {(Apps -- Apps0), Names -- Names0, lager_common_test_backend:get_logs()} of
+      {[], [], []} -> 
         ok;
-      {NewApps, _} when NewApps =/= [] ->
+      {_, _, Log} when Log =/= []->
+        {fail, errors_in_lager_log};
+      {NewApps, _, _} when NewApps =/= [] ->
         %% New applications take precedence over new registered processes
         {fail, {started_applications, NewApps}};
-      {_, NewReg} -> 
+      {_, NewReg, _} -> 
         {fail, {registered_processes, NewReg}}
     end.
 


### PR DESCRIPTION
Several tests do pass even though they produce lager errors. These errors are, however, not visible in the common test output, nor in the console.

This patch makes these errors visible.