### PR TITLE
Fixing local_peer internal address and ansible yaml

### DIFF
--- a/apps/aehttp/src/aehttp_app.erl
+++ b/apps/aehttp/src/aehttp_app.erl
@@ -40,7 +40,7 @@ local_peer_uri() ->
 
 local_internal_http_uri() ->
     Port = get_internal_port(),
-    local_peer(Port).
+    aec_peers:uri_from_ip_port("127.0.0.1", Port).
 
 %%--------------------------------------------------------------------
 stop(_State) ->
@@ -87,13 +87,9 @@ start_websocket_internal() ->
 
 local_peer(Port) ->
     Addr = get_local_peer_address(),
-    case aeu_requests:parse_uri(Addr, Port) of
-        {Scheme, Host, Port} ->    % same port as above
-            aec_peers:uri_from_scheme_ip_port(Scheme, Host, Port);
-        {_Scheme, _Host, _OtherPort} ->
-            erlang:error({port_mismatch,
-                          [{swagger_port_external, Port},
-                           {local_peer_address, Addr}]});
+    case aeu_requests:parse_uri(Addr) of
+        {_Scheme, _Host, _Port} -> % a valid address
+            Addr;
         error ->
             case re:run(Addr, "[:/]", []) of
                 {match, _} ->

--- a/apps/aeutils/priv/epoch_config_schema.json
+++ b/apps/aeutils/priv/epoch_config_schema.json
@@ -23,7 +23,7 @@
                     "properties" : {
                         "peer_address" : {
                             "description" :
-                            "The peer address that the node will present itself with. If port part given, it must match 'port' user config.",
+                            "The peer address that the node will present itself with. It must include scheme, host/ip and a port followed by a trailing slash",
                             "type" : "string",
                             "pattern": "^http://[^:\\.\"!#$%^&*()',/]+(\\.[^:\\.\"!#$%^&*()',/]+)*:[0-9]+/$", 
                             "example" : "http://a.b.c:123/"

--- a/apps/aeutils/src/aeu_requests.erl
+++ b/apps/aeutils/src/aeu_requests.erl
@@ -10,8 +10,7 @@
          new_spend_tx/2
         ]).
 
--export([parse_uri/1,
-         parse_uri/2]).
+-export([parse_uri/1]).
 -import(aeu_debug, [pp/1]).
 
 -type response(Type) :: {ok, Type} | {error, string()}.
@@ -131,16 +130,7 @@ new_spend_tx(IntPeer, #{recipient_pubkey := Kr,
 
 -spec parse_uri(http_uri:uri()) -> {string(), string(), integer()} | error.
 parse_uri(Uri) ->
-  internal_parse_uri(Uri, http_uri:scheme_defaults()).
-
-parse_uri(Uri, DefaultPort) ->
-  internal_parse_uri(Uri, [{http, DefaultPort},
-                           {https, DefaultPort}]).
-
-%% Internal functions
-
-internal_parse_uri(Uri, SchemeDefaults) ->
-    case http_uri:parse(Uri, [{scheme_defaults, SchemeDefaults}]) of
+    case http_uri:parse(Uri) of
         {ok, {Scheme, _UserInfo, Host, Port, _Path, _Query, _Fragment}} ->
             {Scheme, Host, Port};
         {ok, {Scheme, _UserInfo, Host, Port, _Path, _Query}} ->

--- a/deployment/ansible/templates/epoch.yaml.j2
+++ b/deployment/ansible/templates/epoch.yaml.j2
@@ -8,7 +8,7 @@ peers:
 
 http:
     external:
-        peer_address: {{ ansible_default_ipv4.address }}
+        peer_address: http://{{ ansible_default_ipv4.address }}:3013/
 
 mining:
     autostart: true


### PR DESCRIPTION
Changes:

-  Fix `aehttp_app:local_internal_http_uri/0` - it used to return an address based on the `peer_address`; now it returns the correct internal address and port

- Remove the check for  `peer_address`'s port to be the same as node's external HTTP port; this would have prevent users to choose their own ports for example while port forwarding;

- Hence the change above, the port is required part of  `peer_address`; the _default option_ for port is removed

- Fix `anisble` yaml file to include both schema and port for  `peer_address`

- Update of `epoch_config_schema.json` description

