### PR TITLE
Refactor HTTP endpoint for /info

### DIFF
--- a/apps/aecore/test/aec_chain_state_tests.erl
+++ b/apps/aecore/test/aec_chain_state_tests.erl
@@ -809,7 +809,8 @@ time_summary_only_genesis() ->
     {ok, State} = insert_block(Genesis, InitState),
 
     ?assertEqual([{aec_blocks:height(Genesis),
-                   aec_blocks:time_in_msecs(Genesis)}],
+                   aec_blocks:time_in_msecs(Genesis),
+                   aec_blocks:difficulty(Genesis)}],
                  aec_chain_state:get_top_N_blocks_time_summary(State, 30)),
     ok.
 
@@ -826,11 +827,11 @@ time_summary_N_blocks() ->
     B4Time = aec_blocks:time_in_msecs(B4),
 
     Expected30Blocks = Expected5Blocks =
-        [{aec_blocks:height(B4), B4Time, B4Time - B3Time},
-         {aec_blocks:height(B3), B3Time, B3Time - B2Time},
-         {aec_blocks:height(B2), B2Time, B2Time - B1Time},
-         {aec_blocks:height(B1), B1Time, B1Time - B0Time},
-         {aec_blocks:height(B0), B0Time}],
+        [{aec_blocks:height(B4), B4Time, B4Time - B3Time, aec_blocks:difficulty(B4)},
+         {aec_blocks:height(B3), B3Time, B3Time - B2Time, aec_blocks:difficulty(B3)},
+         {aec_blocks:height(B2), B2Time, B2Time - B1Time, aec_blocks:difficulty(B2)},
+         {aec_blocks:height(B1), B1Time, B1Time - B0Time, aec_blocks:difficulty(B1)},
+         {aec_blocks:height(B0), B0Time, aec_blocks:difficulty(B0)}],
 
     ?assertEqual(Expected30Blocks,
                  aec_chain_state:get_top_N_blocks_time_summary(State, 30)),
@@ -838,8 +839,8 @@ time_summary_N_blocks() ->
                  aec_chain_state:get_top_N_blocks_time_summary(State, 5)),
 
     Expected2Blocks =
-        [{aec_blocks:height(B4), B4Time, B4Time - B3Time},
-         {aec_blocks:height(B3), B3Time, B3Time - B2Time}],
+        [{aec_blocks:height(B4), B4Time, B4Time - B3Time, aec_blocks:difficulty(B4)},
+         {aec_blocks:height(B3), B3Time, B3Time - B2Time, aec_blocks:difficulty(B3)}],
 
     ?assertEqual(Expected2Blocks,
                  aec_chain_state:get_top_N_blocks_time_summary(State, 2)),

--- a/apps/aehttp/priv/swagger.json
+++ b/apps/aehttp/priv/swagger.json
@@ -513,6 +513,31 @@
             "schema" : {
               "$ref" : "#/definitions/AccountsBalances"
             }
+          },
+          "403" : {
+            "description" : "Balances not enabled",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          }
+        },
+        "security" : [ ]
+      }
+    },
+    "/version" : {
+      "get" : {
+        "tags" : [ "external" ],
+        "description" : "Get node's version",
+        "operationId" : "GetVersion",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/Version"
+            }
           }
         },
         "security" : [ ]
@@ -531,6 +556,12 @@
             "description" : "successful operation",
             "schema" : {
               "$ref" : "#/definitions/Info"
+            }
+          },
+          "403" : {
+            "description" : "Info not enabled",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
             }
           }
         },
@@ -839,7 +870,7 @@
         }
       }
     },
