### PR TITLE
HTTP Endpoint: getTransactionFromBlock

### DIFF
--- a/apps/aehttp/priv/swagger.json
+++ b/apps/aehttp/priv/swagger.json
@@ -895,6 +895,132 @@
         },
         "security" : [ ]
       }
+    },
+    "/block/tx/height/{height}/{tx_index}" : {
+      "get" : {
+        "tags" : [ "internal" ],
+        "description" : "Get a transaction by index in the block by height",
+        "operationId" : "GetTransactionFromBlockHeight",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "height",
+          "in" : "path",
+          "description" : "Height of the block to search for",
+          "required" : true,
+          "type" : "integer"
+        }, {
+          "name" : "tx_index",
+          "in" : "path",
+          "description" : "Index of the transaction in the block",
+          "required" : true,
+          "type" : "integer"
+        }, {
+          "name" : "tx_objects",
+          "in" : "query",
+          "description" : "Transactions as objects (default is as message pack hashes)",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "The transaction found",
+            "schema" : {
+              "$ref" : "#/definitions/SingleTxHashOrObject"
+            }
+          },
+          "404" : {
+            "description" : "Block or transaction not found",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          }
+        },
+        "security" : [ ]
+      }
+    },
+    "/block/tx/hash/{hash}/{tx_index}" : {
+      "get" : {
+        "tags" : [ "internal" ],
+        "description" : "Get a transaction by index in the block by hash",
+        "operationId" : "GetTransactionFromBlockHash",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "hash",
+          "in" : "path",
+          "description" : "Hash of the block to search for",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "tx_index",
+          "in" : "path",
+          "description" : "Index of the transaction in the block",
+          "required" : true,
+          "type" : "integer"
+        }, {
+          "name" : "tx_objects",
+          "in" : "query",
+          "description" : "Transactions as objects (default is as message pack hashes)",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "The transaction found",
+            "schema" : {
+              "$ref" : "#/definitions/SingleTxHashOrObject"
+            }
+          },
+          "404" : {
+            "description" : "Block or transaction not found",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          }
+        },
+        "security" : [ ]
+      }
+    },
+    "/block/tx/latest/{tx_index}" : {
+      "get" : {
+        "tags" : [ "internal" ],
+        "description" : "Get a transaction by index in the latest block",
+        "operationId" : "GetTransactionFromBlockLatest",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tx_index",
+          "in" : "path",
+          "description" : "Index of the transaction in the block",
+          "required" : true,
+          "type" : "integer"
+        }, {
+          "name" : "tx_objects",
+          "in" : "query",
+          "description" : "Transactions as objects (default is as message pack hashes)",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "The transaction found",
+            "schema" : {
+              "$ref" : "#/definitions/SingleTxHashOrObject"
+            }
+          },
+          "404" : {
+            "description" : "Block or transaction not found",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          }
+        },
+        "security" : [ ]
+      }
     }
   },
   "definitions" : {
@@ -1279,6 +1405,42 @@
         }
       }
     },
