### PR TITLE
Restructure Oracle state trees

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,6 +1,7 @@
 # About this release
 
 [This release](https://github.com/aeternity/epoch/releases/tag/v0.4.1) is focused on stability of the testnet - the public test network of nodes and introduces some API for apps usability build on top of it.
+It also introduces a backward incompatible change in the chain format.
 
 Please follow the instructions below and let us know if you have any problems by [opening a ticket](https://github.com/aeternity/epoch/issues).
 
@@ -114,6 +115,7 @@ Ensure the configured path for storing the blockchain exists:
 ```
 mkdir /tmp/node/my_db
 ```
+As of release "v0.5.0", as the chain format changed from the previous release, please ensure that you do not reuse a persisted blockchain produced by the previous releases "v0.4.x".
 
 You can validate the configuration file before starting the node:
 ```

--- a/apps/aecore/include/blocks.hrl
+++ b/apps/aecore/include/blocks.hrl
@@ -1,9 +1,9 @@
 -include("trees.hrl").
 -include("pow.hrl").
 
--define(PROTOCOL_VERSION, 3).
+-define(PROTOCOL_VERSION, 4).
 
--define(GENESIS_VERSION, 3).
+-define(GENESIS_VERSION, 4).
 -define(GENESIS_HEIGHT, 0).
 
 -define(BLOCK_HEADER_HASH_BYTES, 32).

--- a/apps/aecore/test/aec_mining_tests.erl
+++ b/apps/aecore/test/aec_mining_tests.erl
@@ -31,7 +31,7 @@ mine_block_test_() ->
          fun() ->
                  TopBlock = #block{height = 0,
                                    target = ?HIGHEST_TARGET_SCI},
-                 meck:expect(aec_pow, pick_nonce, 0, 123),
+                 meck:expect(aec_pow, pick_nonce, 0, 39),
 
                  {ok, BlockCandidate, Nonce} = ?TEST_MODULE:create_block_candidate(TopBlock, aec_trees:new(), []),
                  {ok, Block} = ?TEST_MODULE:mine(BlockCandidate, Nonce),

--- a/apps/aeoracle/src/aeo_state_tree.erl
+++ b/apps/aeoracle/src/aeo_state_tree.erl
@@ -8,13 +8,13 @@
 -module(aeo_state_tree).
 
 %% API
--export([ get_interaction/2
+-export([ get_interaction/3
         , get_oracle/2
         , empty/0
         , enter_interaction/2
         , insert_interaction/2
         , insert_oracle/2
-        , lookup_interaction/2
+        , lookup_interaction/3
         , lookup_oracle/2
         , prune/2
         , root_hash/1
@@ -26,20 +26,32 @@
         ]).
 -endif.
 
+%% The oracle state tree keep track of oracles and its associated queries
+%% (interaction objects). The naive approach, storing the interactions directly
+%% in the oracle field in the state tree, does not work well. Since the state
+%% tree has to be a Merkle tree all nodes are serialized. This would mean
+%% deserialize/serialize of all interactions when adding or updating a single
+%% interaction. Instead we have a forest of Merkle trees (on Merkle tree per
+%% oracle) in a separate structure, and only store the root hash of that
+%% interactions tree in the oracle field.
+
 %%%===================================================================
 %%% Types
 %%%===================================================================
 
--type mkey() :: aeo_oracles:id() | aeo_interaction:id().
--type mvalue() :: aeo_oracles:serialized() | aeo_interaction:serialized().
--type mtree() :: aeu_mtrees:tree(mkey(), mvalue()).
+-type otree() :: aeu_mtrees:tree(aeo_oracles:id(), aeo_oracles:serialized()).
+-type itree() :: aeu_mtrees:tree(aeo_interaction:id(), aeo_interaction:serialized()).
 -type interaction() :: aeo_interaction:interaction().
 -type oracle() :: aeo_oracles:oracle().
--type cache() :: gb_sets:set({integer(), binary()}).
+-type itrees() :: gb_trees:tree(aeo_oracles:id(), itree()).
+-type cache_item() :: {oracle, aeo_oracles:id()}
+                    | {interaction, aeo_oracles:id(), aeo_interaction:id()}.
+-type cache() :: gb_sets:set({integer(), cache_item()}).
 -type block_height() :: non_neg_integer().
 
--record(oracle_tree, { mtree = gb_merkle_trees:empty() :: mtree()
-                     , cache = cache_new() :: cache()
+-record(oracle_tree, { otree  = aeu_mtrees:empty() :: otree()
+                     , itrees = gb_trees:empty()   :: itrees()
+                     , cache  = cache_new()        :: cache()
                      }).
 
 -opaque tree() :: #oracle_tree{}.
@@ -47,15 +59,19 @@
 -export_type([ tree/0
              ]).
 
+-define(HASH_SIZE, 32).
+
 %%%===================================================================
 %%% API
 %%%===================================================================
 
 -spec empty() -> tree().
 empty() ->
-    MTree = aeu_mtrees:empty(),
-    #oracle_tree{ mtree = MTree
-                , cache = cache_new()
+    OTree  = aeu_mtrees:empty(),
+    ITrees = gb_trees:empty(),
+    #oracle_tree{ otree  = OTree
+                , itrees = ITrees
+                , cache  = cache_new()
                 }.
 
 -spec prune(block_height(), tree()) -> tree().
@@ -67,27 +83,27 @@ prune(Height, #oracle_tree{} = Tree) ->
 
 -spec enter_interaction(interaction(), tree()) -> tree().
 enter_interaction(I, Tree) ->
-    Id = aeo_interaction:id(I),
-    Serialized = aeo_interaction:serialize(I),
-    Expires = aeo_interaction:expires(I),
-    enter_common(Id, Expires, Serialized, Tree).
+    add_interaction(enter, I, Tree).
 
 -spec insert_interaction(interaction(), tree()) -> tree().
 insert_interaction(I, Tree) ->
-    Id = aeo_interaction:id(I),
-    Serialized = aeo_interaction:serialize(I),
-    Expires = aeo_interaction:expires(I),
-    insert_common(Id, Expires, Serialized, Tree).
+    add_interaction(insert, I, Tree).
 
--spec get_interaction(binary(), tree()) -> interaction().
-get_interaction(Id, Tree) ->
-    aeo_interaction:deserialize(aeu_mtrees:get(Id, Tree#oracle_tree.mtree)).
+-spec get_interaction(aeo_oracles:id(), aeo_interactions:id(), tree()) -> interaction().
+get_interaction(OracleId, Id, Tree) ->
+    ITree = gb_trees:get(OracleId, Tree#oracle_tree.itrees),
+    aeo_interaction:deserialize(aeu_mtrees:get(Id, ITree)).
 
--spec lookup_interaction(binary(), tree()) -> {'value', interaction()} | none.
-lookup_interaction(Id, Tree) ->
-    case aeu_mtrees:lookup(Id, Tree#oracle_tree.mtree) of
-      {value, Val} -> {value, aeo_interaction:deserialize(Val)};
-      none -> none
+-spec lookup_interaction(aeo_oracles:id(), aeo_interactions:id(), tree()) ->
+                                                {'value', interaction()} | none.
+lookup_interaction(OracleId, Id, Tree) ->
+    case gb_trees:lookup(OracleId, Tree#oracle_tree.itrees) of
+        {value, ITree} ->
+            case aeu_mtrees:lookup(Id, ITree) of
+                {value, Val} -> {value, aeo_interaction:deserialize(Val)};
+                none -> none
+            end;
+        none -> none
     end.
 
 -spec insert_oracle(oracle(), tree()) -> tree().
@@ -95,75 +111,103 @@ insert_oracle(O, Tree) ->
     Id = aeo_oracles:id(O),
     Serialized = aeo_oracles:serialize(O),
     Expires = aeo_oracles:expires(O),
-    insert_common(Id, Expires, Serialized, Tree).
+
+    OTree  = aeu_mtrees:insert(Id, Serialized, Tree#oracle_tree.otree),
+    ITrees = gb_trees:insert(Id, aeu_mtrees:empty(), Tree#oracle_tree.itrees),
+    Cache  = cache_push({oracle, Id}, Expires, Tree#oracle_tree.cache),
+    Tree#oracle_tree{ otree  = OTree
+                    , itrees = ITrees
+                    , cache  = Cache
+                    }.
 
 -spec get_oracle(binary(), tree()) -> oracle().
 get_oracle(Id, Tree) ->
-    aeo_oracles:deserialize(aeu_mtrees:get(Id, Tree#oracle_tree.mtree)).
+    aeo_oracles:deserialize(aeu_mtrees:get(Id, Tree#oracle_tree.otree)).
 
 -spec lookup_oracle(binary(), tree()) -> {'value', oracle()} | 'none'.
 lookup_oracle(Id, Tree) ->
-    case aeu_mtrees:lookup(Id, Tree#oracle_tree.mtree) of
+    case aeu_mtrees:lookup(Id, Tree#oracle_tree.otree) of
         {value, Val}  -> {value, aeo_oracles:deserialize(Val)};
         none -> none
     end.
 
 -spec root_hash(tree()) -> {ok, aeu_mtrees:root_hash()} | {error, empty}.
-root_hash(#oracle_tree{mtree = MTree}) ->
-    aeu_mtrees:root_hash(MTree).
+root_hash(#oracle_tree{otree = OTree}) ->
+    aeu_mtrees:root_hash(OTree).
 
 -ifdef(TEST).
 -spec oracle_list(tree()) -> list(oracle()).
-oracle_list(#oracle_tree{mtree = MTree}) ->
-    ToOracle = fun(MaybeO) ->
-                   try [aeo_oracles:deserialize(MaybeO)]
-                   catch _:_ -> [] end end,
-    [ O || {_, Val} <- aeu_mtrees:to_list(MTree), O <- ToOracle(Val) ].
+oracle_list(#oracle_tree{otree = OTree}) ->
+    [ aeo_oracles:deserialize(Val) || {_, Val} <- aeu_mtrees:to_list(OTree) ].
 
 -spec interaction_list(tree()) -> list(interaction()).
-interaction_list(#oracle_tree{mtree = MTree}) ->
-    ToInter = fun(MaybeI) ->
-                  try [aeo_interaction:deserialize(MaybeI)]
-                  catch _:_ -> [] end end,
-    [ I || {_, Val} <- aeu_mtrees:to_list(MTree), I <- ToInter(Val) ].
+interaction_list(#oracle_tree{itrees = ITrees}) ->
+    [ aeo_interaction:deserialize(Val) || {_, ITree} <- gb_trees:to_list(ITrees),
+                                          {_, Val} <- aeu_mtrees:to_list(ITree) ].
 -endif.
 
 %%%===================================================================
 %%% Internal functions
 %%%===================================================================
 
-enter_common(Id, Expires, Serialized, Tree) ->
-    MTree1 = aeu_mtrees:enter(Id, Serialized, Tree#oracle_tree.mtree),
-    Cache = cache_push(Id, Expires, Tree#oracle_tree.cache),
-    Tree#oracle_tree{ mtree = MTree1
-                    , cache = Cache
+add_interaction(How, I, Tree) ->
+    OracleId    = aeo_interaction:oracle_address(I),
+    Oracle      = get_oracle(OracleId, Tree),
+    ITree       = gb_trees:get(OracleId, Tree#oracle_tree.itrees),
+    Id          = aeo_interaction:id(I),
+    SerializedI = aeo_interaction:serialize(I),
+    Expires     = aeo_interaction:expires(I),
+    ITree1      = case How of
+                      enter  -> aeu_mtrees:enter(Id, SerializedI, ITree);
+                      insert -> aeu_mtrees:insert(Id, SerializedI, ITree)
+                  end,
+
+    IRoot       = safe_root_hash(ITree1),
+    SerializedO = aeo_oracles:serialize(
+                      aeo_oracles:set_interactions_hash(IRoot, Oracle)),
+
+    OTree  = aeu_mtrees:enter(OracleId, SerializedO, Tree#oracle_tree.otree),
+    ITrees = gb_trees:update(OracleId, ITree1, Tree#oracle_tree.itrees),
+    Cache  = cache_push({interaction, OracleId, Id}, Expires, Tree#oracle_tree.cache),
+    Tree#oracle_tree{ otree  = OTree
+                    , itrees = ITrees
+                    , cache  = Cache
                     }.
 
-insert_common(Id, Expires, Serialized, Tree) ->
-    MTree1 = aeu_mtrees:insert(Id, Serialized, Tree#oracle_tree.mtree),
-    Cache = cache_push(Id, Expires, Tree#oracle_tree.cache),
-    Tree#oracle_tree{ mtree = MTree1
-                    , cache = Cache
-                    }.
+int_prune(Height, #oracle_tree{ cache = Cache } = Tree) ->
+    int_prune(cache_safe_peek(Cache), Height, Tree).
 
-int_prune(Height, #oracle_tree{cache = Cache, mtree = MTree} = Tree) ->
-    case cache_safe_peek(Cache) of
-        {H, _} when H > Height -> Tree;
-        Other ->
-            {Cache1, Mtree1} = int_prune(Other, Height, Cache, MTree),
-            Tree#oracle_tree{ cache = Cache1
-                            , mtree = Mtree1}
-    end.
-
-int_prune(none,_Height, Cache, MTree) ->
-    {Cache, MTree};
-int_prune({Height, Id}, Height, Cache, MTree) ->
+int_prune(none, _Height, Tree) ->
+    Tree;
+int_prune({Height, Id}, Height, #oracle_tree{ cache = Cache } = Tree) ->
     {{Height, Id}, Cache1} = cache_pop(Cache),
-    MTree1 = aeu_mtrees:delete(Id, MTree),
-    int_prune(cache_safe_peek(Cache1), Height, Cache1, MTree1);
-int_prune({Height1,_Id}, Height2, Cache, MTree) when Height2 < Height1 ->
-    {Cache, MTree}.
+    Tree1 = delete(Id, Tree#oracle_tree{ cache = Cache1 }),
+    int_prune(cache_safe_peek(Cache1), Height, Tree1);
+int_prune({Height1,_Id}, Height2, Tree) when Height2 < Height1 ->
+    Tree.
 
+delete({oracle, Id}, Tree) ->
+    OTree  = aeu_mtrees:delete(Id, Tree#oracle_tree.otree),
+    ITrees = gb_trees:delete(Id, Tree#oracle_tree.itrees),
+    Tree#oracle_tree{ otree = OTree, itrees = ITrees };
+delete({interaction, OracleId, Id}, Tree) ->
+    %% It is possible that the oracle expired first.
+    %% Since {X, {oracle, Hash}} sorts before {X, {interaction, H1, H2}} the
+    %% inverse cannot happen.
+    case gb_trees:lookup(OracleId, Tree#oracle_tree.itrees) of
+        {value, ITree} ->
+            ITree1 = aeu_mtrees:delete(Id, ITree),
+            ITrees = gb_trees:update(OracleId, ITree1, Tree#oracle_tree.itrees),
+            Oracle = get_oracle(OracleId, Tree),
+            IRoot  = safe_root_hash(ITree1),
+            SerializedO = aeo_oracles:serialize(
+                              aeo_oracles:set_interactions_hash(IRoot, Oracle)),
+
+            OTree  = aeu_mtrees:enter(OracleId, SerializedO, Tree#oracle_tree.otree),
+            Tree#oracle_tree{ otree = OTree, itrees = ITrees };
+        none ->
+            Tree
+    end.
 
 %%%===================================================================
 %%% TTL Cache
@@ -184,3 +228,8 @@ cache_safe_peek(C) ->
 cache_pop(C) ->
     gb_sets:take_smallest(C).
 
+safe_root_hash(ITree) ->
+    case aeu_mtrees:root_hash(ITree) of
+        {ok, RootHash} -> RootHash;
+        {error, empty} -> <<0:(?HASH_SIZE*8)>>
+    end.

--- a/deployment/ansible/deploy.yml
+++ b/deployment/ansible/deploy.yml
@@ -39,7 +39,7 @@
           port: 3013
       chain:
         persist: true
-        db_path: "./db12"
+        db_path: "./db13"
       keypair:
         dir: "keys"
         password: "{{ keys_password|default('secret') }}"


### PR DESCRIPTION
The idea is to have the oracle interaction objects as a sub-tree under
the oracle itself. Otherwise it will be (almost) impossible to list all
interactions that belong to a particular oracle.