### PR TITLE
Make symlink-related error - if any - self-descriptive

### DIFF
--- a/apps/aecore/test/aecore_forking_SUITE.erl
+++ b/apps/aecore/test/aecore_forking_SUITE.erl
@@ -291,7 +291,7 @@ cp_file(From, To) ->
     ok.
 
 symlink(From, To) ->
-    ok = file:make_symlink(From, To),
+    {ok, _} = {file:make_symlink(From, To), {From, To}},
     ct:log("symlinked ~s to ~s", [From, To]),
     ok.
 
@@ -434,7 +434,7 @@ make_shortcut(Config) ->
     ok = filelib:ensure_dir(filename:join(PrivDir, "foo")),
     Shortcut = shortcut_dir(Config),
     delete_file(Shortcut),
-    ok = file:make_symlink(PrivDir, Shortcut),
+    symlink(PrivDir, Shortcut),
     ct:log("Made symlink ~s to ~s", [PrivDir, Shortcut]),
     ok.
 

--- a/apps/aecore/test/aecore_sync_SUITE.erl
+++ b/apps/aecore/test/aecore_sync_SUITE.erl
@@ -623,7 +623,7 @@ cp_file(From, To) ->
     ok.
 
 symlink(From, To) ->
-    ok = file:make_symlink(From, To),
+    {ok, _} = {file:make_symlink(From, To), {From, To}},
     ct:log("symlinked ~s to ~s", [From, To]),
     ok.
 
@@ -991,7 +991,7 @@ make_shortcut(Config) ->
     ok = filelib:ensure_dir(filename:join(PrivDir, "foo")),
     Shortcut = shortcut_dir(Config),
     delete_file(Shortcut),
-    ok = file:make_symlink(PrivDir, Shortcut),
+    symlink(PrivDir, Shortcut),
     ct:log("Made symlink ~s to ~s", [PrivDir, Shortcut]),
     ok.
 


### PR DESCRIPTION
Produced while reviewing PR #446.

Sample error without this patch: https://github.com/aeternity/epoch/pull/446#discussion_r154354656

Sample error with this patch:
```
%%% aecore_sync_SUITE ==> init_per_suite: FAILED
%%% aecore_sync_SUITE ==> {{badmatch,{{error,eexist},
            {"/Users/luca/dev/aeternity/epoch/_build/test/rel/epoch/lib",
             "/Users/luca/dev/aeternity/epoch/_build/test/logs/latest.sync/dev1/lib"}}},
 [{aecore_sync_SUITE,symlink,2,
                     [{file,"/Users/luca/dev/aeternity/epoch/_build/test/lib/aecore/test/aecore_sync_SUITE.erl"},
                      {line,574}]},
  {aecore_sync_SUITE,setup_node,4,
                     [{file,"/Users/luca/dev/aeternity/epoch/_build/test/lib/aecore/test/aecore_sync_SUITE.erl"},
                      {line,542}]},
  {aecore_sync_SUITE,'-make_multi/1-lc$^0/1-0-',4,
                     [{file,"/Users/luca/dev/aeternity/epoch/_build/test/lib/aecore/test/aecore_sync_SUITE.erl"},
                      {line,534}]},
  {aecore_sync_SUITE,init_per_suite,1,
                     [{file,"/Users/luca/dev/aeternity/epoch/_build/test/lib/aecore/test/aecore_sync_SUITE.erl"},
                      {line,80}]},
  {test_server,ts_tc,3,[{file,"test_server.erl"},{line,1539}]},
  {test_server,run_test_case_eval1,6,[{file,"test_server.erl"},{line,1140}]},
  {test_server,run_test_case_eval,9,[{file,"test_server.erl"},{line,987}]}]}
%%% aecore_sync_SUITE ==> start_first_node (group two_nodes): SKIPPED
```

----

Testing locally.