### PR TITLE
Pt 153211733 remove unwanted peers

### DIFF
--- a/apps/aecore/include/peers.hrl
+++ b/apps/aecore/include/peers.hrl
@@ -1,5 +1,6 @@
 -record(peer, {
           uri = ""          :: http_uri:uri(),
+          blocked = false   :: boolean(),
           last_seen = 0     :: integer(), % Erlang system time (POSIX time)
           last_pings = []   :: [integer()], % Erlang system time
           ping_tref         :: reference() | undefined

--- a/apps/aecore/src/aec_events.erl
+++ b/apps/aecore/src/aec_events.erl
@@ -24,6 +24,7 @@
                | start_mining
                | tx_created
                | tx_received
+               | peers
                | chain_sync
                | mempool_sync.
 

--- a/apps/aecore/src/aec_sync.erl
+++ b/apps/aecore/src/aec_sync.erl
@@ -148,6 +148,8 @@ init([]) ->
     aec_events:subscribe(block_created),
     aec_events:subscribe(tx_created),
     Peers = application:get_env(aecore, peers, []),
+    BlockedPeers = application:get_env(aecore, blocked_peers, []),
+    [aec_peers:block_peer(P) || P <- BlockedPeers],
     aec_peers:add_and_ping_peers(Peers),
     {ok, #state{}}.
 

--- a/apps/aecore/test/aecore_forking_SUITE.erl
+++ b/apps/aecore/test/aecore_forking_SUITE.erl
@@ -120,9 +120,10 @@ sync_fork_in_wrong_order(Config) ->
     %% unexepctedly last block of dev1 arrives before rest of the chain
     rpc_call(N2, aec_conductor, post_block, [N1Top]), 
 
+    T0 = os:timestamp(),
     start_node_(dev1, Config),
     connect(N1),
-    timer:sleep(200),
+    await_sync_complete(T0, [N1, N2]),
 
     N2Top = rpc_call(N2, aec_conductor, top, []),
     ct:log("top of chain dev2: ~p", [ N2Top ]),
@@ -130,8 +131,39 @@ sync_fork_in_wrong_order(Config) ->
     ok.
 
 
+await_sync_complete(T0, Nodes) ->
+    [subscribe(N, chain_sync) || N <- Nodes],
+    AllEvents = lists:flatten(
+                  [events_since(N, chain_sync, T0) || N <- Nodes]),
+    ct:log("AllEvents = ~p", [AllEvents]),
+    Nodes1 =
+        lists:foldl(
+          fun(Msg, Acc) ->
+                  check_sync_event(Msg, Acc)
+          end, Nodes, AllEvents),
+    ct:log("Nodes1 = ~p", [Nodes1]),
+    collect_sync_events(Nodes1).
 
+collect_sync_events([]) ->
+    done;
+collect_sync_events(Nodes) ->
+    receive
+        {gproc_ps_event, chain_sync, Msg} ->
+            collect_sync_events(check_sync_event(Msg, Nodes))
+    after 20000 ->
+            ct:log("Timeout in collect_sync_events: ~p~n"
+                   "~p", [Nodes, process_info(self(), messages)]),
+            error(timeout)
+    end.
 
+check_sync_event(#{sender := From, info := Info} = Msg, Nodes) ->
+    case Info of
+        {E, _} when E =:= server_done; E =:= client_done ->
+            ct:log("got sync_event ~p", [Msg]),
+            lists:delete(node(From), Nodes);
+        _ ->
+            Nodes
+    end.
 
 
 mine_one_block(N) ->

--- a/apps/aecore/test/aecore_forking_SUITE.erl
+++ b/apps/aecore/test/aecore_forking_SUITE.erl
@@ -421,7 +421,6 @@ shortcut_dir(Config) ->
     Top = ?config(top_dir, Config),
     filename:join(Top, "_build/test/logs/latest.fork").
 
-
 data_dir(N, Config) ->
     filename:join(node_shortcut(N, Config), "data").
 

--- a/apps/aeutils/priv/epoch_config_schema.json
+++ b/apps/aeutils/priv/epoch_config_schema.json
@@ -9,8 +9,18 @@
             "type"  : "array",
             "items" : {
                 "type"    : "string",
-                "pattern": "^http://[^:\\.\"!#$%^&*()',/]+(\\.[^:\\.\"!#$%^&*()',/]+)*:[0-9]+/$", 
-                "example" : "http://a.b.c:123/"
+                "pattern": "^http://[^:\\.\"!#$%^&*()',/]+(\\.[^:\\.\"!#$%^&*()',/]+)*:[0-9]+/$",
+                "example" : "http://somehost.somedomain:123/"
+            }
+        },
+        "blocked_peers" : {
+            "description" :
+            "Pre-configured addresses of epoch nodes NOT to contact",
+            "type"  : "array",
+            "items" : {
+                "type"    : "string",
+                "pattern": "^http://[^:\\.\"!#$%^&*()',/]+(\\.[^:\\.\"!#$%^&*()',/]+)*:[0-9]+/$",
+                "example" : "http://somehost.somedomain:123/"
             }
         },
         "http" : {
@@ -25,8 +35,8 @@
                             "description" :
                             "The peer address that the node will present itself with. It must include scheme, host/ip and a port followed by a trailing slash",
                             "type" : "string",
-                            "pattern": "^http://[^:\\.\"!#$%^&*()',/]+(\\.[^:\\.\"!#$%^&*()',/]+)*:[0-9]+/$", 
-                            "example" : "http://a.b.c:123/"
+                            "pattern": "^http://[^:\\.\"!#$%^&*()',/]+(\\.[^:\\.\"!#$%^&*()',/]+)*:[0-9]+/$",
+                            "example" : "http://somehost.somedomain:123/"
                         },
                         "port" : {
                             "description" :

--- a/config/dev1/sys.config
+++ b/config/dev1/sys.config
@@ -19,7 +19,7 @@
       {db_path, "."},
       {persist, false},
       {autostart, false},
-      {aec_pow_cuckoo, {"lean16", "-t 5", 16}}
+      {aec_pow_cuckoo, {"lean28", "-t 5", 28}}
     ]
   },
 

--- a/config/dev1/sys.config
+++ b/config/dev1/sys.config
@@ -19,7 +19,7 @@
       {db_path, "."},
       {persist, false},
       {autostart, false},
-      {aec_pow_cuckoo, {"lean28", "-t 5", 28}}
+      {aec_pow_cuckoo, {"lean16", "-t 5", 16}}
     ]
   },
 


### PR DESCRIPTION
[Finishes #153211733] https://www.pivotaltracker.com/story/show/153211733

* New API: `aec_peers:block_peer(Uri)`, `aec_peers:unblock_peer(Uri)`
* Pings are not scheduled for blocked peers
* Blocked peers are excluded from broadcast lists
* A static blocklist can be specified in the user config (`"blocked_peers"`)
* A `chain_sync` event, `{sync_aborted, Reason}` is published when a ping results in an error.
* A peer is auto-blocked if it passes the wrong genesis block in a ping
* A pinging peer also blocks the other peer if it receives the ping response `"Different genesis blocks"` or `"Not allowed"`
* The sync_SUITE extended with one testcase where `dev2` is pre-blocked by `dev1`, verifying that the sync attempt is aborted.