### PR TITLE
HTTP endpoint: transactions in block ranges [Finishes #154065064]

### DIFF
--- a/apps/aehttp/priv/swagger.json
+++ b/apps/aehttp/priv/swagger.json
@@ -621,7 +621,7 @@
         }, {
           "name" : "tx_objects",
           "in" : "query",
-          "description" : "Transactions as objects (default is as hashes)",
+          "description" : "Transactions as objects (default is as MessagePack hashes)",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -659,7 +659,7 @@
         }, {
           "name" : "tx_objects",
           "in" : "query",
-          "description" : "Transactions as objects (default is as hashes)",
+          "description" : "Transactions as objects (default is as MessagePack hashes)",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -697,7 +697,7 @@
         "parameters" : [ {
           "name" : "tx_objects",
           "in" : "query",
-          "description" : "Transactions as objects (default is as hashes)",
+          "description" : "Transactions as objects (default is as MessagePack hashes)",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -723,7 +723,7 @@
         "parameters" : [ {
           "name" : "tx_objects",
           "in" : "query",
-          "description" : "Transactions as objects (default is as hashes)",
+          "description" : "Transactions as objects (default is as MessagePack hashes)",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -749,7 +749,7 @@
         "parameters" : [ {
           "name" : "tx_objects",
           "in" : "query",
-          "description" : "Transactions as objects (default is as hashes)",
+          "description" : "Transactions as objects (default is as MessagePack hashes)",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -918,7 +918,7 @@
         }, {
           "name" : "tx_objects",
           "in" : "query",
-          "description" : "Transactions as objects (default is as message pack hashes)",
+          "description" : "Transactions as objects (default is as hashes)",
           "required" : false,
           "type" : "boolean",
           "default" : false
@@ -932,6 +932,58 @@
           },
           "404" : {
             "description" : "Block or transaction not found",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          }
+        },
+        "security" : [ ]
+      }
+    },
+    "/block/txs/list/height" : {
+      "get" : {
+        "tags" : [ "internal" ],
+        "description" : "Get transactions list from a block range by height",
+        "operationId" : "GetTxsListFromBlockRangeByHeight",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "from",
+          "in" : "query",
+          "description" : "Height of the block to start the range",
+          "required" : true,
+          "type" : "integer",
+          "minimum" : 0
+        }, {
+          "name" : "to",
+          "in" : "query",
+          "description" : "Height of the block to end the range",
+          "required" : true,
+          "type" : "integer",
+          "minimum" : 0
+        }, {
+          "name" : "tx_objects",
+          "in" : "query",
+          "description" : "Transactions as objects (default is as MessagePack hashes)",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "The list of transactions in block range",
+            "schema" : {
+              "$ref" : "#/definitions/GenericTxArray"
+            }
+          },
+          "400" : {
+            "description" : "Invalid range",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Range not found",
             "schema" : {
               "$ref" : "#/definitions/Error"
             }
@@ -1014,6 +1066,58 @@
           },
           "404" : {
             "description" : "Block or transaction not found",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          }
+        },
+        "security" : [ ]
+      }
+    },
+    "/block/txs/list/hash" : {
+      "get" : {
+        "tags" : [ "internal" ],
+        "description" : "Get transactions list from a block range by hash",
+        "operationId" : "GetTxsListFromBlockRangeByHash",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "from",
+          "in" : "query",
+          "description" : "Hash of the block to start the range",
+          "required" : true,
+          "type" : "string",
+          "minimum" : 0
+        }, {
+          "name" : "to",
+          "in" : "query",
+          "description" : "Hash of the block to end the range",
+          "required" : true,
+          "type" : "string",
+          "minimum" : 0
+        }, {
+          "name" : "tx_objects",
+          "in" : "query",
+          "description" : "Transactions as objects (default is as MessagePack hashes)",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "The list of transactions in block range",
+            "schema" : {
+              "$ref" : "#/definitions/GenericTxArray"
+            }
+          },
+          "400" : {
+            "description" : "Invalid range",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Range not found",
             "schema" : {
               "$ref" : "#/definitions/Error"
             }
@@ -1131,6 +1235,46 @@
         "properties" : {
           "hash" : {
             "type" : "string"
+          }
+        }
+      } ]
+    },
+    "GenericTxArray" : {
+      "type" : "object",
+      "required" : [ "data_schema" ],
+      "discriminator" : "data_schema",
+      "properties" : {
+        "data_schema" : {
+          "type" : "string"
+        }
+      }
+    },
+    "TxMsgPackHashes" : {
+      "allOf" : [ {
+        "$ref" : "#/definitions/GenericTxArray"
+      }, {
+        "type" : "object",
+        "properties" : {
+          "transactions" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/definitions/Tx"
+            }
+          }
+        }
+      } ]
+    },
+    "TxObjects" : {
+      "allOf" : [ {
+        "$ref" : "#/definitions/GenericTxArray"
+      }, {
+        "type" : "object",
+        "properties" : {
+          "transactions" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/definitions/SignedTxObject"
+            }
           }
         }
       } ]

