### PR TITLE
Pt 154281908 hand coded contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,4 @@ apps/aecore/priv
 aevm_external
 apps/aering/src/aer_parser.erl
 apps/aering/src/aer_scan.erl
-
+apps/aebytecode/src/aeb_asm_scan.erl

--- a/apps/aebytecode/src/aeb_asm.erl
+++ b/apps/aebytecode/src/aeb_asm.erl
@@ -8,7 +8,9 @@
 
 -module(aeb_asm).
 
--export([ pp/1
+-export([ file/2
+        , pp/1
+        , to_hexstring/1
         ]).
 
 -include_lib("aebytecode/include/aeb_opcodes.hrl").
@@ -20,3 +22,56 @@ pp(Asm) ->
 
 format(Asm) ->
     Asm.
+
+
+file(Filename,_Opts) ->
+    {ok, File} = file:read_file(Filename),
+    {ok, Tokens, _} = aeb_asm_scan:scan(binary_to_list(File)),
+    io:format("Tokens ~p~n",[Tokens]),
+    ByteList = to_bytecode(Tokens, 0, #{}, []),
+    list_to_binary(ByteList).
+
+to_hexstring(ByteList) ->
+    "0x" ++ lists:flatten(
+              [io_lib:format("~2.16.0b", [X])
+               || X <- ByteList]).
+
+
+to_bytecode([{mnemonic,_line, Op}|Rest], Address, Env, Code) ->
+    OpCode = aeb_opcodes:m_to_op(Op),
+    OpSize = aeb_opcodes:op_size(OpCode),
+    to_bytecode(Rest, Address + OpSize, Env, [OpCode|Code]);
+to_bytecode([{int,_line, Int}|Rest], Address, Env, Code) ->
+    to_bytecode(Rest, Address, Env, [Int|Code]);
+to_bytecode([{hash,_line, Hash}|Rest], Address, Env, Code) ->
+    to_bytecode(Rest, Address, Env, [Hash|Code]);
+to_bytecode([{id,_line, ID}|Rest], Address, Env, Code) ->
+    to_bytecode(Rest, Address, Env, [{ref, ID}|Code]);
+to_bytecode([{lable,_line, Lable}|Rest], Address, Env, Code) ->
+    to_bytecode(Rest, Address, Env#{Lable => Address}, Code);
+to_bytecode([], _Address, Env, Code) ->
+    io:format("Code ~p~n", [lists:reverse(Code)]),
+    PatchedCode = resolve_refs(Code, Env, []),
+    io:format("PatchedCode ~p~n", [PatchedCode]),
+    expand_args(PatchedCode).
+
+%% Also reverses the code.
+resolve_refs([{ref, ID} | Rest], Env, Code) ->
+    Address = maps:get(ID, Env),
+    resolve_refs(Rest, Env, [Address | Code]);
+resolve_refs([Op | Rest], Env, Code) ->
+    resolve_refs(Rest, Env, [Op | Code]);
+resolve_refs([],_Env, Code) -> Code.
+
+expand_args([OP, Arg | Rest]) when OP >= ?PUSH1 andalso OP =< ?PUSH32 ->
+    BitSize = (aeb_opcodes:op_size(OP) - 1) * 8,
+    Bin = << << X:BitSize>> || X <- [Arg] >>,
+    ArgByteList = binary_to_list(Bin),
+    [OP | ArgByteList] ++ expand_args(Rest);
+expand_args([OP | Rest]) ->
+    [OP | expand_args(Rest)];
+expand_args([]) -> [].
+
+to_bytecode([Op|Rest], Options) ->
+    [aeb_opcodes:m_to_op(Op)|to_bytecode(Rest, Options)];
+to_bytecode([], _) -> [].

--- a/apps/aebytecode/src/aeb_asm.erl
+++ b/apps/aebytecode/src/aeb_asm.erl
@@ -22,7 +22,7 @@
 %%%       3. 256-bit hash strings starting with #
 %%%          followed by up to 64 hex chars
 %%%          #00000deadbeef
-%%%       4. lables as descibed above. 
+%%%       4. labels as descibed above. 
 %%%
 %%% @end
 %%% Created : 21 Dec 2017
@@ -103,8 +103,8 @@ to_bytecode([{hash,_line, Hash}|Rest], Address, Env, Code, Opts) ->
     to_bytecode(Rest, Address, Env, [Hash|Code], Opts);
 to_bytecode([{id,_line, ID}|Rest], Address, Env, Code, Opts) ->
     to_bytecode(Rest, Address, Env, [{ref, ID}|Code], Opts);
-to_bytecode([{lable,_line, Lable}|Rest], Address, Env, Code, Opts) ->
-    to_bytecode(Rest, Address, Env#{Lable => Address}, Code, Opts);
+to_bytecode([{label,_line, Label}|Rest], Address, Env, Code, Opts) ->
+    to_bytecode(Rest, Address, Env#{Label => Address}, Code, Opts);
 to_bytecode([], _Address, Env, Code, Opts) ->
     case proplists:lookup(pp_opcodes, Opts) of
         {pp_opcodes, true} ->

--- a/apps/aebytecode/src/aeb_asm.erl
+++ b/apps/aebytecode/src/aeb_asm.erl
@@ -14,7 +14,7 @@
 %%%      A label is an identifier that ends with a colon.
 %%%      The label is the byte code address of the next instruction.
 %%%         a_label:
-%%%      Immidiates can be of four types:
+%%%      Immediates can be of four types:
 %%%       1. integers
 %%%          42
 %%%       2. hexadecimal integers starting with 0x

--- a/apps/aebytecode/src/aeb_asm_scan.xrl
+++ b/apps/aebytecode/src/aeb_asm_scan.xrl
@@ -1,0 +1,77 @@
+%%% -*- erlang-indent-level:4; indent-tabs-mode: nil -*-
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2017, Aeternity Anstalt
+%%% @doc Assembler lexer.
+%%%
+%%% @end
+%%%-------------------------------------------------------------------
+
+Definitions.
+DIGIT    = [0-9]
+HEXDIGIT = [0-9a-fA-F]
+LOWER    = [a-z_]
+UPPER    = [A-Z]
+MNEMONIC = {UPPER}[A-Z0-9_]*
+INT      = {DIGIT}+
+HEX      = 0x{HEXDIGIT}+
+HASH     = #{HEXDIGIT}+
+WS       = [\000-\s]
+ID       = {LOWER}[a-zA-Z0-9_]*
+LABEL    = {ID}:
+
+Rules.
+{LABEL} :
+ {token, {lable, TokenLine, TokenChars -- ":"}}.
+{MNEMONIC} :
+ {token, {mnemonic, TokenLine, list_to_existing_atom(TokenChars)}}.
+{ID} :
+ {token, {id, TokenLine, TokenChars}}.
+{HEX} :
+ {token, {int, TokenLine, parse_hex(TokenChars)}}.
+{INT} :
+ {token, {int, TokenLine, parse_int(TokenChars)}}.
+{HASH} :
+ {token, {hash, TokenLine, parse_hash(TokenChars)}}.
+
+
+%% Symbols
+,   : {token, {',', TokenLine}}.
+\.  : {token, {'.', TokenLine}}.
+\(  : {token, {'(', TokenLine}}.
+\)  : {token, {')', TokenLine}}.
+\[  : {token, {'[', TokenLine}}.
+\]  : {token, {']', TokenLine}}.
+{   : {token, {'{', TokenLine}}.
+}   : {token, {'}', TokenLine}}.
+
+
+%% Whitespace ignore
+{WS} : skip_token.
+
+%% Comments (TODO: nested comments)
+;;.*                     : skip_token.
+
+. : {error, "Unexpected token: " ++ TokenChars}.
+
+Erlang code.
+
+-export([scan/1]).
+
+-dialyzer({nowarn_function, yyrev/2}).
+
+-ignore_xref([format_error/1, string/2, token/2, token/3, tokens/2, tokens/3]).
+
+-include_lib("aebytecode/include/aeb_opcodes.hrl").
+
+
+parse_hex("0x" ++ Chars) -> list_to_integer(Chars, 16).
+
+parse_int(Chars) -> list_to_integer(Chars).
+
+parse_hash("#" ++ Chars) ->
+    N = list_to_integer(Chars, 16),
+    <<N:256>>.
+
+scan(S) ->
+    string(S).
+

--- a/apps/aebytecode/src/aeb_asm_scan.xrl
+++ b/apps/aebytecode/src/aeb_asm_scan.xrl
@@ -21,7 +21,7 @@ LABEL    = {ID}:
 
 Rules.
 {LABEL} :
- {token, {lable, TokenLine, TokenChars -- ":"}}.
+ {token, {label, TokenLine, TokenChars -- ":"}}.
 {MNEMONIC} :
  {token, {mnemonic, TokenLine, list_to_existing_atom(TokenChars)}}.
 {ID} :

--- a/apps/aebytecode/src/aeb_opcodes.erl
+++ b/apps/aebytecode/src/aeb_opcodes.erl
@@ -8,11 +8,12 @@
 
 -module(aeb_opcodes).
 
--export([ opcode/1
+-export([ dup/1
         , mnemonic/1
         , m_to_op/1
+        , opcode/1
+        , op_size/1
         , push/1
-        , dup/1
         , swap/1
         ]).
 
@@ -437,7 +438,11 @@ m_to_op('REVERT')         -> ?REVERT         ;
 m_to_op('COMMENT')        -> ?COMMENT        ;
 m_to_op('SUICIDE')        -> ?SUICIDE        .
 
+
 push(N) when N >= 1, N =< 32 -> ?PUSH1 + N - 1.
 dup(N)  when N >= 1, N =< 16 -> ?DUP1  + N - 1.
 swap(N) when N >= 1, N =< 16 -> ?SWAP1 + N - 1.
 
+op_size(OP) when OP >= ?PUSH1 andalso OP =< ?PUSH32 ->
+    (OP - ?PUSH1) + 2;
+op_size(_) -> 1.

--- a/apps/aering/test/contracts/identity.aesm
+++ b/apps/aering/test/contracts/identity.aesm
@@ -1,0 +1,63 @@
+;; CONTRACT: Identity
+
+             PUSH1              0
+             CALLDATALOAD
+
+             DUP1
+             ;; Should be the has of
+             ;; the signature of the
+             ;; first function (use 0 as placeholder)
+             PUSH32             0x0000000000000000000000000000
+             EQ
+             PUSH32             id_entry
+             JUMPI              
+
+             STOP
+
+id_entry:    JUMPDEST
+             ;; Skip the function name in the calldata
+             PUSH1              1
+             ;; Load argument on stack                               
+             CALLDATALOAD
+             ;; This function only takes one immidiate as argument.
+
+             ;; Call the local version of the function
+             ;; Get return address
+             PC
+             PUSH1              6
+             ADD
+             ;; Get Argument
+             SWAP1
+             PUSH32             id_local
+             JUMP
+
+
+             ;; return here from local call
+             ;; Store top of stack at mem[0]
+             JUMPDEST
+             PUSH1              0
+             MSTORE
+             ;; Return mem[0]-mem[32] 
+             PUSH1             32
+             PUSH1              0
+             RETURN
+
+             ;; for local calls
+             ;; Stack:
+             ;; |        |
+             ;; | Arg    | <- SP
+             ;; | RetAdr |
+             ;;    ...
+
+id_local:    JUMPDEST
+
+             ;; Just return the argument
+             SWAP1
+             ;; Stack:
+             ;; |        |
+             ;; | RetAdr | <- SP
+             ;; | RetVal | (Arg in this case)
+             ;;    ...
+             
+             JUMP
+

--- a/apps/aering/test/contracts/identity.aesm
+++ b/apps/aering/test/contracts/identity.aesm
@@ -16,7 +16,7 @@
 
 id_entry:    JUMPDEST
              ;; Skip the function name in the calldata
-             PUSH1              1
+             PUSH1              32
              ;; Load argument on stack                               
              CALLDATALOAD
              ;; This function only takes one immidiate as argument.
@@ -24,7 +24,7 @@ id_entry:    JUMPDEST
              ;; Call the local version of the function
              ;; Get return address
              PC
-             PUSH1              6
+             PUSH1              39
              ADD
              ;; Get Argument
              SWAP1
@@ -61,3 +61,7 @@ id_local:    JUMPDEST
              
              JUMP
 
+;; aevm_eeevm:eval(aevm_eeevm_state:init(#{ exec => #{ code => list_to_binary(aeb_asm:file("apps/aering/test/contracts/identity.aesm", [])), address => 0, caller => 0, data => <<0:256, 42:256>>, gas => 1000000, gasPrice => 1, origin => 0, value => 0 }, env => #{currentCoinbase => 0, currentDifficulty => 0, currentGasLimit => 10000, currentNumber => 0, currentTimestamp => 0}, pre => #{}}, #{})).
+
+;; aevm_eeevm:eval(aevm_eeevm_state:init(#{ exec => #{ code => aeb_asm:file("apps/aering/test/contracts/identity.aesm", []), address => 0, caller => 0, data => <<0:256, 42:256>>, gas => 1000000, gasPrice => 1, origin => 0, value => 0 }, env => #{currentCoinbase => 0, currentDifficulty => 0, currentGasLimit => 10000, currentNumber => 0, currentTimestamp => 0}, pre => #{}}, #{ trace => true})).
+;; aec_conductor:stop_mining().

--- a/apps/aering/test/contracts/identity.aesm
+++ b/apps/aering/test/contracts/identity.aesm
@@ -4,7 +4,7 @@
              CALLDATALOAD
 
              DUP1
-             ;; Should be the has of
+             ;; Should be the hash of
              ;; the signature of the
              ;; first function (use 0 as placeholder)
              PUSH32             0x0000000000000000000000000000
@@ -61,7 +61,14 @@ id_local:    JUMPDEST
              
              JUMP
 
+;; Test the code from the shell
 ;; aevm_eeevm:eval(aevm_eeevm_state:init(#{ exec => #{ code => list_to_binary(aeb_asm:file("apps/aering/test/contracts/identity.aesm", [])), address => 0, caller => 0, data => <<0:256, 42:256>>, gas => 1000000, gasPrice => 1, origin => 0, value => 0 }, env => #{currentCoinbase => 0, currentDifficulty => 0, currentGasLimit => 10000, currentNumber => 0, currentTimestamp => 0}, pre => #{}}, #{})).
 
+;; Test the code from the shell with tracing.
 ;; aevm_eeevm:eval(aevm_eeevm_state:init(#{ exec => #{ code => aeb_asm:file("apps/aering/test/contracts/identity.aesm", []), address => 0, caller => 0, data => <<0:256, 42:256>>, gas => 1000000, gasPrice => 1, origin => 0, value => 0 }, env => #{currentCoinbase => 0, currentDifficulty => 0, currentGasLimit => 10000, currentNumber => 0, currentTimestamp => 0}, pre => #{}}, #{ trace => true})).
+
+
+;; Test the code from the shell with tracing.
+;; aevm_eeevm:eval(aevm_eeevm_state:init(#{ exec => #{ code => aeb_asm:file("apps/aering/test/contracts/identity.aesm", [pp_tokens, pp_opcodes, pp_patched_code, pp_hex_string]), address => 0, caller => 0, data => <<0:256, 42:256>>, gas => 1000000, gasPrice => 1, origin => 0, value => 0 }, env => #{currentCoinbase => 0, currentDifficulty => 0, currentGasLimit => 10000, currentNumber => 0, currentTimestamp => 0}, pre => #{}}, #{ trace => true})).
+
 ;; aec_conductor:stop_mining().


### PR DESCRIPTION
This PR implements a simple assembler for the AEVM.
You can now write AEVM/EVM byte code as assembler code in a file with labels in stead of hard coded addresses. This code can then be parsed and turned into byte code.

There is also an example of a hand coded implementation of the identity contract which uses the Ring ABI and returns the same integer as you give as an argument to the call.

The example does not contain an init function yet which should be needed for Ring contracts.
A future PT and PR will add integration test cases for the assembler/VM integration.

(NOTE: this is not needed for the 0.5 release but it should have little impact.)

[Finishes #154281908]