### PR TITLE
Add tx test cases to sync_SUITE + various fixes

### DIFF
--- a/apps/aecore/src/aec_blocks.erl
+++ b/apps/aecore/src/aec_blocks.erl
@@ -137,9 +137,9 @@ serialize_to_map(B = #block{}) ->
      }.
 
 serialize_tx(Tx) ->
-    base64:encode(aec_tx_sign:serialize_to_binary(Tx)).
+    #{tx => base64:encode(aec_tx_sign:serialize_to_binary(Tx))}.
 
-deserialize_tx(Bin) ->
+deserialize_tx(#{<<"tx">> := Bin}) ->
     aec_tx_sign:deserialize_from_binary(base64:decode(Bin)).
 
 -define(STORAGE_VERSION, 1).

--- a/apps/aecore/src/aec_mining.erl
+++ b/apps/aecore/src/aec_mining.erl
@@ -28,8 +28,8 @@ apply_new_txs(#block{txs = Txs} = Block) ->
             case get_txs_to_mine_in_pool() of
                 [] ->
                     {ok, Block};
-                [_|_] = Txs ->
-                    create_block_candidate(Txs)
+                [_|_] = NewTxs ->
+                    create_block_candidate(NewTxs)
             end
     end.
 

--- a/apps/aecore/src/aec_tx_pool.erl
+++ b/apps/aecore/src/aec_tx_pool.erl
@@ -178,10 +178,17 @@ pool_db_open() ->
 
 -spec pool_db_peek(pool_db(), MaxNumber::pos_integer() | infinity) ->
                           [pool_db_value()].
+pool_db_peek(_, 0) -> [];
 pool_db_peek(Mempool, Max) ->
     sel_return(
-      ets:select(Mempool, [{ {'_', '$1'}, [], ['$1'] }], Max)).
+      ets_select(Mempool, [{ {'_', '$1'}, [], ['$1'] }], Max)).
 
+ets_select(T, P, infinity) ->
+    ets:select(T, P);
+ets_select(T, P, N) when is_integer(N), N >= 1 ->
+    ets:select(T, P, N).
+
+sel_return(L) when is_list(L) -> L;
 sel_return('$end_of_table' ) -> [];
 sel_return({Matches, _Cont}) -> Matches.
 

--- a/apps/aehttp/priv/swagger.json
+++ b/apps/aehttp/priv/swagger.json
@@ -181,7 +181,7 @@
       }
     },
     "/transactions" : {
-      "post" : {
+      "get" : {
         "tags" : [ "external" ],
         "description" : "Get transactions in the mempool",
         "operationId" : "GetTxs",
@@ -411,7 +411,12 @@
       }
     },
     "Tx" : {
-      "type" : "string"
+      "type" : "object",
+      "properties" : {
+        "tx" : {
+          "type" : "string"
+        }
+      }
     },
     "Transactions" : {
       "type" : "array",

--- a/apps/aehttp/src/aehttp_app.erl
+++ b/apps/aehttp/src/aehttp_app.erl
@@ -16,7 +16,8 @@
 %% Application callbacks
 -export([start/2, stop/1]).
 
--export([local_peer_uri/0]).
+-export([local_peer_uri/0,
+         local_internal_http_uri/0]).
 
 %%====================================================================
 %% API
@@ -28,13 +29,17 @@ start(_StartType, _StartArgs) ->
     ok = start_swagger_external(),
     ok = start_swagger_internal(),
     ok = start_websocket_internal(),
-    gproc:reg({n,l,{epoch, app, aehttp}}),
     MaxWsHandlers = get_internal_websockets_acceptors(),
     ok = jobs:add_queue(ws_handlers_queue, [{standard_counter, MaxWsHandlers}]),
+    gproc:reg({n,l,{epoch, app, aehttp}}),
     {ok, Pid}.
 
 local_peer_uri() ->
     Port = get_external_port(),
+    local_peer(Port).
+
+local_internal_http_uri() ->
+    Port = get_internal_port(),
     local_peer(Port).
 
 %%--------------------------------------------------------------------

--- a/apps/aehttp/src/swagger/swagger_external_handler.erl
+++ b/apps/aehttp/src/swagger/swagger_external_handler.erl
@@ -91,7 +91,7 @@ allowed_methods(
         operation_id = 'GetTxs'
     }
 ) ->
-    {[<<"POST">>], Req, State};
+    {[<<"GET">>], Req, State};
 
 allowed_methods(
     Req,
@@ -308,6 +308,7 @@ handle_request_json(
         context = Context
     }
 ) ->
+    lager:debug("handle_request_json(~p)", [Req0]),
     case swagger_api:populate_request(OperationID, Req0, ValidatorState) of
         {ok, Populated, Req1} ->
             {Code, Headers, Body} = swagger_logic_handler:handle_request(
@@ -316,6 +317,8 @@ handle_request_json(
                 Populated,
                 Context
             ),
+            lager:debug("OpId = ~p; Code = ~p~nBody = ~p",
+                        [OperationID, Code, Body]),
             _ = swagger_api:validate_response(
                 OperationID,
                 Code,

--- a/apps/aehttp/src/swagger/swagger_router.erl
+++ b/apps/aehttp/src/swagger/swagger_router.erl
@@ -77,7 +77,7 @@ get_operations() ->
         },
         'GetTxs' => #{
             path => "/v1/transactions",
-            method => <<"POST">>,
+            method => <<"GET">>,
             handler => 'swagger_external_handler'
         },
         'Ping' => #{

--- a/apps/aeutils/src/aeu_env.erl
+++ b/apps/aeutils/src/aeu_env.erl
@@ -128,7 +128,9 @@ read_json(F) ->
 
 interpret_json(L, F) when is_list(L) ->
     lists:flatten([interpret_json(Elem, F) || Elem <- L]);
-interpret_json({_K, _V} = E, _) ->
+interpret_json({K, V}, F) when is_list(V) ->
+    {K, interpret_json(V, F)};
+interpret_json(E, _) ->
     E.
 
 read_yaml(F) ->

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -157,7 +157,7 @@ paths:
               description: Successful operation
           security: []
   /transactions:
-    post:
+    get:
       tags:
         - external
       operationId: GetTxs
@@ -326,7 +326,10 @@ definitions:
         type: integer
         format: int64
   Tx:
-    type: string
+    type: object
+    properties:
+       tx:
+         type: string
   Transactions:
     type: array
     items:


### PR DESCRIPTION
[Finishes #152820357]
Errors found and fixed:
- aec_keys must verify key pair read from disk
- aec_keys slightly refactored; check_keypair() fn added
- aec_keys can be configured using epoch.config
- aex_tx_pool:peek() slightly broken
- aeu_requests:transactions() broken
- mempool not updated when mined block written to chain
- add naive (note!) mempool sync to node sync
- aec_sync should always try to write all fetched blocks
- add test cases in sync_SUITE
- tx serialization fixed for swagger compliance
- bug in aeu_env JSON config parsing
- aec_mining pattern-match error when checking mempool for txs