### PR TITLE
Stop slow or suspended native miner

### DIFF
--- a/apps/aecore/src/aec_conductor.hrl
+++ b/apps/aecore/src/aec_conductor.hrl
@@ -7,7 +7,12 @@
 -type(options() :: [option()]).
 
 
--type workers() :: orddict:orddict(pid(), atom()).
+-record(worker_info, {tag   :: atom(),
+                      mon   :: reference(),
+                      timer :: {t, timer:tref()} | 'no_timer'}).
+
+-type worker_info() :: #worker_info{}.
+-type workers() :: orddict:orddict(pid(), worker_info()).
 -type mining_state() :: 'running' | 'stopped'.
 
 -record(candidate, {block     :: block(),

--- a/apps/aecore/src/aecore_app.erl
+++ b/apps/aecore/src/aecore_app.erl
@@ -26,6 +26,7 @@ stop(_State) ->
 check_env() ->
     check_env([{[<<"logging">>, <<"hwm">>]     , fun set_hwm/1},
                {[<<"mining">>, <<"autostart">>], {set_env, autostart}},
+               {[<<"mining">>, <<"attempt_timeout">>], {set_env, mining_attempt_timeout}},
                {[<<"chain">>, <<"persist">>]   , {set_env, persist}},
                {[<<"chain">>, <<"db_path">>]   , {set_env, db_path}}]).
 

--- a/apps/aeutils/priv/epoch_config_schema.json
+++ b/apps/aeutils/priv/epoch_config_schema.json
@@ -146,6 +146,11 @@
                     "description" :
                     "If true, the node will start mining automatically.",
                     "type" : "boolean"
+                },
+                "attempt_timeout" : {
+                    "description" :
+                    "Maximum time (milliseconds) for each attempt to mine a block with a specific nonce.",
+                    "type" : "integer"
                 }
             }
         },


### PR DESCRIPTION
Please refer to commit message for details.

----

TODO:
* [x] Timeout only for mining tag;
* [x] Configurable mining attempt timeout, default 1 hour;
* [x] Update doc in aec_conductor.erl
* [x] Record for worker info kept in aec_conductor state
* [ ] Rebase on recent master