### PR TITLE
Log location where default config is being looked for

### DIFF
--- a/apps/aeutils/src/aeu_env.erl
+++ b/apps/aeutils/src/aeu_env.erl
@@ -160,8 +160,10 @@ search_default_config() ->
             setup:home()],
     lists:foldl(
       fun(D, undefined) ->
-              case filelib:wildcard(
-                     "epoch.{json,yaml}", D) of
+              W = "epoch.{json,yaml}",
+              error_logger:info_msg("Searching for default config file ~s "
+                                    "in directory ~s~n", [W, D]),
+              case filelib:wildcard(W, D) of
                   [] -> undefined;
                   [F|_] -> filename:join(D, F)
               end;


### PR DESCRIPTION
Tested alongside PR 424 and 403. (I had placed invalid config in wrong location, so I logged which locations where looked for, hence this PR.)