### PR TITLE
Remove the notion of aliases from aec_peers

### DIFF
--- a/apps/aecore/test/aec_peers_tests.erl
+++ b/apps/aecore/test/aec_peers_tests.erl
@@ -45,13 +45,6 @@ all_test_() ->
                ok = aec_peers:add("http://localhost:800", false),
                ["http://localhost:800/"] = aec_peers:all()
        end},
-      {"Register source",
-       fun() ->
-               ok = aec_peers:register_source("http://localhost:800",
-                                              "http://somenode:800"),
-               ["http://localhost:800/"] = aec_peers:all(),
-               [{"http://somenode:800/", "http://localhost:800/"}] = aec_peers:aliases()
-       end},
       {"Get random N",
        fun() ->
                do_remove_all(),

--- a/apps/aeutils/src/aeu_http_client.erl
+++ b/apps/aeutils/src/aeu_http_client.erl
@@ -32,12 +32,13 @@ request(BaseUri, post, Endpoint, Params, Header, HTTPOptions, Options) ->
                            {"application/x-www-form-urlencoded",
                             http_uri:encode(Endpoint)}  %% is this correct??
                    end,
-    %% lager:debug("Type = ~p; Body = ~p", [Type, Body]),
+    lager:debug("POST URL = ~p Type = ~p; Body = ~p", [URL, Type, Body]),
     R = httpc:request(post, {URL, Header, Type, Body}, HTTPOptions, Options),
     process_http_return(R).
 
 process_http_return(R) ->
     case R of
+        %% if Body == [] an error is thrown!
         {ok, {{_,_ReturnCode, _State}, _Head, Body}} ->
             try
                 %% lager:debug("Body to parse: ~s", [Body]),
@@ -46,6 +47,7 @@ process_http_return(R) ->
                 {ok, Result}
             catch
                 error:E ->
+                    lager:error("http response ~p", [R]),
                     {error, {parse_error, [E, erlang:get_stacktrace()]}}
             end;
         {error, _} = Error ->


### PR DESCRIPTION
In the aec_peers modules there is a notion of aliases of a certain peer. This is a legacy notion to deal with the different names that localhost can have. We deal with that in configurations now and can remove the aliases for that part.

Aliases as implemented at the moment are unclear. We do trust any incoming URL even if it is not a valid URL to replace the URL we have used to approach the peer. This might be good in a trusted environment, it seems risky to just trust any peer's source response and start talking to that peer instead. Moreover, a lot of code deals with administering the hash of the different peer, even if that peer is basically the same, but has an extra path, the hash will change.

[finish PT-154024594]