### PR TITLE
Do not consume unexpected messages during OS process execution

### DIFF
--- a/apps/aecore/src/aec_pow_cuckoo.erl
+++ b/apps/aecore/src/aec_pow_cuckoo.erl
@@ -219,9 +219,7 @@ wait_for_result(#state{os_pid = OsPid,
                           _                     -> Reason
                       end,
             ?error("OS process died: ~p~n", [Reason2]),
-            {error, {execution_failed, Reason2}};
-        _Other ->
-            wait_for_result(State)
+            {error, {execution_failed, Reason2}}
     end.
 
 %%------------------------------------------------------------------------------


### PR DESCRIPTION
While running PoW generation or validation in a separate OS process,
the code read unexpected messages in addition to the ones expected
from the process. This in not a problem for PoW generation as it runs
from a separate erlang process but the miner performs PoW validation
in its main process. It happened sometimes that the cast messages
the miner is sending to itself were consumed by the receive block
parsing the validation output, confusing the miner state machine.

Finishes PT-153087564