### PR TITLE
[WIP] State separated from block

### DIFF
--- a/apps/aecore/include/blocks.hrl
+++ b/apps/aecore/include/blocks.hrl
@@ -38,7 +38,7 @@
           height = 0              :: height(),
           prev_hash = <<0:?BLOCK_HEADER_HASH_BYTES/unit:8>> :: block_header_hash(),
           txs_hash = <<0:?TXS_HASH_BYTES/unit:8>> :: txs_hash(),
-          root_hash = <<>>        :: binary(),
+          root_hash = <<>>        :: state_hash(),
           target = ?HIGHEST_TARGET_SCI :: aec_pow:sci_int(),
           nonce = 0               :: non_neg_integer(),
           time = 0                :: non_neg_integer(),

--- a/apps/aecore/include/sha256.hrl
+++ b/apps/aecore/include/sha256.hrl
@@ -1,2 +1,1 @@
 -define(HASH_BYTES, 32).
--define(HASH_BITS, 256).

--- a/apps/aecore/include/trees.hrl
+++ b/apps/aecore/include/trees.hrl
@@ -1,5 +1,5 @@
 -record(trees, {
-          accounts :: aec_trees:tree()}).
+          accounts :: aec_accounts:tree()}).
 -type(trees() :: #trees{}).
 
 %% Placeholder to define state Merkle trees

--- a/apps/aecore/src/aec_accounts.erl
+++ b/apps/aecore/src/aec_accounts.erl
@@ -1,32 +1,47 @@
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2017, Aeternity Anstalt
+%%% @doc Accounts, and Merkle trees of accounts.
+%%% @end
+%%%-------------------------------------------------------------------
 -module(aec_accounts).
 
-%% API
--export([empty/0,
-         new/3,
-         get/2,
-         get_with_proof/2,
-         get_all_accounts_balances/1,
-         put/2,
+%% API - account
+-export([new/3,
          balance/1,
          nonce/1,
          height/1,
          earn/3,
-         spend/4,
+         spend/4]).
+
+%% API - accounts tree
+-export([empty/0,
+         get/2,
+         get_with_proof/2,
+         get_all_accounts_balances/1,
+         put/2,
          root_hash/1,
          verify_proof/3]).
+
+-export_type([tree/0]).
 
 -include("common.hrl").
 -include("trees.hrl").
 
-%% TODO: remove? We should not need such API (init via trees)
+-type deterministic_account_binary_with_pubkey() :: binary().
+
+-type key() :: pubkey().
+-type value() :: deterministic_account_binary_with_pubkey().
+-type tree() :: aeu_mtrees:mtree(key(), value()).
+
+-spec empty() -> {ok, tree()}.
 empty() ->
-    {ok, _AccountsTree} = aec_trees:new_merkle_tree().
+    {ok, _AccountsTree} = aeu_mtrees:new().
 
 new(Pubkey, Balance, Height) ->
     #account{pubkey = Pubkey, balance = Balance, height = Height}.
 
 get(Pubkey, AccountsTree) ->
-    case aec_trees:get(Pubkey, AccountsTree) of
+    case aeu_mtrees:get(Pubkey, AccountsTree) of
         {ok, SerializedAccount} when is_binary(SerializedAccount) ->
             Account =
                 #account{pubkey = Pubkey} = %% Hardcoded expectation.
@@ -37,7 +52,7 @@ get(Pubkey, AccountsTree) ->
     end.
 
 get_with_proof(Pubkey, AccountsTree) ->
-    case aec_trees:get_with_proof(Pubkey, AccountsTree) of
+    case aeu_mtrees:get_with_proof(Pubkey, AccountsTree) of
         {ok, {SerializedAccount, Proof}} when is_binary(SerializedAccount) ->
             Account =
                 #account{pubkey = Pubkey} = %% Hardcoded expectation.
@@ -49,7 +64,7 @@ get_with_proof(Pubkey, AccountsTree) ->
 
 -spec get_all_accounts_balances(aec_trees:trees()) -> list({pubkey(), non_neg_integer()}).
 get_all_accounts_balances(AccountsTree) ->
-    AccountsDump = aec_trees:to_orddict(AccountsTree),
+    AccountsDump = aeu_mtrees:to_orddict(AccountsTree),
     lists:foldl(
       fun({Pubkey, SerializedAccount}, Acc) ->
               #account{balance = B} = deserialize(SerializedAccount),
@@ -58,7 +73,7 @@ get_all_accounts_balances(AccountsTree) ->
 
 put(Account, AccountsTree) ->
     {ok, _NewAccountsTree} =
-        aec_trees:put(Account#account.pubkey, serialize(Account), AccountsTree).
+        aeu_mtrees:put(Account#account.pubkey, serialize(Account), AccountsTree).
 
 balance(#account{balance = Balance}) ->
     Balance.
@@ -79,12 +94,13 @@ spend(#account{balance = Balance0} = Account0, Amount, Nonce, Height) ->
                           height = Height}}.
 
 root_hash(AccountsTree) ->
-    aec_trees:root_hash(AccountsTree).
+    aeu_mtrees:root_hash(AccountsTree).
 
 verify_proof(Account, RootHash, Proof) ->
-    aec_trees:verify_proof(
+    aeu_mtrees:verify_proof(
       Account#account.pubkey, serialize(Account), RootHash, Proof).
 
+-spec serialize(account()) -> deterministic_account_binary_with_pubkey().
 serialize(Account) ->
     term_to_binary(Account).
 

--- a/apps/aecore/src/aec_conductor.erl
+++ b/apps/aecore/src/aec_conductor.erl
@@ -58,6 +58,7 @@
 
 %% State trees API
 -export([ get_miner_account_balance/0
+        , get_account_balance/1
         , next_nonce_for_account/1
         , get_all_accounts_balances/0
         ]).
@@ -146,11 +147,14 @@ get_mining_workers() ->
 %%%===================================================================
 %%% State trees API
 
-%% TODO: Added for backwards compability.
+%% For tests.
 -spec get_miner_account_balance() ->   {'ok', integer()}
                                      | {'error', 'account_not_found'}.
 get_miner_account_balance() ->
     {ok, Pubkey} = aec_keys:pubkey(),
+    get_account_balance(Pubkey).
+
+get_account_balance(Pubkey) ->
     LastBlock = top(),
     Trees = aec_blocks:trees(LastBlock),
     AccountsTree = aec_trees:accounts(Trees),

--- a/apps/aecore/src/aec_sha256.erl
+++ b/apps/aecore/src/aec_sha256.erl
@@ -9,12 +9,16 @@
 
 -export([hash/1]).
 
--include("sha256.hrl").
+-export_type([hashable/0,
+              hash/1]).
 
+-include("sha256.hrl").
 
 -type hashable() :: binary().
 
--export_type([hashable/0]).
+%% For enabling code using this module to document types for
+%% readability.
+-type hash(_DataToBeHashed) :: <<_:(?HASH_BYTES*8)>>.
 
 %%%=============================================================================
 %%% API

--- a/apps/aecore/src/aec_sha256.erl
+++ b/apps/aecore/src/aec_sha256.erl
@@ -9,14 +9,10 @@
 
 -export([hash/1]).
 
--ifdef(TEST).
--compile([export_all, nowarn_export_all]).
--endif.
-
 -include("sha256.hrl").
 
 
--type hashable() :: term().
+-type hashable() :: binary().
 
 -export_type([hashable/0]).
 
@@ -25,11 +21,8 @@
 %%%=============================================================================
 
 %%------------------------------------------------------------------------------
-%% Calculate the SHA256 hash value of a binary or an erlang term
+%% Calculate the SHA256 hash value of a binary
 %%------------------------------------------------------------------------------
 -spec hash(hashable()) -> binary().
 hash(Data) when is_binary(Data) ->
-    <<Hash:?HASH_BITS, _/bitstring>> = crypto:hash(sha256, Data),
-    <<Hash:?HASH_BITS>>;
-hash(Term) ->
-    hash(term_to_binary(Term)).
+    <<_:?HASH_BYTES/unit:8>> = crypto:hash(sha256, Data).

--- a/apps/aecore/src/aec_trees.erl
+++ b/apps/aecore/src/aec_trees.erl
@@ -1,3 +1,8 @@
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2017, Aeternity Anstalt
+%%% @doc State trees ADT.
+%%% @end
+%%%-------------------------------------------------------------------
 -module(aec_trees).
 
 -include("common.hrl").
@@ -9,20 +14,11 @@
          all_trees_hash/1,
          accounts/1,
          set_accounts/2,
-         new_merkle_tree/0,
-         get/2,
-         get_with_proof/2,
-         is_trees/1,
-         put/3,
-         root_hash/1,
-         verify_proof/4,
-         to_orddict/1]).
-
--type tree() :: gb_merkle_trees:tree().
+         is_trees/1]).
 
 -spec all_trees_new() -> {ok, trees()}.
 all_trees_new() ->
-    {ok, A} = new_merkle_tree(),
+    {ok, A} = aec_accounts:empty(),
     {ok, #trees{accounts = A}}.
 
 all_trees_hash(Trees) ->
@@ -32,54 +28,14 @@ all_trees_hash(Trees) ->
       {error, empty} -> <<0:?STATE_HASH_BYTES/unit:8>>
     end.
 
--spec accounts(trees()) -> tree() | undefined.
+-spec accounts(trees()) -> aec_accounts:tree() | undefined.
 accounts(Trees) ->
     Trees#trees.accounts.
 
--spec set_accounts(trees(), tree()) -> trees().
+-spec set_accounts(trees(), aec_accounts:tree()) -> trees().
 set_accounts(Trees, Accounts) ->
     Trees#trees{accounts = Accounts}.
-
--spec new_merkle_tree() -> {ok, tree()}.
-new_merkle_tree() ->
-    {ok, gb_merkle_trees:empty()}.
-
-get(Key, Tree) when is_binary(Key) ->
-    case gb_merkle_trees:lookup(Key, Tree) of
-        none ->
-            {error, notfound};
-        Value when is_binary(Value) ->
-            {ok, Value}
-    end.
-
-get_with_proof(Key, Tree) when is_binary(Key) ->
-    case get(Key, Tree) of
-        {ok, Value} when is_binary(Value) ->
-            Proof = gb_merkle_trees:merkle_proof(Key, Tree),
-            {ok, {Value, Proof}};
-        {error, notfound} = E ->
-            E
-    end.
 
 -spec is_trees(any()) -> boolean().
 is_trees(#trees{}) -> true;
 is_trees(_) -> false.
-
-put(Key, Value, Tree) when is_binary(Key), is_binary(Value) ->
-    NewTree = gb_merkle_trees:enter(Key, Value, Tree),
-    {ok, NewTree}.
-
-root_hash(Tree) ->
-    case gb_merkle_trees:root_hash(Tree) of
-        undefined ->
-            {error, empty};
-        Hash when is_binary(Hash) ->
-            {ok, Hash}
-    end.
-
-verify_proof(Key, Value, RootHash, Proof) ->
-    gb_merkle_trees:verify_merkle_proof(Key, Value, RootHash, Proof).
-
--spec to_orddict(tree()) -> list({binary(), binary()}).
-to_orddict(Tree) ->
-    gb_merkle_trees:to_orddict(Tree).

--- a/apps/aecore/src/aec_tx_sign.erl
+++ b/apps/aecore/src/aec_tx_sign.erl
@@ -32,6 +32,9 @@
          deserialize/1,
          deserialize_from_binary/1]).
 
+-export_type([signed_tx/0,
+              deterministic_signed_tx_binary/0]).
+
 -include("common.hrl").
 
 -record(signed_tx, {
@@ -39,7 +42,7 @@
           signatures = ordsets:new() :: ordsets:ordset(binary())}).
 
 -opaque signed_tx() :: #signed_tx{}.
--export_type([signed_tx/0]).
+-type deterministic_signed_tx_binary() :: binary().
 
 %% @doc Given a transaction Tx, a private key or list of keys, 
 %% return the cryptographically signed transaction using the default crypto
@@ -124,7 +127,7 @@ deserialize([?SIG_TX_TYPE, ?SIG_TX_VSN, TxSer, Sigs]) ->
     #signed_tx{data = Tx, signatures = Sigs}.
 
 %% deterministic canonical serialization.
--spec serialize_to_binary(signed_tx()) -> binary().
+-spec serialize_to_binary(signed_tx()) -> deterministic_signed_tx_binary().
 serialize_to_binary(#signed_tx{} = SignedTx) ->
     msgpack:pack(serialize(SignedTx)).
 

--- a/apps/aecore/src/aec_txs_trees.erl
+++ b/apps/aecore/src/aec_txs_trees.erl
@@ -1,10 +1,32 @@
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2017, Aeternity Anstalt
+%%% @doc Merkle trees of transactions.
+%%% @end
+%%%-------------------------------------------------------------------
 -module(aec_txs_trees).
 
+%% API
 -export([new/1,
          root_hash/1]).
 
+-export_type([txs_tree/0,
+              root_hash/0]).
+
+-include("common.hrl").
+-include("blocks.hrl").
+
+-type key() :: aec_sha256:hash(value()).
+-type value() :: aec_tx_sign:deterministic_signed_tx_binary().
+-opaque txs_tree() :: aeu_mtrees:mtree(key(), value()).
+-type root_hash() :: <<_:(?TXS_HASH_BYTES*8)>>.
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+-spec new([aec_tx_sign:signed_tx(), ...]) -> {ok, txs_tree()}.
 new(Txs = [_|_]) ->
-    {ok, EmptyTree} = aec_trees:new_merkle_tree(),
+    {ok, EmptyTree} = new(),
     TxsTree =
         lists:foldl(
           fun(SignedTx, TreeIn) ->
@@ -15,11 +37,21 @@ new(Txs = [_|_]) ->
           Txs),
     {ok, TxsTree}.
 
+-spec root_hash(txs_tree()) -> {ok, root_hash()}.
+root_hash(TxsTree) ->
+    {ok, <<_:?TXS_HASH_BYTES/unit:8>>} = aeu_mtrees:root_hash(TxsTree).
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+
+new() ->
+    aeu_mtrees:new().
+
+put(K, V, T) ->
+    aeu_mtrees:put(K, V, T).
+
 put_signed_tx(SignedTx, TxsTree) ->
     V = aec_tx_sign:serialize_to_binary(SignedTx),
     K = aec_sha256:hash(V),
-    {ok, _NewTxsTree} =
-        aec_trees:put(K, V, TxsTree).
-
-root_hash(TxsTree) ->
-    aec_trees:root_hash(TxsTree).
+    {ok, _NewTxsTree} = put(K, V, TxsTree).

--- a/apps/aecore/test/aec_sha256_tests.erl
+++ b/apps/aecore/test/aec_sha256_tests.erl
@@ -20,10 +20,6 @@ all_test_() ->
      [{"Hash a binary",
        fun() ->
                ?assertEqual(?HASH_BYTES, size(?TEST_MODULE:hash(<<"hello there!">>)))
-       end},
-      {"Hash an erlang term",
-       fun() ->
-               ?assertEqual(?HASH_BYTES, size(?TEST_MODULE:hash({a, b, c})))
        end}
      ]
     }.

--- a/apps/aehttp/src/aehttp_dispatch_ext.erl
+++ b/apps/aehttp/src/aehttp_dispatch_ext.erl
@@ -117,13 +117,10 @@ handle_request('GetAccountBalance', Req, _Context) ->
         not_base64_encoded ->
             {400, [], #{reason => <<"Invalid address">>}};
         _ when is_binary(Pubkey) ->
-            LastBlock = aec_conductor:top(),
-            Trees = aec_blocks:trees(LastBlock),
-            AccountsTree = aec_trees:accounts(Trees),
-            case aec_accounts:get(Pubkey, AccountsTree) of
-                {ok, #account{balance = B}} ->
+            case aec_conductor:get_account_balance(Pubkey) of
+                {ok, B} ->
                     {200, [], #{balance => B}};
-                _ ->
+                {error, account_not_found} ->
                     {404, [], #{reason => <<"Account not found">>}}
             end
     end;

--- a/apps/aeutils/src/aeu_mtrees.erl
+++ b/apps/aeutils/src/aeu_mtrees.erl
@@ -1,0 +1,93 @@
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2017, Aeternity Anstalt
+%%% @doc In-memory Merkle trees.
+%%%
+%%% The root hash depends on the order of the operations performed on
+%%% the tree.
+%%%
+%%% This implementation is a wrapper for `gb_merkle_trees` with
+%%% stricter checks on arguments, less ambiguous return values and
+%%% enabling better type specifications.
+%%%
+%%% @see gb_merkle_trees
+%%% @end
+%%%-------------------------------------------------------------------
+-module(aeu_mtrees).
+
+%% API
+-export([new/0,
+         get/2,
+         get_with_proof/2,
+         put/3,
+         root_hash/1,
+         verify_proof/4,
+         to_orddict/1]).
+
+-export_type([mtree/0,
+              mtree/2,
+              root_hash/0]).
+
+-define(HASH_BYTES, 32).
+-define(IS_KEY(K), is_binary(K)).
+-define(IS_VALUE(V), is_binary(V)).
+
+-type key() :: binary().
+-type value() :: binary().
+-type mtree() :: mtree(key(), value()).
+
+%% Enable specification of types of key and value for enabling code
+%% using this module to document types for readability.
+%% Both key and value must be binaries.
+-type mtree(_K, _V) :: gb_merkle_trees:tree().
+
+-type root_hash() :: <<_:(?HASH_BYTES*8)>>.
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+-spec new() -> mtree().
+new() ->
+    {ok, gb_merkle_trees:empty()}.
+
+get(Key, Tree) when ?IS_KEY(Key) ->
+    case gb_merkle_trees:lookup(Key, Tree) of
+        none ->
+            {error, notfound};
+        Value when is_binary(Value) ->
+            {ok, Value}
+    end.
+
+get_with_proof(Key, Tree) when ?IS_KEY(Key) ->
+    case get(Key, Tree) of
+        {ok, Value} when ?IS_VALUE(Value) ->
+            Proof = gb_merkle_trees:merkle_proof(Key, Tree),
+            {ok, {Value, Proof}};
+        {error, notfound} = E ->
+            E
+    end.
+
+put(Key, Value, Tree) when ?IS_KEY(Key), ?IS_VALUE(Value) ->
+    NewTree = gb_merkle_trees:enter(Key, Value, Tree),
+    {ok, NewTree}.
+
+%% Return root hash of specified non-empty Merkle tree.
+-spec root_hash(mtree()) -> {ok, root_hash()} | {error, empty}.
+root_hash(Tree) ->
+    case gb_merkle_trees:root_hash(Tree) of
+        undefined ->
+            {error, empty};
+        Hash = <<_:?HASH_BYTES/unit:8>> ->
+            {ok, Hash}
+    end.
+
+verify_proof(Key, Value, RootHash, Proof) ->
+    gb_merkle_trees:verify_merkle_proof(Key, Value, RootHash, Proof).
+
+-spec to_orddict(mtree()) -> [{key(), value()}].
+to_orddict(Tree) ->
+    gb_merkle_trees:to_orddict(Tree).
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================

--- a/apps/aeutils/src/aeutils.app.src
+++ b/apps/aeutils/src/aeutils.app.src
@@ -9,7 +9,8 @@
     gproc,
     jobs,
     exometer_core,
-    yamerl
+    yamerl,
+    gb_merkle_trees
    ]},
   {env,[
         {'$setup_hooks',


### PR DESCRIPTION
For your very early review as this work may conflict with yours.
This splits Merkle tree ADT in separate module - please refer to commit message for details.
The actual split of state from block is not done yet.

Dialyzer fails at the moment because blocks.hrl initialized `#block.trees` as `#trees{}` that has an invalid accounts tree.