### PR TITLE
Use travis containers (disable sudo)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: required
+sudo: false
 dist: trusty
 language: erlang
 otp_release:

--- a/ci
+++ b/ci
@@ -24,7 +24,7 @@ case "${1:?}"-"${2:?}" in
             brew update
             brew install erlang && export PATH="$(brew --prefix erlang)"/bin:"$PATH"
         elif [ "${TRAVIS_OS_NAME:?}" = "linux" ]; then
-            sudo -H pip install -r deployment/ansible/pip-requirements.txt
+            pip install --user -r deployment/ansible/pip-requirements.txt
             ansible --version
         fi
         erl -version


### PR DESCRIPTION
We no longer have requirements on sudo, so switch back to (faster) containers.
[Travis reference.](https://docs.travis-ci.com/user/reference/overview/)