### PR TITLE
Use more generic x86-64 Cuckoo PoW binaries for shipping package

### DIFF
--- a/apps/aecuckoo/Makefile
+++ b/apps/aecuckoo/Makefile
@@ -15,8 +15,10 @@ SRC_EXECUTABLES = $(subst priv/bin, c_src/src, $(EXECUTABLES))
 
 SRC_LIBBLAKE = $(subst priv/lib, c_src/src, $(LIBBLAKE))
 
+SRC_ARCH_FLAGS = -m64
+
 REPO = https://github.com/aeternity/cuckoo.git
-COMMIT = fddbf60
+COMMIT = d1b8b77
 
 .PHONY: all
 all: $(LIBBLAKE) $(EXECUTABLES)
@@ -40,11 +42,17 @@ priv/lib priv/bin:
 
 $(SRC_LIBBLAKE): c_src/.git
 	( cd $(<D) && git checkout -q $(COMMIT); )
-	( cd $(@D) && $(MAKE) -s $(@F); )
+	( cd $(@D) && \
+		$(MAKE) $(@F) \
+			GCC_ARCH_FLAGS=$(SRC_ARCH_FLAGS) \
+			GPP_ARCH_FLAGS=$(SRC_ARCH_FLAGS); )
 
 $(SRC_EXECUTABLES): c_src/src/%: c_src/.git
 	( cd $(<D) && git checkout -q $(COMMIT); )
-	( cd $(@D) && $(MAKE) -s libblake2b.so $*; )
+	( cd $(@D) && \
+		$(MAKE) libblake2b.so $* \
+			GCC_ARCH_FLAGS=$(SRC_ARCH_FLAGS) \
+			GPP_ARCH_FLAGS=$(SRC_ARCH_FLAGS); )
 
 c_src/.git:
 	git clone $(REPO) $(@D)


### PR DESCRIPTION
[PT-152965197](https://www.pivotaltracker.com/story/show/152965197)

~It can be merged, thanks to commit d1b8b77 being tracked in the aeternity fork of the cuckoo repo in branch https://github.com/aeternity/cuckoo/tree/user-specified-compiler-flags~
~If PR https://github.com/tromp/cuckoo/pull/30 gets merged upstream, this commit will get into the upstream master, and removing the need for the user-specified-compiler-flags branch.~
It can be merged, thanks to commit d1b8b77 having been merged upstream and present in the master of the https://github.com/aeternity/cuckoo repo.