--- a/apps/aehttp/src/swagger/swagger_api.erl
+++ b/apps/aehttp/src/swagger/swagger_api.erl
@@ -152,6 +152,20 @@ request_params('GetTransactionFromBlockLatest') ->
         'tx_objects'
     ];
 
+request_params('GetTxsListFromBlockRangeByHash') ->
+    [
+        'from',
+        'to',
+        'tx_objects'
+    ];
+
+request_params('GetTxsListFromBlockRangeByHeight') ->
+    [
+        'from',
+        'to',
+        'tx_objects'
+    ];
+
 request_params('PostOracleQueryTx') ->
     [
         'OracleQueryTx'
@@ -429,6 +443,64 @@ request_param_info('GetTransactionFromBlockLatest', 'tx_objects') ->
         ]
     };
 
+request_param_info('GetTxsListFromBlockRangeByHash', 'from') ->
+    #{
+        source => qs_val  ,
+        rules => [
+            {type, 'binary'},
+            {min, 0 },
+            required
+        ]
+    };
+
+request_param_info('GetTxsListFromBlockRangeByHash', 'to') ->
+    #{
+        source => qs_val  ,
+        rules => [
+            {type, 'binary'},
+            {min, 0 },
+            required
+        ]
+    };
+
+request_param_info('GetTxsListFromBlockRangeByHash', 'tx_objects') ->
+    #{
+        source => qs_val  ,
+        rules => [
+            {type, 'boolean'},
+            not_required
+        ]
+    };
+
+request_param_info('GetTxsListFromBlockRangeByHeight', 'from') ->
+    #{
+        source => qs_val  ,
+        rules => [
+            {type, 'integer'},
+            {min, 0 },
+            required
+        ]
+    };
+
+request_param_info('GetTxsListFromBlockRangeByHeight', 'to') ->
+    #{
+        source => qs_val  ,
+        rules => [
+            {type, 'integer'},
+            {min, 0 },
+            required
+        ]
+    };
+
+request_param_info('GetTxsListFromBlockRangeByHeight', 'tx_objects') ->
+    #{
+        source => qs_val  ,
+        rules => [
+            {type, 'boolean'},
+            not_required
+        ]
+    };
+
 request_param_info('PostOracleQueryTx', 'OracleQueryTx') ->
     #{
         source =>   body,
@@ -659,6 +731,20 @@ validate_response('GetTransactionFromBlockHeight', 404, Body, ValidatorState) ->
 validate_response('GetTransactionFromBlockLatest', 200, Body, ValidatorState) ->
     validate_response_body('SingleTxHashOrObject', 'SingleTxHashOrObject', Body, ValidatorState);
 validate_response('GetTransactionFromBlockLatest', 404, Body, ValidatorState) ->
