### PR TITLE
restore SpendTx [finishes #152755356]

### DIFF
--- a/apps/aehttp/priv/swagger.json
+++ b/apps/aehttp/priv/swagger.json
@@ -391,6 +391,25 @@
         }
       }
     },
+    "SpendTx" : {
+      "type" : "object",
+      "properties" : {
+        "sender_pubkey" : {
+          "type" : "string"
+        },
+        "recipient_pubkey" : {
+          "type" : "string"
+        },
+        "amount" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "fee" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      }
+    },
     "Tx" : {
       "type" : "string"
     },

--- a/apps/aehttp/src/aehttp_dispatch_int.erl
+++ b/apps/aehttp/src/aehttp_dispatch_int.erl
@@ -11,11 +11,13 @@
 handle_request('PostSpendTx', #{'SpendTx' := SpendTxObj}, _Context) ->
     case aec_keys:pubkey() of
         {ok, SenderPubkey} ->
+            lager:debug("SenderPubKey matches ours", []),
             RecipientPubkey = maps:get(<<"recipient_pubkey">>, SpendTxObj),
             Amount = maps:get(<<"amount">>, SpendTxObj),
             Fee = maps:get(<<"fee">>, SpendTxObj),
             case aec_next_nonce:pick_for_account(SenderPubkey) of
                 {ok, Nonce} ->
+                    lager:debug("Nonce = ~p", [Nonce]),
                     {ok, SpendTx} =
                         aec_spend_tx:new(
                           #{sender => SenderPubkey,
@@ -23,10 +25,13 @@ handle_request('PostSpendTx', #{'SpendTx' := SpendTxObj}, _Context) ->
                             amount => Amount,
                             fee => Fee,
                             nonce => Nonce}),
+                    lager:debug("SpendTx = ~p", [SpendTx]),
                     {ok, SignedTx} = aec_keys:sign(SpendTx),
                     ok = aec_tx_pool:push(SignedTx),
+                    lager:debug("pushed; peek() -> ~p", [aec_tx_pool:peek(10)]),
                     {200, [], #{}};
                 {error, account_not_found} ->
+                    lager:debug("account not found", []),
                     %% Account was not found in state trees
                     %% so effectively there have been no funds
                     %% ever granted to it.

--- a/apps/aehttp/src/swagger/swagger_api.erl
+++ b/apps/aehttp/src/swagger/swagger_api.erl
@@ -236,11 +236,6 @@ validate_response('PostSpendTx', 404, Body, ValidatorState) ->
 validate_response(_OperationID, _Code, _Body, _ValidatorState) ->
     ok.
 
-%% validate_response_body('list', ReturnBaseType, Body, ValidatorState) ->
-%%     [
-%%         validate(schema, ReturnBaseType, Item, ValidatorState)
-%%     || Item <- Body];
-
 validate_response_body(_, ReturnBaseType, Body, ValidatorState) ->
     validate(schema, ReturnBaseType, Body, ValidatorState).
 

--- a/apps/aehttp/src/swagger/swagger_internal_handler.erl
+++ b/apps/aehttp/src/swagger/swagger_internal_handler.erl
@@ -72,7 +72,7 @@ allowed_methods(Req, State) ->
     }.
 
 is_authorized(Req, State) ->
-    {{false, <<"">>}, Req, State}.
+    {true, Req, State}.
 
 -spec content_types_accepted(Req :: cowboy_req:req(), State :: state()) ->
     {

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -45,7 +45,7 @@ paths:
     get:
       tags:
         - external
-      operationId: GetTop 
+      operationId: GetTop
       description: 'Get the top block header'
       consumes:
         - application/json
@@ -182,7 +182,7 @@ paths:
         - application/json
       produces:
         - application/json
-      parameters: 
+      parameters:
         - in: query
           name: pub_key
           description: 'Public key to extract balance for'
@@ -250,7 +250,7 @@ definitions:
       pow:
         type: array
         items:
-          type: integer 
+          type: integer
       transactions:
         type: array
         items:
@@ -310,6 +310,19 @@ definitions:
     type: object
     properties:
       balance:
+        type: integer
+        format: int64
+  SpendTx:
+    type: object
+    properties:
+      sender_pubkey:
+        type: string
+      recipient_pubkey:
+        type: string
+      amount:
+        type: integer
+        format: int64
+      fee:
         type: integer
         format: int64
   Tx:


### PR DESCRIPTION
During a merge, and while changing the external representation of transactions in swagger, the SpendTx definition was mistakenly removed. However, it's used in an internal method to create a spend transaction, and was perfectly fine for that purpose.