### PR TITLE
[Finishes PT-153539819] Refactor aec_tx_sign to being a real datatype

### DIFF
--- a/apps/aecore/include/txs.hrl
+++ b/apps/aecore/include/txs.hrl
@@ -1,9 +1,3 @@
--record(signed_tx, {
-          data                       :: term(),
-          signatures = ordsets:new() :: ordsets:ordset(binary())}).
--type(signed_tx() :: #signed_tx{}).
-
-
 %% Basic transactions
 
 -record(coinbase_tx, {

--- a/apps/aecore/src/aec_blocks.erl
+++ b/apps/aecore/src/aec_blocks.erl
@@ -83,11 +83,11 @@ set_target(Block, Target) ->
     Block#block{target = Target}.
 
 %% TODO: have a spec for list of transactions
--spec txs(block()) -> list(signed_tx()).
+-spec txs(block()) -> list(aec_tx_sign:signed_tx()).
 txs(Block) ->
     Block#block.txs.
 
--spec new(block(), list(signed_tx()), trees()) -> block().
+-spec new(block(), list(aec_tx_sign:signed_tx()), trees()) -> block().
 new(LastBlock, Txs, Trees0) ->
     LastBlockHeight = height(LastBlock),
     {ok, LastBlockHeaderHash} = hash_internal_representation(LastBlock),

--- a/apps/aecore/src/aec_keys.erl
+++ b/apps/aecore/src/aec_keys.erl
@@ -211,12 +211,9 @@ handle_call({sign, Term}, _From,
         false ->
             {reply, {error, not_a_signer}, State};
         true ->
-            Bin = aec_tx:serialize_to_binary(Term),
-            Signature =
-                crypto:sign(
-                  Algo, Digest, Bin, [PrivKey, crypto:ec_curve(Curve)]),
-            {reply, {ok, #signed_tx{data = Term,
-                                    signatures = [Signature]}}, State}
+            CryptoMap = #{algo => Algo, digest => Digest, curve => Curve},
+            SignedTx = aec_tx_sign:sign(Term, PrivKey, CryptoMap),
+            {reply, {ok, SignedTx}, State}
     end;
 handle_call({verify, Sigs, Term}, _From, #state{crypto = C} = State) ->
     Signers = aec_tx:signers(Term),

--- a/apps/aecore/src/aec_mining.erl
+++ b/apps/aecore/src/aec_mining.erl
@@ -46,12 +46,12 @@ mine(Block, Nonce) ->
 
 %% Internal functions
 
--spec get_txs_to_mine_in_pool() -> list(signed_tx()).
+-spec get_txs_to_mine_in_pool() -> list(aec_tx_sign:signed_tx()).
 get_txs_to_mine_in_pool() ->
     {ok, Txs} = aec_tx_pool:peek(aec_governance:max_txs_in_block() - 1),
     Txs.
 
--spec create_block_candidate(list(signed_tx()), block(), list(header())) ->
+-spec create_block_candidate(list(aec_tx_sign:signed_tx()), block(), list(header())) ->
                   {ok, block(), aec_pow:nonce(), integer()} | {error, term()}.
 create_block_candidate(TxsToMineInPool, TopBlock, AdjHeaders) ->
     case create_signed_coinbase_tx() of
@@ -69,7 +69,7 @@ create_block_candidate(TxsToMineInPool, TopBlock, AdjHeaders) ->
             end
     end.
 
--spec create_signed_coinbase_tx() -> {ok, signed_tx()} | {error, term()}.
+-spec create_signed_coinbase_tx() -> {ok, aec_tx_sign:signed_tx()} | {error, term()}.
 create_signed_coinbase_tx() ->
     case create_coinbase_tx() of
         {ok, CoinbaseTx} ->

--- a/apps/aecore/src/aec_tx_pool.erl
+++ b/apps/aecore/src/aec_tx_pool.erl
@@ -40,7 +40,7 @@
 
 -type pool_db_key() ::
         {negated_fee(), pubkey(), non_neg_integer()} | undefined.
--type pool_db_value() :: signed_tx().
+-type pool_db_value() :: aec_tx_sign:signed_tx().
 -type pool_db() :: atom().
 
 -type event() :: tx_created | tx_received.
@@ -60,18 +60,18 @@ stop() ->
 
 %% INFO: Transaction from the same sender with the same nonce and fee
 %%       will be overwritten
--spec push(signed_tx()|list(signed_tx())) -> ok.
+-spec push(aec_tx_sign:signed_tx()|list(aec_tx_sign:signed_tx())) -> ok.
 push(Tx) ->
     push(Tx, tx_created).
 
--spec push(signed_tx()|list(signed_tx()), event()) -> ok.
+-spec push(aec_tx_sign:signed_tx()|list(aec_tx_sign:signed_tx()), event()) -> ok.
 push([_|_] = Txs, Event) when ?PUSH_EVENT(Event) ->
     gen_server:call(?SERVER, {push, Txs, Event});
 push([], _) -> ok;
 push(Tx, Event) when ?PUSH_EVENT(Event) ->
     gen_server:call(?SERVER, {push, [Tx], Event}).
 
--spec delete(signed_tx()|list(signed_tx())) -> ok.
+-spec delete(aec_tx_sign:signed_tx()|list(aec_tx_sign:signed_tx())) -> ok.
 delete(Txs) when is_list(Txs) ->
     gen_server:call(?SERVER, {delete, Txs});
 delete(Tx) ->
@@ -84,11 +84,11 @@ get_max_nonce(Sender) ->
 %% The specified maximum number of transactions avoids requiring
 %% building in memory the complete list of all transactions in the
 %% pool.
--spec peek(pos_integer() | infinity) -> {ok, [signed_tx()]}.
+-spec peek(pos_integer() | infinity) -> {ok, [aec_tx_sign:signed_tx()]}.
 peek(MaxN) when is_integer(MaxN), MaxN >= 0; MaxN =:= infinity ->
     gen_server:call(?SERVER, {peek, MaxN}).
 
--spec fork_update(AddedToChain::[signed_tx()], RemovedFromChain::[signed_tx()]) -> ok.
+-spec fork_update(AddedToChain::[aec_tx_sign:signed_tx()], RemovedFromChain::[aec_tx_sign:signed_tx()]) -> ok.
 fork_update(AddedToChain, RemovedFromChain) ->
     %% Add back transactions to the pool from discarded part of the chain
     %% Mind that we don't need to add those which are incoming in the fork
@@ -192,7 +192,7 @@ sel_return(L) when is_list(L) -> L;
 sel_return('$end_of_table' ) -> [];
 sel_return({Matches, _Cont}) -> Matches.
 
--spec pool_db_put(pool_db(), pool_db_key(), pool_db_value(), event()) -> true.
+-spec pool_db_put(pool_db(), pool_db_key(), aec_tx_sign:signed_tx(), event()) -> true.
 pool_db_put(_, undefined, _, _) ->
     false; %% Ignore coinbase
 pool_db_put(Mempool, Key, Tx, Event) ->

--- a/apps/aecore/src/aec_tx_sign.erl
+++ b/apps/aecore/src/aec_tx_sign.erl
@@ -1,23 +1,104 @@
 -module(aec_tx_sign).
 
+%% @doc Implements a data structure for cryptographically signed transactions.
+%% This is the envelope around transactions to make them cryptographically safe. 
+%% The transactions normally also have keys of the "signers" in the transaction,
+%% which are extracted using the signers/1 function in the respective transaction
+%% handler.
+%%
+%% The purpose of this module is to provide an API for cryptograpically signed 
+%% transactions and hide all implementation details. Therefore, the record 
+%% #signed_tx{} should be kept private and considered an abstract type.
+%%
+%% A transaction can be signed by one or several signers. Each transaction can
+%% determine its own signers by the transaction callback 'signers'. Since we do not
+%% want to depend upon transaction types in this module, the user of
+%% {@module} should first obtain the signers of the transaction and then call this
+%% {@link sign/2} with these signers. There is a {@link sign/3} function that can sign
+%% with respect to a certain block height. This is handy whenever the governance
+%% variables on what crypto to use would change.
+
 %% API
--export([data/1,
+-export([sign/2,
+         sign/3, 
+         data/1,
          signatures/1,
-         verify/1]).
--export([serialize/1,
+         verify/2]).
+
+%% API that should be avoided to be used
+-export([verify/1,
+         serialize/1,
          serialize_to_binary/1,
          deserialize/1,
          deserialize_from_binary/1]).
 
 -include("common.hrl").
--include("txs.hrl").
 
+-record(signed_tx, {
+          data                       :: term(),
+          signatures = ordsets:new() :: ordsets:ordset(binary())}).
+
+-opaque signed_tx() :: #signed_tx{}.
+-export_type([signed_tx/0]).
+
+%% @doc Given a transaction Tx, a private key or list of keys, 
+%% return the cryptographically signed transaction using the default crypto
+%% parameters.
+-spec sign(term(), list(binary()) | binary()) -> signed_tx().
+sign(Tx, PrivKeys) ->
+  sign(Tx, PrivKeys, #{}).
+
+%% @doc Given a transaction Tx, a private key and a crypto map, 
+%% return the cryptographically signed transaction.
+%% @equiv sign(Tx, [PrivKey], CryptoMap).
+sign(Tx, PrivKey, CryptoMap) when is_binary(PrivKey) ->
+  sign(Tx, [PrivKey], CryptoMap);
+sign(Tx, PrivKeys, CryptoMap) when is_list(PrivKeys) ->
+    Bin = aec_tx:serialize_to_binary(Tx),
+    Algo = maps:get(algo, CryptoMap, ecdsa),
+    Digest = maps:get(digest, CryptoMap, sha256),
+    Curve = maps:get(curve, CryptoMap, secp256k1),
+    Signatures = 
+       [ crypto:sign(Algo, Digest, Bin, [PrivKey, crypto:ec_curve(Curve)]) ||
+         PrivKey <- PrivKeys ],
+    #signed_tx{data = Tx,
+               signatures = Signatures}.
+
+%% @doc Get the original transaction from a signed transaction.
+%% Note that no implicit verification is performed, it just returns the data.
+
+-spec data(signed_tx()) -> any().
+%% We have no type yest for any transaction, and coinbase_tx() | spend_tx()
+%% seems restricted as type.
 data(#signed_tx{data = Data}) ->
     Data.
 
+%% @doc Get the signatures of a signed transaction.
+-spec signatures(signed_tx()) -> list(binary()).
 signatures(#signed_tx{signatures = Sigs}) ->
     Sigs.
 
+%% @doc Verify a signed transaction by checking that the provided keys indeed all
+%% have signed this transaction.
+-spec verify(signed_tx(), list(binary())) -> ok | {error, signature_check_failed}.
+verify(#signed_tx{data = Tx, signatures = Sigs}, Signers) ->
+    %% This works even for Signers being one public key!
+    #signed_tx{signatures = NewSigs} = sign(Tx, Signers),
+    case {NewSigs -- Sigs, Sigs -- NewSigs} of
+        {[], []} ->
+          ok;
+        {DSigs1, []} ->
+          lager:debug("No matching sigs (~p - ~p) additional new signatures", [DSigs1, Sigs]),
+          {error, signature_check_failed};
+        {_, DSigs2} ->
+          lager:debug("No matching sigs (~p - ~p) missing signatures", [DSigs2, Sigs]),
+          {error, signature_check_failed}
+    end.
+  
+
+%% This should not call aec_keys verify, but aec_keys should call this module!
+%% with the keys of the signers.
+-spec verify(signed_tx()) -> ok | {error, signature_check_failed}.
 verify(#signed_tx{data = Data, signatures = Sigs}) ->
     case aec_keys:verify(Sigs, Data) of
         true -> ok;
@@ -32,22 +113,22 @@ verify(#signed_tx{data = Data, signatures = Sigs}) ->
 version() -> ?SIG_TX_VSN.
 type()    -> ?SIG_TX_TYPE.
 
--spec serialize(#signed_tx{}) -> list().
+-spec serialize(signed_tx()) -> list().
 serialize(#signed_tx{data = Tx, signatures = Sigs})  when is_tuple(Tx) ->
     TxSer = aec_tx:serialize(Tx),
     [type(), version(), TxSer, Sigs].
 
--spec deserialize(list()) -> #signed_tx{}.
+-spec deserialize(list()) -> signed_tx().
 deserialize([?SIG_TX_TYPE, ?SIG_TX_VSN, TxSer, Sigs]) ->
     Tx = aec_tx:deserialize(TxSer),
     #signed_tx{data = Tx, signatures = Sigs}.
 
 %% deterministic canonical serialization.
--spec serialize_to_binary(#signed_tx{}) -> binary().
+-spec serialize_to_binary(signed_tx()) -> binary().
 serialize_to_binary(#signed_tx{} = SignedTx) ->
     msgpack:pack(serialize(SignedTx)).
 
--spec deserialize_from_binary(binary()) -> #signed_tx{}.
+-spec deserialize_from_binary(binary()) -> signed_tx().
 deserialize_from_binary(SignedTxBin) when is_binary(SignedTxBin) ->
     {ok, Unpacked} = msgpack:unpack(SignedTxBin),
     lager:debug("unpacked Tx: ~p", [Unpacked]),

--- a/apps/aecore/src/txs/aec_tx.erl
+++ b/apps/aecore/src/txs/aec_tx.erl
@@ -18,8 +18,7 @@
 -include("trees.hrl").
 -include("txs.hrl").
 
--export_type([tx/0,
-              signed_tx/0]).
+-export_type([tx/0]).
 
 %%%=============================================================================
 %%% aec_tx behavior callbacks
@@ -70,15 +69,15 @@ origin(Tx) ->
     Mod = tx_dispatcher:handler(Tx),
     Mod:origin(Tx).
 
--spec filter_out_invalid_signatures(list(signed_tx())) -> list(signed_tx()).
+-spec filter_out_invalid_signatures(list(aec_tx_sign:signed_tx())) -> list(aec_tx_sign:signed_tx()).
 filter_out_invalid_signatures(SignedTxs) ->
     lists:filter(
       fun(SignedTx) ->
               ok =:= aec_tx_sign:verify(SignedTx)
       end, SignedTxs).
 
--spec apply_signed(list(signed_tx()), trees(), non_neg_integer()) ->
-                          {ok, list(signed_tx()), trees()}.
+-spec apply_signed(list(aec_tx_sign:signed_tx()), trees(), non_neg_integer()) ->
+                          {ok, list(aec_tx_sign:signed_tx()), trees()}.
 apply_signed(SignedTxs, Trees0, Height) ->
     {ok, SignedTxs1, Trees1} = apply_on_state_trees(SignedTxs, Trees0, Height),
     TotalFee = calculate_total_fee(SignedTxs1),
@@ -86,7 +85,7 @@ apply_signed(SignedTxs, Trees0, Height) ->
     {ok, SignedTxs1, Trees2}.
 
 %% TODO: there should be an easier way to do this...
--spec is_coinbase(signed_tx()) -> boolean().
+-spec is_coinbase(aec_tx_sign:signed_tx()) -> boolean().
 is_coinbase(Signed) ->
     Tx = aec_tx_sign:data(Signed),
     Mod = tx_dispatcher:handler(Tx),
@@ -161,7 +160,7 @@ process_single(Tx, Trees, Height) ->
     Mod = tx_dispatcher:handler(Tx),
     Mod:process(Tx, Trees, Height).
 
--spec grant_fee_to_miner(list(signed_tx()), trees(), non_neg_integer(), height()) ->
+-spec grant_fee_to_miner(list(aec_tx_sign:signed_tx()), trees(), non_neg_integer(), height()) ->
                                 trees().
 grant_fee_to_miner([], Trees, 0, _Height) ->
     lager:info("Empty block -- no fee"),

--- a/apps/aecore/test/aec_blocks_tests.erl
+++ b/apps/aecore/test/aec_blocks_tests.erl
@@ -93,7 +93,7 @@ validate_test_multiple_coinbase() ->
 
 validate_test_malformed_txs_root_hash() ->
     SignedCoinbase = aec_test_utils:signed_coinbase_tx(),
-    MalformedTxs = [SignedCoinbase, #signed_tx{data = #coinbase_tx{account = <<"malformed_account">>}}],
+    MalformedTxs = [SignedCoinbase, aec_tx_sign:sign(#coinbase_tx{account = <<"malformed_account">>}, <<"pubkey">>)],
     {ok, MalformedTree} = aec_txs_trees:new(MalformedTxs),
     {ok, MalformedRootHash} = aec_txs_trees:root_hash(MalformedTree),
     Block = #block{txs = [SignedCoinbase], txs_hash = MalformedRootHash},
@@ -102,7 +102,7 @@ validate_test_malformed_txs_root_hash() ->
 
 validate_test_malformed_tx_signature() ->
     SignedCoinbase = aec_test_utils:signed_coinbase_tx(),
-    Txs = [SignedCoinbase#signed_tx{signatures = []}],
+    Txs = [{signed_tx, aec_tx_sign:data(SignedCoinbase), []}],
     {ok, Tree} = aec_txs_trees:new(Txs),
     {ok, RootHash} = aec_txs_trees:root_hash(Tree),
     Block = #block{txs = Txs, txs_hash = RootHash},


### PR DESCRIPTION
aec_tx_sign lends itself to being a pure datatype, which makes maintenance of our code base easier and helps testing by mocking only one part and no other modules.