### PR TITLE
[Fixes #152878235] Make the functional adt tests for chain more complete

### DIFF
--- a/apps/aecore/src/aec_chain.erl
+++ b/apps/aecore/src/aec_chain.erl
@@ -51,15 +51,9 @@
         {ok, block()} |
         {error, Reason::{block_not_found, {top_header, header()}}}.
 -type get_header_by_height_reply() ::
-        {ok, header()} |
-        {error, Reason::{chain_too_short, {{chain_height, height()},
-                                           {top_header, header()}}}}.
+        {ok, header()} | {error, atom()}.
 -type get_block_by_height_reply() ::
-        {ok, block()} |
-        {error, Reason::{chain_too_short, {{chain_height, height()},
-                                           {top_header, header()}}} |
-                        {block_not_found, {top_header, header()}}
-        }.
+        {ok, block()} | {error, atom()}.
 -type insert_header_reply_ok() :: ok.
 -type insert_header_reply_error() ::
         {error, Reason::{previous_hash_is_not_top, {top_header, header()}} |

--- a/apps/aecore/src/aec_chain_server.erl
+++ b/apps/aecore/src/aec_chain_server.erl
@@ -99,9 +99,9 @@ handle_call({get_header, Hash}, _From, State) ->
 handle_call({get_block, Hash}, _From, State) ->
     {reply, get_block(Hash, State), State};
 handle_call({get_header_by_height, H}, _From, State) ->
-    {reply, get_header_by_height(H, State), State};
+    {reply, aec_chain_state:get_header_by_height(H, State), State};
 handle_call({get_block_by_height, H}, _From, State) ->
-    {reply, get_block_by_height(H, State), State};
+    {reply, aec_chain_state:get_block_by_height(H, State), State};
 handle_call(difficulty, _From, State) ->
     {reply, difficulty(State), State};
 handle_call({common_ancestor, Hash1, Hash2}, _From, State) ->
@@ -193,44 +193,8 @@ difficulty(State) ->
     {ok, X} = aec_chain_state:difficulty_at_top_header(State),
     X.
 
-
-%% WARNING WARNING WARNING WARNING WARNING WARNING
-%% Temporary implementation beyond this point.
-%% Should be moved to aec_chain_state.
-
-get_block_by_height(H, State) ->
-    case get_header_by_height(H, State) of
-        {error, _} = E -> E;
-        {ok, Header} ->
-            {ok, HeaderHash} = aec_headers:hash_header(Header),
-            get_block(HeaderHash, State)
-    end.
-
-find_header_at_height(H, HeaderHash, State) ->
-    {ok, Header} = aec_chain_state:get_header(HeaderHash, State),
-    Current = aec_headers:height(Header),
-    if Current > H ->
-            find_header_at_height(H, aec_headers:prev_hash(Header), State);
-       Current =:= H ->
-            {ok, Header}
-    end.
-
-get_header_by_height(H, State) ->
-    TopHeader  = aec_chain_state:top_header(State),
-    CH = aec_headers:height(TopHeader),
-    if CH < H ->
-
-            {error, {chain_too_short,
-                     {{chain_height, CH},
-                      {top_header, TopHeader}}}};
-       CH > H ->
-            find_header_at_height(H, aec_headers:prev_hash(TopHeader), State);
-       true ->
-            {ok, TopHeader}
-    end.
-
 %%%===================================================================
-%%% Helper functions for persitence
+%%% Helper functions for persistence
 %%%===================================================================
 
 store_block(Block, StateBefore, State) ->

--- a/apps/aecore/test/aec_chain_state_tests.erl
+++ b/apps/aecore/test/aec_chain_state_tests.erl
@@ -17,156 +17,149 @@
         , aec_keys_cleanup/1
         ]).
 
+-import(aec_chain_state,
+        [ difficulty_at_hash/2
+        , difficulty_at_top_block/1
+        , difficulty_at_top_header/1
+        , get_block/2
+        , get_block_by_height/2
+        , get_header/2
+        , get_header_by_height/2
+        , insert_block/2
+        , insert_header/2
+        , top_block/1
+        , top_block_hash/1
+        , top_header/1
+        , top_header_hash/1
+        ]).
+
+-define(compareBlockResults(B1, B2),
+        ?assertEqual(aec_blocks:serialize_for_network(element(2,B1)),
+                     aec_blocks:serialize_for_network(element(2,B2)))).
+
+-define(assertDifficultyEq(__X__, __Y__),
+        ?assertEqual(trunc(1000 *(__X__)),
+                     trunc(1000*(__Y__)))).
+
 %%%===================================================================
 %%% Test cases
 %%%===================================================================
 
