### PR TITLE
Refactor HTTP integration tests [Finishes #154273965]

### DIFF
--- a/apps/aecore/test/aecore_suite_utils.erl
+++ b/apps/aecore/test/aecore_suite_utils.erl
@@ -98,7 +98,7 @@ stop_node(N, Config) ->
          " && ./bin/epoch stop)"]).
 
 mine_blocks(Node, NumBlocksToMine) ->
-    mine_blocks(Node, NumBlocksToMine, 100).
+    mine_blocks(Node, NumBlocksToMine, 10).
 
 mine_blocks(Node, NumBlocksToMine, MiningRate) ->
     rpc:call(Node, application, set_env, [aecore, expected_mine_rate, MiningRate],


### PR DESCRIPTION
[Pivotal story](https://www.pivotaltracker.com/story/show/154273965)
* Refactored all tests to be ran subsequently without the need of starting and stopping of the node being tested
* Lowered the amount of itterations of tests where this didn't provide any stronger guarantees
* Exposed `aec_conductor:reinit_chain/0` to be used by the tests (that do depend on an empty chain so we don't restart a node just for that).

All the inefficiencies stated above being removed - the integration tests should run a couple of times faster.