### PR TITLE
Genesis block token distribution [Finishes #152479338]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ apps/aecuckoo/priv/bin
 apps/aecuckoo/priv/lib
 apps/aecore/priv/keys
 .chain
+REVISION

--- a/apps/aecore/priv/.genesis/accounts.json
+++ b/apps/aecore/priv/.genesis/accounts.json
@@ -1,0 +1,3 @@
+{
+  "BGWkAh1FRpNiuL+v01pVjEX0AqchlwJycm53A6MILswKEwuhZqV6KkcJwc5ilxhdRnNGWlXCy+Q6EFnbPAZp8MM=": 100000000001
+}

--- a/apps/aecore/src/aec_block_genesis.erl
+++ b/apps/aecore/src/aec_block_genesis.erl
@@ -15,7 +15,7 @@
 %%%   * This means that validation function attempting to check that
 %%%     there is at least a coinbase transaction in a block needs to
 %%%     have a special case for genesis.
-%%% * The hash values in it have special value i.e. all zeros.
+%%% * The hash values in it may have special values i.e. all zeros.
 %%%   * This means that validation function attempting to consider the
 %%%     hashes in a block needs to have a special case for genesis.
 %%% @end
@@ -24,51 +24,53 @@
 
 %% API
 -export([genesis_header/0,
-         genesis_block_as_deserialized_from_network/0,
+         height/0,
          genesis_block/0,
-         height/0]).
+         populated_trees/0]).
 
 -include("common.hrl").
 -include("blocks.hrl").
 
+%% Since preset accounts are being loaded from a file - please use with caution
 genesis_header() ->
-    #header{
-       version = ?GENESIS_VERSION,
-       height = ?GENESIS_HEIGHT,
-       prev_hash = <<0:?BLOCK_HEADER_HASH_BYTES/unit:8>>,
-       txs_hash = <<0:?TXS_HASH_BYTES/unit:8>>,
-       root_hash = <<0:?STATE_HASH_BYTES/unit:8>>,
-       target = ?HIGHEST_TARGET_SCI,
-       pow_evidence = no_value,
-       nonce = 0,
-       time = 0 %% Epoch.
-      }.
-
-genesis_block_as_deserialized_from_network() ->
-    H = genesis_header(),
-    #block{
-       version = H#header.version,
-       height = H#header.height,
-       prev_hash = H#header.prev_hash,
-       txs_hash = H#header.txs_hash,
-       root_hash = H#header.root_hash,
-       target = H#header.target,
-       pow_evidence = H#header.pow_evidence,
-       nonce = H#header.nonce,
-       time = H#header.time,
-       txs = [],
-       trees = _DummyTrees = #trees{}
-      }.
+    aec_blocks:to_header(genesis_block()).
 
 %% Returns the genesis block including the state trees.
 %%
 %% The current implementation of state trees causes a new Erlang term,
-%% representing the initial empty state trees, to be allocated in the
+%% representing the initial state trees, to be allocated in the
 %% heap memory of the calling process.
+%%
+%% Since preset accounts are being loaded from a file - please use with caution
 genesis_block() ->
-    B = genesis_block_as_deserialized_from_network(),
-    {ok, T} = aec_trees:all_trees_new(),
-    B#block{trees = T}.
+    Trees = populated_trees(),
+    #block{
+      version = ?GENESIS_VERSION,
+      height = ?GENESIS_HEIGHT,
+      prev_hash = <<0:?BLOCK_HEADER_HASH_BYTES/unit:8>>,
+      txs_hash = <<0:?TXS_HASH_BYTES/unit:8>>,
+      root_hash = aec_trees:all_trees_hash(Trees),
+      target = ?HIGHEST_TARGET_SCI,
+      pow_evidence = no_value,
+      nonce = 0,
+      time = 0, %% Epoch.
+      trees = Trees
+      }.
+
+populated_trees() ->
+    {ok, T0} = aec_trees:all_trees_new(),
+    PresetAccounts = aec_genesis_block_settings:preset_accounts(),
+    Trees = add_preset_accounts(PresetAccounts, T0),
+    Trees.
+
+add_preset_accounts([], Trees) ->
+    Trees;
+add_preset_accounts([{PubKey, Amt} | T], Trees0) ->
+    Account = aec_accounts:new(PubKey, Amt, 0),
+    AccountsTrees0 = aec_trees:accounts(Trees0),
+    {ok, AccountsTrees} = aec_accounts:put(Account, AccountsTrees0),
+    Trees = aec_trees:set_accounts(Trees0, AccountsTrees),
+    add_preset_accounts(T, Trees).
 
 height() ->
     ?GENESIS_HEIGHT.

