### PR TITLE
Only broadcast blocks that are the new top block

### DIFF
--- a/apps/aecore/src/aec_events.erl
+++ b/apps/aecore/src/aec_events.erl
@@ -18,10 +18,8 @@
 -include("blocks.hrl").
 
 -type event() :: block_created
-               | block_received
-               | header_received
-               | mining_preempted
                | start_mining
+               | top_changed
                | tx_created
                | tx_received
                | peers

--- a/apps/aecore/src/aec_sync.erl
+++ b/apps/aecore/src/aec_sync.erl
@@ -146,6 +146,7 @@ start_link() ->
 
 init([]) ->
     aec_events:subscribe(block_created),
+    aec_events:subscribe(top_changed),
     aec_events:subscribe(tx_created),
     Peers = application:get_env(aecore, peers, []),
     BlockedPeers = application:get_env(aecore, blocked_peers, []),
@@ -180,7 +181,7 @@ handle_info({gproc_ps_event, Event, #{info := Info}}, State) ->
     case Event of
         block_created   -> enqueue(forward, #{status => created,
                                               block => Info}, State);
-        block_received  -> enqueue(forward, #{status => received,
+        top_changed     -> enqueue(forward, #{status => top_changed,
                                               block => Info}, State);
         tx_created      -> enqueue(forward, #{status => created,
                                               tx => Info}, State);


### PR DESCRIPTION
Rely on pings to fill in the gaps if there are any.

Broadcasted blocks are now guaranteed to be correct with respect to
target and state hash as well.
[Finishes #153363096]