### PR TITLE
Websockets using aec_events [Finishes #153476145]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ python-tests:
 	@$(NOSE) --nocapture -c $(PYTHON_TESTS)/nose.cfg $(PYTHON_TESTS)
 
 python-ws-test:
-	@$(PYTHON) $(PYTHON_TESTS)/ws_client.py --port 3014 --log INFO --handler ws_logic
+	@$(PYTHON) $(PYTHON_TESTS)/ws_client.py --port 3114 --log INFO --handler ws_logic
 
 python-integration-tests:
 	@$(NOSE)  --nocapture -c $(PYTHON_TESTS)/nose.cfg --tc-file $(PYTHON_TESTS)/integration/setup.yaml --tc-format yaml $(PYTHON_TESTS)/integration/

--- a/apps/aecore/src/aec_conductor.erl
+++ b/apps/aecore/src/aec_conductor.erl
@@ -598,9 +598,6 @@ handle_mining_reply({{ok, Block},_Candidate}, State) ->
     State1 = State#state{block_candidate = undefined},
     case handle_mined_block(Block, State1) of
         {ok, State2} ->
-            %% TODO: This should listen on some event instead
-            ws_handler:broadcast(miner, mined_block,
-                                 [{height, aec_blocks:height(Block)}]),
             State2;
         {{error, Reason}, State2} ->
             epoch_mining:error("Block insertion failed: ~p.", [Reason]),

--- a/apps/aehttp/src/ws_handler.erl
+++ b/apps/aehttp/src/ws_handler.erl
@@ -11,6 +11,9 @@
 
 -define(GPROC_KEY, {p, l, {?MODULE, broadcast}}).
 
+-define(SUBSCRIBE_EVENTS, [block_created %% node mined a block
+                          ]).
+
 init({tcp, http}, _Req, _Opts) ->
     {upgrade, protocol, cowboy_websocket}.
 
@@ -18,6 +21,11 @@ websocket_init(_TransportName, Req, _Opts) ->
     case jobs:ask(ws_handlers_queue) of
         {ok, JobId} ->
             gproc:reg(?GPROC_KEY),
+            lists:foreach(
+                fun(Event) ->
+                    aec_events:subscribe(Event)
+                end,
+                ?SUBSCRIBE_EVENTS),
             {ok, Req, JobId};
         {error, rejected} ->
             {shutdown, Req}
@@ -29,30 +37,21 @@ websocket_handle({text, MsgBin}, Req, State) ->
 websocket_handle(_Data, Req, State) ->
     {ok, Req, State}.
 
-websocket_info({send, SenderName, Action, Payload}, Req, State) ->
-    MsgWithoutPayload = #{origin =>SenderName, action => Action},
-    EmptyPayload =
-        case Payload of
-            _ when is_list(Payload) ->
-                length(Payload) == 0;
-            _ when is_map(Payload) ->
-                maps:size(Payload) == 0
-        end,
-    Msg =
-        case EmptyPayload of
-            true ->
-                MsgWithoutPayload;
-            false ->
-                maps:put(payload, Payload, MsgWithoutPayload)
-        end,
+websocket_info({gproc_ps_event, Event, Data}, Req, State) ->
+    Msg = create_message_from_event(Event, Data),
     {reply, {text, jsx:encode(Msg)}, Req, State};
-websocket_info(_Info, Req, State) ->
+websocket_info({send, SenderName, Action, Payload}, Req, State) ->
+    Msg = create_message(SenderName, Action, Payload),
+    {reply, {text, jsx:encode(Msg)}, Req, State};
+websocket_info(Info, Req, State) ->
+    lager:info("Unhandled message ~p", [Info]),
     {ok, Req, State}.
 
 websocket_terminate(_Reason, _Req, JobId) ->
     jobs:done(JobId),
     ok.
 
+%% Should be used only in case when aec_events is not appropriate
 broadcast(SenderName, Action) ->
     broadcast(SenderName, Action, []).
 broadcast(SenderName, Action, Payload) ->
@@ -64,3 +63,28 @@ broadcast(SenderName, Action, Payload) ->
 
 send_msg(WsPid, SenderName, Action, Payload) ->
     WsPid ! {send, SenderName, Action, Payload}.
+
+create_message(SenderName, Action, Payload) ->
+    MsgWithoutPayload = #{origin => SenderName,
+                          action => Action},
+    EmptyPayload =
+        case Payload of
+            _ when is_list(Payload) ->
+                Payload == [];
+            _ when is_map(Payload) ->
+                maps:size(Payload) == 0
+        end,
+    case EmptyPayload of
+        true ->
+            MsgWithoutPayload;
+        false ->
+            maps:put(payload, Payload, MsgWithoutPayload)
+    end.
+
+create_message_from_event(block_created, #{info := Block}) ->
+    BlockHeight = aec_blocks:height(Block),
+    {ok, BlockHash} = aec_blocks:hash_internal_representation(Block),
+    Payload =
+        [{height, BlockHeight},
+         {hash, base64:encode(BlockHash)}],
+    create_message(miner, mined_block, Payload).

--- a/py/tests/ws_logic.py
+++ b/py/tests/ws_logic.py
@@ -2,13 +2,13 @@ import ws_client
 import logging
 
 def get_new_block(ws, payload):
-    ws_client.get_block_by_height(ws, payload["height"]) 
+    ws_client.get_block_by_hash(ws, payload["hash"]) 
 
 def print_chain_data(ws, payload):
     data_type = payload["type"]
     value = payload[data_type]
     search_key = "hash"
-    if payload["height"] != None:
+    if "height" in payload:
         search_key = "height"
     logging.info("Recieved data for " + data_type + ", requested by its " +
                 search_key + " = " + str(payload[search_key]))


### PR DESCRIPTION
[Pivotal story](https://www.pivotaltracker.com/story/show/153476145)
### Description
```
The websocket publishing of a mined block is currently separate from the event
handling used by aec_sync. It should be listening to the same events (aec_event)  instead.
```
### Testing

1. Modify the sys.config to mine fast. We need those blocks mined. Example sys.config changes:
```
      {autostart, true},
      {aec_pow_cuckoo, {"mean16s-generic", "-t 5", 16}},
      {expected_mine_rate, 1000}
```
The settings above will attempt to mine one block every second.

2. Build and start the node

3. Start the python websocket test
```
make python-ws-test
```

4. Observe messages like this poping up in the console
```
>> {"action":"mined_block","origin":"miner","payload":{"height":22,"hash":"q2eCwuq7Id9qCcWFyLnX//bvEMz+CeL77dmtrC+PUnQ="}}
<< {"action": "get", "target": "chain", "payload": {"hash": "q2eCwuq7Id9qCcWFyLnX//bvEMz+CeL77dmtrC+PUnQ=", "type": "block"}}
>> {"action":"requested_data","origin":"chain","payload":{"type":"block","hash":"q2eCwuq7Id9qCcWFyLnX//bvEMz+CeL77dmtrC+PUnQ=","block":{"height":22,"nonce":8331622223837979557,"pow":[69,679,1623,1652,1989,2824,3023,4988,5054,6302,6533,6741,11644,11667,13086,13346,13928,13953,14689,17130,17153,17517,18052,18906,19477,20295,20827,20976,21118,21709,22241,23541,24578,25390,26497,27520,30194,30545,30648,31280,31954,32380],"prev_hash":"23Btq5ZSzrYlmCFHlTNvZBOi2rh5PASa9YMYwEFBmr0=","state_hash":"BsxUapw+JIRc7xhD6lQ3K935AF/wJlAzAtbX8gKLC18=","target":542135805,"time":1512656681053,"transactions":[{"tx":"lMQGc2lnX3R4AZOBxAR0eXBlxAhjb2luYmFzZYHEA3ZzbgGBxARhY2N0xEEEfRpJuiu4WkBxXOf69qZgQV9OnwqzMjb+dcDtzJUbc2jajsYYZKyxkiiCIsFEjsbIVKvouK+8ra/+MMYqg6APc5HESDBGAiEAoxGfY8XcyZ2IlqxQE+VIZlNrQRsT0H5T6DPB8fk/vWUCIQDcMjEi3H87L7i1Wb/tkwJA18qvMJZLTzoAydzOBvrHxA=="}],"txs_hash":"4Lwlm5L2AtmGuyrnmG/pJ3DSGRIljlcGmuEVXEPFfx8=","version":1}}}
Recieved data for block, requested by its hash = q2eCwuq7Id9qCcWFyLnX//bvEMz+CeL77dmtrC+PUnQ=
{u'nonce': 8331622223837979557, u'target': 542135805, u'transactions': [{u'tx': u'lMQGc2lnX3R4AZOBxAR0eXBlxAhjb2luYmFzZYHEA3ZzbgGBxARhY2N0xEEEfRpJuiu4WkBxXOf69qZgQV9OnwqzMjb+dcDtzJUbc2jajsYYZKyxkiiCIsFEjsbIVKvouK+8ra/+MMYqg6APc5HESDBGAiEAoxGfY8XcyZ2IlqxQE+VIZlNrQRsT0H5T6DPB8fk/vWUCIQDcMjEi3H87L7i1Wb/tkwJA18qvMJZLTzoAydzOBvrHxA=='}], u'pow': [69, 679, 1623, 1652, 1989, 2824, 3023, 4988, 5054, 6302, 6533, 6741, 11644, 11667, 13086, 13346, 13928, 13953, 14689, 17130, 17153, 17517, 18052, 18906, 19477, 20295, 20827, 20976, 21118, 21709, 22241, 23541, 24578, 25390, 26497, 27520, 30194, 30545, 30648, 31280, 31954, 32380], u'time': 1512656681053, u'height': 22, u'version': 1, u'txs_hash': u'4Lwlm5L2AtmGuyrnmG/pJ3DSGRIljlcGmuEVXEPFfx8=', u'prev_hash': u'23Btq5ZSzrYlmCFHlTNvZBOi2rh5PASa9YMYwEFBmr0=', u'state_hash': u'BsxUapw+JIRc7xhD6lQ3K935AF/wJlAzAtbX8gKLC18='}
```