### PR TITLE
Avoid mocking core OTP application module in tests

### DIFF
--- a/apps/aecore/src/aec_conductor.erl
+++ b/apps/aecore/src/aec_conductor.erl
@@ -459,7 +459,7 @@ spawn_worker(Tag, Fun) ->
 worker_timeout(create_block_candidate) ->
     infinity;
 worker_timeout(mining) ->
-    application:get_env(aecore, mining_attempt_timeout, ?DEFAULT_MINING_ATTEMPT_TIMEOUT);
+    aeu_env:get_env(aecore, mining_attempt_timeout, ?DEFAULT_MINING_ATTEMPT_TIMEOUT);
 worker_timeout(wait_for_keys) ->
     infinity.
 

--- a/apps/aecore/src/aec_pow_cuckoo.erl
+++ b/apps/aecore/src/aec_pow_cuckoo.erl
@@ -88,6 +88,21 @@ verify(Data, Nonce, Evd, Target) when is_list(Evd),
 %%%=============================================================================
 
 %%------------------------------------------------------------------------------
+%% Options handling
+%%------------------------------------------------------------------------------
+
+get_options() ->
+    {_, _, _} = aeu_env:get_env(aecore, aec_pow_cuckoo, ?DEFAULT_CUCKOO_ENV).
+
+get_miner_options() ->
+    {MinerBin, MinerExtraArgs, _} = get_options(),
+    {MinerBin, MinerExtraArgs}.
+
+get_node_bits() ->
+    {_, _, NodeBits} = get_options(),
+    NodeBits.
+
+%%------------------------------------------------------------------------------
 %% Proof of Work generation: use the hash provided
 %%------------------------------------------------------------------------------
 -spec generate_int(Hash :: binary(), Nonce :: aec_pow:nonce(), Target :: aec_pow:sci_int()) ->
@@ -117,9 +132,13 @@ generate_int(Hash, Nonce, Target) ->
                           {'ok', Solution :: pow_cuckoo_solution()} |
                           {'error', term()}.
 generate_int(Header, Target) ->
+    {MinerBin, MinerExtraArgs} = get_miner_options(),
+    generate_int(Header, Target, MinerBin, MinerExtraArgs).
+
+generate_int(Header, Target, MinerBin, MinerExtraArgs) ->
     BinDir = aecuckoo:bin_dir(),
