### PR TITLE
Allow node persistance configuration

### DIFF
--- a/deployment/ansible/deploy.yml
+++ b/deployment/ansible/deploy.yml
@@ -5,6 +5,10 @@
 
   vars:
     project_root: "{{ ansible_env.HOME }}/node"
+    config:
+      chain:
+        persist: true
+        db_path: .
 
   tasks:
     - name: "Required variables"
@@ -42,12 +46,6 @@
       command: "{{ project_root }}/bin/epoch stop"
       when: epoch.stat.exists == True and ping.stdout == "pong"
       tags: [daemon]
-
-    - name: Remove "{{ project_root }}/.chain" directory
-      file:
-        state: absent
-        path: "{{ project_root }}/.chain"
-      tags: [empty-chain]
 
     - name: Extract remote epoch package into {{ project_root }}
       unarchive:

--- a/deployment/ansible/templates/epoch.yaml.j2
+++ b/deployment/ansible/templates/epoch.yaml.j2
@@ -14,4 +14,5 @@ mining:
     autostart: true
 
 chain:
-    persist: true
+    persist: {{ config.chain.persist | bool | lower }}
+    db_path: {{ config.chain.db_path }}


### PR DESCRIPTION
This changes should prevent automatically .chain db deletion and allow configuring new chain db_path in case of format changes.

Relates to https://www.pivotaltracker.com/story/show/152956790