--- a/apps/aecore/src/aec_chain.erl
+++ b/apps/aecore/src/aec_chain.erl
@@ -31,7 +31,9 @@
          insert_header/1,
          top/0,
          top_header/0,
-         write_block/1 %% TODO: rename
+         write_block/1, %% TODO: rename
+         genesis_header/0,
+         genesis_block/0
 	]).
 
 -include("common.hrl").
@@ -138,6 +140,12 @@ insert_header(Header) ->
 write_block(Block) ->
     gen_server:call(?CHAIN_SERVER, {write_block, Block}, ?DEFAULT_CALL_TIMEOUT).
 
+genesis_header() ->
+    gen_server:call(?CHAIN_SERVER, get_genesis_header, ?DEFAULT_CALL_TIMEOUT).
+
+genesis_block() ->
+    gen_server:call(?CHAIN_SERVER, get_genesis_block, ?DEFAULT_CALL_TIMEOUT).
+
 %% Returns the amount of work done on the chain i.e. the total
 %% difficulty of the top header.
 -spec get_total_difficulty() -> get_total_difficulty_reply().
@@ -152,26 +160,26 @@ common_ancestor(Hash1, Hash2) ->
                     {common_ancestor, Hash1, Hash2}).
 
 get_transactions_between(Hash1, Root) ->
-    try get_transactions_between(Hash1, Root, []) of
+    {ok, GenesisHeader} = genesis_header(),
+    {ok, GenesisHash} = aec_headers:hash_header(GenesisHeader),
+    try get_transactions_between(Hash1, Root, GenesisHash, []) of
         Transactions ->
             {ok, Transactions}
     catch throw:Error -> Error
     end.
 
-get_transactions_between(Hash, Hash, Transactions) ->
+get_transactions_between(Hash, Hash, _GenesisHash, Transactions) ->
     Transactions;
-get_transactions_between(Hash, Root, Transactions) ->
-    case aec_headers:hash_header(aec_block_genesis:genesis_header()) of
-        %% Current block is genesis
-        Hash -> Transactions;
-        %% Block is not genesis
-        _ ->
-            case get_block_by_hash(Hash) of
-                {ok, #block{prev_hash = Parent,
-                            txs = BlockTransactions}} ->
-                    get_transactions_between(Parent, Root,
-                                             BlockTransactions ++ Transactions);
-                {error,_} -> throw({error, {block_off_chain, Hash}})
-            end
+get_transactions_between(Hash, _Root, GenesisHash, Transactions)
+    when Hash =:= GenesisHash ->
+    %% Current block is genesis
+    Transactions;
+get_transactions_between(Hash, Root, GenesisHash, Transactions) ->
+    case get_block_by_hash(Hash) of
+        {ok, #block{prev_hash = Parent,
+                    txs = BlockTransactions}} ->
+            get_transactions_between(Parent, Root, GenesisHash,
+                                      BlockTransactions ++ Transactions);
+        {error,_} -> throw({error, {block_off_chain, Hash}})
     end.
 

