### PR TITLE
HTTP API version v1 -> v2

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -36,9 +36,10 @@ This section describes how to run a node as part of the testnet.
 The core nodes of the public test network are accessible from the Internet and expose [an HTTP API](https://github.com/aeternity/epoch/blob/v0.4.1/config/swagger.yaml).
 
 Information, e.g. height, of the top block of the longest chain as seen by these core nodes of the testnet can be obtained by opening in the browser any of the following URLs:
-* http://31.13.248.103:3013/v1/top
-* http://31.13.248.102:3013/v1/top
-* http://31.13.248.105:3013/v1/top
+* http://31.13.248.103:3013/v2/top
+* http://31.13.248.102:3013/v2/top
+* http://31.13.248.105:3013/v2/top
+
 
 ### Setup your node
 
@@ -144,7 +145,7 @@ bin/epoch start
 
 Verify the node is up, by inspecting the current top of the blockchain as seen by the node:
 ```
-curl http://127.0.0.1:3003/v1/top
+curl http://127.0.0.1:3003/v2/top
 ```
 
 If the node is unresponsive, inspect the `log` directory for errors.
@@ -242,12 +243,12 @@ Verify that your node sees the same longest blockchain as the testnet.
 
 Inspect the current top of the blockchain as seen by the testnet:
 ```
-curl http://31.13.248.102:3013/v1/top
+curl http://31.13.248.102:3013/v2/top
 ```
 
 Inspect the current top of the blockchain as seen by your node:
 ```
-curl http://127.0.0.1:3003/v1/top
+curl http://127.0.0.1:3003/v2/top
 ```
 
 Verify that the height is the same; it may take a few minutes for your node to catch up with the testnet blockchain.
@@ -256,13 +257,13 @@ Verify that the height is the same; it may take a few minutes for your node to c
 After the node is successfully connected to the testnet, you could verify that it is mining on the same chain as the rest of the network.
 You can validate it observing the `hash` of the `/top` of the remote nodes:
 ```
-curl http://31.13.248.102:3013/v1/top
+curl http://31.13.248.102:3013/v2/top
 {"hash":"HcebFAby1g7uLgj5KEp3jBsFnKXYEthrP5+r5P2BE9Q=","height":...}
 ```
 
 This is the hash of the block being at the top of the chain of the node and it should be same as the hash in `prev_hash` of the block you're currently mining:
 ```
-curl http://localhost:3113/v1/block/pending
+curl http://localhost:3113/v2/block/pending
 {"data_schema":"BlockWithTxsHashes","height":... ,"prev_hash":"HcebFAby1g7uLgj5KEp3jBsFnKXYEthrP5+r5P2BE9Q=", ...}
 ```
 Height would be +1 of what is in the `/top` of the remote node but this is not
@@ -275,7 +276,7 @@ as strong guarantee as the `prev_hash`.
 
 Retrieve the public key of your node:
 ```
-curl http://127.0.0.1:3103/v1/account/pub-key
+curl http://127.0.0.1:3103/v2/account/pub-key
 ```
 You shall read output like the following:
 ```
@@ -286,7 +287,7 @@ You shall read output like the following:
 
 Retrieve the balance associated to the retrieved public key (replace the public key):
 ```
-curl -G http://127.0.0.1:3003/v1/account/balance --data-urlencode "pub_key=BNngPLE0UBkgJN+z3JR6jOO5Z/7Cz9zseB1JBzexa+ru3x3y/P1hDh5BL7QRfzZ0Mb0Y7PLcVUKik7JDKE7SEo4="
+curl -G http://127.0.0.1:3003/v2/account/balance --data-urlencode "pub_key=BNngPLE0UBkgJN+z3JR6jOO5Z/7Cz9zseB1JBzexa+ru3x3y/P1hDh5BL7QRfzZ0Mb0Y7PLcVUKik7JDKE7SEo4="
 ```
 You shall read output like the following...
 ```
@@ -306,7 +307,7 @@ You need to know the public key to send tokens to.
 
 In order to instruct your node to sign and broadcast a transaction sending tokens to the public key of the other account (recipient - replace the public key):
 ```
-curl -X POST -H "Content-Type: application/json" -d '{"recipient_pubkey":"BJ6H04FSfz0KwteJCcSNo5tXTWr5Tw9eg4QlxYAlTbPqAcmPMl2KNZ+1SsTT7PTRDNseSemh7YlNNZBx/SxCyXM=", "amount":2, "fee":1}' http://127.0.0.1:3103/v1/spend-tx
+curl -X POST -H "Content-Type: application/json" -d '{"recipient_pubkey":"BJ6H04FSfz0KwteJCcSNo5tXTWr5Tw9eg4QlxYAlTbPqAcmPMl2KNZ+1SsTT7PTRDNseSemh7YlNNZBx/SxCyXM=", "amount":2, "fee":1}' http://127.0.0.1:3103/v2/spend-tx
 ```
 
 ## Send tokens between two accounts in local network of two nodes
@@ -382,7 +383,7 @@ bin/epoch start
 
 Verify the node is up, by inspecting the current top of the blockchain as seen by the node:
 ```
-curl http://127.0.0.1:3013/v1/top
+curl http://127.0.0.1:3013/v2/top
 ```
 
 If the node is unresponsive, inspect the `log` directory for errors.
@@ -411,7 +412,7 @@ If node #1 successfully mines a block, you shall read log entries like the follo
 
 Inspect the current top of the blockchain as seen by node #1:
 ```
-curl http://127.0.0.1:3013/v1/top
+curl http://127.0.0.1:3013/v2/top
 ```
 You should read output like the following (notice the height):
 ```
@@ -429,7 +430,7 @@ In order to check the balance of node #1, retrieve its public key then the balan
 
 Retrieve the public key of node #1:
 ```
-curl http://127.0.0.1:3113/v1/account/pub-key
+curl http://127.0.0.1:3113/v2/account/pub-key
 ```
 You shall read output like the following:
 ```
@@ -438,7 +439,7 @@ You shall read output like the following:
 
 Retrieve the balance associated to the retrieved public key (replace the public key retrieved in the previous command):
 ```
-curl -G http://127.0.0.1:3013/v1/account/balance --data-urlencode "pub_key=BNngPLE0UBkgJN+z3JR6jOO5Z/7Cz9zseB1JBzexa+ru3x3y/P1hDh5BL7QRfzZ0Mb0Y7PLcVUKik7JDKE7SEo4="
+curl -G http://127.0.0.1:3013/v2/account/balance --data-urlencode "pub_key=BNngPLE0UBkgJN+z3JR6jOO5Z/7Cz9zseB1JBzexa+ru3x3y/P1hDh5BL7QRfzZ0Mb0Y7PLcVUKik7JDKE7SEo4="
 ```
 You shall read output like the following:
 ```
@@ -507,7 +508,7 @@ bin/epoch start
 
 Verify the node is up, by inspecting the current top of the blockchain as seen by the node:
 ```
-curl http://127.0.0.1:3023/v1/top
+curl http://127.0.0.1:3023/v2/top
 ```
 
 If the node is unresponsive, inspect the `log` directory for errors.
@@ -516,8 +517,8 @@ If the node is unresponsive, inspect the `log` directory for errors.
 
 Inspect the top of the blockchain as seen by nodes #1 and #2: you shall notice that node #2 is at the same height as node #1 - meaning that node #2 synced with node #1.
 ```
-curl http://127.0.0.1:3013/v1/top
-curl http://127.0.0.1:3023/v1/top
+curl http://127.0.0.1:3013/v2/top
+curl http://127.0.0.1:3023/v2/top
 ```
 
 ### Spend tokens from account of node #1 to account of node #2
@@ -526,7 +527,7 @@ Account on node #1 has a positive balance (as check in previous instructions) he
 
 Retrieve the public key of node #2:
 ```
-curl http://127.0.0.1:3123/v1/account/pub-key
+curl http://127.0.0.1:3123/v2/account/pub-key
 ```
 You shall read output like the following:
 ```
@@ -535,7 +536,7 @@ You shall read output like the following:
 
 Instruct node #1 to sign and broadcast a transaction sending tokens to the public key of node #2 (replace the public key retrieved in the previous command):
 ```
-curl -X POST -H "Content-Type: application/json" -d '{"recipient_pubkey":"BJ6H04FSfz0KwteJCcSNo5tXTWr5Tw9eg4QlxYAlTbPqAcmPMl2KNZ+1SsTT7PTRDNseSemh7YlNNZBx/SxCyXM=", "amount":2, "fee":1}' http://127.0.0.1:3113/v1/spend-tx
+curl -X POST -H "Content-Type: application/json" -d '{"recipient_pubkey":"BJ6H04FSfz0KwteJCcSNo5tXTWr5Tw9eg4QlxYAlTbPqAcmPMl2KNZ+1SsTT7PTRDNseSemh7YlNNZBx/SxCyXM=", "amount":2, "fee":1}' http://127.0.0.1:3113/v2/spend-tx
 ```
 
 Node #1 will share the transaction with other nodes in the block and also consider it for inclusion in block for future mining.
@@ -558,18 +559,18 @@ You shall read a log entry like the following:
 2017-12-08 16:49:24.080 [info] <0.1644.0> Attempt to process operation: 'PostTx'
 ```
 
-Retrieve the balance of node #1 until you notice that tokens have been subtracted i.e. 2 tokens to account of node #2 and 1 token to the miner - either node #1 or #2 (replace the public key retrieved by command `curl http://127.0.0.1:3113/v1/account/pub-key`):
+Retrieve the balance of node #1 until you notice that tokens have been subtracted i.e. 2 tokens to account of node #2 and 1 token to the miner - either node #1 or #2 (replace the public key retrieved by command `curl http://127.0.0.1:3113/v2/account/pub-key`):
 ```
-curl -G http://127.0.0.1:3013/v1/account/balance --data-urlencode "pub_key=BNngPLE0UBkgJN+z3JR6jOO5Z/7Cz9zseB1JBzexa+ru3x3y/P1hDh5BL7QRfzZ0Mb0Y7PLcVUKik7JDKE7SEo4="
+curl -G http://127.0.0.1:3013/v2/account/balance --data-urlencode "pub_key=BNngPLE0UBkgJN+z3JR6jOO5Z/7Cz9zseB1JBzexa+ru3x3y/P1hDh5BL7QRfzZ0Mb0Y7PLcVUKik7JDKE7SEo4="
 ```
 You shall read output like the following:
 ```
 {"balance":167}
 ```
 
-Retrieve the balance of node #2 (replace the public key retrieved by command `curl http://127.0.0.1:3123/v1/account/pub-key`):
+Retrieve the balance of node #2 (replace the public key retrieved by command `curl http://127.0.0.1:3123/v2/account/pub-key`):
 ```
-curl -G http://127.0.0.1:3023/v1/account/balance --data-urlencode "pub_key=BJ6H04FSfz0KwteJCcSNo5tXTWr5Tw9eg4QlxYAlTbPqAcmPMl2KNZ+1SsTT7PTRDNseSemh7YlNNZBx/SxCyXM="
+curl -G http://127.0.0.1:3023/v2/account/balance --data-urlencode "pub_key=BJ6H04FSfz0KwteJCcSNo5tXTWr5Tw9eg4QlxYAlTbPqAcmPMl2KNZ+1SsTT7PTRDNseSemh7YlNNZBx/SxCyXM="
 ```
 You shall read output like the following:
 ```

--- a/apps/aecore/src/aec_peers.erl
+++ b/apps/aecore/src/aec_peers.erl
@@ -505,6 +505,8 @@ ping_peer(Peer) ->
                 {error, protocol_violation} ->
                     block_peer(Uri);
                 _ ->
+                    %% If we ping a peer with wrong API version, time out in aue_request 
+                    %% and Peer is errored until it upgrades/downgrades to the same version.
                     log_ping_error(Peer)
             end;
         {error, timeout} ->
@@ -661,5 +663,3 @@ parse_uri(Uri) ->
 -spec uri_of_peer(peer()) -> http_uri:uri().
 uri_of_peer(#peer{host = Host, scheme = Scheme, port = Port}) ->
     aeu_requests:pp_uri({Scheme, Host, Port}).
-
-

--- a/apps/aecore/test/aec_peers_tests.erl
+++ b/apps/aecore/test/aec_peers_tests.erl
@@ -39,6 +39,7 @@ all_test_() ->
        end},
       {"Remove a peer",
        fun() ->
+               %% Note that v1 is unimportant and ignored
                ?assertEqual(ok, aec_peers:remove("http://someone.somewhere:1337/v1")),
                ?assertEqual(1, length(aec_peers:all()))
        end},

--- a/apps/aecore/test/aecore_forking_SUITE.erl
+++ b/apps/aecore/test/aecore_forking_SUITE.erl
@@ -88,8 +88,9 @@ create_dev1_chain(Config) ->
     aecore_suite_utils:connect(N1),
     {ok, Blocks} = aecore_suite_utils:mine_blocks(N1, 8), 
     true = (length(lists:usort(Blocks)) >= 4),
-    N1Top = lists:last(Blocks),
-    ct:log("top of chain dev1: ~p", [ N1Top ]),
+    N1Top = rpc:call(N1, aec_conductor, top, [], 5000),
+    ct:log("top of chain dev1: ~p (mined ~p)", [ N1Top, hd(Blocks)]),
+    N1Top = hd(Blocks),
     aecore_suite_utils:stop_node(dev1, Config),   %% make sure we do not sync with dev2.
     ok.
 

--- a/apps/aehttp/priv/swagger.json
+++ b/apps/aehttp/priv/swagger.json
@@ -9,7 +9,7 @@
       "email" : "apiteam@aeternity.com"
     }
   },
-  "basePath" : "/v1",
+  "basePath" : "/v2",
   "tags" : [ {
     "name" : "external",
     "description" : "External API"
@@ -1068,6 +1068,19 @@
     }
   },
   "definitions" : {
+    "EncodedHash" : {
+      "type" : "string"
+    },
+    "Pow" : {
+      "type" : "array",
+      "items" : {
+        "type" : "integer",
+        "format" : "int32"
+      }
+    },
+    "Uri" : {
+      "type" : "string"
+    },
     "Header" : {
       "type" : "object",
       "properties" : {
@@ -1076,13 +1089,13 @@
           "format" : "int64"
         },
         "prev_hash" : {
-          "type" : "string"
+          "$ref" : "#/definitions/EncodedHash"
         },
         "state_hash" : {
-          "type" : "string"
+          "$ref" : "#/definitions/EncodedHash"
         },
         "txs_hash" : {
-          "type" : "string"
+          "$ref" : "#/definitions/EncodedHash"
         },
         "target" : {
           "type" : "integer",
@@ -1097,14 +1110,10 @@
           "format" : "int64"
         },
         "version" : {
-          "type" : "integer",
-          "format" : "int64"
+          "type" : "integer"
         },
         "pow" : {
-          "type" : "array",
-          "items" : {
-            "type" : "integer"
-          }
+          "$ref" : "#/definitions/Pow"
         }
       }
     },
@@ -1237,12 +1246,12 @@
         },
         "share" : {
           "type" : "integer",
-          "format" : "int64"
+          "maximum" : 32
         },
         "peers" : {
           "type" : "array",
           "items" : {
-            "type" : "string"
+            "$ref" : "#/definitions/Uri"
           }
         }
       }

--- a/apps/aehttp/src/aehttp_dispatch_ext.erl
+++ b/apps/aehttp/src/aehttp_dispatch_ext.erl
@@ -237,6 +237,9 @@ add_missing_to_genesis_block(Val) ->
     Val.
 
 handle_ping(#{<<"source">> := Src} = PingObj) ->
+    %% Source only contains host and port
+    %% If the http API version differs, then response ping will go
+    %% to wrong endpoint and eventually timeout.
     IsBlocked = aec_peers:is_blocked(Src),
     case IsBlocked of
         false -> handle_ping_(Src, PingObj);

--- a/apps/aehttp/src/swagger/swagger_router.erl
+++ b/apps/aehttp/src/swagger/swagger_router.erl
@@ -56,172 +56,172 @@ group_paths() ->
 get_operations() ->
     #{ 
         'GetAccountBalance' => #{
-            path => "/v1/account/balance",
+            path => "/v2/account/balance",
             method => <<"GET">>,
             handler => 'swagger_external_handler'
         },
         'GetAccountsBalances' => #{
-            path => "/v1/balances",
+            path => "/v2/balances",
             method => <<"GET">>,
             handler => 'swagger_external_handler'
         },
         'GetBlockByHash' => #{
-            path => "/v1/block-by-hash",
+            path => "/v2/block-by-hash",
             method => <<"GET">>,
             handler => 'swagger_external_handler'
         },
         'GetBlockByHeight' => #{
-            path => "/v1/block-by-height",
+            path => "/v2/block-by-height",
             method => <<"GET">>,
             handler => 'swagger_external_handler'
         },
         'GetInfo' => #{
-            path => "/v1/info",
+            path => "/v2/info",
             method => <<"GET">>,
             handler => 'swagger_external_handler'
         },
         'GetTop' => #{
-            path => "/v1/top",
+            path => "/v2/top",
             method => <<"GET">>,
             handler => 'swagger_external_handler'
         },
         'GetTxs' => #{
-            path => "/v1/transactions",
+            path => "/v2/transactions",
             method => <<"GET">>,
             handler => 'swagger_external_handler'
         },
         'GetVersion' => #{
-            path => "/v1/version",
+            path => "/v2/version",
             method => <<"GET">>,
             handler => 'swagger_external_handler'
         },
         'Ping' => #{
-            path => "/v1/ping",
+            path => "/v2/ping",
             method => <<"POST">>,
             handler => 'swagger_external_handler'
         },
         'PostBlock' => #{
-            path => "/v1/block",
+            path => "/v2/block",
             method => <<"POST">>,
             handler => 'swagger_external_handler'
         },
         'PostTx' => #{
-            path => "/v1/tx",
+            path => "/v2/tx",
             method => <<"POST">>,
             handler => 'swagger_external_handler'
         },
         'GetActiveRegisteredOracles' => #{
-            path => "/v1/oracles",
+            path => "/v2/oracles",
             method => <<"GET">>,
             handler => 'swagger_internal_handler'
         },
         'GetBlockByHashInternal' => #{
-            path => "/v1/block/hash/:hash",
+            path => "/v2/block/hash/:hash",
             method => <<"GET">>,
             handler => 'swagger_internal_handler'
         },
         'GetBlockByHeightInternal' => #{
-            path => "/v1/block/height/:height",
+            path => "/v2/block/height/:height",
             method => <<"GET">>,
             handler => 'swagger_internal_handler'
         },
         'GetBlockGenesis' => #{
-            path => "/v1/block/genesis",
+            path => "/v2/block/genesis",
             method => <<"GET">>,
             handler => 'swagger_internal_handler'
         },
         'GetBlockLatest' => #{
-            path => "/v1/block/latest",
+            path => "/v2/block/latest",
             method => <<"GET">>,
             handler => 'swagger_internal_handler'
         },
         'GetBlockNumber' => #{
-            path => "/v1/block/number",
+            path => "/v2/block/number",
             method => <<"GET">>,
             handler => 'swagger_internal_handler'
         },
         'GetBlockPending' => #{
-            path => "/v1/block/pending",
+            path => "/v2/block/pending",
             method => <<"GET">>,
             handler => 'swagger_internal_handler'
         },
         'GetBlockTxsCountByHash' => #{
-            path => "/v1/block/txs/count/hash/:hash",
+            path => "/v2/block/txs/count/hash/:hash",
             method => <<"GET">>,
             handler => 'swagger_internal_handler'
         },
         'GetBlockTxsCountByHeight' => #{
-            path => "/v1/block/txs/count/height/:height",
+            path => "/v2/block/txs/count/height/:height",
             method => <<"GET">>,
             handler => 'swagger_internal_handler'
         },
         'GetGenesisBlockTxsCount' => #{
-            path => "/v1/block/txs/count/genesis",
+            path => "/v2/block/txs/count/genesis",
             method => <<"GET">>,
             handler => 'swagger_internal_handler'
         },
         'GetLatestBlockTxsCount' => #{
-            path => "/v1/block/txs/count/latest",
+            path => "/v2/block/txs/count/latest",
             method => <<"GET">>,
             handler => 'swagger_internal_handler'
         },
         'GetOracleQuestions' => #{
-            path => "/v1/oracle-questions",
+            path => "/v2/oracle-questions",
             method => <<"GET">>,
             handler => 'swagger_internal_handler'
         },
         'GetPendingBlockTxsCount' => #{
-            path => "/v1/block/txs/count/pending",
+            path => "/v2/block/txs/count/pending",
             method => <<"GET">>,
             handler => 'swagger_internal_handler'
         },
         'GetPubKey' => #{
-            path => "/v1/account/pub-key",
+            path => "/v2/account/pub-key",
             method => <<"GET">>,
             handler => 'swagger_internal_handler'
         },
         'GetTransactionFromBlockHash' => #{
-            path => "/v1/block/tx/hash/:hash/:tx_index",
+            path => "/v2/block/tx/hash/:hash/:tx_index",
             method => <<"GET">>,
             handler => 'swagger_internal_handler'
         },
         'GetTransactionFromBlockHeight' => #{
-            path => "/v1/block/tx/height/:height/:tx_index",
+            path => "/v2/block/tx/height/:height/:tx_index",
             method => <<"GET">>,
             handler => 'swagger_internal_handler'
         },
         'GetTransactionFromBlockLatest' => #{
-            path => "/v1/block/tx/latest/:tx_index",
+            path => "/v2/block/tx/latest/:tx_index",
             method => <<"GET">>,
             handler => 'swagger_internal_handler'
         },
         'GetTxsListFromBlockRangeByHash' => #{
-            path => "/v1/block/txs/list/hash",
+            path => "/v2/block/txs/list/hash",
             method => <<"GET">>,
             handler => 'swagger_internal_handler'
         },
         'GetTxsListFromBlockRangeByHeight' => #{
-            path => "/v1/block/txs/list/height",
+            path => "/v2/block/txs/list/height",
             method => <<"GET">>,
             handler => 'swagger_internal_handler'
         },
         'PostOracleQueryTx' => #{
-            path => "/v1/oracle-query-tx",
+            path => "/v2/oracle-query-tx",
             method => <<"POST">>,
             handler => 'swagger_internal_handler'
         },
         'PostOracleRegisterTx' => #{
-            path => "/v1/oracle-register-tx",
+            path => "/v2/oracle-register-tx",
             method => <<"POST">>,
             handler => 'swagger_internal_handler'
         },
         'PostOracleResponseTx' => #{
-            path => "/v1/oracle-response-tx",
+            path => "/v2/oracle-response-tx",
             method => <<"POST">>,
             handler => 'swagger_internal_handler'
         },
         'PostSpendTx' => #{
-            path => "/v1/spend-tx",
+            path => "/v2/spend-tx",
             method => <<"POST">>,
             handler => 'swagger_internal_handler'
         }

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -1358,12 +1358,12 @@ internal_address() ->
 
 http_request(Host, get, Path, Params) ->
     URL = binary_to_list(
-            iolist_to_binary([Host, "/v1/", Path, encode_get_params(Params)])),
+            iolist_to_binary([Host, "/v2/", Path, encode_get_params(Params)])),
     ct:log("GET ~p", [URL]),
     R = httpc:request(get, {URL, []}, [], []),
     process_http_return(R);
 http_request(Host, post, Path, Params) ->
-    URL = binary_to_list(iolist_to_binary([Host, "/v1/", Path])),
+    URL = binary_to_list(iolist_to_binary([Host, "/v2/", Path])),
     {Type, Body} = case Params of
                        Map when is_map(Map) ->
                            %% JSON-encoded

--- a/apps/aeutils/include/endpoints.hrl
+++ b/apps/aeutils/include/endpoints.hrl
@@ -1,0 +1,138 @@
+%% This code is generated from swagger.yaml
+%% do not manually change it.
+
+
+operation(Id) ->
+    maps:get(Id, operations()).
+
+operations() ->
+    #{ 
+        'GetAccountBalance' => #{
+            path => <<"/v2/account/balance">>,
+            method => get
+        },
+        'GetAccountsBalances' => #{
+            path => <<"/v2/balances">>,
+            method => get
+        },
+        'GetBlockByHash' => #{
+            path => <<"/v2/block-by-hash">>,
+            method => get
+        },
+        'GetBlockByHeight' => #{
+            path => <<"/v2/block-by-height">>,
+            method => get
+        },
+        'GetInfo' => #{
+            path => <<"/v2/info">>,
+            method => get
+        },
+        'GetTop' => #{
+            path => <<"/v2/top">>,
+            method => get
+        },
+        'GetTxs' => #{
+            path => <<"/v2/transactions">>,
+            method => get
+        },
+        'GetVersion' => #{
+            path => <<"/v2/version">>,
+            method => get
+        },
+        'Ping' => #{
+            path => <<"/v2/ping">>,
+            method => post
+        },
+        'PostBlock' => #{
+            path => <<"/v2/block">>,
+            method => post
+        },
+        'PostTx' => #{
+            path => <<"/v2/tx">>,
+            method => post
+        },
+        'GetActiveRegisteredOracles' => #{
+            path => <<"/v2/oracles">>,
+            method => get
+        },
+        'GetBlockByHashInternal' => #{
+            path => <<"/v2/block/hash">>,
+            method => get
+        },
+        'GetBlockByHeightInternal' => #{
+            path => <<"/v2/block/height">>,
+            method => get
+        },
+        'GetBlockGenesis' => #{
+            path => <<"/v2/block/genesis">>,
+            method => get
+        },
+        'GetBlockLatest' => #{
+            path => <<"/v2/block/latest">>,
+            method => get
+        },
+        'GetBlockNumber' => #{
+            path => <<"/v2/block/number">>,
+            method => get
+        },
+        'GetBlockPending' => #{
+            path => <<"/v2/block/pending">>,
+            method => get
+        },
+        'GetBlockTxsCountByHash' => #{
+            path => <<"/v2/block/txs/count/hash">>,
+            method => get
+        },
+        'GetBlockTxsCountByHeight' => #{
+            path => <<"/v2/block/txs/count/height">>,
+            method => get
+        },
+        'GetGenesisBlockTxsCount' => #{
+            path => <<"/v2/block/txs/count/genesis">>,
+            method => get
+        },
+        'GetLatestBlockTxsCount' => #{
+            path => <<"/v2/block/txs/count/latest">>,
+            method => get
+        },
+        'GetOracleQuestions' => #{
+            path => <<"/v2/oracle-questions">>,
+            method => get
+        },
+        'GetPendingBlockTxsCount' => #{
+            path => <<"/v2/block/txs/count/pending">>,
+            method => get
+        },
+        'GetPubKey' => #{
+            path => <<"/v2/account/pub-key">>,
+            method => get
+        },
+        'GetTransactionFromBlockHash' => #{
+            path => <<"/v2/block/tx/hash">>,
+            method => get
+        },
+        'GetTransactionFromBlockHeight' => #{
+            path => <<"/v2/block/tx/height">>,
+            method => get
+        },
+        'GetTransactionFromBlockLatest' => #{
+            path => <<"/v2/block/tx/latest">>,
+            method => get
+        },
+        'PostOracleQueryTx' => #{
+            path => <<"/v2/oracle-query-tx">>,
+            method => post
+        },
+        'PostOracleRegisterTx' => #{
+            path => <<"/v2/oracle-register-tx">>,
+            method => post
+        },
+        'PostOracleResponseTx' => #{
+            path => <<"/v2/oracle-response-tx">>,
+            method => post
+        },
+        'PostSpendTx' => #{
+            path => <<"/v2/spend-tx">>,
+            method => post
+        }
+    }.

--- a/apps/aeutils/src/aeu_http_client.erl
+++ b/apps/aeutils/src/aeu_http_client.erl
@@ -1,10 +1,13 @@
 -module(aeu_http_client).
 
 %% API
--export([request/4]).
+-export([request/3]).
 
+%% include generated code
+-include("../include/endpoints.hrl").
 
-request(BaseUri, Method, Endpoint, Params) ->
+-spec request(iodata(), atom(), list({string(), iodata()}) | map()) -> {ok, any()} | {error, any()}. 
+request(BaseUri, OperationId, Params) ->
     Timeout = aeu_env:user_config_or_env(
                 [<<"http">>, <<"external">>,<<"request_timeout">>],
                 aehttp, http_request_timeout, 1000),
@@ -12,6 +15,7 @@ request(BaseUri, Method, Endpoint, Params) ->
                  [<<"http">>, <<"external">>, <<"connect_timeout">>],
                  aehttp, http_connect_timeout, min(Timeout, 1000)),
     HTTPOptions = [{timeout, Timeout}, {connect_timeout, CTimeout}],
+    #{path := Endpoint, method := Method} = operation(OperationId),
     request(BaseUri, Method, Endpoint, Params, [], HTTPOptions, []).
 
 request(BaseUri, get, Endpoint, Params, Header, HTTPOptions, Options) ->
@@ -54,20 +58,10 @@ process_http_return(R) ->
             Error
     end.
 
+-spec encode_get_params(map() | list({string(), iodata()})) -> iodata().
 encode_get_params(#{} = Ps) ->
     encode_get_params(maps:to_list(Ps));
-encode_get_params([{K,V}|T]) ->
-    ["?", [str(K),"=",uenc(V)
-           | [["&", str(K1), "=", uenc(V1)]
-              || {K1, V1} <- T]]];
-encode_get_params([]) ->
-    [].
-
-%% str(A) when is_atom(A) ->
-%%     atom_to_binary(A, latin1);
-str(S) when is_list(S); is_binary(S) ->
-    S.
-
-uenc(V) ->
-    http_uri:encode(V).
+encode_get_params(Params) when is_list(Params) ->
+    ["?", lists:join( "&", [ [http_uri:encode(K), "=" , http_uri:encode(V)] 
+                             || {K,V} <- Params ] ) ].
 

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -7,7 +7,7 @@ info:
   termsOfService: 'https://www.aeternity.com/terms/'
   contact:
     email: apiteam@aeternity.com
-basePath: /v1
+basePath: /v2
 tags:
   - name: external
     description: External API
@@ -920,6 +920,18 @@ paths:
       security: []
 
 definitions:
+  EncodedHash:
+    type: string
+  Pow:
+    type: array
+    items:
+      type: integer
+      format: int32
+    minItems: 42
+    maxItems: 42
+  Uri:
+    type: string
+    ## format: uri
   Header:
     type: object
     properties:
@@ -927,11 +939,11 @@ definitions:
         type: integer
         format: int64
       prev_hash:
-        type: string
+        $ref: '#/definitions/EncodedHash'
       state_hash:
-        type: string
+        $ref: '#/definitions/EncodedHash'
       txs_hash:
-        type: string
+        $ref: '#/definitions/EncodedHash'
       target:
         type: integer
         format: int64
@@ -943,11 +955,8 @@ definitions:
         format: int64
       version:
         type: integer
-        format: int64
       pow:
-        type: array
-        items:
-          type: integer
+        $ref: '#/definitions/Pow'
   Block:
     allOf:
       - $ref: '#/definitions/Header'
@@ -1031,11 +1040,12 @@ definitions:
         type: number
       share:
         type: integer
-        format: int64
+        maximum: 32
       peers:
         type: array
         items:
-          type: string
+          $ref: '#/definitions/Uri'
+          maxItems: 32
     required:
     - source
     - genesis_hash
@@ -1111,7 +1121,7 @@ definitions:
         type: integer
         format: int64
       ttl:
-        "$ref": '#/definitions/TTL'
+        $ref: '#/definitions/TTL'
   OracleQueryTx:
     type: object
     properties:
@@ -1123,9 +1133,9 @@ definitions:
         type: integer
         format: int64
       query_ttl:
-        "$ref": '#/definitions/TTL'
+        $ref: '#/definitions/TTL'
       response_ttl:
-        "$ref": '#/definitions/RelativeTTL'
+        $ref: '#/definitions/RelativeTTL'
       fee:
         type: integer
         format: int64
@@ -1303,7 +1313,7 @@ definitions:
           que: string
           response_spec: string
           ttl: 
-            "$ref": '#/definitions/TTL'
+            $ref: '#/definitions/TTL'
           fee: integer
         required:
         - account
@@ -1323,9 +1333,9 @@ definitions:
           query: string
           query_fee: integer
           query_ttl: 
-            "$ref": '#/definitions/TTL'
+            $ref: '#/definitions/TTL'
           response_ttl: 
-            "$ref": '#/definitions/TTL'
+            $ref: '#/definitions/TTL'
           fee: integer
         required:
         - sender
@@ -1347,9 +1357,9 @@ definitions:
           query: string
           query_fee: integer
           query_ttl: 
-            "$ref": '#/definitions/TTL'
+            $ref: '#/definitions/TTL'
           response_ttl: 
-            "$ref": '#/definitions/TTL'
+            $ref: '#/definitions/TTL'
           fee: integer
         required:
         - account

--- a/deployment/ansible/deploy.yml
+++ b/deployment/ansible/deploy.yml
@@ -43,6 +43,7 @@
       keypair:
         dir: "keys"
         password: "{{ keys_password|default('secret') }}"
+    api_base_uri: http://{{ ansible_ssh_host }}:{{ config.http.external.port }}/v2
 
   tasks:
     - block:
@@ -157,7 +158,7 @@
 
       - name: API health check
         uri:
-          url: http://{{ ansible_ssh_host }}:{{ config.http.external.port }}/v1/top
+          url: "{{ api_base_uri }}/top"
           timeout: 5
         connection: local
         tags: [health-check]

--- a/py/tests/integration/common.py
+++ b/py/tests/integration/common.py
@@ -28,12 +28,12 @@ logging.getLogger("urllib3").setLevel(logging.ERROR)
 EXT_API = {}
 for node, node_config in config['nodes'].iteritems():
     EXT_API[node] = ExternalApi(ApiClient(host=node_config['host'] + ':'
-                + str(node_config['ports']['external_api']) + '/v1'))
+                + str(node_config['ports']['external_api']) + '/v2'))
 
 INT_API = {}
 for node, node_config in config['nodes'].iteritems():
     INT_API[node] = InternalApi(ApiClient(host=node_config['host'] + ':'
-                + str(node_config['ports']['internal_api']) + '/v1'))
+                + str(node_config['ports']['internal_api']) + '/v2'))
 
 def external_api(name):
     return EXT_API[name]

--- a/py/tests/release.py
+++ b/py/tests/release.py
@@ -24,7 +24,7 @@ NODE_SETUP_COMMANDS = [
 # node's setup
 SETUP = {
         "node1": {
-            "host": "localhost:9813/v1",
+            "host": "localhost:9813/v2",
             "name": "epoch1",
             "config": '''[
 {aecore,
@@ -49,7 +49,7 @@ SETUP = {
 '''
                 },
         "node2": {
-            "host": "localhost:9823/v1",
+            "host": "localhost:9823/v2",
             "name": "epoch2",
             "config": '''[
 {aecore,
@@ -73,7 +73,7 @@ SETUP = {
 '''
                 },
         "node3": {
-            "host": "localhost:9833/v1",
+            "host": "localhost:9833/v2",
             "name": "epoch3",
             "config": '''[
 {aecore,

--- a/py/tests/swagger_client/configuration.py
+++ b/py/tests/swagger_client/configuration.py
@@ -45,7 +45,7 @@ class Configuration(object):
         Constructor
         """
         # Default Base url
-        self.host = "http://localhost/v1"
+        self.host = "http://localhost/v2"
         # Default api client
         self.api_client = None
         # Temp file folder for downloading files


### PR DESCRIPTION
Changing API version from v1 to v2
- updated in config/swagger.yaml
- Modified manually in documentation, python tests
- Modified tests that used hard-coded v2 (bascially in aehttp
- Re-generated code (swagger.json, swagger_router and endpoints.hrl).
Generated code probably should not be part of the repo, but for now we do it this way.

[Finishes PtT-154222225] 