### PR TITLE
Speed up CI by deleting xref job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,13 +52,9 @@ matrix:
       osx_image: xcode8.3 # [`xcode8.3` is Xcode 8.3.3 on OS X 10.12](https://docs.travis-ci.com/user/reference/osx#OS-X-Version)
       language: generic
       env: JOB=package
-  allow_failures:
-    - env: JOB=xref
-  fast_finish: true
 env:
   - JOB=test
   - JOB=dialyzer
-  - JOB=xref
   - JOB=package
 cache:
   directories:

--- a/ci
+++ b/ci
@@ -49,10 +49,6 @@ case "${1:?}"-"${2:?}" in
         BuildDir="${3:?}"
         ( cd "${BuildDir:?}" && make dialyzer; )
         ;;
-    script-xref)
-        BuildDir="${3:?}"
-        ( cd "${BuildDir:?}" && ./rebar3 xref; )
-        ;;
     script-package)
         BuildDir="${3:?}"
         ( cd "${BuildDir:?}" && ./rebar3 as prod tar; )


### PR DESCRIPTION
... as known to fail, and slowing down CI for next build (as it
consumes one worker).