### PR TITLE
Optimize PostBlock of block with height 0 [Finishes #153180259]

### DIFF
--- a/apps/aecore/src/aec_block_genesis.erl
+++ b/apps/aecore/src/aec_block_genesis.erl
@@ -28,7 +28,14 @@
           genesis_block_with_state/0,
           populated_trees/0 ]).
 
+-export([prev_hash/0,
+         pow/0,
+         txs_hash/0,
+         transactions/0]).
+
+-ifdef(TEST).
 -export([genesis_block_with_state/1]).
+-endif.
 
 -include("common.hrl").
 -include("blocks.hrl").
@@ -37,6 +44,18 @@
 genesis_header() ->
     {B, _S} = genesis_block_with_state(),
     aec_blocks:to_header(B).
+
+prev_hash() ->
+    <<0:?BLOCK_HEADER_HASH_BYTES/unit:8>>.
+
+txs_hash() ->
+    <<0:?TXS_HASH_BYTES/unit:8>>.
+
+pow() ->
+    no_value.
+
+transactions() ->
+    [].
 
 %% Returns the genesis block and the state trees.
 %%
@@ -54,11 +73,12 @@ genesis_block_with_state(Map) ->
         #block{
            version = ?GENESIS_VERSION,
            height = ?GENESIS_HEIGHT,
-           prev_hash = <<0:?BLOCK_HEADER_HASH_BYTES/unit:8>>,
-           txs_hash = <<0:?TXS_HASH_BYTES/unit:8>>,
+           prev_hash = prev_hash(),
+           txs_hash = txs_hash(),
            root_hash = aec_trees:hash(Trees),
            target = ?HIGHEST_TARGET_SCI,
-           pow_evidence = no_value,
+           txs = transactions(),
+           pow_evidence = pow(),
            nonce = 0,
            time = 0 %% Epoch.
           },

--- a/apps/aehttp/src/aehttp_dispatch_ext.erl
+++ b/apps/aehttp/src/aehttp_dispatch_ext.erl
@@ -189,17 +189,11 @@ empty_fields_in_genesis() ->
 % if this changes - both functions should be changes:
 % empty_fields_in_genesis/0 and values_for_empty_fields_in_genesis/0
 values_for_empty_fields_in_genesis() ->
-    % this is a fake genesis block - there are no preset accounts
-    % since they only impact state_hash we're not getting it from the fake
-    % genesis block - this is OK 
-    {FakeGB, _} = aec_block_genesis:genesis_block_with_state(
-                    #{preset_accounts => []}),
-    % assert the assumptions
-    false = lists:member(<<"state_hash">>, empty_fields_in_genesis()),
     true = lists:member(<<"transactions">>, empty_fields_in_genesis()),
-    GBMap = aec_blocks:serialize_to_map(FakeGB),
-    maps:filter(fun(K, _) -> lists:member(K, empty_fields_in_genesis()) end,
-                GBMap).
+    #{<<"prev_hash">> => base64:encode(aec_block_genesis:prev_hash()),
+      <<"pow">> => aec_headers:serialize_pow_evidence(aec_block_genesis:pow()),
+      <<"txs_hash">> => base64:encode(aec_block_genesis:txs_hash()),
+      <<"transactions">> => aec_block_genesis:transactions()}.
 
 %% to be used for both headers and blocks
 cleanup_genesis(#{<<"height">> := 0} = Genesis) ->


### PR DESCRIPTION
[Pivotal story](https://www.pivotaltracker.com/story/show/153180259)
When we send a genesis block via the HTTP interface - we clean up the empty JSON fields; upon receiving them we should populate them back to produce a serializable JSON structure.
Some points taken into account:
* we don't want to call the `aec_block_genesis:genesis_block_with_state/0` on every post (gensis) block we get because it has side effects (reads from disc)
* we don't want to get the genesis from the chain since it results in a unneeded application depenency

