### PR TITLE
Add json-schema defs for user-provided configs + corresp code support

### DIFF
--- a/apps/aecore/src/aecore.app.src
+++ b/apps/aecore/src/aecore.app.src
@@ -1,3 +1,4 @@
+%% -*- erlang-indent-level: 4; indent-tabs-mode: nil -*-
 {application, aecore,
  [{description, "Blockchain for aeapps"},
   {vsn, "0.1.0"},
@@ -28,7 +29,8 @@
         {'$setup_hooks',
          [
           {normal, [
-                    {110, {aec_peers, check_env, []}}
+                    {110, {aec_peers, check_env, []}},
+                    {110, {aecore_app, check_env, []}}
                    ]}
          ]}
         ]},

--- a/apps/aecore/src/aecore_app.erl
+++ b/apps/aecore/src/aecore_app.erl
@@ -4,6 +4,7 @@
 
 %% Application callbacks
 -export([start/2, stop/1]).
+-export([check_env/0]).
 
 %%====================================================================
 %% API
@@ -15,3 +16,83 @@ start(_StartType, _StartArgs) ->
 
 stop(_State) ->
     ok.
+
+%% Checking user-provided configs. The logic is somewhat complicated
+%% by the fact that 'setup' is not guaranteed to start before lager,
+%% so we have to be prepared to apply changes to both the lager env
+%% and the (possibly) running lager. (This problem is solvable, but not
+%% trivially. Basically, the epoch.rel file must be pre-sorted and passed
+%% to relx.
+check_env() ->
+    check_env([{[<<"logging">>, <<"hwm">>]     , fun set_hwm/1},
+               {[<<"logging">>, <<"console">>] , fun set_console/1},
+               {[<<"mining">>, <<"autostart">>], {set_env, autostart}},
+               {[<<"chain">>, <<"persist">>]   , {set_env, persist}},
+               {[<<"chain">>, <<"autostart">>] , {set_env, autostart}}]).
+
+check_env(Spec) ->
+    lists:foreach(
+      fun({K, F}) ->
+              case aeu_env:user_config(K) of
+                  undefined -> ignore;
+                  {ok, V}   -> set_env(F, V)
+              end
+      end, Spec).
+
+set_env({set_env, K}, V) when is_atom(K) ->
+    io:fwrite("setenv K=~p, V=~p~n", [K, V]),
+    application:set_env(aecore, K, V);
+set_env(F, V) when is_function(F, 1) ->
+    F(V).
+
+set_hwm(HWM) when is_integer(HWM) ->
+    application:set_env(lager, error_logger_hwm, HWM),
+    if_running(lager, fun() -> live_set_hwm(HWM) end).
+
+live_set_hwm(Hwm) ->
+    lists:map(
+      fun(Sink) ->
+              [lager:set_loghwm(Sink, lager_console_backend, Hwm)
+               || {lager_console_backend,_}
+                      <- gen_event:which_handlers(Sink)]
+      end, lager:list_all_sinks()).
+
+set_console(Level0) when is_binary(Level0) ->
+    Level = binary_to_existing_atom(Level0, latin1),
+    case application:get_env(lager, handlers) of
+        {ok, Handlers} ->
+            Handlers1 = set_console_loglevel(Handlers, Level),
+            application:set_env(lager, handlers, Handlers1);
+        undefined when Level =:= none ->
+            application:set_env(lager, handlers,
+                                [{lager_console_backend, [{level, Level}]}]);
+        _ -> ignore
+    end,
+    case application:get_env(lager, extra_sinks) of
+        {ok, Sinks} ->
+            Sinks1 = set_console_loglevel(Sinks, Level),
+            application:set_env(lager, extra_sinks, Sinks1);
+        undefined ->
+            ignore
+    end,
+    if_running(lager, fun() -> live_set_console(Level) end).
+
+live_set_console(Level) ->
+    catch lager:set_loglevel(lager_console_backend, Level).
+
+set_console_loglevel({lager_console_backend, Opts}, Level) ->
+    {lager_console_backend, lists:keystore(level, 1, Opts, {level, Level})};
+set_console_loglevel(T, Level) when is_tuple(T) ->
+    list_to_tuple([set_console_loglevel(E, Level)
+                   || E <- tuple_to_list(T)]);
+set_console_loglevel(L, Level) when is_list(L) ->
+    [set_console_loglevel(E, Level) || E <- L];
+set_console_loglevel(E, _) ->
+    E.
+
+if_running(App, F) ->
+    case lists:keymember(App, 1, application:which_applications()) of
+        true  ->
+            F();
+        false -> ok
+    end.

--- a/apps/aecore/test/aecore_sync_SUITE.erl
+++ b/apps/aecore/test/aecore_sync_SUITE.erl
@@ -602,13 +602,13 @@ write_config(F, Config) ->
 
 config(N, Config) ->
     {A,B,C} = os:timestamp(),
-    [
      #{<<"keys">> =>
-           [
-            #{<<"dir">> => bin(keys_dir(N, Config)),
-              <<"password">> => bin(io_lib:format("~w.~w.~w", [A,B,C]))}
-           ]}
-    ].
+           #{<<"dir">> => bin(keys_dir(N, Config)),
+             <<"password">> => bin(io_lib:format("~w.~w.~w", [A,B,C]))},
+       <<"logging">> =>
+           #{<<"hwm">> => 500}
+      }.
+
 %% data_dir(Config) ->
 %%     ?config(data_dir, Config).
 

--- a/apps/aeutils/priv/epoch_config_schema.json
+++ b/apps/aeutils/priv/epoch_config_schema.json
@@ -1,0 +1,39 @@
+{
+    "$schema" : "http://json-schema.org/draft-04/schema#",
+    "type" : "object",
+    "properties" : {
+        "peers" : {
+            "type" : "array",
+            "items" : {
+                "type" : "string"
+            }
+        },
+        "keys" : {
+            "type" : "object",
+            "properties" : {
+                "dir"      : { "type" : "string" },
+                "password" : { "type" : "string" }
+            }
+        },
+        "chain" : {
+            "type" : "object",
+            "persist" : { "type" : "boolean" },
+            "db_path"   : { "type" : "string" }
+        },
+        "mining" : {
+            "type" : "object",
+            "properties" : {
+                "autostart" : { "type" : "boolean" }
+            }
+        },
+        "logging" : {
+            "type"    : "object",
+            "hwm"     : { "type" : "integer",
+                          "minimum" : 50 },
+            "console" : {
+                "type" : "string",
+                "enum" : [ "debug", "info", "notice", "warning",
+                           "error", "critical", "alert", "emergency" ]}
+        }
+    }
+}


### PR DESCRIPTION
- JSON-Schema file aeutils/priv/epoch_config_schema.json
- Config files on .json or .yaml format validated against the schema
- Added some config support, e.g. for chain persistence, autostart,
  lager loglevel and overload limit

[Fixes #152745563]