-    {Exe, Extra, _} = application:get_env(aecore, aec_pow_cuckoo, ?DEFAULT_CUCKOO_ENV),
-    Cmd = lists:concat([ld_lib_env(), " ",  "./", Exe, " -h ", Header, " ", Extra]),
+    Cmd = lists:concat([ld_lib_env(), " ",  "./", MinerBin,
+                        " -h ", Header, " ", MinerExtraArgs]),
     ?info("Executing cmd: ~p", [Cmd]),
     Old = process_flag(trap_exit, true),
     try exec:run(Cmd,
@@ -161,15 +180,16 @@ generate_int(Header, Target) ->
 -spec verify_proof(Hash :: binary(), Nonce :: aec_pow:nonce(),
                    Solution :: aec_pow:pow_evidence()) -> boolean().
 verify_proof(Hash, Nonce, Solution) ->
-    {_Exe, _Extra, Size} = application:get_env(aecore, aec_pow_cuckoo, ?DEFAULT_CUCKOO_ENV),
+    verify_proof(Hash, Nonce, Solution, get_node_bits()).
 
+verify_proof(Hash, Nonce, Solution, NodeBits) ->
     %% Cuckoo has an 80 byte header, we have to use that as well
     %% packed Hash + Nonce = 56 bytes, add 24 bytes of 0:s
     Header0 = pack_header_and_nonce(Hash, Nonce),
     Header = <<(list_to_binary(Header0))/binary, 0:(8*24)>>,
     {K0, K1, K2, K3} = aeu_siphash24:create_keys(Header),
 
-    EdgeMask = (1 bsl (Size - 1)) - 1,
+    EdgeMask = (1 bsl (NodeBits - 1)) - 1,
     try
         %% Generate Uv pairs representing endpoints by hashing the proof
         %% XOR points together: for a closed cycle they must match somewhere
@@ -409,17 +429,16 @@ stop_execution(OsPid) ->
 %%   control accordingly.
 %% @end
 %%------------------------------------------------------------------------------
--spec get_node_size() -> integer().
+-spec get_node_size() -> non_neg_integer().
 get_node_size() ->
-    case application:get_env(aecore, aec_pow_cuckoo, ?DEFAULT_CUCKOO_ENV) of
-        %% Refs:
-        %% * https://github.com/tromp/cuckoo/blob/488c03f5dbbfdac6d2d3a7e1d0746c9a7dafc48f/src/Makefile#L214-L215
-        %% * https://github.com/tromp/cuckoo/blob/488c03f5dbbfdac6d2d3a7e1d0746c9a7dafc48f/src/cuckoo.h#L26-L30
-        {_, _, L} when is_integer(L), L > 32 ->
-            8;
-        {_, _, L} when is_integer(L), L > 0 ->
-            4
-    end.
+    node_size(get_node_bits()).
+
+%% Refs:
+%% * https://github.com/tromp/cuckoo/blob/488c03f5dbbfdac6d2d3a7e1d0746c9a7dafc48f/src/Makefile#L214-L215
+%% * https://github.com/tromp/cuckoo/blob/488c03f5dbbfdac6d2d3a7e1d0746c9a7dafc48f/src/cuckoo.h#L26-L30
+-spec node_size(non_neg_integer()) -> non_neg_integer().
+node_size(NodeBits) when is_integer(NodeBits), NodeBits > 32 -> 8;
+node_size(NodeBits) when is_integer(NodeBits), NodeBits >  0 -> 4.
 
 %%------------------------------------------------------------------------------
 %% White paper, section 9: rather than adjusting the nodes/edges ratio, a
@@ -429,7 +448,9 @@ get_node_size() ->
 -spec test_target(Soln :: pow_cuckoo_solution(), Target :: aec_pow:sci_int()) ->
                              boolean().
 test_target(Soln, Target) ->
-    NodeSize = get_node_size(),
+    test_target(Soln, Target, get_node_size()).
+
+test_target(Soln, Target, NodeSize) ->
     Bin = solution_to_binary(lists:sort(Soln), NodeSize * 8, <<>>),
     Hash = aec_sha256:hash(Bin),
     aec_pow:test_target(Hash, Target).

--- a/apps/aecore/test/aec_conductor_tests.erl
+++ b/apps/aecore/test/aec_conductor_tests.erl
@@ -43,13 +43,12 @@ teardown_minimal(TmpKeysDir) ->
     ok.
 
 setup_cuckoo_pow() ->
-    meck:new(application, [unstick, passthrough]),
+    ok = meck:new(aeu_env, [passthrough]),
     aec_test_utils:mock_fast_cuckoo_pow(),
     ok = application:ensure_started(erlexec).
 
 teardown_cuckoo_pow(_) ->
-    meck:unload(application),
-    ok.
+    ok = meck:unload(aeu_env).
 
 setup_common() ->
     setup_cuckoo_pow(),
@@ -119,8 +118,8 @@ miner_timeout_test_() ->
     {foreach,
      fun() ->
              ok = meck:new(aec_pow_cuckoo, [passthrough]),
-             ok = meck:new(application, [unstick, passthrough]),
-             ok = meck:expect(application, get_env, 3,
+             ok = meck:new(aeu_env, [passthrough]),
+             ok = meck:expect(aeu_env, get_env, 3,
                               fun
                                   (aecore, mining_attempt_timeout, _) ->
                                       500;
@@ -134,7 +133,7 @@ miner_timeout_test_() ->
      fun(TmpKeysDir) ->
              ok = ?TEST_MODULE:stop(),
              teardown_minimal(TmpKeysDir),
-             ok = meck:unload(application),
+             ok = meck:unload(aeu_env),
              ok = meck:unload(aec_pow_cuckoo)
      end,
      [{"Time out miner that does not return", fun test_time_out_miner/0}

--- a/apps/aecore/test/aec_mining_tests.erl
+++ b/apps/aecore/test/aec_mining_tests.erl
@@ -144,7 +144,7 @@ difficulty_recalculation_test_() ->
 setup(PoWMod) ->
     case PoWMod of
         aec_pow_cuckoo ->
-            meck:new(application, [unstick, passthrough]),
+            ok = meck:new(aeu_env, [passthrough]),
             aec_test_utils:mock_fast_and_deterministic_cuckoo_pow(),
             ok = application:ensure_started(erlexec);
         aec_pow_sha256 ->
@@ -195,7 +195,7 @@ cleanup(_, PoWMod) ->
     ok = aec_tx_pool:stop(),
     case PoWMod of
         aec_pow_cuckoo ->
-            meck:unload(application);
+            ok = meck:unload(aeu_env);
         aec_pow_sha256 ->
             ok
     end.

--- a/apps/aecore/test/aec_pow_cuckoo_tests.erl
+++ b/apps/aecore/test/aec_pow_cuckoo_tests.erl
@@ -21,12 +21,12 @@
 pow_test_() ->
     {setup,
      fun() ->
-             meck:new(application, [unstick, passthrough]),
+             ok = meck:new(aeu_env, [passthrough]),
              aec_test_utils:mock_fast_and_deterministic_cuckoo_pow(),
              ok = application:ensure_started(erlexec)
      end,
      fun(_) ->
-             meck:unload(application)
+             ok = meck:unload(aeu_env)
      end,
      [{"Generate with a winning nonce and high target threshold, verify it",
        {timeout, 60,

--- a/apps/aecore/test/aec_test_utils.erl
+++ b/apps/aecore/test/aec_test_utils.erl
@@ -81,7 +81,7 @@ mock_fast_and_deterministic_cuckoo_pow() ->
     mock_fast_cuckoo_pow({"mean16s-generic", "", 16}).
 
 mock_fast_cuckoo_pow({_MinerBin, _MinerExtraArgs, _NodeBits} = Cfg) ->
-    meck:expect(application, get_env, 3,
+    meck:expect(aeu_env, get_env, 3,
                 fun
                     (aecore, aec_pow_cuckoo, _) ->
                        Cfg;


### PR DESCRIPTION
Finishes PT-153872214.

I built prod-package , deployed locally, changed mining attempt timeout in epoch.yaml and changed aec_pow_cuckoo in sys.config and they were picked.