### PR TITLE
Remove extra newlines from lager logs

### DIFF
--- a/apps/aecore/src/aec_conductor.erl
+++ b/apps/aecore/src/aec_conductor.erl
@@ -241,7 +241,7 @@ init(Options) ->
     State3 = aec_conductor_chain:init(State2),
     TopBlockHash = aec_conductor_chain:get_top_block_hash(State3),
     State4 = State3#state{seen_top_block_hash = TopBlockHash},
-    epoch_mining:info("Miner process initilized ~p~n", [State4]),
+    epoch_mining:info("Miner process initilized ~p", [State4]),
     %% NOTE: The init continues at handle_info(timeout, State).
     {ok, State4, 0}.
 
@@ -678,7 +678,7 @@ handle_post_block(Block, State) ->
     handle_add_block(Block, State, block_received).
 
 handle_mined_block(Block, State) ->
-    epoch_mining:info("Block mined: Height = ~p~nHash = ~s",
+    epoch_mining:info("Block mined: Height = ~p; Hash = ~s",
                       [aec_blocks:height(Block),
                        as_hex(aec_blocks:root_hash(Block))]),
     handle_add_block(Block, State, block_created).

--- a/apps/aecore/src/aec_peers.erl
+++ b/apps/aecore/src/aec_peers.erl
@@ -346,7 +346,7 @@ handle_cast({source, SrcUri, Alias} = _R,
             As1 = gb_trees:enter(Alias, SrcUri, As),
             {noreply, metrics(State#state{peers = Peers1, aliases = As1})};
         _Other ->
-            lager:debug("unexpected result (source):~n~p", [_Other]),
+            lager:debug("unexpected result (source): ~p", [_Other]),
             {noreply, State}
     end;
 handle_cast({add_and_ping, PeerRecs}, State) ->

--- a/apps/aecore/src/aec_pow_cuckoo.erl
+++ b/apps/aecore/src/aec_pow_cuckoo.erl
@@ -101,7 +101,7 @@ generate_int(Hash, Nonce, Target) ->
         {ok, Soln} ->
             {ok, {Nonce, Soln}};
         {error, no_value} ->
-            ?debug("No cuckoo solution found~n", []),
+            ?debug("No cuckoo solution found", []),
             {error, no_solution};
         {error, Reason} ->
             %% Executable failed (segfault, not found, etc.): let miner decide
@@ -120,7 +120,7 @@ generate_int(Header, Target) ->
     BinDir = aecuckoo:bin_dir(),
     {Exe, Extra, _} = application:get_env(aecore, aec_pow_cuckoo, ?DEFAULT_CUCKOO_ENV),
     Cmd = lists:concat([ld_lib_env(), " ",  "./", Exe, " -h ", Header, " ", Extra]),
-    ?info("Executing cmd: ~p~n", [Cmd]),
+    ?info("Executing cmd: ~p", [Cmd]),
     Old = process_flag(trap_exit, true),
     try exec:run(Cmd,
                  [{stdout, self()},
@@ -310,7 +310,7 @@ wait_for_result(#state{os_pid = OsPid,
             {Lines, NewBuffer} = handle_fragmented_lines(Str, Buffer),
             (State#state.parser)(Lines, State#state{buffer = NewBuffer});
         {stderr, OsPid, Msg} ->
-            ?error("ERROR: ~s~n", [Msg]),
+            ?error("ERROR: ~s", [Msg]),
             wait_for_result(State);
         {'EXIT',_From, shutdown} ->
             %% Someone is telling us to stop
@@ -325,7 +325,7 @@ wait_for_result(#state{os_pid = OsPid,
                           {exit_status, ExStat} -> exec:status(ExStat);
                           _                     -> Reason
                       end,
-            ?error("OS process died: ~p~n", [Reason2]),
+            ?error("OS process died: ~p", [Reason2]),
             {error, {execution_failed, Reason2}}
     end.
 
@@ -374,16 +374,16 @@ parse_generation_result(["Solution" ++ ValuesStr | Rest], #state{os_pid = OsPid,
     Soln = [list_to_integer(V, 16) || V <- string:tokens(ValuesStr, " ")],
     case test_target(Soln, Target) of
         true ->
-            ?debug("Solution found: ~p~n", [Soln]),
+            ?debug("Solution found: ~p", [Soln]),
             stop_execution(OsPid),
             {ok, Soln};
         false ->
             %% failed to meet target: go on, we may find another solution
-            ?debug("Failed to meet target~n", []),
+            ?debug("Failed to meet target", []),
             parse_generation_result(Rest, State)
     end;
 parse_generation_result([Msg | T], State) ->
-    ?debug("~s~n", [Msg]),
+    ?debug("~s", [Msg]),
     parse_generation_result(T, State).
 
 %%------------------------------------------------------------------------------
@@ -395,10 +395,10 @@ parse_generation_result([Msg | T], State) ->
 stop_execution(OsPid) ->
     case exec:kill(OsPid, 9) of
         {error, Reason} ->
-            ?debug("Failed to stop mining OS process ~p: ~p (may have already finished).~n",
+            ?debug("Failed to stop mining OS process ~p: ~p (may have already finished).",
                    [OsPid, Reason]);
         R ->
-            ?debug("Mining OS process ~p stopped successfully: ~p~n",
+            ?debug("Mining OS process ~p stopped successfully: ~p",
                    [OsPid, R])
     end.
 

--- a/apps/aecore/src/aec_sync.erl
+++ b/apps/aecore/src/aec_sync.erl
@@ -87,7 +87,7 @@ local_ping_object() ->
 %%    - Otherwise, trigger a sync, return 'ok'.
 -spec compare_ping_objects(ping_obj(), ping_obj()) -> ok | {error, any()}.
 compare_ping_objects(Local, Remote) ->
-    lager:debug("Compare, Local: ~p~nRemote: ~p", [pp(Local), pp(Remote)]),
+    lager:debug("Compare, Local: ~p; Remote: ~p", [pp(Local), pp(Remote)]),
     Src = maps:get(<<"source">>, Remote),
     Res = case {maps:get(<<"genesis_hash">>, Local),
                 maps:get(<<"genesis_hash">>, Remote)} of
@@ -302,14 +302,14 @@ do_fetch_block(Hash, PeerUri) ->
         {ok, Block} ->
             case header_hash(Block) =:= Hash of
                 true ->
-                    lager:debug("block fetched from ~p (~p)~n~p",
+                    lager:debug("block fetched from ~p (~p); ~p",
                                 [PeerUri, pp(Hash), pp(Block)]),
                     {ok, Block};
                 false ->
                     {error, hash_mismatch}
             end;
         {error, _} = Error ->
-            lager:debug("failed to fetch block from ~p,~nHash = ~p~nError = ~p",
+            lager:debug("failed to fetch block from ~p; Hash = ~p; Error = ~p",
                         [PeerUri, pp(Hash), Error]),
             Error
     end.

--- a/apps/aecore/src/aec_tx_pool.erl
+++ b/apps/aecore/src/aec_tx_pool.erl
@@ -204,7 +204,7 @@ pool_db_put(Mempool, Key, Tx, Event) ->
                     aec_events:publish(Event, Tx),
                     true;
                 {error, Reason} ->
-                    lager:error("verification error: ~p~nTx = ~p",
+                    lager:error("verification error: ~p; Tx = ~p",
                                 [Reason, Tx]),
                     false
             end;

--- a/apps/aeutils/src/aeu_requests.erl
+++ b/apps/aeutils/src/aeu_requests.erl
@@ -172,7 +172,7 @@ process_request(Peer, post, Request, Params, Header, HTTPOptions, Options) ->
                            {"application/x-www-form-urlencoded",
                             http_uri:encode(Request)}
                    end,
-    %% lager:debug("Type = ~p~nBody = ~p", [Type, Body]),
+    %% lager:debug("Type = ~p; Body = ~p", [Type, Body]),
     R = httpc:request(post, {URL, Header, Type, Body}, HTTPOptions, Options),
     process_http_return(R).
 
@@ -180,7 +180,7 @@ process_http_return(R) ->
     case R of
         {ok, {{_,_ReturnCode, _State}, _Head, Body}} ->
             try
-                %% lager:debug("Body to parse:~n~s", [Body]),
+                %% lager:debug("Body to parse: ~s", [Body]),
                 Result = jsx:decode(iolist_to_binary(Body), [return_maps]),
                 lager:debug("Decoded response: ~p", [pp(Result)]),
                 {ok, Result}


### PR DESCRIPTION
This is to unify the log lines, otherwise it chokes the logs collector.