+    "SingleTxHashOrObject" : {
+      "type" : "object",
+      "required" : [ "data_schema" ],
+      "discriminator" : "data_schema",
+      "properties" : {
+        "data_schema" : {
+          "type" : "string"
+        }
+      }
+    },
+    "SingleTxObject" : {
+      "allOf" : [ {
+        "$ref" : "#/definitions/TxHashOrObject"
+      }, {
+        "type" : "object",
+        "required" : [ "transaction" ],
+        "properties" : {
+          "transaction" : {
+            "$ref" : "#/definitions/SignedTxObject"
+          }
+        }
+      } ]
+    },
+    "SingleTxHash" : {
+      "allOf" : [ {
+        "$ref" : "#/definitions/TxHashOrObject"
+      }, {
+        "type" : "object",
+        "required" : [ "transaction" ],
+        "properties" : {
+          "transaction" : {
+            "$ref" : "#/definitions/Tx"
+          }
+        }
+      } ]
+    },
     "SignedTxObject" : {
       "type" : "object",
       "properties" : {
@@ -1296,10 +1458,14 @@
     },
     "GenericTxObject" : {
       "type" : "object",
+      "required" : [ "type" ],
       "discriminator" : "type",
       "properties" : {
-        "data_schema" : {
+        "type" : {
           "type" : "string"
+        },
+        "vsn" : {
+          "type" : "integer"
         }
       }
     },

--- a/apps/aehttp/src/swagger/swagger_api.erl
+++ b/apps/aehttp/src/swagger/swagger_api.erl
@@ -132,6 +132,26 @@ request_params('GetPubKey') ->
     [
     ];
 
+request_params('GetTransactionFromBlockHash') ->
+    [
+        'hash',
+        'tx_index',
+        'tx_objects'
+    ];
+
+request_params('GetTransactionFromBlockHeight') ->
+    [
+        'height',
+        'tx_index',
+        'tx_objects'
+    ];
+
+request_params('GetTransactionFromBlockLatest') ->
+    [
+        'tx_index',
+        'tx_objects'
+    ];
+
 request_params('PostOracleQueryTx') ->
     [
         'OracleQueryTx'
@@ -334,6 +354,78 @@ request_param_info('GetOracleQuestions', 'oracle_pub_key') ->
         rules => [
             {type, 'binary'},
             required
+        ]
+    };
+
+request_param_info('GetTransactionFromBlockHash', 'hash') ->
+    #{
+        source =>  binding ,
+        rules => [
+            {type, 'binary'},
+            required
+        ]
+    };
+
+request_param_info('GetTransactionFromBlockHash', 'tx_index') ->
+    #{
+        source =>  binding ,
+        rules => [
+            {type, 'integer'},
+            required
+        ]
+    };
+
+request_param_info('GetTransactionFromBlockHash', 'tx_objects') ->
+    #{
+        source => qs_val  ,
+        rules => [
+            {type, 'boolean'},
+            not_required
+        ]
+    };
+
+request_param_info('GetTransactionFromBlockHeight', 'height') ->
+    #{
+        source =>  binding ,
+        rules => [
+            {type, 'integer'},
+            required
+        ]
+    };
+
+request_param_info('GetTransactionFromBlockHeight', 'tx_index') ->
+    #{
+        source =>  binding ,
+        rules => [
+            {type, 'integer'},
+            required
+        ]
+    };
+
+request_param_info('GetTransactionFromBlockHeight', 'tx_objects') ->
+    #{
+        source => qs_val  ,
+        rules => [
+            {type, 'boolean'},
+            not_required
+        ]
+    };
+
+request_param_info('GetTransactionFromBlockLatest', 'tx_index') ->
+    #{
+        source =>  binding ,
+        rules => [
+            {type, 'integer'},
+            required
+        ]
+    };
+
+request_param_info('GetTransactionFromBlockLatest', 'tx_objects') ->
+    #{
+        source => qs_val  ,
+        rules => [
+            {type, 'boolean'},
+            not_required
         ]
     };
 
@@ -552,6 +644,21 @@ validate_response('GetPendingBlockTxsCount', 200, Body, ValidatorState) ->
 validate_response('GetPubKey', 200, Body, ValidatorState) ->
     validate_response_body('PubKey', 'PubKey', Body, ValidatorState);
 validate_response('GetPubKey', 404, Body, ValidatorState) ->
+    validate_response_body('Error', 'Error', Body, ValidatorState);
+
+validate_response('GetTransactionFromBlockHash', 200, Body, ValidatorState) ->
+    validate_response_body('SingleTxHashOrObject', 'SingleTxHashOrObject', Body, ValidatorState);
+validate_response('GetTransactionFromBlockHash', 404, Body, ValidatorState) ->
+    validate_response_body('Error', 'Error', Body, ValidatorState);
+
+validate_response('GetTransactionFromBlockHeight', 200, Body, ValidatorState) ->
+    validate_response_body('SingleTxHashOrObject', 'SingleTxHashOrObject', Body, ValidatorState);
+validate_response('GetTransactionFromBlockHeight', 404, Body, ValidatorState) ->
+    validate_response_body('Error', 'Error', Body, ValidatorState);
+
+validate_response('GetTransactionFromBlockLatest', 200, Body, ValidatorState) ->
+    validate_response_body('SingleTxHashOrObject', 'SingleTxHashOrObject', Body, ValidatorState);
+validate_response('GetTransactionFromBlockLatest', 404, Body, ValidatorState) ->
     validate_response_body('Error', 'Error', Body, ValidatorState);
 
 validate_response('PostOracleQueryTx', 200, Body, ValidatorState) ->

