### PR TITLE
Fix non-deterministic test: Remove state check in aec_miner_tests

### DIFF
--- a/apps/aecore/test/aec_miner_tests.erl
+++ b/apps/aecore/test/aec_miner_tests.erl
@@ -226,8 +226,6 @@ chain_test_() ->
                        [_GB, B1, B2] = aec_test_utils:gen_block_chain(3),
                        BH2 = aec_blocks:to_header(B2),
                        ?assertEqual(ok, ?TEST_MODULE:post_block(B1)),
-                       {State1, _Data1} = sys:get_state(aec_miner),
-                       ?assertEqual(configure, State1),
                        ?assertEqual(ok, ?TEST_MODULE:post_block(B2)),
                        aec_test_utils:wait_for_it(
                          fun () -> aec_chain:top_header() end,


### PR DESCRIPTION
Test contained a race between aec_miner:post_block(...) that will bring
the miner into state running, and the sys:get_state(...) call... The
actual intermittent state of the miner is not interesting so the check
is better removed.