-only_genesis_test_() ->
+%%%===================================================================
+%%% Basic access tests
+
+basic_access_test_() ->
     {setup,
-     fun() ->
-             ok = application:ensure_started(gproc)
-     end,
-     fun(_) ->
-             ok = application:stop(gproc)
-     end,
-     [{"Insert genesis header, then genesis block"
-       , fun() ->
-                 State1 = aec_chain_state:new(),
-                 ?assertEqual(undefined, aec_chain_state:top_header(State1)),
-                 ?assertEqual(undefined, aec_chain_state:top_block(State1)),
-                 GenesisHeader = genesis_header(),
-                 {ok, State2} = aec_chain_state:insert_header(GenesisHeader, State1),
-                 ?assertEqual(header_hash(GenesisHeader),
-                              aec_chain_state:top_header_hash(State2)),
-                 ?assertEqual(undefined,
-                              aec_chain_state:top_block_hash(State2)),
-                 GenesisBlock = genesis_block(),
-                 {ok, State3} = aec_chain_state:insert_block(GenesisBlock, State2),
-                 ?assertEqual(header_hash(GenesisHeader),
-                              aec_chain_state:top_header_hash(State3)),
-                 ?assertEqual(block_hash(GenesisBlock),
-                              aec_chain_state:top_block_hash(State3)),
-                 ok
-         end},
-      {"Insert genesis block directly"
-       , fun() ->
-                 State1 = aec_chain_state:new(),
-                 ?assertEqual(undefined, aec_chain_state:top_header(State1)),
-                 ?assertEqual(undefined, aec_chain_state:top_block(State1)),
-                 GenesisBlock = genesis_block(),
-                 {ok, State2} = aec_chain_state:insert_block(GenesisBlock, State1),
-                 ?assertEqual(block_hash(GenesisBlock),
-                              aec_chain_state:top_header_hash(State2)),
-                 ?assertEqual(block_hash(GenesisBlock),
-                              aec_chain_state:top_block_hash(State2)),
-                 ok
-         end}
+     fun aec_test_utils:aec_keys_setup/0,
+     fun aec_test_utils:aec_keys_cleanup/1,
+     [ {"Access for header chain", fun basic_access_test_header_chain/0}
+     , {"Access for block chain", fun basic_access_test_block_chain/0}
      ]}.
+
+basic_access_test_header_chain() ->
+    %% Create a chain that we are going to use.
+    Chain = aec_test_utils:gen_block_chain(3),
+    [BH0, BH1, BH2] = [aec_blocks:to_header(B) || B <- Chain],
+    [B0H, B1H, B2H] = [block_hash(B) || B <- Chain],
+
+    %% Add a couple of headers - not blocks - to the chain.
+    NewState = new_state(),
+    {ok, State0} = insert_header(BH0, NewState),
+    {ok, State1} = insert_header(BH1, State0),
+    {ok, State2} = insert_header(BH2, State1),
+
+    %% Check highest header.
+    ?assertEqual(BH1, top_header(State1)),
+    ?assertEqual(BH2, top_header(State2)),
+
+    %% Check by hash.
+    ?assertEqual({ok, BH0}, get_header(B0H, State2)),
+    ?assertEqual({ok, BH1}, get_header(B1H, State2)),
+    ?assertEqual({ok, BH2}, get_header(B2H, State2)),
+    ?assertEqual(error, get_header(B1H, State0)),
+    ?assertEqual(error, get_header(B2H, State0)),
+
+    %% Check by height.
+    ?assertEqual({ok, BH0}, get_header_by_height(0, State2)),
+    ?assertEqual({ok, BH1}, get_header_by_height(1, State2)),
+    ?assertEqual({ok, BH2}, get_header_by_height(2, State2)),
+    ?assertEqual({error, chain_too_short},
+                 get_header_by_height(3, State2)),
+
+    %% Test getting blocks for a header chain.
+    %% We only have the block for the genesis.
+
+    %% Get by hash
+    ?assertMatch(error, get_block(B0H, State2)),
+    ?assertEqual(error, get_block(B1H, State2)),
+    ?assertEqual(error, get_block(B2H, State2)),
+
+    %% Get by height
+    ?assertMatch({error, block_not_found},
+                 get_block_by_height(0, State2)),
+    ?assertMatch({error, block_not_found},
+                 get_block_by_height(1, State2)),
+    ?assertMatch({error, block_not_found},
+                 get_block_by_height(2, State2)),
+    ?assertMatch({error, chain_too_short},
+                 get_block_by_height(3, State2)).
+
+basic_access_test_block_chain() ->
+    %% Create a chain that we are going to use.
+    Chain = [B0, B1, B2] = aec_test_utils:gen_block_chain(3),
+    [BH0, BH1, BH2] = [aec_blocks:to_header(B) || B <- Chain],
+    [B0H, B1H, B2H] = [block_hash(H) || H <- Chain],
+
+    %% Add a couple of blocks to the chain.
+    NewState = new_state(),
+    {ok, State0} = insert_block(B0, NewState),
+    {ok, State1} = insert_block(B1, State0),
+    {ok, State2} = insert_block(B2, State1),
+
+    %% Check highest header.
+    ?assertEqual(BH1, top_header(State1)),
+    ?assertEqual(BH2, top_header(State2)),
+
+    %% Check highest block
+    ?compareBlockResults({ok, B0}, {ok, top_block(State0)}),
+    ?compareBlockResults({ok, B1}, {ok, top_block(State1)}),
+    ?compareBlockResults({ok, B2}, {ok, top_block(State2)}),
+
+    %% Check by hash.
+    ?assertEqual({ok, BH0}, get_header(B0H, State2)),
+    ?assertEqual({ok, BH1}, get_header(B1H, State2)),
+    ?assertEqual({ok, BH2}, get_header(B2H, State2)),
+    ?assertEqual(error, get_header(B1H, State0)),
+    ?assertEqual(error, get_header(B2H, State0)),
+    ?compareBlockResults({ok, B0}, get_block(B0H, State2)),
+    ?compareBlockResults({ok, B1}, get_block(B1H, State2)),
+    ?compareBlockResults({ok, B2}, get_block(B2H, State2)),
+    ?assertEqual(error, get_block(B1H, State0)),
+    ?assertEqual(error, get_block(B2H, State0)),
+
+    %% Check by height
+    ?assertEqual({ok, BH0}, get_header_by_height(0, State2)),
+    ?assertEqual({ok, BH1}, get_header_by_height(1, State2)),
+    ?assertEqual({ok, BH2}, get_header_by_height(2, State2)),
+    ?compareBlockResults({ok, B0}, get_block_by_height(0, State2)),
+    ?compareBlockResults({ok, B1}, get_block_by_height(1, State2)),
+    ?compareBlockResults({ok, B2}, get_block_by_height(2, State2)),
+    ?assertEqual({error, chain_too_short}, get_block_by_height(3, State2)).
+
+%%%===================================================================
+%%% GC tests
 
 gc_test_() ->
     {foreach,
      fun setup_meck_and_keys/0,
      fun teardown_meck_and_keys/1,
-     [{gc_test_slogan(Length, Max, Interval, KeepAll)
-      , fun() ->
-                %% Generate blockchain and write it to the state.
-                BC = gen_block_chain(Length),
-                State1 = aec_chain_state:new(gc_opts(KeepAll, Max, Interval)),
-                State2 = write_blocks_to_chain(BC, State1),
-
-                %% Get the state trees that we would have persisted.
-                Trees = aec_chain_state:get_state_trees_for_persistance(State2),
-
-                %% Check that the top block hash is among the persisted.
-                TopHash = aec_chain_state:top_block_hash(State2),
-                ?assertMatch({TopHash, _}, lists:keyfind(TopHash, 1, Trees)),
-
-                %% Compute the hashes that always should be persisted...
-                KeepAllHashes =
-                    [block_hash(lists:nth(X, BC))
-                     || X <- lists:seq(Length - KeepAll + 1, Length)],
-                %% ...and check that they are indeed persisted.
-                ?assertEqual(lists:duplicate(length(KeepAllHashes), true),
-                             [lists:keymember(X, 1, Trees)
-                              || X <- KeepAllHashes]),
-
-                %% Compute the hashes that should be sparsely persisted...
-                KeepSparseHashes =
-                    [block_hash(lists:nth(X, BC))
-                     || X <- lists:seq(Length-KeepAll, Length-Max,-Interval)],
-                %% ...and check that they are indeed persisted.
-                ?assertEqual(lists:duplicate(length(KeepSparseHashes), true),
-                             [lists:keymember(X, 1, Trees)
-                              || X <- KeepSparseHashes]),
-
-                %% Check that we have have covered all the hashes that
-                %% we will persist (and that the hashes were unique).
-                HashSet = ordsets:from_list(KeepAllHashes ++ KeepSparseHashes),
-                ?assertEqual(ordsets:size(HashSet), length(Trees)),
-                ?assertEqual(ordsets:size(HashSet),
-                             length(KeepSparseHashes) + length(KeepAllHashes)),
-                ok
-        end}
+     [{ gc_test_slogan(Length, Max, Interval, KeepAll)
+      , gc_test_gen(Length, Max, Interval, KeepAll)}
       || {Length, Max, Interval, KeepAll} <- gc_test_params()
      ]}.
 
-postponed_validation_test_() ->
-    {foreach,
-     fun() ->
-         setup_meck_and_keys()
-     end,
-     fun(TmpDir) ->
-         teardown_meck_and_keys(TmpDir)
-     end,
-     [{"Test that an invalid block in a different fork is validated when that "
-       "fork takes over as main chain",
-       fun() ->
-               B0 = genesis_block(),
-               MainBC = [_,_,_] = [B0 | extend_block_chain_by_difficulties_with_nonce_and_coinbase(B0, [2, 2], 111)],
-               AltChain = [B1,B2] = extend_block_chain_by_difficulties_with_nonce_and_coinbase(B0, [1, 100], 222),
-
-               %% Assert that we are creating a fork
-               ?assertNotEqual(MainBC, [B0, B1, B2]),
-
-               State0 = aec_chain_state:new(),
-
-               %% Insert the main chain.
-               State1 = lists:foldl(fun(B, Acc) ->
-                                            {ok, Acc1} = aec_chain_state:insert_block(B, Acc),
-                                            Acc1
-                                    end, State0, MainBC),
-
-               %% Assert that the fork would have taken over if it was ok.
-               %% Insert the main chain.
-               State2 = lists:foldl(fun(B, Acc) ->
-                                            {ok, Acc1} = aec_chain_state:insert_block(B, Acc),
-                                            Acc1
-                                    end, State1, AltChain),
-               ?assertEqual(aec_blocks:hash_internal_representation(B2),
-                            aec_blocks:hash_internal_representation(aec_chain_state:top_block(State2))),
-
-               %% Insert the first block of the fork with a bad root hash
-               Bad = B1#block{root_hash = <<"I'm not really a hash">>},
-               {ok, State3} = aec_chain_state:insert_block(Bad, State1),
-
-               {ok, Hash} = aec_blocks:hash_internal_representation(Bad),
-               B2Bad = B2#block{prev_hash = Hash},
-
-               %% Check that the fork is not taking over
-               ?assertEqual(aec_chain_state:top_block(State1),
-                            aec_chain_state:top_block(State3)),
-
-               ?assertEqual({ok, aec_chain_state:top_block_hash(State1)},
-                            aec_blocks:hash_internal_representation(lists:last(MainBC))),
-
-               %% When the fork takes over, the bad block should be found invalid.
-               ?assertMatch({error, _},
-                            aec_chain_state:insert_block(B2Bad, State3)),
-
-               ok
-       end
-      }
-     ]}.
+gc_test_gen(Length, Max, Interval, KeepAll) ->
+    fun() -> gc_test_fun(Length, Max, Interval, KeepAll)end.
 
 gc_test_slogan(Length, Max, Interval, KeepAll) ->
     S = io_lib:format("Create chain, test that only"
@@ -182,10 +175,340 @@ gc_test_params() ->
     , {100, 30, 10, 5}
     ].
 
+gc_test_fun(Length, Max, Interval, KeepAll) ->
+    %% Generate blockchain and write it to the state.
+    BC = aec_test_utils:gen_block_chain(Length),
+    State1 = new_state(gc_opts(KeepAll, Max, Interval)),
+    State2 = write_blocks_to_chain(BC, State1),
+
+    %% Get the state trees that we would have persisted.
+    Trees = aec_chain_state:get_state_trees_for_persistance(State2),
+
+    %% Check that the top block hash is among the persisted.
+    TopHash = top_block_hash(State2),
+    ?assertMatch({TopHash, _}, lists:keyfind(TopHash, 1, Trees)),
+
+    %% Compute the hashes that always should be persisted...
+    KeepAllHashes =
+        [block_hash(lists:nth(X, BC))
+         || X <- lists:seq(Length - KeepAll + 1, Length)],
+    %% ...and check that they are indeed persisted.
+    ?assertEqual(lists:duplicate(length(KeepAllHashes), true),
+                 [lists:keymember(X, 1, Trees)
+                  || X <- KeepAllHashes]),
+
+    %% Compute the hashes that should be sparsely persisted...
+    KeepSparseHashes =
+        [block_hash(lists:nth(X, BC))
+         || X <- lists:seq(Length-KeepAll, Length-Max,-Interval)],
+    %% ...and check that they are indeed persisted.
+    ?assertEqual(lists:duplicate(length(KeepSparseHashes), true),
+                 [lists:keymember(X, 1, Trees)
+                  || X <- KeepSparseHashes]),
+
+    %% Check that we have have covered all the hashes that
+    %% we will persist (and that the hashes were unique).
+    HashSet = ordsets:from_list(KeepAllHashes ++ KeepSparseHashes),
+    ?assertEqual(ordsets:size(HashSet), length(Trees)),
+    ?assertEqual(ordsets:size(HashSet),
+                 length(KeepSparseHashes) + length(KeepAllHashes)),
+    ok.
+
+%%%===================================================================
+%%% Out of order tests
+
+out_of_order_test_() ->
+    {setup,
+     fun aec_test_utils:aec_keys_setup/0,
+     fun aec_test_utils:aec_keys_cleanup/1,
+     [ {"Out of order insert of header chain",
+        fun out_of_order_test_header_chain/0}
+     , {"Out of order insert of block chain",
+        fun out_of_order_test_block_chain/0}
+     , {"Out of order insert of mixed chain",
+        fun out_of_order_test_mixed_chain/0}
+     ]}.
+
+out_of_order_test_header_chain() ->
+    %% Create a chain that we are going to use.
+    Chain = aec_test_utils:gen_block_chain(3),
+    [BH0, BH1, BH2] = [aec_blocks:to_header(B) || B <- Chain],
+    [B0H,_B1H, B2H] = [block_hash(H) || H <- Chain],
+
+    %% Insert the headers in different order and assert
+    %% that the end result is the same
+    S = new_state(),
+    ?assertEqual(B2H, top_header_hash(write_headers_to_chain([BH0, BH1, BH2], S))),
+    ?assertEqual(B2H, top_header_hash(write_headers_to_chain([BH0, BH2, BH1], S))),
+    ?assertEqual(B2H, top_header_hash(write_headers_to_chain([BH1, BH0, BH2], S))),
+    ?assertEqual(B2H, top_header_hash(write_headers_to_chain([BH1, BH2, BH0], S))),
+    ?assertEqual(B2H, top_header_hash(write_headers_to_chain([BH2, BH0, BH1], S))),
+    ?assertEqual(B2H, top_header_hash(write_headers_to_chain([BH2, BH1, BH0], S))),
+
+    %% Check that the top header is not moving if the chain is not complete.
+    ?assertEqual(B0H, top_header_hash(write_headers_to_chain([BH0, BH2], S))),
+    ?assertEqual(undefined, top_header_hash(write_headers_to_chain([BH1, BH2], S))),
+    ok.
+
+out_of_order_test_block_chain() ->
+    %% Create a chain that we are going to use.
+    Chain = [B0, B1, B2] = aec_test_utils:gen_block_chain(3),
+    [B0H,_B1H, B2H] = [block_hash(H) || H <- Chain],
+
+    %% Insert the headers in different order and assert
+    %% that the end result is the same
+    S = new_state(),
+    ?assertEqual(B2H, top_header_hash(write_blocks_to_chain([B0, B1, B2], S))),
+    ?assertEqual(B2H, top_header_hash(write_blocks_to_chain([B0, B2, B1], S))),
+    ?assertEqual(B2H, top_header_hash(write_blocks_to_chain([B1, B0, B2], S))),
+    ?assertEqual(B2H, top_header_hash(write_blocks_to_chain([B1, B2, B0], S))),
+    ?assertEqual(B2H, top_header_hash(write_blocks_to_chain([B2, B0, B1], S))),
+    ?assertEqual(B2H, top_header_hash(write_blocks_to_chain([B2, B1, B0], S))),
+
+    %% Check that the top block is not moving if the chain is not complete.
+    ?assertEqual(B0H, top_block_hash(write_blocks_to_chain([B0, B2], S))),
+    ?assertEqual(undefined, top_block_hash(write_blocks_to_chain([B1, B2], S))),
+    ok.
+
+out_of_order_test_mixed_chain() ->
+    %% Create a chain that we are going to use.
+    Chain = [B0, B1, B2] = aec_test_utils:gen_block_chain(3),
+    [BH0, BH1,_BH2] = [aec_blocks:to_header(B) || B <- Chain],
+    [B0H, B1H, B2H] = [block_hash(H) || H <- Chain],
+
+    %% Check that the top header hash and the top block hash is moving
+    %% in the correct way.
+    {ok, State1} = insert_header(BH0, new_state()),
+    ?assertEqual(B0H, top_header_hash(State1)),
+    ?assertEqual(undefined, top_block_hash(State1)),
+    {ok, State2} = insert_header(BH1, State1),
+    ?assertEqual(B1H, top_header_hash(State2)),
+    ?assertEqual(undefined, top_block_hash(State2)),
+    {ok, State3} = insert_block(B0, State2),
+    ?assertEqual(B1H, top_header_hash(State3)),
+    ?assertEqual(B0H, top_block_hash(State3)),
+    {ok, State4} = insert_block(B2, State3),
+    ?assertEqual(B2H, top_header_hash(State4)),
+    ?assertEqual(B0H, top_block_hash(State4)),
+    {ok, State5} = insert_block(B1, State4),
+    ?assertEqual(B2H, top_header_hash(State5)),
+    ?assertEqual(B2H, top_block_hash(State5)),
+    ok.
+
+%%%===================================================================
+%%% Broken chain tests
+
+broken_chain_test_() ->
+    {foreach,
+     fun setup_meck_and_keys/0,
+     fun teardown_meck_and_keys/1,
+     [{"Test that an invalid block in a different fork is validated when that "
+       "fork tries to take over as main chain",
+       fun broken_chain_postponed_validation/0},
+      {"Add a block that points to the wrong place in the main chain"
+       " because of its height",
+       fun broken_chain_wrong_height/0},
+      {"Add a block with the wrong state hash",
+       fun broken_chain_wrong_state_hash/0}
+      ]}.
+
+broken_chain_postponed_validation() ->
+    MainBC = gen_block_chain_by_difficulty([2, 2], 111),
+    AltChain = [B0, B1, B2] = gen_block_chain_by_difficulty([1, 100], 222),
+
+    %% Assert that we are creating a fork
+    ?assertNotEqual(MainBC, AltChain),
+    ?assertEqual(hd(MainBC), B0),
+
+    %% Insert the main chain.
+    State0 = write_blocks_to_chain(MainBC, new_state()),
+
+    %% Assert that the fork would have taken over if it was ok.
+    State1 = write_blocks_to_chain(AltChain, State0),
+    ?assertEqual(aec_blocks:hash_internal_representation(B2),
+                 aec_blocks:hash_internal_representation(top_block(State1))),
+
+    %% Insert the first block of the fork with a bad root hash
+    Bad = B1#block{root_hash = <<"I'm not really a hash">>},
+    {ok, State2} = insert_block(Bad, State0),
+
+    {ok, Hash} = aec_blocks:hash_internal_representation(Bad),
+    B2Bad = B2#block{prev_hash = Hash},
+
+    %% Check that the fork is not taking over
+    ?assertEqual(top_block(State0), top_block(State2)),
+    ?assertEqual(top_block_hash(State2), block_hash(lists:last(MainBC))),
+
+    %% When the fork takes over, the bad block should be found invalid.
+    ?assertMatch({error, _}, insert_block(B2Bad, State2)),
+    ok.
+
+
+broken_chain_wrong_height() ->
+    %% Create a chain that we are going to use.
+    [B0, B1, B2] = aec_test_utils:gen_block_chain(3),
+
+    %% Insert up to last block.
+    State0 = write_blocks_to_chain([B0, B1], new_state()),
+
+    %% Check that we can insert the unmodified last block
+    ?assertMatch({ok, _}, insert_block(B2, State0)),
+
+    %% Change the height of the last block to an incompatible height.
+    ?assertEqual({error, height_inconsistent_with_previous_hash},
+                 insert_block(B2#block{height = 4}, State0)),
+    ?assertEqual({error, height_inconsistent_with_previous_hash},
+                 insert_block(B2#block{height = 1}, State0)),
+    ok.
+
+broken_chain_wrong_state_hash() ->
+    [B0, B1, B2] = aec_test_utils:gen_block_chain(3),
+
+    %% Insert up to last block.
+    State0 = write_blocks_to_chain([B0, B1], new_state()),
+
+    %% Check that we can insert the unmodified last block
+    ?assertMatch({ok, _}, insert_block(B2, State0)),
+
+    %% Change the state hash to something wrong.
+    Hash = B2#block.root_hash,
+    Bogus = case <<1:(bit_size(Hash))>> =:= Hash of
+                true  -> <<0:(bit_size(Hash))>>;
+                false -> <<1:(bit_size(Hash))>>
+            end,
+    ?assertNotEqual(Hash, Bogus),
+    ?assertMatch({error, {root_hash_mismatch, _, _}},
+                 insert_block(B2#block{root_hash = Bogus}, State0)),
+    ok.
+
+
+%%%===================================================================
+%%% Total difficulty test
+
+-define(GENESIS_DIFFICULTY, 553713663.0).
+
+total_difficulty_test_() ->
+    {foreach,
+     fun setup_meck_and_keys/0,
+     fun teardown_meck_and_keys/1,
+     [{"Get work in chain of only genesis",
+       fun total_difficulty_only_genesis/0},
+      {"Get work in header chain",
+       fun total_difficulty_in_chain/0
+      }]
+    }.
+
+total_difficulty_only_genesis() ->
+    {ok, State0} = insert_block(genesis_block(), new_state()),
+    {ok, Difficulty} = difficulty_at_top_header(State0),
+    ?assertDifficultyEq(?GENESIS_DIFFICULTY, Difficulty).
+
+total_difficulty_in_chain() ->
+    [B0, B1, B2, B3] = Chain = gen_block_chain_by_difficulty([1, 1, 1], 111),
+    State = write_blocks_to_chain(Chain, new_state()),
+    {ok, DiffTopH} = difficulty_at_top_header(State),
+    {ok, DiffTopB} = difficulty_at_top_block(State),
+    {ok, Diff0} = difficulty_at_hash(block_hash(B0), State),
+    {ok, Diff1} = difficulty_at_hash(block_hash(B1), State),
+    {ok, Diff2} = difficulty_at_hash(block_hash(B2), State),
+    {ok, Diff3} = difficulty_at_hash(block_hash(B3), State),
+
+    ?assertDifficultyEq(?GENESIS_DIFFICULTY + 3, DiffTopH),
+    ?assertDifficultyEq(?GENESIS_DIFFICULTY + 3, DiffTopB),
+    ?assertDifficultyEq(?GENESIS_DIFFICULTY + 0, Diff0),
+    ?assertDifficultyEq(?GENESIS_DIFFICULTY + 1, Diff1),
+    ?assertDifficultyEq(?GENESIS_DIFFICULTY + 2, Diff2),
+    ?assertDifficultyEq(?GENESIS_DIFFICULTY + 3, Diff3),
+
+    ok.
+
+%%%===================================================================
+%%% Forking tests
+
+forking_test_() ->
+    {foreach,
+     fun setup_meck_and_keys/0,
+     fun teardown_meck_and_keys/1,
+     [ {"Fork on genesis", fun fork_on_genesis/0}
+     , {"Fork on shorter chain because of difficulty", fun fork_on_shorter/0}
+     , {"Fork on last block", fun fork_on_last_block/0}
+     ]}.
+
+fork_on_genesis() ->
+    EasyChain = gen_block_chain_by_difficulty([1, 1, 1], 111),
+    HardChain = gen_block_chain_by_difficulty([2, 2, 2], 111),
+    fork_common(EasyChain, HardChain).
+
+fork_on_last_block() ->
+    CommonChain = gen_block_chain_by_difficulty([1, 1], 111),
+    EasyChain = extend_chain(CommonChain, [1], 111),
+    HardChain = extend_chain(CommonChain, [2], 222),
+    fork_common(EasyChain, HardChain).
+
+fork_on_shorter() ->
+    EasyChain = gen_block_chain_by_difficulty([1, 1, 1], 111),
+    HardChain = gen_block_chain_by_difficulty([2, 3], 111),
+    fork_common(EasyChain, HardChain).
+
+fork_common(EasyChain, HardChain) ->
+    TopHashEasy = block_hash(lists:last(EasyChain)),
+    TopHashHard = block_hash(lists:last(HardChain)),
+    %% Insert blocks
+    ok = fork_common_block(EasyChain, TopHashEasy, HardChain, TopHashHard),
+    %% Out of order
+    ok = fork_common_block(lists:reverse(EasyChain), TopHashEasy,
+                           lists:reverse(HardChain), TopHashHard),
+    %% Insert headers
+    EasyHeaders = [aec_blocks:to_header(X) || X <- EasyChain],
+    HardHeaders = [aec_blocks:to_header(X) || X <- HardChain],
+    ok = fork_common_headers(EasyHeaders, TopHashEasy, HardHeaders, TopHashHard),
+    %% Out of order
+    ok = fork_common_headers(lists:reverse(EasyHeaders), TopHashEasy,
+                             lists:reverse(HardHeaders), TopHashHard),
+
+    ok.
+
+fork_common_block(EasyChain, TopHashEasy, HardChain, TopHashHard) ->
+    InitState = new_state(),
+
+    %% The second chain should take over
+    State1 = write_blocks_to_chain(EasyChain, InitState),
+    State2 = write_blocks_to_chain(HardChain, State1),
+    ?assertEqual(TopHashEasy, top_block_hash(State1)),
+    ?assertEqual(TopHashHard, top_block_hash(State2)),
+
+    %% The second chain should not take over
+    State3 = write_blocks_to_chain(HardChain, InitState),
+    State4 = write_blocks_to_chain(EasyChain, State3),
+    ?assertEqual(TopHashHard, top_block_hash(State3)),
+    ?assertEqual(TopHashHard, top_block_hash(State4)),
+    ok.
+
+fork_common_headers(EasyChain, TopHashEasy, HardChain, TopHashHard) ->
+    InitState = new_state(),
+
+    %% The second chain should take over
+    State1 = write_headers_to_chain(EasyChain, InitState),
+    State2 = write_headers_to_chain(HardChain, State1),
+    ?assertEqual(TopHashEasy, top_header_hash(State1)),
+    ?assertEqual(TopHashHard, top_header_hash(State2)),
+
+    %% The second chain should not take over
+    State3 = write_headers_to_chain(HardChain, InitState),
+    State4 = write_headers_to_chain(EasyChain, State3),
+    ?assertEqual(TopHashHard, top_header_hash(State3)),
+    ?assertEqual(TopHashHard, top_header_hash(State4)),
+    ok.
 
 %%%===================================================================
 %%% Internal functions
 %%%===================================================================
+
+new_state() ->
+    aec_chain_state:new().
+
+new_state(Opts) ->
+    aec_chain_state:new(Opts).
 
 setup_meck_and_keys() ->
     aec_test_utils:mock_difficulty_as_target(),
@@ -196,9 +519,15 @@ teardown_meck_and_keys(TmpDir) ->
     aec_test_utils:aec_keys_cleanup(TmpDir).
 
 write_blocks_to_chain([H|T], State) ->
-    {ok, State1} = aec_chain_state:insert_block(H, State),
+    {ok, State1} = insert_block(H, State),
     write_blocks_to_chain(T, State1);
 write_blocks_to_chain([], State) ->
+    State.
+
+write_headers_to_chain([H|T], State) ->
+    {ok, State1} = insert_header(H, State),
+    write_headers_to_chain(T, State1);
+write_headers_to_chain([], State) ->
     State.
 
 gc_opts(KeepAll, Max, Interval) ->
@@ -207,26 +536,17 @@ gc_opts(KeepAll, Max, Interval) ->
      , keep_all_snapshots_height => KeepAll
      }.
 
-gen_block_chain(Length) ->
-  gen_block_chain(Length, 1).
+gen_block_chain_by_difficulty(Diffs, Nonce) ->
+    B0 = genesis_block(),
+    [B0 | extend_block_chain_by_difficulties_with_nonce_and_coinbase(B0, Diffs, Nonce)].
 
-gen_block_chain(Length, Difficulty) ->
-  gen_block_chain(Length, Difficulty, 111).
-
-gen_block_chain(Length, Difficulty, Nounce) ->
-  Ds = lists:duplicate(Length - 1, Difficulty),
-  G = genesis_block(),
-  [G|extend_block_chain_by_difficulties_with_nonce_and_coinbase(G, Ds, Nounce)].
+extend_chain(Base, Diffs, Nonce) ->
+    B = lists:last(Base),
+    Base ++
+        extend_block_chain_by_difficulties_with_nonce_and_coinbase(B, Diffs, Nonce).
 
 genesis_block() ->
     aec_block_genesis:genesis_block().
-
-genesis_header() ->
-    aec_block_genesis:genesis_header().
-
-header_hash(Header) ->
-    {ok, H} = aec_headers:hash_header(Header),
-    H.
 
 block_hash(Block) ->
     {ok, H} = aec_blocks:hash_internal_representation(Block),

--- a/apps/aecore/test/aec_chain_tests.erl
+++ b/apps/aecore/test/aec_chain_tests.erl
@@ -123,17 +123,15 @@ header_chain_test_() ->
              ?assertEqual({ok, BH0}, aec_chain:get_header_by_height(0)),
              ?compareBlockResults({ok, B0}, aec_chain:get_block_by_height(0)),
              ?assertEqual({ok, BH1}, aec_chain:get_header_by_height(1)),
-             ?assertEqual({error, {block_not_found, {top_header, BH2}
-                                  }}, aec_chain:get_block_by_height(1)),
+             ?assertEqual({error, block_not_found},
+                          aec_chain:get_block_by_height(1)),
              ?assertEqual({ok, BH2}, aec_chain:get_header_by_height(2)),
-             ?assertEqual({error, {block_not_found, {top_header, BH2}
-                                  }}, aec_chain:get_block_by_height(2)),
-             ?assertEqual({error, {chain_too_short, {{chain_height, 2},
-                                                     {top_header, BH2}}
-                                  }}, aec_chain:get_header_by_height(3)),
-             ?assertEqual({error, {chain_too_short, {{chain_height, 2},
-                                                     {top_header, BH2}}
-                                  }}, aec_chain:get_block_by_height(3))
+             ?assertEqual({error, block_not_found},
+                          aec_chain:get_block_by_height(2)),
+             ?assertEqual({error, chain_too_short},
+                          aec_chain:get_header_by_height(3)),
+             ?assertEqual({error, chain_too_short},
+                          aec_chain:get_block_by_height(3))
      end}.
 
 block_chain_test_() ->
@@ -189,16 +187,14 @@ block_chain_test_() ->
                ?assertEqual({ok, BH0}, aec_chain:get_header_by_height(0)),
                ?compareBlockResults({ok, B0}, aec_chain:get_block_by_height(0)),
                ?assertEqual({ok, BH1}, aec_chain:get_header_by_height(1)),
-               ?assertEqual({error, {block_not_found, {top_header, BH2}
-                                    }}, aec_chain:get_block_by_height(1)),
+               ?assertEqual({error, block_not_found},
+                            aec_chain:get_block_by_height(1)),
                ?assertEqual({ok, BH2}, aec_chain:get_header_by_height(2)),
                ?assertEqual({ok, B2}, aec_chain:get_block_by_height(2)),
-               ?assertEqual({error, {chain_too_short, {{chain_height, 2},
-                                                       {top_header, BH2}}
-                                    }}, aec_chain:get_header_by_height(3)),
-               ?assertEqual({error, {chain_too_short, {{chain_height, 2},
-                                                       {top_header, BH2}}
-                                    }}, aec_chain:get_block_by_height(3))
+               ?assertEqual({error, chain_too_short},
+                            aec_chain:get_header_by_height(3)),
+               ?assertEqual({error, chain_too_short},
+                            aec_chain:get_block_by_height(3))
        end},
      {"Build chain with genesis block plus 2 headers, then store block corresponding to header before top header",
        fun() ->
@@ -243,14 +239,12 @@ block_chain_test_() ->
                ?assertEqual({ok, BH1}, aec_chain:get_header_by_height(1)),
                ?compareBlockResults({ok, B1}, aec_chain:get_block_by_height(1)),
                ?assertEqual({ok, BH2}, aec_chain:get_header_by_height(2)),
-               ?assertEqual({error, {block_not_found, {top_header, BH2}
-                                    }}, aec_chain:get_block_by_height(2)),
-               ?assertEqual({error, {chain_too_short, {{chain_height, 2},
-                                                       {top_header, BH2}}
-                                    }}, aec_chain:get_header_by_height(3)),
-               ?assertEqual({error, {chain_too_short, {{chain_height, 2},
-                                                       {top_header, BH2}}
-                                    }}, aec_chain:get_block_by_height(3))
+               ?assertEqual({error, block_not_found},
+                            aec_chain:get_block_by_height(2)),
+               ?assertEqual({error, chain_too_short},
+                            aec_chain:get_header_by_height(3)),
+               ?assertEqual({error, chain_too_short},
+                            aec_chain:get_block_by_height(3))
        end}]}.
 
 get_work_test_() ->

--- a/apps/aehttp/src/aehttp_dispatch_ext.erl
+++ b/apps/aehttp/src/aehttp_dispatch_ext.erl
@@ -57,7 +57,11 @@ handle_request('GetBlockByHeight', Req, _Context) ->
             Resp = cleanup_genesis(aec_blocks:serialize_to_map(Block)),
             lager:debug("Resp = ~p", [Resp]),
             {200, [], Resp};
-        {error, {chain_too_short, _}} ->
+        {error, no_top_header} ->
+            {404, [], #{reason => <<"No top header">>}};
+        {error, block_not_found} ->
+            {404, [], #{reason => <<"Block not found">>}};
+        {error, chain_too_short} ->
             {404, [], #{reason => <<"Chain too short">>}}
     end;
 

--- a/apps/aehttp/src/ws_int_dispatch.erl
+++ b/apps/aehttp/src/ws_int_dispatch.erl
@@ -37,7 +37,7 @@ do_execute(chain, get, QueryPayload) ->
                 {aec_chain:get_block_by_hash(Hash), {hash, Hash0}}
         end,
     case BlockFound of
-        {error, {ErrMsg, _Top}} ->
+        {error, ErrMsg} ->
             {error, ErrMsg};
         {ok, Block} ->
             Val0 =


### PR DESCRIPTION
As a step of moving away from the aec_chain_server, I re-implement the tests that goes through the chain server api to testing of the functional adt.

All chain server tests are kept for now, but (at least) the same test coverage should now be on the functional adt so that we know that we do not miss any functionality when moving forward.

The new tests also covers more of the functionality since the chain server tests where adapted from the  original implementation.

Note that the API return values has changed slightly for get_{block,header}_by_height, in the error cases, so the corresponding call sites had to be updated as well. Since there was so few I include the changes in this PR. The corresponding error returns for get_{block,header}_by_hash is left for later, in order to change the functionality as little as possible at this stage.