-    "Info" : {
+    "Version" : {
       "type" : "object",
       "properties" : {
         "version" : {
@@ -850,7 +881,12 @@
         },
         "genesis_hash" : {
           "type" : "string"
-        },
+        }
+      }
+    },
+    "Info" : {
+      "type" : "object",
+      "properties" : {
         "last_30_blocks_time" : {
           "type" : "array",
           "items" : {
@@ -873,6 +909,9 @@
         "time_delta_to_parent" : {
           "type" : "integer",
           "format" : "int64"
+        },
+        "difficulty" : {
+          "type" : "number"
         }
       }
     },

--- a/apps/aehttp/src/swagger/swagger_api.erl
+++ b/apps/aehttp/src/swagger/swagger_api.erl
@@ -46,6 +46,10 @@ request_params('GetTxs') ->
     [
     ];
 
+request_params('GetVersion') ->
+    [
+    ];
+
 request_params('Ping') ->
     [
         'Ping'
@@ -309,6 +313,8 @@ validate_response('GetAccountBalance', 404, Body, ValidatorState) ->
 
 validate_response('GetAccountsBalances', 200, Body, ValidatorState) ->
     validate_response_body('AccountsBalances', 'AccountsBalances', Body, ValidatorState);
+validate_response('GetAccountsBalances', 403, Body, ValidatorState) ->
+    validate_response_body('Error', 'Error', Body, ValidatorState);
 
 validate_response('GetBlockByHash', 200, Body, ValidatorState) ->
     validate_response_body('Block', 'Block', Body, ValidatorState);
@@ -322,12 +328,17 @@ validate_response('GetBlockByHeight', 404, Body, ValidatorState) ->
 
 validate_response('GetInfo', 200, Body, ValidatorState) ->
     validate_response_body('Info', 'Info', Body, ValidatorState);
+validate_response('GetInfo', 403, Body, ValidatorState) ->
+    validate_response_body('Error', 'Error', Body, ValidatorState);
 
 validate_response('GetTop', 200, Body, ValidatorState) ->
     validate_response_body('Top', 'Top', Body, ValidatorState);
 
 validate_response('GetTxs', 200, Body, ValidatorState) ->
     validate_response_body('Transactions', 'Transactions', Body, ValidatorState);
+
+validate_response('GetVersion', 200, Body, ValidatorState) ->
+    validate_response_body('Version', 'Version', Body, ValidatorState);
 
 validate_response('Ping', 200, Body, ValidatorState) ->
     validate_response_body('Ping', 'Ping', Body, ValidatorState);

--- a/apps/aehttp/src/swagger/swagger_external_handler.erl
+++ b/apps/aehttp/src/swagger/swagger_external_handler.erl
@@ -112,6 +112,14 @@ allowed_methods(
 allowed_methods(
     Req,
     State = #state{
+        operation_id = 'GetVersion'
+    }
+) ->
+    {[<<"GET">>], Req, State};
+
+allowed_methods(
+    Req,
+    State = #state{
         operation_id = 'Ping'
     }
 ) ->
@@ -142,6 +150,9 @@ allowed_methods(Req, State) ->
         Req :: cowboy_req:req(),
         State :: state()
     }.
+
+
+
 
 
 
@@ -233,6 +244,16 @@ valid_content_headers(
     Req0,
     State = #state{
         operation_id = 'GetTxs'
+    }
+) ->
+    Headers = [],
+    {Result, Req} = validate_headers(Headers, Req0),
+    {Result, Req, State};
+
+valid_content_headers(
+    Req0,
+    State = #state{
+        operation_id = 'GetVersion'
     }
 ) ->
     Headers = [],

--- a/apps/aehttp/src/swagger/swagger_router.erl
+++ b/apps/aehttp/src/swagger/swagger_router.erl
@@ -90,6 +90,11 @@ get_operations() ->
             method => <<"GET">>,
             handler => 'swagger_external_handler'
         },
+        'GetVersion' => #{
+            path => "/v1/version",
+            method => <<"GET">>,
+            handler => 'swagger_external_handler'
+        },
         'Ping' => #{
             path => "/v1/ping",
             method => <<"POST">>,

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -452,6 +452,27 @@ paths:
           description: successful operation
           schema:
             $ref: '#/definitions/AccountsBalances'
+        '403':
+          description: Balances not enabled
+          schema:
+            $ref: '#/definitions/Error'
+      security: []
+  /version:
+    get:
+      tags:
+        - external
+      operationId: GetVersion
+      description: 'Get node''s version'
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters: []
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            $ref: '#/definitions/Version'
       security: []
   /info:
     get:
@@ -469,6 +490,10 @@ paths:
           description: successful operation
           schema:
             $ref: '#/definitions/Info'
+        '403':
+          description: Info not enabled
+          schema:
+            $ref: '#/definitions/Error'
       security: []
 
 definitions:
@@ -701,7 +726,7 @@ definitions:
       balance:
         type: integer
         format: int64
-  Info:
+  Version:
     type: object
     properties:
       version:
@@ -710,6 +735,9 @@ definitions:
         type: string
       genesis_hash:
         type: string
+  Info:
+    type: object
+    properties:
       last_30_blocks_time:
         type: array
         items:
@@ -726,6 +754,8 @@ definitions:
       time_delta_to_parent:
         type: integer
         format: int64
+      difficulty:
+        type: number
 
   Error:
     type: object


### PR DESCRIPTION
[Pivotal story](https://www.pivotaltracker.com/story/show/153780478)
* created a public /version for returning the `version`, `revision` and `genesis hash`
* protected /info (to be active only when a setting is on) and added more data to it - block difficulties
* when setting is off, returning `401` (instead of `404`)