### PR TITLE
Add a user-config checking tool [Finishes #153312606]

### DIFF
--- a/apps/check_config/src/check_config.app.src
+++ b/apps/check_config/src/check_config.app.src
@@ -1,0 +1,14 @@
+%% -*- erlang-indent-level: 4; indent-tabs-mode: nil -*-
+{application, check_config,
+ [{description, "escript for checking epoch user config files"},
+  {vsn, "0.1.0"},
+  {registered, []},
+  {applications,
+   [kernel,
+    stdlib,
+    jsx,
+    yamerl,
+    jesse
+   ]},
+  {env,[]}
+ ]}.

--- a/apps/check_config/src/check_config.erl
+++ b/apps/check_config/src/check_config.erl
@@ -1,0 +1,24 @@
+-module(check_config).
+-export([main/1]).
+
+main([File, Schema]) ->
+    check_config(File, Schema);
+main([File]) ->
+    Schema = filename:join(
+               filename:dirname(
+                 filename:dirname(escript:script_name())),
+               "data/epoch_config_schema.json"),
+    check_config(File, Schema);
+main(_) ->
+    usage().
+
+check_config(Cfg, Schema) ->
+    application:ensure_all_started(jesse),
+    application:ensure_all_started(yamerl),
+    application:ensure_all_started(jsx),
+    Res = aeu_env:check_config(Cfg, Schema),
+    io:fwrite("Res = ~p~n", [Res]).
+
+usage() ->
+    io:format("Usage: check_config file [schema]~n", []),
+    halt(1).

--- a/rebar.config
+++ b/rebar.config
@@ -42,9 +42,17 @@
                              {include_src, true}]}]
             },
             {dev1, [{relx, [{dev_mode, false},
-                             {include_erts, false},
-                             {sys_config, "./config/dev1/sys.config"},
-                             {vm_args, "./config/dev1/vm.args"}]}
+                            {include_erts, false},
+                            {sys_config, "./config/dev1/sys.config"},
+                            {vm_args, "./config/dev1/vm.args"},
+                            {overlay, [{mkdir, "{{output_dir}}/data"},
+                                       {copy,
+                                        "_build/dev1/bin/check_config",
+                                        "{{output_dir}}/bin/check_config"},
+                                       {copy,
+                                       "_build/dev1/lib/aeutils/priv/epoch_config_schema.json",
+                                       "{{output_dir}}/data/epoch_config_schema.json"}]}
+                           ]}
                     ]
             },
             {test, [{relx, [{dev_mode, true},
@@ -65,8 +73,16 @@
            ]
 }.
 
+
+{escript_main_app, check_config}.
+{escript_name, "check_config"}.
+{escript_incl_apps, [aeutils, jsx, yamerl, jesse, rfc3339]}.
+{escript_shebang, "#!/usr/bin/env escript\n"}.
+{escript_comment, "%%\n"}.
+
 {provider_hooks,
- [{post, [{compile, {tx_xform, generate}}]}]}.
+ [{post, [{compile, {tx_xform, generate}},
+          {compile, escriptize}]}]}.
 
 {pre_hooks, [{"(linux|darwin|solaris|netbsd|freebsd)", compile,
               "git rev-parse HEAD > ${REBAR_ROOT_DIR}/REVISION"}]}.


### PR DESCRIPTION
- The tool ends up as epoch/bin/check_config
- Usage: check_config epoch.{json|yaml} [schema]
- Pretty-prints validation errors to make the more user-friendly
- Also some added support for reducing error output for invalid
  user configs