### PR TITLE
fix chain_probe specification [Finishes #153875684] [Finishes #153873975]

### DIFF
--- a/apps/aecore/src/aec_chain_metrics_probe.erl
+++ b/apps/aecore/src/aec_chain_metrics_probe.erl
@@ -31,7 +31,7 @@ ad_hoc_spec() ->
     [{module, ?MODULE},
      {type, probe},
      {cache, 5000},
-     {options, [{sample_interval, 5000}]}].
+     {sample_interval, 5000}].
 
 
 


### PR DESCRIPTION
In a rewrite fixing other problems, the startup specification for the `aec_chain_metrics_probe` became erroneous. As a result, the probe wasn't sampling at all. The only affected datapoint was `total_difficulty`.