### PR TITLE
Allow group read on node dir for integration purposes

### DIFF
--- a/deployment/ansible/deploy.yml
+++ b/deployment/ansible/deploy.yml
@@ -26,7 +26,8 @@
       file:
           path: "{{ project_root }}"
           state: directory
-          mode: 0700
+          # allow group read for integration purposes  (e.g. logs)
+          mode: 0750
 
     - name: Download epoch package
       get_url:


### PR DESCRIPTION
We need to read logs with other integration user (e.g. Datadog user: dd-agent).
This user will be added to the "epoch" group.