--- a/apps/aehttp/src/swagger/swagger_internal_handler.erl
+++ b/apps/aehttp/src/swagger/swagger_internal_handler.erl
@@ -168,6 +168,30 @@ allowed_methods(
 allowed_methods(
     Req,
     State = #state{
+        operation_id = 'GetTransactionFromBlockHash'
+    }
+) ->
+    {[<<"GET">>], Req, State};
+
+allowed_methods(
+    Req,
+    State = #state{
+        operation_id = 'GetTransactionFromBlockHeight'
+    }
+) ->
+    {[<<"GET">>], Req, State};
+
+allowed_methods(
+    Req,
+    State = #state{
+        operation_id = 'GetTransactionFromBlockLatest'
+    }
+) ->
+    {[<<"GET">>], Req, State};
+
+allowed_methods(
+    Req,
+    State = #state{
         operation_id = 'PostOracleQueryTx'
     }
 ) ->
@@ -222,7 +246,6 @@ allowed_methods(Req, State) ->
         Req :: cowboy_req:req(),
         State :: state()
     }.
-
 
 is_authorized(Req, State) ->
     {true, Req, State}.
@@ -376,6 +399,36 @@ valid_content_headers(
     Req0,
     State = #state{
         operation_id = 'GetPubKey'
+    }
+) ->
+    Headers = [],
+    {Result, Req} = validate_headers(Headers, Req0),
+    {Result, Req, State};
+
+valid_content_headers(
+    Req0,
+    State = #state{
+        operation_id = 'GetTransactionFromBlockHash'
+    }
+) ->
+    Headers = [],
+    {Result, Req} = validate_headers(Headers, Req0),
+    {Result, Req, State};
+
+valid_content_headers(
+    Req0,
+    State = #state{
+        operation_id = 'GetTransactionFromBlockHeight'
+    }
+) ->
+    Headers = [],
+    {Result, Req} = validate_headers(Headers, Req0),
+    {Result, Req, State};
+
+valid_content_headers(
+    Req0,
+    State = #state{
+        operation_id = 'GetTransactionFromBlockLatest'
     }
 ) ->
     Headers = [],

--- a/apps/aehttp/src/swagger/swagger_router.erl
+++ b/apps/aehttp/src/swagger/swagger_router.erl
@@ -180,6 +180,21 @@ get_operations() ->
             method => <<"GET">>,
             handler => 'swagger_internal_handler'
         },
+        'GetTransactionFromBlockHash' => #{
+            path => "/v1/block/tx/hash/:hash/:tx_index",
+            method => <<"GET">>,
+            handler => 'swagger_internal_handler'
+        },
+        'GetTransactionFromBlockHeight' => #{
+            path => "/v1/block/tx/height/:height/:tx_index",
+            method => <<"GET">>,
+            handler => 'swagger_internal_handler'
+        },
+        'GetTransactionFromBlockLatest' => #{
+            path => "/v1/block/tx/latest/:tx_index",
+            method => <<"GET">>,
+            handler => 'swagger_internal_handler'
+        },
         'PostOracleQueryTx' => #{
             path => "/v1/oracle-query-tx",
             method => <<"POST">>,

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -81,7 +81,12 @@
 
     block_txs_count_by_height_not_found/1,
     block_txs_count_by_hash_not_found/1,
-    block_txs_count_by_broken_hash/1
+    block_txs_count_by_broken_hash/1,
+
+    block_tx_index_by_height/1,
+    block_tx_index_by_hash/1,
+    block_tx_index_latest/1,
+    block_tx_index_not_founds/1
    ]).
 
 -include_lib("common_test/include/ct.hrl").
@@ -158,7 +163,12 @@ groups() ->
 
        block_txs_count_by_height_not_found,
        block_txs_count_by_hash_not_found,
-       block_txs_count_by_broken_hash
+       block_txs_count_by_broken_hash,
+
+       block_tx_index_by_height,
+       block_tx_index_by_hash,
+       block_tx_index_latest,
+       block_tx_index_not_founds
       ]}
     ].
 
