### PR TITLE
Pt 153442614 aec peers crashes

### DIFF
--- a/apps/aeutils/priv/epoch_config_schema.json
+++ b/apps/aeutils/priv/epoch_config_schema.json
@@ -23,6 +23,26 @@
                 "example" : "http://somehost.somedomain:123/"
             }
         },
+        "sync" : {
+            "type" : "object",
+            "additionalProperties" : false,
+            "properties" : {
+                "ping_interval" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "properties" : {
+                        "min" : {
+                            "description" : "Minimum ping interval (ms)",
+                            "type" : "integer"
+                        },
+                        "max" : {
+                            "description" : "Maximum ping interval (ms)",
+                            "type" : "integer"
+                        }
+                    }
+                }
+            }
+        },
         "http" : {
             "type" : "object",
             "additionalProperties" : false,
@@ -41,6 +61,14 @@
                         "port" : {
                             "description" :
                             "Listen port for external HTTP interface.",
+                            "type" : "integer"
+                        },
+                        "request_timeout" : {
+                            "description" : "HTTP Request timeout.",
+                            "type" : "integer"
+                        },
+                        "connect_timeout" : {
+                            "description" : "HTTP Request connect timeout.",
                             "type" : "integer"
                         }
                     }

--- a/apps/aeutils/src/aeu_env.erl
+++ b/apps/aeutils/src/aeu_env.erl
@@ -13,12 +13,16 @@
 
 -export([user_config/0, user_config/1]).
 -export([user_map/0, user_map/1]).
+-export([user_config_or_env/4]).
 -export([read_config/0]).
 -export([check_config/1]).
 
 -type basic_type() :: number() | binary() | boolean().
 -type basic_or_list()  :: basic_type() | [basic_type()].
 -type config_tree() :: [{binary(), config_tree() | basic_or_list()}].
+
+-type env_key() :: atom() | list().
+-type config_key() :: binary() | [binary()].
 
 %% This function is similar to application:get_env/2, except
 %% 1. It uses the setup:get_env/2 function, which supports a number
@@ -67,6 +71,15 @@ user_config(Key) when is_list(Key) ->
     get_env(aeutils, ['$user_config'|Key]);
 user_config(Key) when is_binary(Key) ->
     get_env(aeutils, ['$user_config',Key]).
+
+-spec user_config_or_env(config_key(), atom(), env_key(), any()) -> any().
+user_config_or_env(CfgKey, App, EnvKey, Default) ->
+    case user_config(CfgKey) of
+        undefined ->
+            get_env(App, EnvKey, Default);
+        {ok, Value} ->
+            Value
+    end.
 
 %% The user_map() functions are equivalent to user_config(), but
 %% operate on a tree of maps rather than a tree of {K,V} tuples.

--- a/config/sys.config
+++ b/config/sys.config
@@ -27,7 +27,7 @@
    [{queues,
      [{sync_jobs, [passive]},
       {sync_workers, [{regulators,
-                       [{counter, [{limit, 10}]}
+                       [{counter, [{limit, 20}]}
                        ]},
                       {producer, {aec_sync, sync_worker, []}}
                      ]}


### PR DESCRIPTION
    Remove optimistic use of gb_trees:get from aec_peers [Finishes #153442614]
    - add_and_ping could crash on get() if uri coincided with existing alias
    - also add an 'errored' set, which is excluded from get_random()
      this means we don't try to broadcast to peers we haven't yet been
      able to ping successfully
