### PR TITLE
Ansible rolling deploys

### DIFF
--- a/deployment/ansible/deploy.yml
+++ b/deployment/ansible/deploy.yml
@@ -24,6 +24,8 @@
   remote_user: epoch
   # Facts are already collected in the previous playbook
   gather_facts: no
+  max_fail_percentage: 25
+  serial: "25%"
 
   vars:
     project_root: "{{ ansible_env.HOME }}/node"

--- a/deployment/ansible/deploy.yml
+++ b/deployment/ansible/deploy.yml
@@ -33,6 +33,10 @@
 
     env: unknown
     config:
+      http:
+        external:
+          peer_address: http://{{ ansible_default_ipv4.address }}:3013/
+          port: 3013
       chain:
         persist: true
         db_path: "./db12"
@@ -141,3 +145,18 @@
     - name: Start epoch daemon
       command: "{{ project_root }}/bin/epoch start"
       tags: [daemon]
+
+    - name: Wait epoch node API to boot
+      wait_for:
+        port: "{{ config.http.external.port }}"
+        host: "{{ ansible_ssh_host }}"
+        timeout: 5
+      connection: local
+      tags: [health-check]
+
+    - name: API health check
+      uri:
+        url: http://{{ ansible_ssh_host }}:{{ config.http.external.port }}/v1/top
+        timeout: 5
+      connection: local
+      tags: [health-check]

--- a/deployment/ansible/deploy.yml
+++ b/deployment/ansible/deploy.yml
@@ -1,7 +1,29 @@
 ---
+# Additional playbook that runs on a group first host only and gather facts from all hosts
+# This is required to allow deploying on fraction of group hosts
+# For example rolling updates and deploying only to single hosts of a group
+#
+# For example below command will deploy only to ae-dev2-epoch-n0 host in dev2 group
+# ansible-playbook --limit="ae-dev2-epoch-n0" --extra-vars "env=dev2" deploy.yml
+
+- name: Facts setup
+  hosts: all
+  remote_user: epoch
+  # Executor facts will be gathered anyway in the task below
+  gather_facts: no
+  tasks:
+    - name: Gather facts from all hosts in {{ env }} group
+      setup:
+      run_once: yes
+      delegate_to: "{{ item }}"
+      delegate_facts: yes
+      with_items: "{{ groups[env] }}"
+
 - name: Deploy epoch package
   hosts: all
   remote_user: epoch
+  # Facts are already collected in the previous playbook
+  gather_facts: no
 
   vars:
     project_root: "{{ ansible_env.HOME }}/node"

--- a/deployment/ansible/deploy.yml
+++ b/deployment/ansible/deploy.yml
@@ -150,7 +150,7 @@
       wait_for:
         port: "{{ config.http.external.port }}"
         host: "{{ ansible_ssh_host }}"
-        timeout: 5
+        timeout: 300
       connection: local
       tags: [health-check]
 

--- a/deployment/ansible/templates/epoch.yaml.j2
+++ b/deployment/ansible/templates/epoch.yaml.j2
@@ -10,7 +10,8 @@ keys:
 
 http:
     external:
-        peer_address: http://{{ ansible_default_ipv4.address }}:3013/
+        peer_address: {{ config.http.external.peer_address }}
+        port: {{ config.http.external.port }}
 
 mining:
     autostart: true

--- a/deployment/ansible/templates/epoch.yaml.j2
+++ b/deployment/ansible/templates/epoch.yaml.j2
@@ -1,10 +1,8 @@
 ---
-{% if 'epoch' in group_names %}
 peers:
-    {% for host in ansible_play_hosts | difference([inventory_hostname]) %}
+    {% for host in groups[env] | difference([inventory_hostname]) %}
 - "http://{{ hostvars[host]['ansible_default_ipv4']['address'] }}:3013/"
     {% endfor %}
-{%- endif %}
 
 keys:
     dir: {{ config.keypair.dir }}


### PR DESCRIPTION
This introduce [Anisible rolling deploys](http://docs.ansible.com/ansible/latest/playbooks_delegation.html#rolling-update-batch-size) so that hosts are taken down for deploy in batch size of 25%.

This would guarantee much more stable network and as a side effect this makes it more similar to the production network where we don't control and deploy all nodes at once.

https://www.pivotaltracker.com/story/show/153589689