### PR TITLE
Fixed swagger-generated code [Finishes #153443167]

### DIFF
--- a/apps/aehttp/src/swagger/swagger_api.erl
+++ b/apps/aehttp/src/swagger/swagger_api.erl
@@ -185,11 +185,15 @@ populate_request_params(OperationID, [FieldParams | T], Req0, ValidatorState, Mo
 
 populate_request_param(OperationID, Name, Req0, ValidatorState) ->
     #{rules := Rules, source := Source} = request_param_info(OperationID, Name),
-    {Value, Req} = get_value(Source, Name, Req0),
-    case prepare_param(Rules, Name, Value, ValidatorState) of
-        {ok, Result} -> {ok, Name, Result, Req};
-        {error, Reason} ->
-            {error, Reason, Req}
+    case get_value(Source, Name, Req0) of
+        {error, Reason, Req} ->
+            {error, Reason, Req};
+        {Value, Req} ->
+            case prepare_param(Rules, Name, Value, ValidatorState) of
+                {ok, Result} -> {ok, Name, Result, Req};
+                {error, Reason} ->
+                    {error, Reason, Req}
+            end
     end.
 
 -spec validate_response(
@@ -411,11 +415,16 @@ validation_error(ViolatedRule, Name, Info) ->
     throw({wrong_param, Name, ViolatedRule, Info}).
 
 -spec get_value(body | qs_val | header | binding, Name :: any(), Req0 :: cowboy_req:req()) ->
-    {Value :: any(), Req :: cowboy_req:req()}.
+    {Value :: any(), Req :: cowboy_req:req()} | 
+    {error, Reason :: any(), Req :: cowboy_req:req()}.
 get_value(body, _Name, Req0) ->
     {ok, Body, Req} = cowboy_req:body(Req0),
-    Value = prepare_body(Body),
-    {Value, Req};
+    case prepare_body(Body) of
+        {error, Reason} ->
+            {error, Reason, Req};
+        Value ->
+            {Value, Req}
+    end;
 
 get_value(qs_val, Name, Req0) ->
     {QS, Req} = cowboy_req:qs_vals(Req0),
@@ -435,7 +444,13 @@ get_value(binding, Name, Req0) ->
 prepare_body(Body) ->
     case Body of
         <<"">> -> <<"">>;
-        _ -> jsx:decode(Body, [return_maps])
+        _ ->
+            try
+                jsx:decode(Body, [return_maps]) 
+            catch
+              error:_ ->
+                {error, {invalid_body, not_json, Body}}
+            end
     end.
 
 validate_with_schema(Body, Definition, ValidatorState) ->


### PR DESCRIPTION
[Pivotal Story](https://www.pivotaltracker.com/story/show/153443167)

### Negative example
Example of handling a broken JSON:
```
$ curl -i -X POST -H "Content-Type: application/json" -d '{"recipient_pubkey":"BM6kKMXypU/6GBllWxB4+SGbIrb7VbzRid7I0Vbae3xoBYaQyaGboeILRZn+Q9ycLXP6cJB/rojPXK/S5W7m2wg=", "amount":5 "fee":1}' http://127.0.0.1:3113/v1/spend-tx

HTTP/1.1 400 Bad Request
server: Cowboy
date: Wed, 06 Dec 2017 14:25:08 GMT
content-length: 0
content-type: application/json
```

Message in crash.json (we can modify it as we please) is:
```
Unable to process request for 'PostSpendTx': {invalid_body,not_json,<<"{\"recipient_pubkey\":\"BM6kKMXypU/6GBllWxB4+SGbIrb7VbzRid7I0Vbae3xoBYaQyaGboeILRZn+Q9ycLXP6cJB/rojPXK/S5W7m2wg=\", \"amount\":5 \"fee\":1}">>}
```


### Positive example
Example of handling a correct JSON:
```
$ curl -i -X POST -H "Content-Type: application/json" -d '{"recipient_pubkey":"BM6kKMXypU/6GBllWxB4+SGbIrb7VbzRid7I0Vbae3xoBYaQyaGboeILRZn+Q9ycLXP6cJB/rojPXK/S5W7m2wg=", "amount":5, "fee":1}' http://127.0.0.1:3113/v1/spend-tx
HTTP/1.1 200 OK
server: Cowboy
date: Wed, 06 Dec 2017 15:10:07 GMT
content-length: 2
content-type: application/json

{}
```
I will push the changes upstream, if anyone needs to generate a swagger code, please use [this branch](https://github.com/aeternity/swagger-codegen/tree/erlang_server_broken_json)