### PR TITLE
PT-154027381 Non-stale chain total difficulty metric

### DIFF
--- a/apps/aecore/src/aec_chain_metrics_probe.erl
+++ b/apps/aecore/src/aec_chain_metrics_probe.erl
@@ -30,7 +30,6 @@
 ad_hoc_spec() ->
     [{module, ?MODULE},
      {type, probe},
-     {cache, 5000},
      {sample_interval, 5000}].
 
 

--- a/apps/aecore/src/aec_conductor.erl
+++ b/apps/aecore/src/aec_conductor.erl
@@ -293,9 +293,7 @@ handle_call(get_top_header,_From, State) ->
 handle_call(get_top_header_hash,_From, State) ->
     {reply, aec_conductor_chain:get_top_header_hash(State), State};
 handle_call(get_total_difficulty,_From, State) ->
-    Res = aec_conductor_chain:get_total_difficulty(State),
-    aec_metrics:try_update([ae,epoch,aecore,chain,total_difficulty], Res),
-    {reply, Res, State};
+    {reply, aec_conductor_chain:get_total_difficulty(State), State};
 handle_call({has_block, Hash},_From, State) ->
     {reply, aec_conductor_chain:has_block(Hash, State), State};
 handle_call({hash_is_connected_to_genesis, Hash},_From, State) ->

--- a/apps/aecore/src/aec_metrics.erl
+++ b/apps/aecore/src/aec_metrics.erl
@@ -54,6 +54,7 @@ default_dests() ->
 update(Metric, Value) ->
     exometer:update(Metric, Value).
 
+-spec try_update([atom(), ...], number()) -> ok | {error, not_found}.
 try_update(Metric, Value) ->
     try update(Metric, Value)
     catch

--- a/apps/aecore/src/aec_metrics.erl
+++ b/apps/aecore/src/aec_metrics.erl
@@ -54,7 +54,7 @@ default_dests() ->
 update(Metric, Value) ->
     exometer:update(Metric, Value).
 
--spec try_update([atom(), ...], number()) -> ok | {error, not_found}.
+-spec try_update(exometer:name(), number()) -> ok | {error, not_found}.
 try_update(Metric, Value) ->
     try update(Metric, Value)
     catch


### PR DESCRIPTION
Fixed by disabling exometer cache for total difficulty metric - that is currently affected by a race condition and should have negligible impact on performance.

Finishes [PT-154027381](https://www.pivotaltracker.com/story/show/154027381).
Supersedes PR GH-553.
  