+    validate_response_body('Error', 'Error', Body, ValidatorState);
+
+validate_response('GetTxsListFromBlockRangeByHash', 200, Body, ValidatorState) ->
+    validate_response_body('GenericTxArray', 'GenericTxArray', Body, ValidatorState);
+validate_response('GetTxsListFromBlockRangeByHash', 400, Body, ValidatorState) ->
+    validate_response_body('Error', 'Error', Body, ValidatorState);
+validate_response('GetTxsListFromBlockRangeByHash', 404, Body, ValidatorState) ->
+    validate_response_body('Error', 'Error', Body, ValidatorState);
+
+validate_response('GetTxsListFromBlockRangeByHeight', 200, Body, ValidatorState) ->
+    validate_response_body('GenericTxArray', 'GenericTxArray', Body, ValidatorState);
+validate_response('GetTxsListFromBlockRangeByHeight', 400, Body, ValidatorState) ->
+    validate_response_body('Error', 'Error', Body, ValidatorState);
+validate_response('GetTxsListFromBlockRangeByHeight', 404, Body, ValidatorState) ->
     validate_response_body('Error', 'Error', Body, ValidatorState);
 
 validate_response('PostOracleQueryTx', 200, Body, ValidatorState) ->

--- a/apps/aehttp/src/swagger/swagger_internal_handler.erl
+++ b/apps/aehttp/src/swagger/swagger_internal_handler.erl
@@ -192,6 +192,22 @@ allowed_methods(
 allowed_methods(
     Req,
     State = #state{
+        operation_id = 'GetTxsListFromBlockRangeByHash'
+    }
+) ->
+    {[<<"GET">>], Req, State};
+
+allowed_methods(
+    Req,
+    State = #state{
+        operation_id = 'GetTxsListFromBlockRangeByHeight'
+    }
+) ->
+    {[<<"GET">>], Req, State};
+
+allowed_methods(
+    Req,
+    State = #state{
         operation_id = 'PostOracleQueryTx'
     }
 ) ->
@@ -246,6 +262,31 @@ allowed_methods(Req, State) ->
         Req :: cowboy_req:req(),
         State :: state()
     }.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 is_authorized(Req, State) ->
     {true, Req, State}.
@@ -429,6 +470,26 @@ valid_content_headers(
     Req0,
     State = #state{
         operation_id = 'GetTransactionFromBlockLatest'
+    }
+) ->
+    Headers = [],
+    {Result, Req} = validate_headers(Headers, Req0),
+    {Result, Req, State};
+
+valid_content_headers(
+    Req0,
+    State = #state{
+        operation_id = 'GetTxsListFromBlockRangeByHash'
+    }
+) ->
+    Headers = [],
+    {Result, Req} = validate_headers(Headers, Req0),
+    {Result, Req, State};
+
+valid_content_headers(
+    Req0,
+    State = #state{
+        operation_id = 'GetTxsListFromBlockRangeByHeight'
     }
 ) ->
     Headers = [],

--- a/apps/aehttp/src/swagger/swagger_router.erl
+++ b/apps/aehttp/src/swagger/swagger_router.erl
@@ -195,6 +195,16 @@ get_operations() ->
             method => <<"GET">>,
             handler => 'swagger_internal_handler'
         },
+        'GetTxsListFromBlockRangeByHash' => #{
+            path => "/v1/block/txs/list/hash",
+            method => <<"GET">>,
+            handler => 'swagger_internal_handler'
+        },
+        'GetTxsListFromBlockRangeByHeight' => #{
+            path => "/v1/block/txs/list/height",
+            method => <<"GET">>,
+            handler => 'swagger_internal_handler'
+        },
         'PostOracleQueryTx' => #{
             path => "/v1/oracle-query-tx",
             method => <<"POST">>,

--- a/apps/aehttp/src/swagger/swagger_server.erl
+++ b/apps/aehttp/src/swagger/swagger_server.erl
@@ -1,7 +1,7 @@
 -module(swagger_server).
 
 
--define(DEFAULT_ACCEPTORS_POOLSIZE, 10).
+-define(DEFAULT_ACCEPTORS_POOLSIZE, 100).
 -define(DEFAULT_LOGIC_HANDLER, swagger_default_logic_handler).
 
 -export([child_spec/2]).

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -538,7 +538,7 @@ paths:
           type : integer
         - in: query
           name: tx_objects
-          description: 'Transactions as objects (default is as hashes)'
+          description: 'Transactions as objects (default is as MessagePack hashes)'
           type: boolean
           default: false
       responses:
@@ -569,7 +569,7 @@ paths:
           type : string 
         - in: query
           name: tx_objects
-          description: 'Transactions as objects (default is as hashes)'
+          description: 'Transactions as objects (default is as MessagePack hashes)'
           type: boolean
           default: false
       responses:
