### PR TITLE
Update JSON schema

### DIFF
--- a/apps/aecore/src/aec_peers.erl
+++ b/apps/aecore/src/aec_peers.erl
@@ -21,6 +21,7 @@
          get_random/1,
          get_random/2,
          uri_from_ip_port/2,
+         uri_from_scheme_ip_port/3,
          uri/1,
          set_local_peer_uri/1,
          get_local_peer_uri/0,
@@ -161,7 +162,11 @@ get_random(N, Exclude) when is_integer(N), N >= 0, is_list(Exclude) ->
 %%------------------------------------------------------------------------------
 -spec uri_from_ip_port(IP :: string(), Port :: number()) -> uri().
 uri_from_ip_port(IP, Port) ->
-    "http://" ++ IP ++ ":" ++ integer_to_list(Port) ++ "/".
+    uri_from_scheme_ip_port(http, IP, Port).
+
+-spec uri_from_scheme_ip_port(Scheme :: atom(), IP :: string(), Port :: number()) -> uri().
+uri_from_scheme_ip_port(Scheme, IP, Port) ->
+    atom_to_list(Scheme) ++ "://" ++ IP ++ ":" ++ integer_to_list(Port) ++ "/".
 
 %%------------------------------------------------------------------------------
 %% Get uri of peer

--- a/apps/aehttp/src/aehttp_app.erl
+++ b/apps/aehttp/src/aehttp_app.erl
@@ -87,9 +87,9 @@ start_websocket_internal() ->
 
 local_peer(Port) ->
     Addr = get_local_peer_address(),
-    case aeu_requests:parse_uri(Addr) of
-        {_Scheme, _Host, Port} ->    % same port as above
-            Addr;
+    case aeu_requests:parse_uri(Addr, Port) of
+        {Scheme, Host, Port} ->    % same port as above
+            aec_peers:uri_from_scheme_ip_port(Scheme, Host, Port);
         {_Scheme, _Host, _OtherPort} ->
             erlang:error({port_mismatch,
                           [{swagger_port_external, Port},

--- a/apps/aeutils/priv/epoch_config_schema.json
+++ b/apps/aeutils/priv/epoch_config_schema.json
@@ -9,6 +9,7 @@
             "type"  : "array",
             "items" : {
                 "type"    : "string",
+                "pattern": "^http://[^:\\.\"!#$%^&*()',/]+(\\.[^:\\.\"!#$%^&*()',/]+)*:[0-9]+/$", 
                 "example" : "http://a.b.c:123/"
             }
         },
@@ -24,6 +25,7 @@
                             "description" :
                             "The peer address that the node will present itself with. If port part given, it must match 'port' user config.",
                             "type" : "string",
+                            "pattern": "^http://[^:\\.\"!#$%^&*()',/]+(\\.[^:\\.\"!#$%^&*()',/]+)*:[0-9]+/$", 
                             "example" : "http://a.b.c:123/"
                         },
                         "port" : {
@@ -39,7 +41,7 @@
                     "properties" : {
                         "port" : {
                             "description" :
-                            "Listen port for external HTTP interface.",
+                            "Listen port for internal HTTP interface.",
                             "type" : "integer"
                         }
                     }

--- a/apps/aeutils/src/aeu_requests.erl
+++ b/apps/aeutils/src/aeu_requests.erl
@@ -10,7 +10,8 @@
          new_spend_tx/2
         ]).
 
--export([parse_uri/1]).
+-export([parse_uri/1,
+         parse_uri/2]).
 -import(aeu_debug, [pp/1]).
 
 -type response(Type) :: {ok, Type} | {error, string()}.
@@ -130,7 +131,16 @@ new_spend_tx(IntPeer, #{recipient_pubkey := Kr,
 
 -spec parse_uri(http_uri:uri()) -> {string(), string(), integer()} | error.
 parse_uri(Uri) ->
-    case http_uri:parse(Uri) of
+  internal_parse_uri(Uri, http_uri:scheme_defaults()).
+
+parse_uri(Uri, DefaultPort) ->
+  internal_parse_uri(Uri, [{http, DefaultPort},
+                           {https, DefaultPort}]).
+
+%% Internal functions
+
+internal_parse_uri(Uri, SchemeDefaults) ->
+    case http_uri:parse(Uri, [{scheme_defaults, SchemeDefaults}]) of
         {ok, {Scheme, _UserInfo, Host, Port, _Path, _Query, _Fragment}} ->
             {Scheme, Host, Port};
         {ok, {Scheme, _UserInfo, Host, Port, _Path, _Query}} ->
@@ -140,8 +150,6 @@ parse_uri(Uri) ->
             error
     end.
 
-
-%% Internal functions
 
 -spec process_request(aec_peers:peer(), get, string()) ->
 			     response(B) when


### PR DESCRIPTION
[Pivotal task](https://www.pivotaltracker.com/story/show/152959514)
We expect a `peer_address` to be filled in the YAML file, this address is the one peers are going to use to ping and post blocks to.
If the address is `SCHEMA://HOST:PORT/` according to what is provided the node behaved differently
```
N    |  SCHEMA          |  HOST         |  PORT 
1    |   yes            |  yes          |  yes
2    |   no             |  yes          |  yes
3    |   no             |  yes          |  no
4    |   yes            |  yes          |  no
```
All cases except `1`  and `3` were resulting in a node not starting.

This PR addresses case `4` - provided a `SCHEMA` and `HOST` we use the port of the extenal API to setup the node as a default `PORT` value.
This PR does not address case `2` (when no `SCHEMA` is provided and there is a `PORT`) - node will still crash in this case.

Note: `aec_peers:uri_from_scheme_ip_port/2,3` works with both IPs and host names and should probably be renamed. I haven't investigated it and it is not part of this PR.