### PR TITLE
Refactor aec_peers to get local peer from aeu_env.

### DIFF
--- a/apps/aecore/src/aec_peers.erl
+++ b/apps/aecore/src/aec_peers.erl
@@ -274,7 +274,8 @@ start_link() ->
     gen_server:start_link({local, ?MODULE} ,?MODULE, ok, []).
 
 init(ok) ->
-    PeerUri = aehttp_app:local_peer_uri(),
+    LocalPeer = aeu_env:local_peer(),
+    PeerUri = aeu_requests:pp_uri(LocalPeer),  %% TODO: keep datatype, not string
     do_set_local_peer_uri(
       PeerUri,
       #state{peers=gb_trees:empty(),

--- a/apps/aecore/src/aec_sync.erl
+++ b/apps/aecore/src/aec_sync.erl
@@ -7,8 +7,6 @@
 -module(aec_sync).
 
 -behaviour(gen_server).
--compile({parse_transform, lager_transform}).
--include("peers.hrl").
 
 -import(aeu_debug, [pp/1]).
 

--- a/apps/aecore/test/aec_peers_tests.erl
+++ b/apps/aecore/test/aec_peers_tests.erl
@@ -23,7 +23,7 @@ all_test_() ->
        fun() ->
                {Status, Peer} = aec_peers:get_random(),
                ?assertEqual(ok, Status),
-               ?assertEqual("http://someone.somewhere:1337/v1/", Peer#peer.uri)
+               ?assertEqual("http://someone.somewhere:1337/v1/", aec_peers:uri(Peer))
        end},
       {"Add a peer by object",
        fun() ->

--- a/apps/aecore/test/aecore_sync_SUITE.erl
+++ b/apps/aecore/test/aecore_sync_SUITE.erl
@@ -872,7 +872,10 @@ get_pool(N) ->
 new_tx(#{node1 := N1, node2 := N2, amount := Am, fee := Fee} = M) ->
     PK1 = maps_get(pk1, M, fun() -> ok(get_pubkey(N1)) end),
     PK2 = maps_get(pk2, M, fun() -> ok(get_pubkey(N2)) end),
-    Uri = rpc_call(N1, aehttp_app, local_internal_http_uri, []),
+    Port = rpc_call(N1, aeu_env, user_config_or_env, 
+                    [ [<<"http">>, <<"internal">>, <<"port">>], 
+                      aehttp, [internal, swagger_port], 8143]),
+    Uri = aeu_requests:pp_uri({http, "127.0.0.1", Port}),
     {ok, ok} = aeu_requests:new_spend_tx(
                  Uri, #{sender_pubkey => PK1,
                         recipient_pubkey => PK2,

--- a/apps/aehttp/src/aehttp_app.erl
+++ b/apps/aehttp/src/aehttp_app.erl
@@ -16,9 +16,6 @@
 %% Application callbacks
 -export([start/2, stop/1]).
 
--export([local_peer_uri/0,
-         local_internal_http_uri/0]).
-
 %%====================================================================
 %% API
 %%====================================================================
@@ -34,13 +31,6 @@ start(_StartType, _StartArgs) ->
     gproc:reg({n,l,{epoch, app, aehttp}}),
     {ok, Pid}.
 
-local_peer_uri() ->
-    Port = get_external_port(),
-    local_peer(Port).
-
-local_internal_http_uri() ->
-    Port = get_internal_port(),
-    "http://127.0.0.1:"  ++ integer_to_list(Port) ++ "/".
 
 %%--------------------------------------------------------------------
 stop(_State) ->
@@ -85,75 +75,20 @@ start_websocket_internal() ->
                                  [{env, [{dispatch, Dispatch}]}]),
     ok.
 
-local_peer(Port) ->
-    Addr = get_local_peer_address(),
-    case aeu_requests:parse_uri(Addr) of
-        {_Scheme, _Host, _Port} -> % a valid address
-            Addr;
-        error ->
-            case re:run(Addr, "[:/]", []) of
-                {match, _} ->
-                    erlang:error({cannot_parse, [{local_peer_address,
-                                                  Addr}]});
-                nomatch ->
-                    "http://" ++ Addr ++ ":" ++ integer_to_list(Port) ++ "/"
-            end
-    end.
-
--spec get_local_peer_address() -> string().
-get_local_peer_address() ->
-    H =
-        case aeu_env:user_config(
-              [<<"http">>, <<"external">>, <<"peer_address">>]) of
-            {ok, A} ->
-                binary_to_list(A);
-            undefined ->
-                case aeu_env:get_env(aehttp, local_peer_address) of
-                    {ok, Addr} ->
-                        Addr;
-                    undefined ->
-                        {ok, Host} = inet:gethostname(),
-                        Host
-                end
-        end,
-    case io_lib:deep_latin1_char_list(H) of
-        true ->
-            H;
-        false ->
-            erlang:error(unsupported_external_peer_address)
-    end.
-
 get_external_port() ->
-    case aeu_env:user_config([<<"http">>, <<"external">>, <<"port">>]) of
-        {ok, P} -> P;
-        undefined ->
-            aeu_env:get_env(
-              aehttp, swagger_port_external, ?DEFAULT_SWAGGER_EXTERNAL_PORT)
-    end.
+    aeu_env:user_config_or_env([<<"http">>, <<"external">>, <<"port">>],
+                               aehttp, swagger_port_external, ?DEFAULT_SWAGGER_EXTERNAL_PORT).
 
 get_internal_port() ->
-    case aeu_env:user_config([<<"http">>, <<"internal">>, <<"port">>]) of
-        {ok, P} -> P;
-        undefined ->
-            aeu_env:get_env(
-              aehttp, [internal, swagger_port], ?DEFAULT_SWAGGER_INTERNAL_PORT)
-    end.
+    aeu_env:user_config_or_env([<<"http">>, <<"internal">>, <<"port">>],
+                               aehttp, [internal, swagger_port], ?DEFAULT_SWAGGER_INTERNAL_PORT).
 
 get_internal_websockets_port() ->
-    case aeu_env:user_config([<<"websocket">>, <<"internal">>, <<"port">>]) of
-        {ok, P} -> P;
-        undefined ->
-            aeu_env:get_env(
-              aehttp, [internal, websocket, port],
-              ?DEFAULT_WEBSOCKET_INTERNAL_PORT)
-    end.
+    aeu_env:user_config_or_env([<<"websocket">>, <<"internal">>, <<"port">>],
+                               aehttp, [internal, websocket, port],?DEFAULT_WEBSOCKET_INTERNAL_PORT).
 
 get_internal_websockets_acceptors() ->
-    case aeu_env:user_config(
-           [<<"websocket">>, <<"internal">>, <<"acceptors">>]) of
-        {ok, Sz} -> Sz;
-        undefined ->
-            aeu_env:get_env(
-              aehttp,
-              [internal, websocket, handlers], ?INT_ACCEPTORS_POOLSIZE)
-    end.
+    aeu_env:user_config_or_env([<<"websocket">>, <<"internal">>, <<"acceptors">>],
+                               aehttp, [internal, websocket, handlers], ?INT_ACCEPTORS_POOLSIZE).
+
+

--- a/apps/aeutils/src/aeu_env.erl
+++ b/apps/aeutils/src/aeu_env.erl
@@ -394,3 +394,33 @@ schema() ->
 load_schema(F) ->
     [Schema] = jsx:consult(F, [return_maps]),
     Schema.
+
+%%% getting local peer from environment
+
+-define(DEFAULT_SWAGGER_EXTERNAL_PORT, 8043).
+
+-spec local_peer() -> {http_uri:scheme(), http_uri:host(), http_uri:port()}.
+local_peer() ->
+    ExternalPort = 
+        user_config_or_env([<<"http">>, <<"external">>, <<"port">>],
+                                   aehttp, swagger_port_external, ?DEFAULT_SWAGGER_EXTERNAL_PORT),
+    ExternalAddr = 
+        user_config_or_env([<<"http">>, <<"external">>, <<"peer_address">>], 
+                           aehttp, local_peer_address, undefined),
+    case ExternalAddr of
+        undefined ->
+            {ok, Host} = inet:gethostname(),
+            {http, Host, ExternalPort};
+        Uri ->
+          case http_uri:parse(Uri) of
+              {ok, {Scheme, _UserInfo, Host, Port, _Path, _Query, _Fragment}} ->
+                  {Scheme, Host, Port};
+              {ok, {Scheme, _UserInfo, Host, Port, _Path, _Query}} ->
+                  {Scheme, Host, Port};
+              {error, _Reason} ->
+                  lager:debug("cannot parse Uri (~p): ~p", [Uri, _Reason]),
+                  erlang:error({cannot_parse, [{local_peer_address, Uri}]})
+          end
+    end.
+    
+

--- a/apps/aeutils/src/aeu_requests.erl
+++ b/apps/aeutils/src/aeu_requests.erl
@@ -7,7 +7,8 @@
          transactions/1,
          send_tx/2,
          send_block/2,
-         new_spend_tx/2
+         new_spend_tx/2,
+         pp_uri/1
         ]).
 
 -export([parse_uri/1]).
@@ -141,7 +142,7 @@ new_spend_tx(IntPeer, #{recipient_pubkey := Kr,
             Error
     end.
 
--spec parse_uri(http_uri:uri()) -> {string(), string(), integer()} | error.
+-spec parse_uri(http_uri:uri()) -> {http_uri:scheme(), http_uri:host(), http_uri:port()} | error.
 parse_uri(Uri) ->
     case http_uri:parse(Uri) of
         {ok, {Scheme, _UserInfo, Host, Port, _Path, _Query, _Fragment}} ->
@@ -239,3 +240,11 @@ check_returned_source(#{<<"source">> := Source}, Peer) ->
        true ->
             ok
     end.
+
+
+-spec pp_uri({http_uri:schema(), http_uri:host(), http_uri:port()}) -> string().  %% TODO: | unicode:unicode_binary().
+pp_uri({Schema, Host, Port}) when is_binary(Host) ->
+  pp_uri({Schema, binary_to_list(Host), Port});
+pp_uri({Schema, Host, Port}) ->
+    atom_to_list(Schema) ++ "://" ++ Host ++ ":" ++ integer_to_list(Port) ++ "/".
+


### PR DESCRIPTION
[Finishes PT-153729865]

The application aehttp was called from aec_peers, which seems not right. Instead, the aec_peers module now gets the local host from the environment handling (user config, application environment, etc). It's not super clean, since we refer to swagger constants and aehttp application environment in aeu_env, but I believe that we can get rid of that by making aecore own this information in a later stage.