@@ -599,7 +599,7 @@ paths:
       parameters:
         - in: query
           name: tx_objects
-          description: 'Transactions as objects (default is as hashes)'
+          description: 'Transactions as objects (default is as MessagePack hashes)'
           type: boolean
           default: false
       responses:
@@ -621,7 +621,7 @@ paths:
       parameters:
         - in: query
           name: tx_objects
-          description: 'Transactions as objects (default is as hashes)'
+          description: 'Transactions as objects (default is as MessagePack hashes)'
           type: boolean
           default: false
       responses:
@@ -643,7 +643,7 @@ paths:
       parameters:
         - in: query
           name: tx_objects
-          description: 'Transactions as objects (default is as hashes)'
+          description: 'Transactions as objects (default is as MessagePack hashes)'
           type: boolean
           default: false
       responses:
@@ -819,6 +819,48 @@ paths:
           schema:
             $ref: '#/definitions/Error'
       security: []
+  /block/txs/list/height:
+    get:
+      tags:
+        - internal
+      operationId: GetTxsListFromBlockRangeByHeight
+      description: 'Get transactions list from a block range by height'
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters: 
+        - in: query 
+          name: from 
+          description: 'Height of the block to start the range'
+          required: true
+          type : integer
+          minimum: 0
+        - in: query 
+          name: to
+          description: 'Height of the block to end the range'
+          required: true
+          type : integer
+          minimum: 0
+        - in: query
+          name: tx_objects
+          description: 'Transactions as objects (default is as MessagePack hashes)'
+          type: boolean
+          default: false
+      responses:
+        '200':
+          description: The list of transactions in block range
+          schema:
+            $ref: '#/definitions/GenericTxArray'
+        '400':
+          description: Invalid range
+          schema:
+            $ref: '#/definitions/Error'
+        '404':
+          description: Range not found
+          schema:
+            $ref: '#/definitions/Error'
+      security: []
   /block/tx/hash/{hash}/{tx_index}:
     get:
       tags:
@@ -883,6 +925,48 @@ paths:
             $ref: '#/definitions/SingleTxHashOrObject'
         '404':
           description: Block or transaction not found
+          schema:
+            $ref: '#/definitions/Error'
+      security: []
+  /block/txs/list/hash:
+    get:
+      tags:
+        - internal
+      operationId: GetTxsListFromBlockRangeByHash
+      description: 'Get transactions list from a block range by hash'
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters: 
+        - in: query 
+          name: from 
+          description: 'Hash of the block to start the range'
+          required: true
+          type : string
+          minimum: 0
+        - in: query 
+          name: to
+          description: 'Hash of the block to end the range'
+          required: true
+          type : string
+          minimum: 0
+        - in: query
+          name: tx_objects
+          description: 'Transactions as objects (default is as MessagePack hashes)'
+          type: boolean
+          default: false
+      responses:
+        '200':
+          description: The list of transactions in block range
+          schema:
+            $ref: '#/definitions/GenericTxArray'
+        '400':
+          description: Invalid range
+          schema:
+            $ref: '#/definitions/Error'
+        '404':
+          description: Range not found
           schema:
             $ref: '#/definitions/Error'
       security: []
@@ -960,6 +1044,32 @@ definitions:
         properties:
           hash:
             type: string
+  GenericTxArray:
+    type: object
+    discriminator: data_schema
+    properties:
+      data_schema:
+        type: string
+    required:
+    - data_schema
+  TxMsgPackHashes:
+    allOf:
+      - $ref: '#/definitions/GenericTxArray'
+      - type: object
+        properties:
+          transactions:
+            type: array
+            items:
+              $ref: '#/definitions/Tx'
+  TxObjects:
+    allOf:
+      - $ref: '#/definitions/GenericTxArray'
+      - type: object
+        properties:
+          transactions:
+            type: array
+            items:
+              $ref: '#/definitions/SignedTxObject'
   Ping:
     type: object
     properties:


