### PR TITLE
Create key pair and account when node starts (for test stability)

### DIFF
--- a/apps/aecore/test/aec_miner_tests.erl
+++ b/apps/aecore/test/aec_miner_tests.erl
@@ -173,7 +173,7 @@ miner_test_() ->
                                      = sys:get_state(aec_miner),
                                  MinerState
                          end, waiting_for_keys),
-                        ?assertNotEqual(error, aec_keys:new("mynewpassword")),
+                        ?assertNotEqual(error, aec_keys:new(<<"mynewpassword">>)),
                         ?show_miner_state(),
                         wait_for_running(),
                         ?show_miner_state(),

--- a/apps/aecore/test/aec_test_utils.erl
+++ b/apps/aecore/test/aec_test_utils.erl
@@ -148,7 +148,7 @@ signed_coinbase_tx(Account, _AccountNonce) ->
 aec_keys_setup() ->
     TmpKeysDir = mktempd(),
     ok = application:ensure_started(crypto),
-    {ok, _} = aec_keys:start_link(["mypassword", TmpKeysDir]),
+    {ok, _} = aec_keys:start_link([<<"mypassword">>, TmpKeysDir]),
     wait_for_it(fun() -> whereis(aec_keys) =/= undefined end, true),
     TmpKeysDir.
 

--- a/apps/aecore/test/aecore_tests.erl
+++ b/apps/aecore/test/aecore_tests.erl
@@ -10,7 +10,7 @@ application_test() ->
   App = aecore,
   application:load(App),
   application:stop(App),
-  application:set_env(aecore, password, "Thisisweird"),
+  application:set_env(aecore, password, <<"Thisisweird">>),
   {ok, Deps} = application:get_key(App, applications), 
   AlreadyRunning = [ Name || {Name, _,_} <- application:which_applications() ],
   [ ?assertEqual(ok, application:ensure_started(Dep)) || Dep <- Deps ],


### PR DESCRIPTION
... by guaranteeing that if `aec_keys` service started, key pair has
been created.

This PR is the implementation of the minimal portion of PT-152483887 for test stability.

----

As the `aec_keys`-related test issues were intermittent, you may consider including this in your local branch for an hour or so before approving.