### PR TITLE
Pt 153319614 make forking suite timing safe [Finishes #153319614]

### DIFF
--- a/apps/aecore/test/aecore_forking_SUITE.erl
+++ b/apps/aecore/test/aecore_forking_SUITE.erl
@@ -421,7 +421,6 @@ shortcut_dir(Config) ->
     Top = ?config(top_dir, Config),
     filename:join(Top, "_build/test/logs/latest.fork").
 
-
 data_dir(N, Config) ->
     filename:join(node_shortcut(N, Config), "data").
 

--- a/config/dev1/sys.config
+++ b/config/dev1/sys.config
@@ -19,7 +19,7 @@
       {db_path, "."},
       {persist, false},
       {autostart, false},
-      {aec_pow_cuckoo, {"lean16", "-t 5", 16}}
+      {aec_pow_cuckoo, {"lean28", "-t 5", 28}}
     ]
   },
 

--- a/config/dev1/sys.config
+++ b/config/dev1/sys.config
@@ -19,7 +19,7 @@
       {db_path, "."},
       {persist, false},
       {autostart, false},
-      {aec_pow_cuckoo, {"lean28", "-t 5", 28}}
+      {aec_pow_cuckoo, {"lean16", "-t 5", 16}}
     ]
   },
 


### PR DESCRIPTION
Instead of using `timer:sleep()`, set up subscriptions and wait for `chain_sync` events to arrive from both nodes.