### PR TITLE
A quick-fix for keys invalidation when making a new build

### DIFF
--- a/apps/aecore/test/aecore_tests.erl
+++ b/apps/aecore/test/aecore_tests.erl
@@ -10,7 +10,7 @@ application_test() ->
   App = aecore,
   application:load(App),
   application:stop(App),
-  application:set_env(aecore, password, <<"Thisisweird">>),
+  application:set_env(aecore, password, <<"secret">>),
   {ok, Deps} = application:get_key(App, applications), 
   AlreadyRunning = [ Name || {Name, _,_} <- application:which_applications() ],
   [ ?assertEqual(ok, application:ensure_started(Dep)) || Dep <- Deps ],


### PR DESCRIPTION
running the tests generates a new key-pair in
`apps/aecore/priv/keys`
(since the config is not loaded - the default directory is used). This results in generating a new keypair (if none was present). They're encrypted with a password set in the tests themselves.

When making a new build - everything from the priv directories is copied to the new build. If no keys directory is set in the config, the default one is used (actually generated by the tests and encrypted with the password set in the tests themselves). This results in the node crashing because of the invalid key pair (decoded with a wrong password)

This is a temp fix: the old key pair is still replaced in the new build but at least is a valid one.
The issue with keys replacement will be addressed in [this Pivotal task](https://www.pivotaltracker.com/n/projects/2124891/stories/152920911)