### PR TITLE
Fixing setting of a local peer address

### DIFF
--- a/apps/aehttp/src/aehttp_app.erl
+++ b/apps/aehttp/src/aehttp_app.erl
@@ -104,18 +104,28 @@ local_peer(Port) ->
             end
     end.
 
+
+-spec get_local_peer_address() -> string().
 get_local_peer_address() ->
-    case aeu_env:user_config(
-           [<<"http">>, <<"external">>, <<"peer_address">>]) of
-        {ok, A} -> A;
-        undefined ->
-            case aeu_env:get_env(aehttp, local_peer_address) of
-                {ok, Addr} ->
-                    Addr;
-                undefined ->
-                    {ok, Host} = inet:gethostname(),
-                    Host
-            end
+    H =
+        case aeu_env:user_config(
+              [<<"http">>, <<"external">>, <<"peer_address">>]) of
+            {ok, A} ->
+                binary_to_list(A);
+            undefined ->
+                case aeu_env:get_env(aehttp, local_peer_address) of
+                    {ok, Addr} ->
+                        Addr;
+                    undefined ->
+                        {ok, Host} = inet:gethostname(),
+                        Host
+                end
+        end,
+    case io_lib:deep_latin1_char_list(H) of
+        true ->
+            H;
+        false ->
+            erlang:error(unsupported_external_peer_address)
     end.
 
 get_external_port() ->


### PR DESCRIPTION
Example log crash:
```
2017-11-17 12:16:32.762 [info] <0.673.0> Application aecore exited with reason: {{shutdown,{failed_to_start_child,aec_peers,{badarg,[{erlang,'++',[<<"31.13.251.51">>,":3013/"],[]},{aec_peers,uri_from_ip_port,2,[{file,"/home/travis/build/aeternity/epoch/_build/prod/lib/aecore/src/aec_peers.erl"},{line,164}]},{aec_peers,init,1,[{file,"/home/travis/build/aeternity/epoch/_build/prod/lib/aecore/src/aec_peers.erl"},{line,225}]},{gen_server,init_it,2,[{file,"gen_server.erl"},{line,365}]},{gen_server,init_it,6,[{file,"gen_server.erl"},{line,333}]},{proc_lib,init_p_do_apply,3,[...]}]}}},...} 
```



This fixes the crash but we lack the support for UTF-8 strings; this should be addressed by another PR. Pivotal task for it could be found [here](https://www.pivotaltracker.com/story/show/152958631)