### PR TITLE
Removed unneccesary function cointains_coinbase_tx.

### DIFF
--- a/apps/aecore/src/aec_blocks.erl
+++ b/apps/aecore/src/aec_blocks.erl
@@ -19,8 +19,7 @@
          deserialize_from_map/1,
          hash_internal_representation/1,
          root_hash/1,
-         validate/1,
-         cointains_coinbase_tx/1]).
+         validate/1]).
 
 -ifdef(TEST).
 -compile([export_all, nowarn_export_all]).
@@ -263,8 +262,3 @@ validate_txs_hash(#block{txs = Txs,
         _Other ->
             {error, malformed_txs_hash}
     end.
-
-cointains_coinbase_tx(#block{txs = []}) ->
-    false;
-cointains_coinbase_tx(#block{txs = [CoinbaseTx | _Rest]}) ->
-    aec_tx:is_coinbase(CoinbaseTx).

--- a/apps/aecore/src/aec_mining.erl
+++ b/apps/aecore/src/aec_mining.erl
@@ -65,14 +65,9 @@ create_block_candidate(TxsToMineInPool) ->
             {ok, LastBlock} = aec_chain:top(),
             Trees = aec_blocks:trees(LastBlock),
             Block0 = aec_blocks:new(LastBlock, Txs, Trees),
-            case aec_blocks:cointains_coinbase_tx(Block0) of
-                true ->
-                    Block = maybe_recalculate_difficulty(Block0),
-                    RandomNonce = aec_pow:pick_nonce(),
-                    {ok, Block, RandomNonce};
-                false ->
-                    {error, coinbase_tx_rejected}
-            end
+            Block = maybe_recalculate_difficulty(Block0),
+            RandomNonce = aec_pow:pick_nonce(),
+            {ok, Block, RandomNonce}
     end.
 
 -spec create_signed_coinbase_tx() -> {ok, signed_tx()} | {error, term()}.


### PR DESCRIPTION
Cleaning up the code a bit to move towards ADTs.

Since all transactions in the miner pool should be signed (as also derived from the types), we do not need to check once more that they are.