### PR TITLE
Fix race condition and comment why invalid source pings are ignored

### DIFF
--- a/apps/aehttp/src/aehttp_dispatch_ext.erl
+++ b/apps/aehttp/src/aehttp_dispatch_ext.erl
@@ -244,6 +244,7 @@ handle_ping(#{<<"source">> := Src} = PingObj) ->
     case IsBlocked of
         false -> handle_ping_(Src, PingObj);
         true  ->
+            %% invalid Source URIs are by definition blocked
             abort_sync(Src, 403, <<"Not allowed">>)
     end.
 


### PR DESCRIPTION
- added comment:
  When a remote node pings us with a "source" field containing an invalid URL, then this is ignored by considering the source blocked.
- fixed a race: if we restart peers while a sync job is in progress, the peer cannot be found. We handle this case better by adding it back when http request returns successful, but not if it happen to error.
- refactored the code to be more testable by moving ping_peer from aec_peers into aec_sync. aec_peers is doing the admin, aec_sync is doing the communication.