### PR TITLE
Rename aec_trees:new/0

### DIFF
--- a/apps/aecore/src/aec_accounts.erl
+++ b/apps/aecore/src/aec_accounts.erl
@@ -19,7 +19,7 @@
 
 %% TODO: remove? We should not need such API (init via trees)
 empty() ->
-    {ok, _AccountsTree} = aec_trees:new().
+    {ok, _AccountsTree} = aec_trees:new_merkle_tree().
 
 new(Pubkey, Balance, Height) ->
     #account{pubkey = Pubkey, balance = Balance, height = Height}.

--- a/apps/aecore/src/aec_trees.erl
+++ b/apps/aecore/src/aec_trees.erl
@@ -9,7 +9,7 @@
          all_trees_hash/1,
          accounts/1,
          set_accounts/2,
-         new/0,
+         new_merkle_tree/0,
          get/2,
          get_with_proof/2,
          is_trees/1,
@@ -21,7 +21,7 @@
 
 -spec all_trees_new() -> {ok, trees()}.
 all_trees_new() ->
-    {ok, A} = new(),
+    {ok, A} = new_merkle_tree(),
     {ok, #trees{accounts = A}}.
 
 all_trees_hash(Trees) ->
@@ -39,8 +39,8 @@ accounts(Trees) ->
 set_accounts(Trees, Accounts) ->
     Trees#trees{accounts = Accounts}.
 
--spec new() -> {ok, tree()}.
-new() ->
+-spec new_merkle_tree() -> {ok, tree()}.
+new_merkle_tree() ->
     {ok, gb_merkle_trees:empty()}.
 
 get(Key, Tree) when is_binary(Key) ->

--- a/apps/aecore/src/aec_txs_trees.erl
+++ b/apps/aecore/src/aec_txs_trees.erl
@@ -4,7 +4,7 @@
          root_hash/1]).
 
 new(Txs = [_|_]) ->
-    {ok, EmptyTree} = aec_trees:new(),
+    {ok, EmptyTree} = aec_trees:new_merkle_tree(),
     TxsTree =
         lists:foldl(
           fun(SignedTx, TreeIn) ->


### PR DESCRIPTION
[Pivotal task](https://www.pivotaltracker.com/story/show/153028708)
`aec_trees:new/0` returns a Merkle tree which is not  `#trees{}` (the main record used in aec_trees)
Renamed it to  `aec_trees:new_merkle_tree/0`