### PR DESCRIPTION
[Pivotal story](https://www.pivotaltracker.com/story/show/154065064)
Notable Changes:
* Exposed functionality for getting a range of blocks (from - to), limited by the number of blocks to get

##  Approaches
There were a couple of differen approaches I could think of. Bellow you can find my argumentation.
### OptionA: calculations are done inside the process of aec_conductor
A single message is sent to aec_conductor and all calculations are done inside its process.
**Pros**:
* no race conditions

**Cons**:
* if a large range is requested, this could get computation heavy and block the aec_conductor process (this the restriction on size of the range)
* adding more functions to aec_conductor's interface

### OptionB: calculations are done inside the process of the cowboy request
Blocks are fetched by aec_conductor one by one.
**Pros**:
* no need for limiting the range size

**Cons**:
* possibly races (for example when other fork wins)


### OptionC: calculations are done inside separate process
A new process is spawned to do the calculations.
**Pros**:
* no need for limiting the range size
* no races

**Cons**:
* spawning a new process would result in copying the whole chain state inside the new process' memory space


Having in mind arguments above, this PR implements **OptionA**.


##  Endpoints
### getTransactionFromBlockRange

**Description**: Returns a list of transactions based on a fromBlock hash or number and a toBlock hash or number.
**Endpoints**:
GET /block/txs/list/height
GET /block/txs/list/hash
**Options**:
_from_ - string/integer to start from
_to_ - string/integer to end
_tx_objects_ - (optional, default false) If true, the returned block will contain all transactions as objects, if false it will only contains the transaction message pack encoded hashes

```
$ curl "http://127.0.0.1:3113/v1/block/txs/list/height?from=1&to=2"
{"data_schema":"TxMsgPackHashes","transactions":[{"tx":"lMQGc2lnX3R4AZOBxAR0eXBlxAhjb2luYmFzZYHEA3ZzbgGBxARhY2N0xEEEOEIF9XpI01khqk6w1A1YnJBybVRZAXN/so5OQu5d30GFdQHvH+t/EiaqApuFfbX3BG12yV1DqiQrmAFDz9rUppHERjBEAiAiAbaQthewsg/379QtVVl1KvdFxDVjmxpBt41DARNzFgIgHnhhc/gnG/oFJ7IrSyzJzpxspnw+GhTKM0ugKPvNCtU="},{"tx":"lMQGc2lnX3R4AZOBxAR0eXBlxAhjb2luYmFzZYHEA3ZzbgGBxARhY2N0xEEEOEIF9XpI01khqk6w1A1YnJBybVRZAXN/so5OQu5d30GFdQHvH+t/EiaqApuFfbX3BG12yV1DqiQrmAFDz9rUppHERjBEAiBWBXOA+B4e3oo27YbSkCfpbyLz6bFZyhOQV4reHnZdAwIgc8LnG4jcIuDy3dDu7C21jwyVCCx2DCFJmDRPCZJdaxQ="}]}

$ curl "http://127.0.0.1:3113/v1/block/txs/list/height?from=1&to=2&tx_objects=false"
{"data_schema":"TxMsgPackHashes","transactions":[{"tx":"lMQGc2lnX3R4AZOBxAR0eXBlxAhjb2luYmFzZYHEA3ZzbgGBxARhY2N0xEEEOEIF9XpI01khqk6w1A1YnJBybVRZAXN/so5OQu5d30GFdQHvH+t/EiaqApuFfbX3BG12yV1DqiQrmAFDz9rUppHERjBEAiAiAbaQthewsg/379QtVVl1KvdFxDVjmxpBt41DARNzFgIgHnhhc/gnG/oFJ7IrSyzJzpxspnw+GhTKM0ugKPvNCtU="},{"tx":"lMQGc2lnX3R4AZOBxAR0eXBlxAhjb2luYmFzZYHEA3ZzbgGBxARhY2N0xEEEOEIF9XpI01khqk6w1A1YnJBybVRZAXN/so5OQu5d30GFdQHvH+t/EiaqApuFfbX3BG12yV1DqiQrmAFDz9rUppHERjBEAiBWBXOA+B4e3oo27YbSkCfpbyLz6bFZyhOQV4reHnZdAwIgc8LnG4jcIuDy3dDu7C21jwyVCCx2DCFJmDRPCZJdaxQ="}]}

$ curl "http://127.0.0.1:3113/v1/block/txs/list/height?from=1&to=2&tx_objects=true"
{"data_schema":"TxObjects","transactions":[{"signatures":["MEQCICIBtpC2F7CyD/fv1C1VWXUq90XENWObGkG3jUMBE3MWAiAeeGFz+Ccb+gUnsitLLMnOnGymfD4aFMozS6Ao+80K1Q=="],"tx":{"account":"BDhCBfV6SNNZIapOsNQNWJyQcm1UWQFzf7KOTkLuXd9BhXUB7x/rfxImqgKbhX219wRtdsldQ6okK5gBQ8/a1KY=","type":"CoinbaseTxObject","vsn":1}},{"signatures":["MEQCIFYFc4D4Hh7eijbthtKQJ+lvIvPpsVnKE5BXit4edl0DAiBzwucbiNwi4PLd0O7sLbWPDJUILHYMIUmYNE8Jkl1rFA=="],"tx":{"account":"BDhCBfV6SNNZIapOsNQNWJyQcm1UWQFzf7KOTkLuXd9BhXUB7x/rfxImqgKbhX219wRtdsldQ6okK5gBQ8/a1KY=","type":"CoinbaseTxObject","vsn":1}}]}
```

```
$ curl "http://127.0.0.1:3113/v1/block/txs/list/hash?from=z%2B1HBGHOs32l5UGg7ikclA8l%2FuBoCAGZt12lbZ%2BalSM%3D&to=z%2B1HBGHOs32l5UGg7ikclA8l%2FuBoCAGZt12lbZ%2BalSM%3D"
{"data_schema":"TxMsgPackHashes","transactions":[{"tx":"lMQGc2lnX3R4AZOBxAR0eXBlxAhjb2luYmFzZYHEA3ZzbgGBxARhY2N0xEEEOEIF9XpI01khqk6w1A1YnJBybVRZAXN/so5OQu5d30GFdQHvH+t/EiaqApuFfbX3BG12yV1DqiQrmAFDz9rUppHESDBGAiEAk721wMLvicbzR4atkI/xlI9tfTYcwLYQxzJKR+zTSfsCIQD86WV2+gcNp+n3YJ6gWgTkfF4CP5UtdSDL1Oi1mdkmYQ=="}]}

$ curl "http://127.0.0.1:3113/v1/block/txs/list/hash?from=z%2B1HBGHOs32l5UGg7ikclA8l%2FuBoCAGZt12lbZ%2BalSM%3D&to=z%2B1HBGHOs32l5UGg7ikclA8l%2FuBoCAGZt12lbZ%2BalSM%3D&tx_objects=false"
{"data_schema":"TxMsgPackHashes","transactions":[{"tx":"lMQGc2lnX3R4AZOBxAR0eXBlxAhjb2luYmFzZYHEA3ZzbgGBxARhY2N0xEEEOEIF9XpI01khqk6w1A1YnJBybVRZAXN/so5OQu5d30GFdQHvH+t/EiaqApuFfbX3BG12yV1DqiQrmAFDz9rUppHESDBGAiEAk721wMLvicbzR4atkI/xlI9tfTYcwLYQxzJKR+zTSfsCIQD86WV2+gcNp+n3YJ6gWgTkfF4CP5UtdSDL1Oi1mdkmYQ=="}]}

$ curl "http://127.0.0.1:3113/v1/block/txs/list/hash?from=z%2B1HBGHOs32l5UGg7ikclA8l%2FuBoCAGZt12lbZ%2BalSM%3D&to=z%2B1HBGHOs32l5UGg7ikclA8l%2FuBoCAGZt12lbZ%2BalSM%3D&tx_objects=true"
{"data_schema":"TxObjects","transactions":[{"signatures":["MEYCIQCTvbXAwu+JxvNHhq2Qj/GUj219NhzAthDHMkpH7NNJ+wIhAPzpZXb6Bw2n6fdgnqBaBOR8XgI/lS11IMvU6LWZ2SZh"],"tx":{"account":"BDhCBfV6SNNZIapOsNQNWJyQcm1UWQFzf7KOTkLuXd9BhXUB7x/rfxImqgKbhX219wRtdsldQ6okK5gBQ8/a1KY=","type":"CoinbaseTxObject","vsn":1}}]}
```