### PR TITLE
Enable user to check user config offline

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -71,7 +71,14 @@
                    ]},
             {prod, [{relx, [{dev_mode, false},
                             {include_erts, true},
-                            {include_src, false}]}
+                            {include_src, false},
+                            {overlay, [{copy,
+                                        "_build/prod/bin/check_config",
+                                        "bin/check_config"},
+                                       {copy,
+                                        "_build/prod/lib/aeutils/priv/epoch_config_schema.json",
+                                        "data/epoch_config_schema.json"}]}
+                           ]}
                    ]}
            ]
 }.


### PR DESCRIPTION
TODO:
* [ ] Fix `bin/check_config epoch.yaml` returning `env: escript: No such file or directory` (`find . -name escript` outputs `./erts-9.1.4/bin/escript`)
* [x] Fix `tar: Removing leading '/' from member names` when running `tar xf` (resulting in `find . -name check_config` returning 2 results: `./bin/check_config` `./Users/luca/dev/aeternity/epoch/_build/prod/rel/epoch/bin/check_config`)