@@ -751,7 +761,7 @@ internal_block_not_found_by_hash(_Config) ->
                     H = random_hash(),
                     {error, block_not_found} = rpc(aec_conductor,
                                                    get_block_by_hash, [H]), 
-                    Hash = base64:encode(H),
+                    Hash = aec_base58c:encode(block_hash, H),
                     {ok, 404, #{<<"reason">> := <<"Block not found">>}}
                         = get_internal_block_by_hash(Hash, Opt)
                 end,
@@ -763,7 +773,7 @@ internal_block_not_found_by_hash(_Config) ->
 internal_block_not_found_by_broken_hash(_Config) ->
     lists:foreach(
         fun(_) ->
-            <<_, BrokenHash/binary>> = base64:encode(random_hash()),
+            <<_, BrokenHash/binary>> = aec_base58c:encode(block_hash, random_hash()),
             lists:foreach(
                 fun(Opt) ->
                     {ok, 400, #{<<"reason">> := <<"Invalid hash">>}} =
@@ -940,7 +950,7 @@ block_txs_count_by_hash_not_found(_Config) ->
             H = random_hash(),
             {error, block_not_found} = rpc(aec_conductor,
                                             get_block_by_hash, [H]), 
-            Hash = base64:encode(H),
+            Hash = aec_base58c:encode(block_hash, H),
             {ok, 404, #{<<"reason">> := <<"Block not found">>}}
                 = get_block_txs_count_by_hash(Hash)
         end,
@@ -950,12 +960,109 @@ block_txs_count_by_hash_not_found(_Config) ->
 block_txs_count_by_broken_hash(_Config) ->
     lists:foreach(
         fun(_) ->
-            <<_, BrokenHash/binary>> = base64:encode(random_hash()),
+            <<_, BrokenHash/binary>> = aec_base58c:encode(block_hash, random_hash()),
             {ok, 400, #{<<"reason">> := <<"Invalid hash">>}} =
                 get_block_txs_count_by_hash(BrokenHash)
         end,
         lists:seq(1, 10)),
     ok.
+
+block_tx_index_by_height(_Config) ->
+    generic_block_tx_index_test(fun get_block_tx_by_index_height/3).
+
+block_tx_index_by_hash(_Config) ->
+    CallApiFun =
+        fun(H, Index, Opts) ->
+            {ok, Hash} = block_hash_by_height(H),
+            get_block_tx_by_index_hash(Hash, Index, Opts)
+        end,
+    generic_block_tx_index_test(CallApiFun).
+
+block_tx_index_latest(_Config) ->
+    generic_block_tx_index_test(
+        fun(_, Index, Opts) ->
+            get_block_tx_by_index_latest(Index, Opts)
+        end).
+
+block_tx_index_not_founds(_Config) ->
+    RandomHeight = rand:uniform(999) + 1, % 1..1000
+    Test =
+        fun(Code, ErrMsg, Fun, Cases) ->
+            lists:foreach(
+                fun({H, I}) ->
+                    lists:foreach(
+                        fun(Opt) ->
+                            {ok, Code, #{<<"reason">> := ErrMsg}} = Fun(H, I, Opt) end,
+                        [default, false, true])
+                end,
+                Cases)
+        end,
+    Test(404, <<"Chain too short">>, fun get_block_tx_by_index_height/3,
+         [{1, 0},
+          {1, 1},
+          {RandomHeight, 0},
+          {RandomHeight, 1},
+          {RandomHeight + 1, 0},
+          {RandomHeight + 1, 1}]),
+    Test(404, <<"Block not found">>, fun get_block_tx_by_index_hash/3,
+         [{aec_base58c:encode(block_hash, random_hash()), 0},
+          {aec_base58c:encode(block_hash, random_hash()), 1}]),
+    BlocksToMine = 3,
+    lists:foreach(
+        fun(Height) ->
+            {ok, 200, #{<<"count">> := TxsCount}} = get_block_txs_count_by_height(Height),
+            Test(404, <<"Transaction not found">>, fun get_block_tx_by_index_height/3,
+                [{Height, TxsCount + 1},
+                 {Height, TxsCount + 2},
+                 {Height, TxsCount + rand:uniform(1000) + 1}
+                ]),
+            {ok, Hash} = block_hash_by_height(Height),
+            Test(404, <<"Transaction not found">>, fun get_block_tx_by_index_hash/3,
+                [{Hash, TxsCount + 1},
+                 {Hash, TxsCount + 2},
+                 {Hash, TxsCount + rand:uniform(1000) + 1}
+                ]),
+            aecore_suite_utils:mine_blocks(aecore_suite_utils:node_name(?NODE), 1),
+            add_spend_txs()
+        end, lists:seq(0, BlocksToMine)),
+    
+    ok.
+
+
+generic_block_tx_index_test(CallApi) when is_function(CallApi, 3)->
+    BlocksToMine = 10,
+    lists:foreach(
+        fun(Height) ->
+            lists:foreach(
+                fun({Opts, DataSchema}) ->
+                    {ok, 200, BlockMap} =
+                        get_internal_block_by_height(Height, Opts),
+                    AllTxs = maps:get(<<"transactions">>, BlockMap, []),
+                    TxsIdxs =
+                        case length(AllTxs) of
+                            0 ->
+                                [];
+                            TxsLength ->
+                                lists:seq(1, TxsLength)
+                        end,
+                    lists:foreach(
+                        fun({Tx, Index}) ->
+                            {ok, 200, #{<<"data_schema">> := DataSchema,
+                                        <<"transaction">> := Tx}} = CallApi(Height,
+                                                                            Index,
+                                                                            Opts)
+                        end,
+                        lists:zip(AllTxs, TxsIdxs))
+                end,
+                [{default, <<"SingleTxHash">>},
+                 {false,  <<"SingleTxHash">>},
+                 {true,  <<"SingleTxObject">>}]),
+            aecore_suite_utils:mine_blocks(aecore_suite_utils:node_name(?NODE), 1),
+            add_spend_txs()
+        end,
+        lists:seq(0, BlocksToMine)), % from genesis
+    ok.
+
 
 %% ============================================================
 %% HTTP Requests 
@@ -1059,6 +1166,24 @@ get_block_txs_count_preset(Segment) ->
     Host = internal_address(),
     http_request(Host, get, "block/txs/count/" ++ Segment, []).
 
+get_block_tx_by_index_height(Height, Index, TxObjects) ->
+    Params = tx_objects_params(TxObjects),
+    Host = internal_address(),
+    http_request(Host, get, "block/tx/height/" ++ integer_to_list(Height) ++
+                                       "/" ++ integer_to_list(Index), Params).
+
+get_block_tx_by_index_hash(Hash, Index, TxObjects) when is_binary(Hash) ->
+    get_block_tx_by_index_hash(binary_to_list(Hash), Index, TxObjects);
+get_block_tx_by_index_hash(Hash, Index, TxObjects) ->
+    Params = tx_objects_params(TxObjects),
+    Host = internal_address(),
+    http_request(Host, get, "block/tx/hash/" ++ http_uri:encode(Hash) ++
+                                       "/" ++ integer_to_list(Index), Params).
+
+get_block_tx_by_index_latest(Index, TxObjects) ->
+    Params = tx_objects_params(TxObjects),
+    Host = internal_address(),
+    http_request(Host, get, "block/tx/latest/" ++ integer_to_list(Index), Params).
 %% ============================================================
 %% private functions
 %% ============================================================
@@ -1196,7 +1321,7 @@ prepare_for_spending(BlocksToMine) ->
 block_hash_by_height(Height) ->
     {ok, B} = rpc(aec_conductor, get_block_by_height, [Height]),
     {ok, HBin} = aec_blocks:hash_internal_representation(B),
-    Hash = binary_to_list(base64:encode(HBin)),
+    Hash = binary_to_list(aec_base58c:encode(block_hash, HBin)),
     {ok, Hash}.
 
 -spec get_pending_block() -> {error, no_candidate}

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -783,6 +783,109 @@ paths:
                 type: integer
                 description: Count
       security: []
+  /block/tx/height/{height}/{tx_index}:
+    get:
+      tags:
+        - internal
+      operationId: GetTransactionFromBlockHeight
+      description: 'Get a transaction by index in the block by height'
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters: 
+        - in: path 
+          name: height
+          description: 'Height of the block to search for'
+          required: true
+          type: integer
+        - in: path 
+          name: tx_index
+          description: 'Index of the transaction in the block'
+          required: true
+          type: integer
+        - in: query
+          name: tx_objects
+          description: 'Transactions as objects (default is as hashes)'
+          type: boolean
+          default: false
+      responses:
+        '200':
+          description: The transaction found 
+          schema:
+            $ref: '#/definitions/SingleTxHashOrObject'
+        '404':
+          description: Block or transaction not found
+          schema:
+            $ref: '#/definitions/Error'
+      security: []
+  /block/tx/hash/{hash}/{tx_index}:
+    get:
+      tags:
+        - internal
+      operationId: GetTransactionFromBlockHash
+      description: 'Get a transaction by index in the block by hash'
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters: 
+        - in: path 
+          name: hash
+          description: 'Hash of the block to search for'
+          required: true
+          type: string 
+        - in: path 
+          name: tx_index
+          description: 'Index of the transaction in the block'
+          required: true
+          type: integer
+        - in: query
+          name: tx_objects
+          description: 'Transactions as objects (default is as message pack hashes)'
+          type: boolean
+          default: false
+      responses:
+        '200':
+          description: The transaction found 
+          schema:
+            $ref: '#/definitions/SingleTxHashOrObject'
+        '404':
+          description: Block or transaction not found
+          schema:
+            $ref: '#/definitions/Error'
+      security: []
+  /block/tx/latest/{tx_index}:
+    get:
+      tags:
+        - internal
+      operationId: GetTransactionFromBlockLatest
+      description: 'Get a transaction by index in the latest block'
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters: 
+        - in: path 
+          name: tx_index
+          description: 'Index of the transaction in the block'
+          required: true
+          type: integer
+        - in: query
+          name: tx_objects
+          description: 'Transactions as objects (default is as message pack hashes)'
+          type: boolean
+          default: false
+      responses:
+        '200':
+          description: The transaction found 
+          schema:
+            $ref: '#/definitions/SingleTxHashOrObject'
+        '404':
+          description: Block or transaction not found
+          schema:
+            $ref: '#/definitions/Error'
+      security: []
 
 definitions:
   Header:
@@ -1066,11 +1169,37 @@ definitions:
     required:
     - height
 
+  SingleTxHashOrObject:
+    type: object
+    discriminator: data_schema 
+    properties:
+      data_schema:
+        type: string
+    required:
+    - data_schema
+  SingleTxObject:
+    allOf:
+      - $ref: '#/definitions/TxHashOrObject'
+      - type: object
+        properties:
+          transaction:
+            $ref: '#/definitions/SignedTxObject'
+        required:
+        - transaction
+  SingleTxHash:
+    allOf:
+      - $ref: '#/definitions/TxHashOrObject'
+      - type: object
+        properties:
+          transaction:
+            $ref: '#/definitions/Tx'
+        required:
+        - transaction
   SignedTxObject:
     type: object
     properties:
       tx:
-        "$ref": '#/definitions/GenericTxObject'
+        $ref: '#/definitions/GenericTxObject'
       signatures:
         type: array
         minItems: 1
@@ -1081,9 +1210,10 @@ definitions:
     type: object
     discriminator: type 
     properties:
-      data_schema:
+      type:
         type: string
-        vsn: integer
+      vsn:
+        type: integer
     required:
     - type
   CoinbaseTxObject:


### PR DESCRIPTION
[Pivotal story](https://www.pivotaltracker.com/story/show/154168041)
**getTransactionFromBlock** ([ref](http://web3js.readthedocs.io/en/1.0/web3-eth.html#gettransactionfromblock)) 
**Description**: Returns a transaction based on a block hash or number and the transactions index position.
**Endpoints**:
GET /block/tx/height/{height}/{tx_index}
GET /block/tx/hash/{hash}/{tx_index}
GET /block/tx/latest/{tx_index}
**Options**:
*tx_objects* - (optional, default false) If true, the returned block will contain all transactions as objects, if false it will only contains the transaction message pack encoded hashes