### PR TITLE
Increase ansible timeout to 30s

### DIFF
--- a/deployment/ansible/ansible.cfg
+++ b/deployment/ansible/ansible.cfg
@@ -2,6 +2,7 @@
 callback_whitelist = profile_tasks
 host_key_checking = False
 inventory = inventory/openstack.yml
+timeout = 30
 
 [ssh_connection]
 ssh_args = -o ForwardAgent=yes -o ControlMaster=auto -o ControlPersist=1800s


### PR DESCRIPTION
Because of high instance load, most of the nodes are quite unresponsive causing [ansible deploy timeouts](http://docs.ansible.com/ansible/latest/intro_configuration.html#timeout).

Increasing from default 10s to 30s
