### PR TITLE
Check config start script extension

### DIFF
--- a/apps/check_config/priv/extensions/check_config.sh
+++ b/apps/check_config/priv/extensions/check_config.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Simple wrapper to run check_config
+# Relx extensions cannot be binary files but sourced bash files only
+
+$SCRIPT_DIR/check_config $@

--- a/apps/check_config/priv/extensions/check_config.sh
+++ b/apps/check_config/priv/extensions/check_config.sh
@@ -2,5 +2,7 @@
 
 # Simple wrapper to run check_config
 # Relx extensions cannot be binary files but sourced bash files only
+# Also append ERTS BINDIR to PATH to run the escript
 
+PATH=$BINDIR:$PATH
 $SCRIPT_DIR/check_config $@

--- a/rebar.config
+++ b/rebar.config
@@ -32,11 +32,16 @@
                    {copy, "VERSION" , "VERSION"},
                    {mkdir, "data/aecore/.genesis"},
                    {copy, "data/aecore/.genesis/accounts.json", "data/aecore/.genesis/accounts.json"},
-                   {copy, "hooks/pre_start.sh", "bin/hooks/pre_start.sh"}]},
+                   {copy, "hooks/pre_start.sh", "bin/hooks/pre_start.sh"},
+                   {copy, "apps/check_config/priv/extensions/check_config.sh", "bin/extensions/check_config"}
+                   ]},
 
         {extended_start_script, true},
         {extended_start_script_hooks, [
           {pre_start, [{custom, "hooks/pre_start.sh"}]}
+        ]},
+        {extended_start_script_extensions, [
+              {check_config, "extensions/check_config"}
         ]}]
 }.
 


### PR DESCRIPTION
[PT 153509936](https://www.pivotaltracker.com/story/show/153509936).

Purpose: Makes usage of check_config much easier than https://github.com/aeternity/epoch/commit/4de3bbe0ad87c299e89720ef115e82667ea9eeb5#diff-89f3cba2993eebd391f32c27f3772d7bR115

Usage: `bin/epoch check_config epoch.yaml`