--- a/apps/aecore/src/aec_genesis_block_settings.erl
+++ b/apps/aecore/src/aec_genesis_block_settings.erl
@@ -1,0 +1,24 @@
+-module(aec_genesis_block_settings).
+
+-export([dir/0,
+         preset_accounts/0]).
+
+dir() ->
+    filename:join(code:priv_dir(aecore), ".genesis").
+
+preset_accounts() ->
+    PresetAccountsFile = filename:join([dir(), "accounts.json"]),
+    case file:read_file(PresetAccountsFile) of
+        {error, _Err} ->
+            % no setup, no preset accounts
+            erlang:error(genesis_accounts_file_missing);
+        {ok, JSONData} ->
+            Accounts =
+                lists:map(
+                    fun({EncodedPubKey, Amt}) ->
+                        {base64:decode(EncodedPubKey), Amt}
+                    end,
+                    jsx:decode(JSONData)),
+            % ensure deterministic ordering of accounts
+            lists:keysort(1, Accounts)
+    end.

--- a/apps/aecore/src/aec_sync.erl
+++ b/apps/aecore/src/aec_sync.erl
@@ -67,7 +67,7 @@ set_subset_size(Sz) when is_integer(Sz), Sz > 0 ->
 -type ping_object() :: map().
 -spec local_ping_object() -> ping_object().
 local_ping_object() ->
-    GHdr = aec_block_genesis:genesis_header(),
+    {ok, GHdr} = aec_chain:genesis_header(),
     {ok, GHash} = aec_headers:hash_header(GHdr),
     {ok, TopHdr} = aec_chain:top_header(),
     {ok, TopHash} = aec_headers:hash_header(TopHdr),
@@ -234,7 +234,7 @@ do_start_sync(PeerUri) ->
     fetch_headers(PeerUri, genesis_hash(), []).
 
 genesis_hash() ->
-    GHdr = aec_block_genesis:genesis_header(),
+    {ok, GHdr} = aec_chain:genesis_header(),
     {ok, GHash} = aec_headers:hash_header(GHdr),
     GHash.
 

--- a/apps/aecore/src/aec_trees.erl
+++ b/apps/aecore/src/aec_trees.erl
@@ -31,7 +31,7 @@ all_trees_hash(Trees) ->
       {error, empty} -> <<0:?STATE_HASH_BYTES/unit:8>>
     end.
 
--spec accounts(trees()) -> tree().
+-spec accounts(trees()) -> tree() | undefined.
 accounts(Trees) ->
     Trees#trees.accounts.
 

--- a/apps/aehttp/src/aehttp_dispatch_ext.erl
+++ b/apps/aehttp/src/aehttp_dispatch_ext.erl
@@ -158,7 +158,6 @@ mk_num(B) when is_binary(B) ->
 
 empty_fields_in_genesis() ->
     [ <<"prev_hash">>,
-      <<"state_hash">>,
       <<"pow">>,
       <<"txs_hash">>,
       <<"transactions">>].
@@ -170,8 +169,8 @@ cleanup_genesis(Val) ->
     Val.
 
 add_missing_to_genesis_block(#{<<"height">> := 0} = Block) ->
-    GB = aec_blocks:serialize_to_map(
-           aec_block_genesis:genesis_block_as_deserialized_from_network()),
+    {ok, GenesisBlock} = aec_chain:genesis_block(),
+    GB = aec_blocks:serialize_to_map(GenesisBlock),
     EmptyFields = maps:with(empty_fields_in_genesis(), GB),
     maps:merge(Block, EmptyFields);
 add_missing_to_genesis_block(Val) ->

--- a/deployment/ansible/deploy.yml
+++ b/deployment/ansible/deploy.yml
@@ -9,7 +9,7 @@
     config:
       chain:
         persist: true
-        db_path: "./db3"
+        db_path: "./db4"
 
   tasks:
     - name: "Required variables"


### PR DESCRIPTION
`apps/aecore/priv/genesis/accounts.json` stores the public addresses that will have tokens in the genesis block. Currently it has only one address - the one of the spender account in [testnet-keys](https://github.com/aeternity/testnet-keys)

NB: changing anything in this file will result in a different genesis block (with a different hash) that will not be compatible with any chain so far.

This PR also includes some cleanup in `apps/aecore/src/aec_block_genesis.erl` and in `apps/aecore/src/aec_chain_state.erl`