### PR TITLE
Resolve test issues with mining difficutly

### DIFF
--- a/apps/aecore/src/aec_spend_tx.erl
+++ b/apps/aecore/src/aec_spend_tx.erl
@@ -9,6 +9,7 @@
          fee/1,
          nonce/1,
          origin/1,
+         recipient/1,
          check/3,
          process/3,
          signers/1,
@@ -45,6 +46,10 @@ nonce(#spend_tx{nonce = Nonce}) ->
 -spec origin(spend_tx()) -> pubkey().
 origin(#spend_tx{sender = Sender}) ->
     Sender.
+
+-spec recipient(spend_tx()) -> pubkey().
+recipient(#spend_tx{recipient = Recipient}) ->
+    Recipient.
 
 -spec check(spend_tx(), trees(), height()) -> {ok, trees()} | {error, term()}.
 check(#spend_tx{recipient = RecipientPubkey} = SpendTx, Trees0, Height) ->

--- a/apps/aecore/test/aecore_sync_SUITE.erl
+++ b/apps/aecore/test/aecore_sync_SUITE.erl
@@ -170,7 +170,7 @@ test_subscription(_Config) ->
 
 mine_on_first(_Config) ->
     N = aecore_suite_utils:node_name(dev1),
-    aecore_suite_utils:mine_one_block(N),
+    aecore_suite_utils:mine_blocks(N, 1),
     ok.
 
 start_second_node(Config) ->
@@ -273,7 +273,7 @@ mine_on_third(Config) ->
 mine_and_compare(N1, Config) ->
     AllNodes = [N || {_, N} <- ?config(nodes, Config)],
     PrevTop = rpc:call(N1, aec_conductor, top, [], 5000),
-    ok = aecore_suite_utils:mine_one_block(N1),
+    aecore_suite_utils:mine_blocks(N1, 1),
     NewTop = rpc:call(N1, aec_conductor, top, [], 5000),
     true = (NewTop =/= PrevTop),
     Bal1 = get_balance(N1),


### PR DESCRIPTION
[Pivotal story](https://www.pivotaltracker.com/story/show/153780170)
The problem used to be recalibration of the mining difficulty durring tests - when a test tried to mine the eleventh block - it took more than 30s and the `aecore_suit_tests:mine_blocks_loop/1` timed out. Curriously   all tests used to mine right up to block 10, otherwise we would have found it earlier.

Also cleaned up a little bit `aecore_suite_utils` interface, removing `mine_one_block/1` function.