### PR TITLE
Pt 153696599 unwanted dependency

### DIFF
--- a/apps/aecore/include/trees.hrl
+++ b/apps/aecore/include/trees.hrl
@@ -1,5 +1,6 @@
 -record(trees, {
-          accounts :: aec_trees:tree()}).
+          accounts :: aec_trees:tree(),
+          oracles  :: aec_trees:tree() }).
 -type(trees() :: #trees{}).
 
 %% Placeholder to define state Merkle trees

--- a/apps/aecore/src/aec_peers.erl
+++ b/apps/aecore/src/aec_peers.erl
@@ -24,8 +24,6 @@
          get_random/0,
          get_random/1,
          get_random/2,
-         uri_from_ip_port/2,
-         uri_from_scheme_ip_port/3,
          uri/1,
          set_local_peer_uri/1,
          get_local_peer_uri/0,
@@ -190,17 +188,6 @@ get_random(all, Exclude) when is_list(Exclude) ->
     gen_server:call(?MODULE, {get_random, all, Exclude});
 get_random(N, Exclude) when is_integer(N), N >= 0, is_list(Exclude) ->
     gen_server:call(?MODULE, {get_random, N, Exclude}).
-
-%%------------------------------------------------------------------------------
-%% Get url from IP and port. IP format: xxx.xxx.xxx.xxx
-%%------------------------------------------------------------------------------
--spec uri_from_ip_port(IP :: string(), Port :: number()) -> uri().
-uri_from_ip_port(IP, Port) ->
-    uri_from_scheme_ip_port(http, IP, Port).
-
--spec uri_from_scheme_ip_port(Scheme :: atom(), IP :: string(), Port :: number()) -> uri().
-uri_from_scheme_ip_port(Scheme, IP, Port) ->
-    atom_to_list(Scheme) ++ "://" ++ IP ++ ":" ++ integer_to_list(Port) ++ "/".
 
 %%------------------------------------------------------------------------------
 %% Get uri of peer

--- a/apps/aecore/src/aec_sync.erl
+++ b/apps/aecore/src/aec_sync.erl
@@ -13,7 +13,8 @@
 -import(aeu_debug, [pp/1]).
 
 %% API
--export([connect_peer/1
+-export([connect_peer/1,
+         start_link/0
         ]).
 
 -export([subset_size/0,
@@ -24,7 +25,7 @@
          compare_ping_objects/2]).
 
 %% gen_server callbacks
--export([start_link/0, init/1, handle_call/3, handle_cast/2,
+-export([init/1, handle_call/3, handle_cast/2,
 	 handle_info/2,  terminate/2, code_change/3]).
 
 %% Callback for jobs producer queue

--- a/apps/aecore/src/aec_trees.erl
+++ b/apps/aecore/src/aec_trees.erl
@@ -8,7 +8,9 @@
 -export([all_trees_new/0,
          all_trees_hash/1,
          accounts/1,
+         oracles/1,
          set_accounts/2,
+         set_oracles/2,
          new_merkle_tree/0,
          get/2,
          get_with_proof/2,
@@ -22,7 +24,8 @@
 -spec all_trees_new() -> {ok, trees()}.
 all_trees_new() ->
     {ok, A} = new_merkle_tree(),
-    {ok, #trees{accounts = A}}.
+    Oracles = aeo_state_tree:new(),
+    {ok, #trees{accounts = A, oracles = Oracles}}.
 
 all_trees_hash(Trees) ->
     %% TODO Consider all state trees - not only accounts.
@@ -35,9 +38,17 @@ all_trees_hash(Trees) ->
 accounts(Trees) ->
     Trees#trees.accounts.
 
+-spec oracles(trees()) -> tree().
+oracles(Trees) ->
+    Trees#trees.oracles.
+
 -spec set_accounts(trees(), tree()) -> trees().
 set_accounts(Trees, Accounts) ->
     Trees#trees{accounts = Accounts}.
+
+-spec set_oracles(trees(), tree()) -> trees().
+set_oracles(Trees, Oracles) ->
+    Trees#trees{oracles = Oracles}.
 
 -spec new_merkle_tree() -> {ok, tree()}.
 new_merkle_tree() ->

--- a/apps/aecore/src/aecore.app.src
+++ b/apps/aecore/src/aecore.app.src
@@ -30,7 +30,8 @@
     msgpack,
     erlexec,
     aecuckoo,
-    aetx
+    aetx,
+    aeoracle
    ]},
   {env, [
          {exometer_predefined,

--- a/apps/aecore/test/aec_peers_tests.erl
+++ b/apps/aecore/test/aec_peers_tests.erl
@@ -44,10 +44,6 @@ all_test_() ->
                ?assertEqual(ok, aec_peers:remove("http://someone.somewhere:1337/v1")),
                ?assertEqual(1, length(aec_peers:all()))
        end},
-      {"Uri_from_ip_port",
-       fun() ->
-               ?assertEqual("http://123.123.123.123:1337/", aec_peers:uri_from_ip_port("123.123.123.123", 1337))
-       end},
       {"Remove all",
        fun do_remove_all/0},
       {"Add peer",

--- a/apps/aehttp/src/aehttp_app.erl
+++ b/apps/aehttp/src/aehttp_app.erl
@@ -40,7 +40,7 @@ local_peer_uri() ->
 
 local_internal_http_uri() ->
     Port = get_internal_port(),
-    aec_peers:uri_from_ip_port("127.0.0.1", Port).
+    "http://127.0.0.1:"  ++ integer_to_list(Port) ++ "/".
 
 %%--------------------------------------------------------------------
 stop(_State) ->
@@ -96,10 +96,13 @@ local_peer(Port) ->
                     erlang:error({cannot_parse, [{local_peer_address,
                                                   Addr}]});
                 nomatch ->
-                    aec_peers:uri_from_ip_port(Addr, Port)
+                    "http://" ++ Addr ++ ":" ++ integer_to_list(Port) ++ "/"
             end
     end.
 
+%%------------------------------------------------------------------------------
+%% Get url from IP and port. IP format: xxx.xxx.xxx.xxx
+%%------------------------------------------------------------------------------
 
 -spec get_local_peer_address() -> string().
 get_local_peer_address() ->

--- a/apps/aeoracle/include/oracle_txs.hrl
+++ b/apps/aeoracle/include/oracle_txs.hrl
@@ -1,0 +1,31 @@
+-include_lib("apps/aecore/include/common.hrl").
+
+-record(oracle_register_tx, {
+          account                                 :: pubkey(),
+          nonce                                   :: integer(),
+          query_spec    = "string()"              :: aeo_oracles:type_spec(),
+          response_spec = "boolean() | integer()" :: aeo_oracles:type_spec(),
+          query_fee                               :: integer(),
+          ttl                                     :: aeo_oracles:ttl(),
+          fee                                     :: integer()
+          }).
+
+-record(oracle_query_tx, {
+          sender       :: pubkey(),
+          nonce        :: integer(),
+          oracle       :: pubkey(),
+          query        :: string(),
+          query_fee    :: integer(),
+          query_ttl    :: aeo_oracles:ttl(),
+          response_ttl :: aeo_oracles:relative_ttl(),
+          fee          :: integer()
+          }).
+
+-record(oracle_response_tx, {
+          oracle         :: pubkey(),
+          nonce          :: integer(),
+          interaction_id :: aeo_interaction:oracle_tx_id(),
+          response       :: aeo_interaction:oracle_response(),
+          fee            :: integer()
+          }).
+

--- a/apps/aeoracle/src/aeo_interaction.erl
+++ b/apps/aeoracle/src/aeo_interaction.erl
@@ -1,0 +1,173 @@
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2017, Aeternity Anstalt
+%%% @doc
+%%% ADT for oracle interaction objects.
+%%% @end
+%%%-------------------------------------------------------------------
+
+-module(aeo_interaction).
+
+%% API
+-export([ deserialize/1
+        , expires/1
+        , fee/1
+        , id/1
+        , new/2
+        , oracle_address/1
+        , response/1
+        , response_ttl/1
+        , sender_address/1
+        , sender_nonce/1
+        , serialize/1
+        , set_expires/2
+        , set_fee/2
+        , set_oracle_address/2
+        , set_response/2
+        , set_response_ttl/2
+        , set_sender_address/2
+        , set_sender_nonce/2
+        ]).
+
+-include_lib("apps/aecore/include/common.hrl").
+
+%%%===================================================================
+%%% Types
+%%%===================================================================
+
+-type block_height()    :: integer().
+-type oracle_response() :: aeo_oracles:response().
+-type relative_ttl()    :: aeo_oracles:relative_ttl().
+
+-record(interaction, { sender_address :: pubkey()
+                     , sender_nonce   :: integer()
+                     , oracle_address :: pubkey()
+                     , response       :: oracle_response() | 'undefined'
+                     , expires        :: block_height()
+                     , response_ttl   :: relative_ttl()
+                     , fee            :: integer()
+                     }).
+
+-opaque interaction() :: #interaction{}.
+
+-export_type([ interaction/0
+             ]).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+-spec new(aeo_query_tx:query_tx(), height()) -> interaction().
+new(QTx, BlockHeight) ->
+    Expires = aeo_utils:ttl_expiry(BlockHeight, aeo_query_tx:query_ttl(QTx)),
+    I = #interaction{ sender_address = aeo_query_tx:sender(QTx)
+                    , sender_nonce   = aeo_query_tx:nonce(QTx)
+                    , oracle_address = aeo_query_tx:oracle(QTx)
+                    , response       = undefined
+                    , expires        = Expires
+                    , response_ttl   = aeo_query_tx:response_ttl(QTx)
+                    , fee            = aeo_query_tx:query_fee(QTx)
+                    },
+    assert_fields(I).
+
+-spec id(interaction()) -> binary().
+id(I) ->
+    Bin = <<(I#interaction.sender_address):32/binary,
+            (I#interaction.sender_nonce):256,
+            (I#interaction.oracle_address):32/binary>>,
+    aec_sha256:hash(Bin).
+
+-spec serialize(interaction()) -> binary().
+serialize(#interaction{} = I) ->
+    term_to_binary(I).
+
+-spec deserialize(binary()) -> interaction().
+deserialize(B) ->
+    try binary_to_term(B) of
+        #interaction{} = I -> I;
+        Other -> error({not_interaction, Other})
+    catch _:_ -> error(invalid_binary)
+    end.
+
+%%%===================================================================
+%%% Getters
+
+-spec sender_address(interaction()) -> pubkey().
+sender_address(I) -> I#interaction.sender_address.
+
+-spec sender_nonce(interaction()) -> integer().
+sender_nonce(I) -> I#interaction.sender_nonce.
+
+-spec oracle_address(interaction()) -> pubkey().
+oracle_address(I) -> I#interaction.oracle_address.
+
+-spec response(interaction()) -> oracle_response().
+response(I) -> I#interaction.response.
+
+-spec expires(interaction()) -> block_height().
+expires(I) -> I#interaction.expires.
+
+-spec response_ttl(interaction()) -> relative_ttl().
+response_ttl(I) -> I#interaction.response_ttl.
+
+-spec fee(interaction()) -> integer().
+fee(I) -> I#interaction.fee.
+
+%%%===================================================================
+%%% Setters
+
+-spec set_sender_address(pubkey(), interaction()) -> interaction().
+set_sender_address(X, I) ->
+    I#interaction{sender_address = assert_field(sender_address, X)}.
+
+-spec set_sender_nonce(integer(), interaction()) -> interaction().
+set_sender_nonce(X, I) ->
+    I#interaction{sender_nonce = assert_field(sender_nonce, X)}.
+
+-spec set_oracle_address(pubkey(), interaction()) -> interaction().
+set_oracle_address(X, I) ->
+    I#interaction{oracle_address = assert_field(oracle_address, X)}.
+
+-spec set_response(oracle_response(), interaction()) -> interaction().
+set_response(X, I) ->
+    I#interaction{response = assert_field(response, X)}.
+
+-spec set_expires(block_height(), interaction()) -> interaction().
+set_expires(X, I) ->
+    I#interaction{expires = assert_field(expires, X)}.
+
+-spec set_response_ttl(relative_ttl(), interaction()) -> interaction().
+set_response_ttl(X, I) ->
+    I#interaction{response_ttl = assert_field(response_ttl, X)}.
+
+-spec set_fee(integer(), interaction()) -> interaction().
+set_fee(X, I) ->
+    I#interaction{fee = assert_field(fee, X)}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+
+assert_fields(I) ->
+    List = [ {sender_address, I#interaction.sender_address}
+           , {sender_nonce  , I#interaction.sender_nonce}
+           , {oracle_address, I#interaction.oracle_address}
+           , {response      , I#interaction.response}
+           , {expires       , I#interaction.expires}
+           , {response_ttl  , I#interaction.response_ttl}
+           , {fee           , I#interaction.fee}
+           ],
+    List1 = [try assert_field(X, Y), [] catch _:X -> X end
+             || {X, Y} <- List],
+    case lists:flatten(List1) of
+        [] -> I;
+        Other -> error({missing, Other})
+    end.
+
+assert_field(sender_address, X) when is_binary(X), byte_size(X) =:= 32 -> X;
+assert_field(sender_nonce  , X) when is_integer(X), X >= 0 -> X;
+assert_field(oracle_address, X) when is_binary(X), byte_size(X) =:= 32 -> X;
+assert_field(response      , X) when is_list(X); 'undefined' -> X;
+assert_field(expires       , X) when is_integer(X), X >= 0 -> X;
+assert_field(response_ttl  , {delta, I} = X) when is_integer(I), I > 0 -> X;
+assert_field(fee           , X) when is_integer(X), X >= 0 -> X;
+assert_field(Field,          X) -> error({illegal, Field, X}).

--- a/apps/aeoracle/src/aeo_oracles.erl
+++ b/apps/aeoracle/src/aeo_oracles.erl
@@ -1,0 +1,157 @@
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2017, Aeternity Anstalt
+%%% @doc
+%%% ADT for oracle objects
+%%% @end
+%%%-------------------------------------------------------------------
+
+-module(aeo_oracles).
+
+-include_lib("apps/aecore/include/common.hrl").
+
+%% API
+-export([ deserialize/1
+        , expires/1
+        , id/1
+        , new/2
+        , owner/1
+        , query_fee/1
+        , query_format/1
+        , response_format/1
+        , serialize/1
+        , set_expires/2
+        , set_owner/2
+        , set_query_fee/2
+        , set_query_format/2
+        , set_response_format/2
+        ]).
+
+%%%===================================================================
+%%% Types
+%%%===================================================================
+
+-type amount()       :: integer().
+
+-type relative_ttl() :: {delta, integer()}.
+-type fixed_ttl()    :: {block, integer()}.
+-type ttl()          :: relative_ttl() | fixed_ttl().
+
+-type type_spec()    :: string().
+
+-type response() :: boolean() | integer().
+
+
+-record(oracle, { owner           :: pubkey() | 'undefined'
+                , query_format    :: type_spec() | 'undefined'
+                , response_format :: type_spec() | 'undefined'
+                , query_fee       :: amount() | 'undefined'
+                , expires         :: height() | 'undefined'
+                }).
+
+
+-opaque oracle() :: #oracle{}.
+
+-export_type([ fixed_ttl/0
+             , oracle/0
+             , response/0
+             , relative_ttl/0
+             , ttl/0
+             , type_spec/0
+             ]).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+-spec id(oracle()) -> pubkey().
+id(O) ->
+  owner(O).
+
+-spec new(aeo_register_tx:register_tx(), height()) -> oracle().
+new(RTx, BlockHeight) ->
+    Expires = aeo_utils:ttl_expiry(BlockHeight, aeo_register_tx:ttl(RTx)),
+    O = #oracle{ owner = aeo_register_tx:account(RTx)
+               , query_format = aeo_register_tx:query_spec(RTx)
+               , response_format = aeo_register_tx:response_spec(RTx)
+               , query_fee = aeo_register_tx:query_fee(RTx)
+               , expires = Expires
+               },
+    assert_fields(O).
+
+-spec serialize(oracle()) -> binary().
+serialize(#oracle{} = I) ->
+    term_to_binary(I).
+
+-spec deserialize(binary()) -> oracle().
+deserialize(B) ->
+    try binary_to_term(B) of
+        #oracle{} = I -> I;
+        Other -> error({not_interaction, Other})
+    catch _:_ -> error(invalid_binary)
+    end.
+
+%%%===================================================================
+%%% Getters
+
+-spec owner(oracle()) -> pubkey().
+owner(O) -> O#oracle.owner.
+
+-spec query_format(oracle()) -> type_spec().
+query_format(O) -> O#oracle.query_format.
+
+-spec response_format(oracle()) -> type_spec().
+response_format(O) -> O#oracle.response_format.
+
+-spec query_fee(oracle()) -> amount().
+query_fee(O) -> O#oracle.query_fee.
+
+-spec expires(oracle()) -> height().
+expires(O) -> O#oracle.expires.
+
+%%%===================================================================
+%%% Setters
+
+-spec set_owner(pubkey(), oracle()) -> oracle().
+set_owner(X, O) ->
+    O#oracle{owner = assert_field(owner, X)}.
+
+-spec set_query_format(type_spec(), oracle()) -> oracle().
+set_query_format(X, O) ->
+    O#oracle{query_format = assert_field(query_format, X)}.
+
+-spec set_response_format(type_spec(), oracle()) -> oracle().
+set_response_format(X, O) ->
+    O#oracle{response_format = assert_field(response_format, X)}.
+
+-spec set_query_fee(amount(), oracle()) -> oracle().
+set_query_fee(X, O) ->
+    O#oracle{query_fee = assert_field(query_fee, X)}.
+
+-spec set_expires(height(), oracle()) -> oracle().
+set_expires(X, O) ->
+    O#oracle{expires = assert_field(expires, X)}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+
+assert_fields(O) ->
+    List = [ {owner          , O#oracle.owner}
+           , {query_format   , O#oracle.query_format}
+           , {response_format, O#oracle.response_format}
+           , {query_fee      , O#oracle.query_fee}
+           , {expires        , O#oracle.expires}
+           ],
+    List1 = [try assert_field(X, Y), [] catch _:X -> X end
+             || {X, Y} <- List],
+    case lists:flatten(List1) of
+        [] -> O;
+        Other -> error({missing, Other})
+    end.
+
+assert_field(owner           , X) when is_binary(X), byte_size(X) =:= 32 -> X;
+assert_field(query_format    , X) when is_list(X) -> X;
+assert_field(response_format , X) when is_list(X) -> X;
+assert_field(query_fee       , X) when is_integer(X), X >= 0 -> X;
+assert_field(expires         , X) when is_integer(X), X >= 0 -> X;
+assert_field(Field           , X) -> error({illegal, Field, X}).

--- a/apps/aeoracle/src/aeo_query_tx.erl
+++ b/apps/aeoracle/src/aeo_query_tx.erl
@@ -1,0 +1,195 @@
+%%%=============================================================================
+%%% @copyright 2017, Aeternity Anstalt
+%%% @doc
+%%%    Module defining the Oracle register transaction
+%%% @end
+%%%=============================================================================
+-module(aeo_query_tx).
+
+-include("oracle_txs.hrl").
+-include_lib("apps/aecore/include/trees.hrl").
+
+-behavior(aetx).
+
+%% Behavior API
+-export([new/1,
+         fee/1,
+         nonce/1,
+         origin/1,
+         check/3,
+         process/3,
+         signers/1,
+         serialize/1,
+         deserialize/1,
+         type/0
+        ]).
+
+%% Additional getters
+-export([oracle/1,
+         query/1,
+         query_fee/1,
+         query_ttl/1,
+         response_ttl/1,
+         sender/1]).
+
+
+-define(ORACLE_QUERY_TX_TYPE, <<"oracle_query">>).
+-define(ORACLE_QUERY_TX_VSN, 1).
+-define(ORACLE_QUERY_TX_FEE, 2).
+
+-opaque query_tx() :: #oracle_query_tx{}.
+
+-export_type([query_tx/0]).
+
+-spec sender(query_tx()) -> pubkey().
+sender(#oracle_query_tx{sender = SenderPubKey}) ->
+    SenderPubKey.
+
+-spec oracle(query_tx()) -> pubkey().
+oracle(#oracle_query_tx{oracle = OraclePubKey}) ->
+    OraclePubKey.
+
+-spec query(query_tx()) -> string().
+query(#oracle_query_tx{query = Query}) ->
+    Query.
+
+-spec query_fee(query_tx()) -> integer().
+query_fee(#oracle_query_tx{query_fee = QueryFee}) ->
+    QueryFee.
+
+-spec query_ttl(query_tx()) -> aeo_oracles:ttl().
+query_ttl(#oracle_query_tx{query_ttl = QueryTTL}) ->
+    QueryTTL.
+
+-spec response_ttl(query_tx()) -> aeo_oracles:relative_ttl().
+response_ttl(#oracle_query_tx{response_ttl = ResponseTTL}) ->
+    ResponseTTL.
+
+-spec new(map()) -> {ok, query_tx()}.
+new(#{sender        := SenderPubKey,
+      nonce         := Nonce,
+      oracle        := Oracle,
+      query         := Query,
+      query_fee     := QueryFee,
+      query_ttl     := QueryTTL,
+      response_ttl  := ResponseTTL,
+      fee           := Fee}) ->
+    {ok, #oracle_query_tx{sender        = SenderPubKey,
+                          nonce         = Nonce,
+                          oracle        = Oracle,
+                          query         = Query,
+                          query_fee     = QueryFee,
+                          query_ttl     = QueryTTL,
+                          response_ttl  = ResponseTTL,
+                          fee           = Fee}}.
+
+-spec fee(query_tx()) -> integer().
+fee(#oracle_query_tx{fee = F}) ->
+    F.
+
+-spec nonce(query_tx()) -> non_neg_integer().
+nonce(#oracle_query_tx{nonce = Nonce}) ->
+    Nonce.
+
+-spec origin(query_tx()) -> pubkey().
+origin(#oracle_query_tx{sender = SenderPubKey}) ->
+    SenderPubKey.
+
+%% SenderAccount should exist, and have enough funds for the fee + the query_fee.
+%% Oracle should exist, and query_fee should be enough
+%% Fee should cover TTL
+%% TODO: Check the query? Check TTL relative to Oracle TTL?
+-spec check(query_tx(), trees(), height()) -> {ok, trees()} | {error, term()}.
+check(#oracle_query_tx{sender = SenderPubKey, nonce = Nonce,
+                       oracle = OraclePubKey, query_fee = QFee,
+                       query_ttl = TTL, fee = Fee}, Trees, Height) ->
+    Checks =
+        [fun() -> aetx_utils:check_account(SenderPubKey, Trees, Height, Nonce, Fee + QFee) end,
+         fun() -> aoe_utils:check_ttl_fee(Height, TTL, Fee - ?ORACLE_QUERY_TX_FEE) end,
+         fun() -> check_oracle(OraclePubKey, Trees, QFee) end],
+
+    case aeu_validation:run(Checks) of
+        ok              -> {ok, Trees};
+        {error, Reason} -> {error, Reason}
+    end.
+
+-spec signers(query_tx()) -> [pubkey()].
+signers(#oracle_query_tx{sender = SenderPubKey}) ->
+    [SenderPubKey].
+
+-spec process(query_tx(), trees(), height()) -> {ok, trees()}.
+process(#oracle_query_tx{sender = SenderPubKey, nonce = Nonce, fee = Fee,
+                         query_fee = QueryFee} = Query, Trees0, Height) ->
+    AccountsTree0 = aec_trees:accounts(Trees0),
+    OraclesTree0  = aec_trees:oracles(Trees0),
+
+    {ok, Sender0} = aec_accounts:get(SenderPubKey, AccountsTree0),
+    {ok, Sender1} = aec_accounts:spend(Sender0, QueryFee + Fee, Nonce, Height),
+    {ok, AccountsTree1} = aec_accounts:put(Sender1, AccountsTree0),
+
+    Interaction = aeo_interaction:new(Query, Height),
+    OraclesTree1 = aeo_state_tree:put_interaction(Interaction, OraclesTree0),
+
+    Trees1 = aec_trees:set_accounts(Trees0, AccountsTree1),
+    Trees2 = aec_trees:set_oracles(Trees1, OraclesTree1),
+
+    {ok, Trees2}.
+
+serialize(#oracle_query_tx{sender        = SenderPubKey,
+                           nonce         = Nonce,
+                           oracle        = OraclePubKey,
+                           query         = Query,
+                           query_fee     = QueryFee,
+                           query_ttl     = QueryTTL,
+                           response_ttl  = ResponseTTL,
+                           fee           = Fee}) ->
+    [#{<<"type">>         => type()},
+     #{<<"vsn">>          => version()},
+     #{<<"sender">>       => SenderPubKey},
+     #{<<"nonce">>        => Nonce},
+     #{<<"oracle">>       => OraclePubKey},
+     #{<<"query">>        => Query},
+     #{<<"query_fee">>    => QueryFee},
+     #{<<"query_ttl">>    => QueryTTL},
+     #{<<"response_ttl">> => ResponseTTL},
+     #{<<"fee">>          => Fee}].
+
+deserialize([#{<<"type">>         := ?ORACLE_QUERY_TX_TYPE},
+             #{<<"vsn">>          := ?ORACLE_QUERY_TX_VSN},
+             #{<<"sender">>       := SenderPubKey},
+             #{<<"nonce">>        := Nonce},
+             #{<<"oracle">>       := OraclePubKey},
+             #{<<"query">>        := Query},
+             #{<<"query_fee">>    := QueryFee},
+             #{<<"query_ttl">>    := QueryTTL},
+             #{<<"response_ttl">> := ResponseTTL},
+             #{<<"fee">>          := Fee}]) ->
+    #oracle_query_tx{sender        = SenderPubKey,
+                     nonce         = Nonce,
+                     oracle        = OraclePubKey,
+                     query         = Query,
+                     query_fee     = QueryFee,
+                     query_ttl     = QueryTTL,
+                     response_ttl  = ResponseTTL,
+                     fee           = Fee}.
+
+-spec type() -> binary().
+type() ->
+    ?ORACLE_QUERY_TX_TYPE.
+
+-spec version() -> non_neg_integer().
+version() ->
+    ?ORACLE_QUERY_TX_VSN.
+
+%% -- Local functions  -------------------------------------------------------
+
+check_oracle(OraclePubKey, Trees, QueryFee) ->
+    OraclesTree  = aec_trees:oracles(Trees),
+    case aeo_state_tree:find_oracle(OraclePubKey, OraclesTree) of
+        {ok, Oracle} ->
+            case QueryFee >= aeo_oracles:query_fee(Oracle) of
+                true  -> ok;
+                false -> {error, query_fee_too_low}
+            end;
+        {error, _E}  -> {error, oracle_does_not_exist}
+    end.

--- a/apps/aeoracle/src/aeo_register_tx.erl
+++ b/apps/aeoracle/src/aeo_register_tx.erl
@@ -1,0 +1,177 @@
+%%%=============================================================================
+%%% @copyright 2017, Aeternity Anstalt
+%%% @doc
+%%%    Module defining the Oracle register transaction
+%%% @end
+%%%=============================================================================
+-module(aeo_register_tx).
+
+-include("oracle_txs.hrl").
+-include_lib("apps/aecore/include/trees.hrl").
+
+-behavior(aetx).
+
+%% Behavior API
+-export([new/1,
+         fee/1,
+         nonce/1,
+         origin/1,
+         check/3,
+         process/3,
+         signers/1,
+         serialize/1,
+         deserialize/1,
+         type/0
+        ]).
+
+%% Additional getters
+-export([account/1,
+         query_spec/1,
+         query_fee/1,
+         response_spec/1,
+         ttl/1]).
+
+-define(ORACLE_REGISTER_TX_TYPE, <<"oracle_register">>).
+-define(ORACLE_REGISTER_TX_VSN, 1).
+-define(ORACLE_REGISTER_TX_FEE, 4).
+
+-opaque register_tx() :: #oracle_register_tx{}.
+
+-export_type([register_tx/0]).
+
+-spec account(register_tx()) -> pubkey().
+account(#oracle_register_tx{account = AccountPubKey}) ->
+    AccountPubKey.
+
+-spec query_spec(register_tx()) -> aeo_oracles:type_spec().
+query_spec(#oracle_register_tx{query_spec = QuerySpec}) ->
+    QuerySpec.
+
+-spec response_spec(register_tx()) -> aeo_oracles:type_spec().
+response_spec(#oracle_register_tx{response_spec = ResponseSpec}) ->
+    ResponseSpec.
+
+-spec query_fee(register_tx()) -> integer().
+query_fee(#oracle_register_tx{query_fee = QueryFee}) ->
+    QueryFee.
+
+-spec ttl(register_tx()) -> aeo_oracles:ttl().
+ttl(#oracle_register_tx{ttl = TTL}) ->
+    TTL.
+
+-spec fee(register_tx()) -> integer().
+fee(#oracle_register_tx{fee = Fee}) ->
+    Fee.
+
+-spec new(map()) -> {ok, register_tx()}.
+new(#{account       := AccountPubKey,
+      nonce         := Nonce,
+      query_spec    := QuerySpec,
+      response_spec := ResponseSpec,
+      query_fee     := QueryFee,
+      ttl           := TTL,
+      fee           := Fee}) ->
+    {ok, #oracle_register_tx{account       = AccountPubKey,
+                             nonce         = Nonce,
+                             query_spec    = QuerySpec,
+                             response_spec = ResponseSpec,
+                             query_fee     = QueryFee,
+                             ttl           = TTL,
+                             fee           = Fee}}.
+
+-spec nonce(register_tx()) -> non_neg_integer().
+nonce(#oracle_register_tx{nonce = Nonce}) ->
+    Nonce.
+
+-spec origin(register_tx()) -> pubkey().
+origin(#oracle_register_tx{account = AccountPubKey}) ->
+    AccountPubKey.
+
+%% Account should exist, and have enough funds for the fee + the query_fee.
+-spec check(register_tx(), trees(), height()) -> {ok, trees()} | {error, term()}.
+check(#oracle_register_tx{account = AccountPubKey, nonce = Nonce, query_fee = QFee,
+                          ttl = TTL, fee = Fee}, Trees, Height) ->
+    Checks =
+        [fun() -> aetx_utils:check_account(AccountPubKey, Trees, Height, Nonce, Fee + QFee) end,
+         fun() -> ensure_not_oracle(AccountPubKey, Trees) end,
+         fun() -> aeo_utils:check_ttl_fee(Height, TTL, Fee - ?ORACLE_REGISTER_TX_FEE) end],
+
+    case aeu_validation:run(Checks) of
+        ok              -> {ok, Trees};
+        {error, Reason} -> {error, Reason}
+    end.
+
+-spec signers(register_tx()) -> [pubkey()].
+signers(#oracle_register_tx{account = AccountPubKey}) ->
+    [AccountPubKey].
+
+-spec process(register_tx(), trees(), height()) -> {ok, trees()}.
+process(#oracle_register_tx{account       = AccountPubKey,
+                            nonce         = Nonce,
+                            query_fee     = QueryFee,
+                            fee           = Fee} = RegisterTx, Trees0, Height) ->
+    AccountsTree0 = aec_trees:accounts(Trees0),
+    OraclesTree0  = aec_trees:oracles(Trees0),
+
+    {ok, Account0} = aec_accounts:get(AccountPubKey, AccountsTree0),
+    {ok, Account1} = aec_accounts:spend(Account0, QueryFee + Fee, Nonce, Height),
+    {ok, AccountsTree1} = aec_accounts:put(Account1, AccountsTree0),
+
+    Oracle = aeo_oracles:new(RegisterTx, Height),
+    OraclesTree1 = aeo_state_tree:put_oracle(Oracle, OraclesTree0),
+
+    Trees1 = aec_trees:set_accounts(Trees0, AccountsTree1),
+    Trees2 = aec_trees:set_oracles(Trees1, OraclesTree1),
+
+    {ok, Trees2}.
+
+serialize(#oracle_register_tx{account       = AccountPubKey,
+                              nonce         = Nonce,
+                              query_spec    = QuerySpec,
+                              response_spec = ResponseSpec,
+                              query_fee     = QueryFee,
+                              ttl           = TTL,
+                              fee           = Fee}) ->
+    [#{<<"type">> => type()},
+     #{<<"vsn">> => version()},
+     #{<<"account">> => AccountPubKey},
+     #{<<"nonce">> => Nonce},
+     #{<<"query_spec">> => QuerySpec},
+     #{<<"response_spec">> => ResponseSpec},
+     #{<<"query_fee">> => QueryFee},
+     #{<<"ttl">> => TTL},
+     #{<<"fee">> => Fee}].
+
+deserialize([#{<<"type">>          := ?ORACLE_REGISTER_TX_TYPE},
+             #{<<"vsn">>           := ?ORACLE_REGISTER_TX_VSN},
+             #{<<"account">>       := AccountPubKey},
+             #{<<"nonce">>         := Nonce},
+             #{<<"query_spec">>    := QuerySpec},
+             #{<<"response_spec">> := ResponseSpec},
+             #{<<"query_fee">>     := QueryFee},
+             #{<<"ttl">>           := TTL},
+             #{<<"fee">>           := Fee}]) ->
+    #oracle_register_tx{account       = AccountPubKey,
+                        nonce         = Nonce,
+                        query_spec    = QuerySpec,
+                        response_spec = ResponseSpec,
+                        query_fee     = QueryFee,
+                        ttl           = TTL,
+                        fee           = Fee}.
+
+-spec type() -> binary().
+type() ->
+    ?ORACLE_REGISTER_TX_TYPE.
+
+-spec version() -> non_neg_integer().
+version() ->
+    ?ORACLE_REGISTER_TX_VSN.
+
+%% -- Local functions  -------------------------------------------------------
+
+ensure_not_oracle(PubKey, Trees) ->
+    OraclesTree  = aec_trees:oracles(Trees),
+    case aeo_state_tree:find_oracle(PubKey, OraclesTree) of
+        {ok, _Oracle} -> {error, account_is_already_an_oracle};
+        {error, _E}   -> ok
+    end.

--- a/apps/aeoracle/src/aeo_response_tx.erl
+++ b/apps/aeoracle/src/aeo_response_tx.erl
@@ -1,0 +1,167 @@
+%%%=============================================================================
+%%% @copyright 2017, Aeternity Anstalt
+%%% @doc
+%%%    Module defining the Oracle register transaction
+%%% @end
+%%%=============================================================================
+-module(aeo_response_tx).
+
+-include("oracle_txs.hrl").
+-include_lib("apps/aecore/include/trees.hrl").
+
+-behavior(aetx).
+
+%% Behavior API
+-export([new/1,
+         fee/1,
+         nonce/1,
+         origin/1,
+         check/3,
+         process/3,
+         signers/1,
+         serialize/1,
+         deserialize/1,
+         type/0
+        ]).
+
+%% Additional getters
+-export([oracle/1,
+         interaction_id/1,
+         response/1]).
+
+
+-define(ORACLE_RESPONSE_TX_TYPE, <<"oracle_query">>).
+-define(ORACLE_RESPONSE_TX_VSN, 1).
+-define(ORACLE_RESPONSE_TX_FEE, 2).
+
+-opaque response_tx() :: #oracle_response_tx{}.
+
+-export_type([response_tx/0]).
+
+-spec oracle(response_tx()) -> pubkey().
+oracle(#oracle_response_tx{oracle = OraclePubKey}) ->
+    OraclePubKey.
+
+-spec interaction_id(response_tx()) -> aeo_interaction:oracle_tx_id().
+interaction_id(#oracle_response_tx{interaction_id = IId}) ->
+    IId.
+
+-spec response(response_tx()) -> aeo_interaction:oracle_response().
+response(#oracle_response_tx{response = Response}) ->
+    Response.
+
+-spec new(map()) -> {ok, response_tx()}.
+new(#{oracle         := Oracle,
+      nonce          := Nonce,
+      interaction_id := IId,
+      response       := Response,
+      fee            := Fee}) ->
+    {ok, #oracle_response_tx{oracle         = Oracle,
+                             nonce          = Nonce,
+                             interaction_id = IId,
+                             response       = Response,
+                             fee            = Fee}}.
+
+-spec fee(response_tx()) -> integer().
+fee(#oracle_response_tx{fee = F}) ->
+    F.
+
+-spec nonce(response_tx()) -> non_neg_integer().
+nonce(#oracle_response_tx{nonce = Nonce}) ->
+    Nonce.
+
+-spec origin(response_tx()) -> pubkey().
+origin(#oracle_response_tx{oracle = OraclePubKey}) ->
+    OraclePubKey.
+
+%% Oracle should exist, and have enough funds for the fee.
+%% Interaction id should match oracle.
+-spec check(response_tx(), trees(), height()) -> {ok, trees()} | {error, term()}.
+check(#oracle_response_tx{oracle = OraclePubKey, nonce = Nonce,
+                          interaction_id = IId, fee = Fee}, Trees, Height) ->
+    case check_interaction_id(IId, Trees, OraclePubKey) of
+        {ok, ResponseTTL} ->
+            Checks =
+                [fun() -> aetx_utils:check_account(OraclePubKey, Trees,
+                                                   Height, Nonce, Fee) end,
+                 fun() -> aoe_utils:check_ttl_fee(Height, ResponseTTL,
+                                                  Fee - ?ORACLE_RESPONSE_TX_FEE) end],
+
+            case aeu_validation:run(Checks) of
+                ok              -> {ok, Trees};
+                {error, Reason} -> {error, Reason}
+            end;
+        Err = {error, _} -> Err
+    end.
+
+-spec signers(response_tx()) -> [pubkey()].
+signers(#oracle_response_tx{oracle = OraclePubKey}) ->
+    [OraclePubKey].
+
+-spec process(response_tx(), trees(), height()) -> {ok, trees()}.
+process(#oracle_response_tx{oracle = OraclePubKey, nonce = Nonce,
+                            interaction_id = IId, response = Response,
+                            fee = Fee}, Trees0, Height) ->
+    AccountsTree0 = aec_trees:accounts(Trees0),
+    OraclesTree0  = aec_trees:oracles(Trees0),
+
+    Interaction0 = aeo_state_tree:get_interaction(IId, OraclesTree0),
+    Interaction1 = aeo_interaction:set_response(Response, Interaction0),
+    OraclesTree1 = aeo_state_tree:put_interaction(Interaction1, OraclesTree0),
+
+    {ok, OracleAccount0} = aec_accounts:get(OraclePubKey, AccountsTree0),
+    {ok, OracleAccount1} = aec_accounts:spend(OracleAccount0, Fee, Nonce, Height),
+    QueryFee             = aeo_interaction:fee(Interaction0),
+    {ok, OracleAccount2} = aec_accounts:earn(OracleAccount1, QueryFee, Nonce),
+    {ok, AccountsTree1}  = aec_accounts:put(OracleAccount2, AccountsTree0),
+
+    Trees1 = aec_trees:set_accounts(Trees0, AccountsTree1),
+    Trees2 = aec_trees:set_oracles(Trees1, OraclesTree1),
+
+    {ok, Trees2}.
+
+serialize(#oracle_response_tx{oracle         = OraclePubKey,
+                              nonce          = Nonce,
+                              interaction_id = IId,
+                              response       = Response,
+                              fee            = Fee}) ->
+    [#{<<"type">>           => type()},
+     #{<<"vsn">>            => version()},
+     #{<<"oracle">>         => OraclePubKey},
+     #{<<"nonce">>          => Nonce},
+     #{<<"interaction_id">> => IId},
+     #{<<"response">>       => Response},
+     #{<<"fee">>            => Fee}].
+
+deserialize([#{<<"type">>           := ?ORACLE_RESPONSE_TX_TYPE},
+             #{<<"vsn">>            := ?ORACLE_RESPONSE_TX_VSN},
+             #{<<"oracle">>         := OraclePubKey},
+             #{<<"nonce">>          := Nonce},
+             #{<<"interaction_id">> := IId},
+             #{<<"response">>       := Response},
+             #{<<"fee">>            := Fee}]) ->
+    #oracle_response_tx{oracle         = OraclePubKey,
+                        nonce          = Nonce,
+                        interaction_id = IId,
+                        response       = Response,
+                        fee            = Fee}.
+
+-spec type() -> binary().
+type() ->
+    ?ORACLE_RESPONSE_TX_TYPE.
+
+-spec version() -> non_neg_integer().
+version() ->
+    ?ORACLE_RESPONSE_TX_VSN.
+
+%% -- Local functions  -------------------------------------------------------
+check_interaction_id(IId, Trees, OraclePubKey) ->
+    OraclesTree  = aec_trees:oracles(Trees),
+    case aeo_state_tree:find_interaction(IId, OraclesTree) of
+        {ok, Interaction} ->
+            case OraclePubKey == aeo_interaction:oracle_address(Interaction) of
+                true  -> {ok, aeo_interaction:response_ttl(Interaction)};
+                false -> {error, oracle_does_not_match_interaction_id}
+            end;
+        {error, _E}  -> {error, oracle_interaction_id_does_not_exist}
+    end.

--- a/apps/aeoracle/src/aeo_state_tree.erl
+++ b/apps/aeoracle/src/aeo_state_tree.erl
@@ -1,0 +1,83 @@
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2017, Aeternity Anstalt
+%%% @doc
+%%% ADT for keeping the state of oracles
+%%% @end
+%%%-------------------------------------------------------------------
+
+-module(aeo_state_tree).
+
+%% API
+-export([ get_interaction/2
+        , get_oracle/2
+        , find_interaction/2
+        , find_oracle/2
+        , new/0
+        , put_interaction/2
+        , put_oracle/2
+        ]).
+
+%%%===================================================================
+%%% Types
+%%%===================================================================
+
+-type tree() :: gb_merkle_trees:tree().
+-type interaction() :: aeo_interaction:interaction().
+-type oracle() :: aeo_oracles:oracle().
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+-spec new() -> tree().
+new() ->
+    {ok, Tree} = aec_trees:new_merkle_tree(),
+    Tree.
+
+-spec put_interaction(interaction(), tree()) -> tree().
+put_interaction(I, Tree) ->
+    Id = aeo_interaction:id(I),
+    Serialized = aeo_interaction:serialize(I),
+    {ok, Tree1} = aec_trees:put(Id, Serialized, Tree),
+    Tree1.
+
+-spec get_interaction(binary(), tree()) -> interaction().
+get_interaction(Id, Tree) ->
+    case aec_trees:get(Id, Tree) of
+        {ok, Val}  -> aeo_interaction:deserialize(Val); %% Will fail with exception if invalid
+        {error, E} -> error(E)
+    end.
+
+-spec find_interaction(binary(), tree()) -> {'ok', interaction()} | {'error', term()}.
+find_interaction(Id, Tree) ->
+    case aec_trees:get(Id, Tree) of
+        {ok, Val}  ->
+            try {ok, aeo_interaction:deserialize(Val)}
+            catch error:What -> {error, What}
+            end;
+        {error, _} = E -> E
+    end.
+
+-spec put_oracle(oracle(), tree()) -> tree().
+put_oracle(O, Tree) ->
+    Id = aeo_oracles:id(O),
+    Serialized = aeo_oracles:serialize(O),
+    {ok, Tree1} = aec_trees:put(Id, Serialized, Tree),
+    Tree1.
+
+-spec get_oracle(binary(), tree()) -> oracle().
+get_oracle(Id, Tree) ->
+    case aec_trees:get(Id, Tree) of
+        {ok, Val}  -> aeo_oracles:deserialize(Val); %% Will fail with exception if invalid
+        {error, E} -> error(E)
+    end.
+
+-spec find_oracle(binary(), tree()) -> {'ok', oracle()} | {'error', term()}.
+find_oracle(Id, Tree) ->
+    case aec_trees:get(Id, Tree) of
+        {ok, Val}  ->
+            try {ok, aeo_oracles:deserialize(Val)}
+            catch error:What -> {error, What}
+            end;
+        {error, _} = E -> E
+    end.

--- a/apps/aeoracle/src/aeo_utils.erl
+++ b/apps/aeoracle/src/aeo_utils.erl
@@ -1,0 +1,48 @@
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2017, Aeternity Anstalt
+%%% @doc
+%%% Utility functions for AE Oracles
+%%% @end
+%%%-------------------------------------------------------------------
+
+-module(aeo_utils).
+
+-include_lib("apps/aecore/include/common.hrl").
+
+-export([check_ttl_fee/3,
+         ttl_delta/2,
+         ttl_expiry/2,
+         ttl_fee/2]).
+
+-define(ORACLE_TTL_FEE, 0.001).
+
+%% TODO: This should also include size of the thing that has a TTL
+-spec check_ttl_fee(height(), aeo_oracles:ttl(), non_neg_integer()) ->
+                        ok | {error, too_low_fee} | {error, too_low_height}.
+check_ttl_fee(Height, TTL, Fee) ->
+    try
+        NBlocks = ttl_delta(Height, TTL),
+        case ttl_fee(0, NBlocks) =< Fee of
+            true  -> ok;
+            false -> {error, too_low_fee}
+        end
+    catch error:{too_low_height, _, _} ->
+        {error, too_low_height}
+    end.
+
+-spec ttl_delta(height(), aeo_oracles:ttl()) -> non_neg_integer().
+ttl_delta(CurrHeight, TTL) ->
+    case TTL of
+        {delta, D} -> D;
+        {block, H} when H > CurrHeight -> H - CurrHeight;
+        {block, H} -> error({too_low_height, H, CurrHeight})
+    end.
+
+-spec ttl_expiry(height(), aeo_oracles:ttl()) -> height().
+ttl_expiry(CurrentHeight, TTL) ->
+    CurrentHeight + ttl_delta(CurrentHeight, TTL).
+
+-spec ttl_fee(non_neg_integer(), non_neg_integer()) -> non_neg_integer().
+ttl_fee(_Size, NBlocks) ->
+    ceil(NBlocks * ?ORACLE_TTL_FEE).
+

--- a/apps/aeoracle/src/aeoracle.app.src
+++ b/apps/aeoracle/src/aeoracle.app.src
@@ -1,0 +1,16 @@
+{application, aeoracle,
+ [{description, "AE Oracle"},
+  {vsn, "0.1.0"},
+  {registered, []},
+  {applications,
+   [kernel,
+    stdlib,
+    lager,
+    crypto
+   ]},
+  {env,[]},
+  {modules, []},
+  {maintainers, []},
+  {licenses, []},
+  {links, []}
+ ]}.

--- a/apps/aeoracle/test/aeoracle_SUITE.erl
+++ b/apps/aeoracle/test/aeoracle_SUITE.erl
@@ -1,0 +1,23 @@
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2017, Aeternity Anstalt
+%%% @doc CT test suite for AE Oracles
+%%% @end
+%%%-------------------------------------------------------------------
+-module(aeoracle_SUITE).
+
+%% common_test exports
+-export([all/0]).
+
+%% test case exports
+-export([aeoracle_exist/1]).
+
+-include_lib("common_test/include/ct.hrl").
+
+all() ->
+    [aeoracle_exist].
+
+aeoracle_exist(_) ->
+    case application:load(aeoracle) of
+        ok -> ok;
+        {error, {already_loaded, _}} -> ok
+    end.

--- a/apps/aetx/src/aetx_utils.erl
+++ b/apps/aetx/src/aetx_utils.erl
@@ -1,0 +1,67 @@
+%%%=============================================================================
+%%% @copyright 2017, Aeternity Anstalt
+%%% @doc
+%%%    Common utility functions for AE transactions
+%%% @end
+%%%=============================================================================
+-module(aetx_utils).
+
+-include_lib("apps/aecore/include/common.hrl").
+-include_lib("apps/aecore/include/trees.hrl").
+
+-export([check_account/5]).
+
+%% Checks that an account (PubKey) exist at this height, has enough funds,
+%% and that the Nonce is ok.
+-spec check_account(Account :: pubkey(),
+                    Trees   :: trees(),
+                    Height  :: height(),
+                    Nonce   :: non_neg_integer(),
+                    Amount  :: non_neg_integer()) -> ok | {error, term()}.
+check_account(AccountPubKey, Trees, Height, Nonce, Amount) ->
+    AccountsTrees = aec_trees:accounts(Trees),
+    case aec_accounts:get(AccountPubKey, AccountsTrees) of
+        {ok, #account{} = Account} ->
+            BalanceOk = check_balance(Account, Amount),
+            HeightOk  = check_height(Account, Height),
+            NonceOk   = check_nonce(Account, Nonce),
+            checks_ok([BalanceOk, HeightOk, NonceOk]);
+        {error, notfound} ->
+            {error, account_not_found}
+    end.
+
+
+-spec check_balance(account(), non_neg_integer()) ->
+                           ok | {error, insufficient_funds}.
+check_balance(#account{balance = Balance}, Amount) ->
+    case Balance >= Amount of
+        true ->
+            ok;
+        false ->
+            {error, insufficient_funds}
+    end.
+
+-spec check_nonce(account(), non_neg_integer()) ->
+                         ok | {error, account_nonce_too_high}.
+check_nonce(#account{nonce = ANonce}, Nonce) ->
+    case Nonce > ANonce of
+        true ->
+            ok;
+        false ->
+            {error, account_nonce_too_high}
+    end.
+
+-spec check_height(account(), height()) ->
+                          ok | {error, account_height_too_big}.
+check_height(#account{height = AHeight}, Height) ->
+    case AHeight =< Height of
+        true ->
+            ok;
+        false ->
+            {error, sender_account_height_too_big}
+    end.
+
+-spec checks_ok(list(ok | {error, term()})) -> ok | {error, term()}.
+checks_ok([])        -> ok;
+checks_ok([ok | Xs]) -> checks_ok(Xs);
+checks_ok([Err | _]) -> Err.

--- a/apps/aeutils/src/aeu_validation.erl
+++ b/apps/aeutils/src/aeu_validation.erl
@@ -1,6 +1,9 @@
 -module(aeu_validation).
 
--export([run/2]).
+-export([run/1, run/2]).
+
+run(Checks) ->
+    run(Checks, []).
 
 run([], _Args) ->
     ok;


### PR DESCRIPTION
aehttp and aec_peers are interdependent. This is a first patch to make them less so.

The API function from aec_peers that is removed, was not used anywhere else than in aehttp.