### PR TITLE
Remove unwanted dependencies

### DIFF
--- a/apps/aecore/src/aec_peers.erl
+++ b/apps/aecore/src/aec_peers.erl
@@ -24,8 +24,6 @@
          get_random/0,
          get_random/1,
          get_random/2,
-         uri_from_ip_port/2,
-         uri_from_scheme_ip_port/3,
          uri/1,
          set_local_peer_uri/1,
          get_local_peer_uri/0,
@@ -190,17 +188,6 @@ get_random(all, Exclude) when is_list(Exclude) ->
     gen_server:call(?MODULE, {get_random, all, Exclude});
 get_random(N, Exclude) when is_integer(N), N >= 0, is_list(Exclude) ->
     gen_server:call(?MODULE, {get_random, N, Exclude}).
-
-%%------------------------------------------------------------------------------
-%% Get url from IP and port. IP format: xxx.xxx.xxx.xxx
-%%------------------------------------------------------------------------------
--spec uri_from_ip_port(IP :: string(), Port :: number()) -> uri().
-uri_from_ip_port(IP, Port) ->
-    uri_from_scheme_ip_port(http, IP, Port).
-
--spec uri_from_scheme_ip_port(Scheme :: atom(), IP :: string(), Port :: number()) -> uri().
-uri_from_scheme_ip_port(Scheme, IP, Port) ->
-    atom_to_list(Scheme) ++ "://" ++ IP ++ ":" ++ integer_to_list(Port) ++ "/".
 
 %%------------------------------------------------------------------------------
 %% Get uri of peer

--- a/apps/aecore/src/aec_sync.erl
+++ b/apps/aecore/src/aec_sync.erl
@@ -13,7 +13,8 @@
 -import(aeu_debug, [pp/1]).
 
 %% API
--export([connect_peer/1
+-export([connect_peer/1,
+         start_link/0
         ]).
 
 -export([subset_size/0,
@@ -24,7 +25,7 @@
          compare_ping_objects/2]).
 
 %% gen_server callbacks
--export([start_link/0, init/1, handle_call/3, handle_cast/2,
+-export([init/1, handle_call/3, handle_cast/2,
 	 handle_info/2,  terminate/2, code_change/3]).
 
 %% Callback for jobs producer queue

--- a/apps/aecore/test/aec_peers_tests.erl
+++ b/apps/aecore/test/aec_peers_tests.erl
@@ -44,10 +44,6 @@ all_test_() ->
                ?assertEqual(ok, aec_peers:remove("http://someone.somewhere:1337/v1")),
                ?assertEqual(1, length(aec_peers:all()))
        end},
-      {"Uri_from_ip_port",
-       fun() ->
-               ?assertEqual("http://123.123.123.123:1337/", aec_peers:uri_from_ip_port("123.123.123.123", 1337))
-       end},
       {"Remove all",
        fun do_remove_all/0},
       {"Add peer",

--- a/apps/aehttp/src/aehttp_app.erl
+++ b/apps/aehttp/src/aehttp_app.erl
@@ -40,7 +40,7 @@ local_peer_uri() ->
 
 local_internal_http_uri() ->
     Port = get_internal_port(),
-    aec_peers:uri_from_ip_port("127.0.0.1", Port).
+    "http://127.0.0.1:"  ++ integer_to_list(Port) ++ "/".
 
 %%--------------------------------------------------------------------
 stop(_State) ->
@@ -96,10 +96,9 @@ local_peer(Port) ->
                     erlang:error({cannot_parse, [{local_peer_address,
                                                   Addr}]});
                 nomatch ->
-                    aec_peers:uri_from_ip_port(Addr, Port)
+                    "http://" ++ Addr ++ ":" ++ integer_to_list(Port) ++ "/"
             end
     end.
-
 
 -spec get_local_peer_address() -> string().
 get_local_peer_address() ->


### PR DESCRIPTION
The module aec_peers calls aehttp, which calls back to aec_peers again.
This is a first small commit to unraffle the dependencies between these modules aec_sync, aec_peers and aehttp application.

[finishes PT-153696599]