### PR TITLE
Implement a functional Merkle Patricia Tree

### DIFF
--- a/apps/aeutils/src/aeu_mp_trees.erl
+++ b/apps/aeutils/src/aeu_mp_trees.erl
@@ -1,0 +1,543 @@
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2017, Aeternity Anstalt
+%%% @doc Merkle Patricia Trees
+%%%
+%%% @end
+%%%-------------------------------------------------------------------
+
+-module(aeu_mp_trees).
+
+-export([ new/0
+        , new/2
+        , delete/2
+        , get/2
+        , pp/1
+        , put/3
+        , root_hash/1
+        ]).
+
+-export_type([tree/0
+             ]).
+
+-record(mpt, { hash = <<>> :: <<>> | hash() %% <<>> for the empty tree
+             , db   = dict:new() :: dict:dict()
+             }).
+
+-opaque tree() :: #mpt{}.
+
+-type tree_node() :: null() | leaf() | extension() | branch().
+
+-type null()         :: <<>>.
+-type leaf()         :: {'leaf', path(), value()}.
+-type extension()    :: {'ext', path(), hash()}.
+-type branch()       :: {'branch', branch_tuple()}.
+-type branch_tuple() :: {enc_node(), enc_node(), enc_node(), enc_node(),
+                         enc_node(), enc_node(), enc_node(), enc_node(),
+                         enc_node(), enc_node(), enc_node(), enc_node(),
+                         enc_node(), enc_node(), enc_node(), enc_node(),
+                         value()}.
+
+-type enc_node()       :: null() | short_rlp_node() | hash().
+-type short_rlp_node() :: aeu_rlp:encoded(). %% size < 32 bytes
+
+-type raw_node()      :: null() | raw_leaf() | raw_extension() | raw_branch().
+-type raw_leaf()      :: [encoded_path()|value()]. %% [encoded_path(), value()].
+-type raw_extension() :: [encoded_path()|hash()].  %% [encoded_path(), hash()].
+-type raw_branch()    :: [enc_node()|value()].     %% [16x enc_node() + value()]
+
+-type path()         :: <<>> | key(). %% Hex string.
+-type encoded_path() :: binary().  %% Compact encoding of hex sequence.
+
+-type key()          :: <<_:4,_:_*4>>. %% Non-empty hexstring
+-type value()        :: aeu_rlp:encodable().
+-type hash()         :: <<_:256>>.
+
+-type db()           :: dict:dict().
+
+%%-define(debug_on, true).
+-ifdef(debug_on).
+-define(debug(___FMT___, ___ARGS___), io:format(___FMT___, ___ARGS___)).
+-else.
+-define(debug(___FMT___, ___ARGS___), ok).
+-endif.
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+-spec new() -> tree().
+new() ->
+    #mpt{}.
+
+-spec new(hash(), db()) -> tree().
+new(RootHash, DB) ->
+    #mpt{ hash = RootHash
+        , db   = DB
+        }.
+
+-spec get(bitstring(), tree()) -> value() | <<>>.
+get(Key, #mpt{hash = Hash, db = DB}) ->
+    ?debug("\n", []),
+    int_get(Key, decode_node(Hash, DB), DB).
+
+-spec put(key(), value() | <<>>, tree()) -> tree().
+%% @doc Note that putting <<>> as value is equivalent to deleting the value.
+put(Key, <<>>, #mpt{} = Mpt) when is_bitstring(Key), Key =/= <<>> ->
+    delete(Key, Mpt);
+put(Key, Val, #mpt{} = Mpt) when is_bitstring(Key), Key =/= <<>> ->
+    #mpt{hash = Hash, db = DB} = Mpt,
+    assert_val(Val),
+    try int_put(Key, Val, decode_node(Hash, DB), DB) of
+        {NewTree, DB1} ->
+            {NewHash, DB2} = force_encoded_node_to_hash(NewTree, DB1),
+            Mpt#mpt{ hash = NewHash, db = DB2}
+    catch throw:unchanged -> Mpt
+    end.
+
+-spec delete(key(), tree()) -> tree().
+delete(Key, #mpt{} = Mpt) when is_bitstring(Key) ->
+    #mpt{hash = Hash, db = DB} = Mpt,
+    try int_delete(Key, decode_node(Hash, DB), DB) of
+        {<<>>, DB1} ->
+            Mpt#mpt{hash = <<>>, db   = DB1};
+        {NewTree, DB1} ->
+            {NewHash, DB2} = force_encoded_node_to_hash(NewTree, DB1),
+            Mpt#mpt{ hash = NewHash, db = DB2}
+    catch throw:unchanged -> Mpt
+    end.
+
+-spec root_hash(tree()) -> <<>> | hash().
+root_hash(#mpt{hash = H}) -> H.
+
+-spec pp(tree()) -> 'ok'.
+pp(#mpt{hash = Hash, db = DB}) ->
+    io:format("Root: ~s\n", [hexstring(Hash)]),
+    [io:format("~s\n", [S])
+     || S <- lists:flatten([pp_tree(decode_node(Hash, DB), DB)])],
+    ok.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+
+assert_val(Val) ->
+    aeu_rlp:encode(Val),
+    ok.
+
+%%%===================================================================
+%%% Get
+
+-spec int_get(path(), tree_node(), db()) -> value() | <<>>.
+
+int_get(_Path, <<>>,_DB) ->
+    <<>>;
+int_get(<<>>, {branch, Branch},_DB) when tuple_size(Branch) =:= 17 ->
+    branch_value(Branch);
+int_get(Path, {branch, Branch}, DB) when tuple_size(Branch) =:= 17 ->
+    <<Next:4, Rest/bits>> = Path,
+    NextNode = decode_node(branch_next(Next, Branch), DB),
+    int_get(Rest, NextNode, DB);
+int_get(Path, {Type, NodePath, NodeVal}, DB) when Type =:= ext; Type =:= leaf ->
+    S = bit_size(NodePath),
+    case Path of
+        NodePath when Type =:= leaf ->
+            NodeVal;
+        <<NodePath:S/bits, _/bits>> when Type =:= leaf ->
+            <<>>;
+        <<NodePath:S/bits, Rest/bits>> when Type =:= ext ->
+            int_get(Rest, decode_node(NodeVal, DB), DB);
+        _ ->
+            <<>>
+    end.
+
+%%%===================================================================
+%%% Put
+
+-spec int_put(path(), value(), tree_node(), db()) -> {enc_node(), db()}.
+%% throws 'unchanged' if no action is required
+int_put(Key, Val, <<>>, DB) ->
+    leaf(Key, Val, DB);
+int_put(Key1, Val1, {leaf, Key2, Val2}, DB) ->
+    {Common, K1, K2} = find_common_path(Key1, Key2),
+    case {K1, K2} of
+        {<<>>, <<>>} when Val1 =:= Val2 ->
+            %% The same key and the same value.
+            throw(unchanged);
+        {<<>>, <<>>} ->
+            %% The same key. Just update the value.
+            leaf(Key1, Val1, DB);
+        {<<>>, <<K:4, Rest/bits>>} ->
+            %% We need a branch before the old leaf
+            {L, DB1} = leaf(Rest, Val2, DB),
+            {Branch, DB2} = branch([{K, L}], Val1, DB1),
+            maybe_extension(Common, Branch, DB2);
+        {<<K:4, Rest/bits>>, <<>>} ->
+            %% We need a branch before the new leaf
+            {L, DB1} = leaf(Rest, Val1, DB),
+            {Branch, DB2} = branch([{K, L}], Val2, DB1),
+            maybe_extension(Common, Branch, DB2);
+        {<<Next1:4, Rest1/bits>>, <<Next2:4, Rest2/bits>>} ->
+            %% We need a branch before both leaves
+            {L1, DB1} = leaf(Rest1, Val1, DB),
+            {L2, DB2} = leaf(Rest2, Val2, DB1),
+            {Branch, DB3} = branch([{Next1, L1}, {Next2, L2}], <<>>, DB2),
+            maybe_extension(Common, Branch, DB3)
+    end;
+int_put(<<>> =_Key, Val, {branch, Branch}, DB) ->
+    %% Update the value of the branch
+    case branch_value(Branch) =:= Val of
+        true  -> throw(unchanged);
+        false -> branch(set_branch_value(Branch, Val), DB)
+    end;
+int_put(<<Next:4, Rest/bits>>, Val, {branch, Branch}, DB) ->
+    NextNode = decode_node(branch_next(Next, Branch), DB),
+    {NewNode, DB1} = int_put(Rest, Val, NextNode, DB),
+    Branch1 = set_branch_next(Next, Branch, NewNode),
+    branch(Branch1, DB1);
+int_put(Key1, Val, {ext, Key2, Hash} = Ext, DB) ->
+    {Common, K1, K2} = find_common_path(Key1, Key2),
+    case {K1, K2} of
+        {<<>>, <<>>} ->
+            %% The same preamble
+            {NewNode, DB1} = int_put(<<>>, Val, decode_node(Hash, DB), DB),
+            extension(Common, NewNode, DB1);
+        {_, <<>>} ->
+            %% The whole extension is passed
+            {NewNode, DB1} = int_put(K1, Val, decode_node(Hash, DB), DB),
+            extension(Common, NewNode, DB1);
+        {<<>>, <<Next2:4, Rest2/bits>>} ->
+            %% We need to branch out
+            {NewNode2, DB1} = update_extension_path(Ext, Rest2, DB),
+            {Branch, DB2} = branch([{Next2, NewNode2}], Val, DB1),
+            maybe_extension(Common, Branch, DB2);
+        {<<Next1:4, Rest1/bits>>, <<Next2:4, Rest2/bits>>} ->
+            {NewNode1, DB1} = leaf(Rest1, Val, DB),
+            {NewNode2, DB2} = update_extension_path(Ext, Rest2, DB1),
+            BranchList = [{Next1, NewNode1}, {Next2, NewNode2}],
+            {Branch, DB3} = branch(BranchList, <<>>, DB2),
+            maybe_extension(Common, Branch, DB3)
+    end.
+
+find_common_path(B1, B2) ->
+    Offset = find_common_path_1(B1, B2),
+    <<Common:Offset/bits, Left1/bits>> = B1,
+    <<_     :Offset/bits, Left2/bits>> = B2,
+    {Common, Left1, Left2}.
+
+find_common_path_1(<<X:4, Rest1/bits>>,
+                   <<X:4, Rest2/bits>>) ->
+    4 + find_common_path_1(Rest1, Rest2);
+find_common_path_1(_, _) ->
+    0.
+
+%%%===================================================================
+%%% Delete
+
+-spec int_delete(path(), tree_node(), db()) -> {enc_node(), db()}.
+%% throws 'unchanged' if no action is required
+int_delete(_Key, <<>>,_DB) ->
+    throw(unchanged);
+int_delete(Key1, {leaf, Key2, _} = _Node, DB) ->
+    ?debug("~w: ~s ~s\n", [?LINE, hexstring(Key1), pp_node(_Node, DB)]),
+    case Key1 =:= Key2 of
+        true  -> {<<>>, DB};
+        false -> throw(unchanged)
+    end;
+int_delete(Key1, {ext, Key2, Hash} = _Node, DB) ->
+    ?debug("~w: ~s ~s\n", [?LINE, hexstring(Key1), pp_node(_Node, DB)]),
+    S = bit_size(Key2),
+    case Key1 of
+        <<Key2:S/bits, Rest/bits>> ->
+            {NewNode, DB1} = int_delete(Rest, decode_node(Hash, DB), DB),
+            case decode_node(NewNode, DB1) of
+                {leaf, Path, Val} ->
+                    leaf(<<Key2/bits, Path/bits>>, Val, DB1);
+                {ext, Path, Hash1} ->
+                    extension(<<Key2/bits, Path/bits>>, Hash1, DB1);
+                {branch, _} ->
+                    extension(Key2, NewNode, DB1)
+            end;
+        _ ->
+            throw(unchanged)
+    end;
+int_delete(Key, {branch, Branch} = _Node, DB) ->
+    ?debug("~w: ~s ~s\n", [?LINE, hexstring(Key), pp_node(_Node, DB)]),
+    Val = branch_value(Branch),
+    case Key of
+        <<>> when Val =:= <<>> -> throw(unchanged);
+        <<>> -> try_reduce_branch(set_branch_value(Branch, <<>>), DB);
+        <<Next:4, Rest/bits>> ->
+            Node = decode_node(branch_next(Next, Branch), DB),
+            case int_delete(Rest, Node, DB) of
+                {<<>>, DB1} ->
+                    try_reduce_branch(set_branch_next(Next, Branch, <<>>), DB1);
+                {NewNode, DB1} ->
+                    branch(set_branch_next(Next, Branch, NewNode), DB1)
+            end
+    end.
+
+try_reduce_branch(Branch, DB) ->
+    case get_singleton_branch(Branch) of
+        error        -> branch(Branch, DB);
+        none         -> error({empty_branch, Branch});
+        {value, Val} -> leaf(<<>>, Val, DB);
+        {Next, NextNode} ->
+            case decode_node(NextNode, DB) of
+                {leaf, Path, Val} ->
+                    leaf(<<Next:4, Path/bits>>, Val, DB);
+                {ext, Path, Val} ->
+                    extension(<<Next:4, Path/bits>>, Val, DB);
+                {branch,_B} ->
+                    extension(<<Next:4>>, NextNode, DB)
+            end
+    end.
+
+get_singleton_branch(Branch) ->
+    InitAcc = case branch_value(Branch) of
+                  <<>> -> none;
+                  Val  -> {value, Val}
+              end,
+    get_singleton_branch(Branch, 0, InitAcc).
+
+get_singleton_branch(_Branch, N, Res) when N > 15 ->
+    Res;
+get_singleton_branch(Branch, N, Acc) ->
+    Node = branch_next(N, Branch),
+    case Node =:= <<>> of
+        true ->
+            get_singleton_branch(Branch, N + 1, Acc);
+        false when Acc =/= none ->
+            %% More than one value
+            error;
+        false ->
+            %% First value
+            get_singleton_branch(Branch, N + 1, {N, Node})
+    end.
+
+%%%===================================================================
+%%% Prettyprinter
+
+pp_node(Node, DB) ->
+    pp_node(Node, DB, false).
+
+pp_tree(Node, DB) ->
+    pp_node(Node, DB, true).
+
+pp_node(<<>>,_DB,_Children) -> <<"<<>>">>;
+pp_node({leaf, Path, Val}, DB,_Children) ->
+    {Node, _} = leaf(Path, Val, DB),
+    Hash = node_hash(Node),
+    S = io_lib:format("~s: {leaf, ~s, ~w}",
+                      [hexstring(Hash), hexstring(Path), Val]),
+    iolist_to_binary(S);
+pp_node({ext, Path, ChildHash}, DB, Children) ->
+    {Node, _} = extension(Path, ChildHash, DB),
+    Hash = node_hash(Node),
+    S = io_lib:format("~s: {ext, ~s, ~s}",
+                      [hexstring(Hash), hexstring(Path), hexstring(ChildHash)]),
+    [iolist_to_binary(S)
+     | if Children -> pp_node(decode_node(ChildHash, DB), DB, Children);
+          true -> []
+       end];
+pp_node({branch, Branch}, DB, Children) ->
+    {Node, _} = branch(Branch, DB),
+    Hash = node_hash(Node),
+    BranchElements = [pp_branch_element(X)
+                      || X <- lists:droplast(tuple_to_list(Branch))],
+    BranchString = "[" ++ string:join(BranchElements, ",") ++ "]",
+    Val = branch_value(Branch),
+    S = io_lib:format("~s: {branch, ~s, ~p}",
+                      [hexstring(Hash), BranchString, Val]),
+    [iolist_to_binary(S)
+     | if Children ->
+               [pp_node(decode_node(X, DB), DB)
+                || X <- lists:droplast(tuple_to_list(Branch)), X =/= <<>>];
+          true -> []
+       end].
+
+pp_branch_element(<<>>) -> "<<>>";
+pp_branch_element(Bin) when byte_size(Bin) =:= 32 -> [hexstring(Bin)];
+pp_branch_element(Bin) -> ["*", hexstring(node_hash(Bin))].
+
+hexstring(Bin) ->
+    [hexchar(X) || <<X:4>> <= Bin].
+
+hexchar(X) when X > -1, X < 10 -> $0 + X;
+hexchar(X) when X > -1, X < 16 -> $A + X - 10.
+
+%%%===================================================================
+%%% Nodes
+
+-spec node_hash(enc_node()) -> hash().
+node_hash(<<>>) -> error(no_hash_for_null);
+node_hash(Bin) when byte_size(Bin) < 32   -> crypto:hash(sha256, Bin);
+node_hash(Bin) when byte_size(Bin) =:= 32 -> Bin.
+
+-spec decode_node(enc_node(), db()) -> tree_node().
+decode_node(<<>> = X,_DB) -> X;
+decode_node(Bin,_DB) when byte_size(Bin) < 32 ->
+    case aeu_rlp:decode(Bin) of
+        [CPath, Val] ->
+            {Type, Path} = decode_path(CPath),
+            {Type, Path, Val};
+        [_|_] = Branch ->
+            {branch, list_to_tuple(Branch)}
+    end;
+decode_node(Hash, DB) when byte_size(Hash) =:= 32 ->
+    case db_get(Hash, DB) of
+        [CPath, Val] ->
+            {Type, Path} = decode_path(CPath),
+            {Type, Path, Val};
+        [_|_] = Branch ->
+            {branch, list_to_tuple(Branch)}
+    end.
+
+-spec encode_node(raw_node(), db()) -> {enc_node(), db()}.
+encode_node(Node, DB) ->
+    Rlp = aeu_rlp:encode(Node),
+    case byte_size(Rlp) < 32 of
+        true  -> {Rlp, DB};
+        false ->
+            Hash = crypto:hash(sha256, Rlp),
+            {Hash, db_put(Hash, Node, DB)}
+    end.
+
+%% An extension must refer to a hash rather than the rlp encoding of a node.
+-spec force_encoded_node_to_hash(enc_node(), db()) -> {hash(), db()}.
+force_encoded_node_to_hash(<<>>,_DB) ->
+    error(cannot_store_null);
+force_encoded_node_to_hash(Hash, DB) when byte_size(Hash) =:= 32 ->
+    {Hash, DB};
+force_encoded_node_to_hash(Rlp, DB) when byte_size(Rlp) < 32 ->
+    Node = aeu_rlp:decode(Rlp),
+    Hash = node_hash(Rlp),
+    {Hash, db_put(Hash, Node, DB)}.
+
+%% A hash might have been forced for being refered in an extension.
+%% Resolve the hash and find out if we should use the encoded node instead.
+maybe_resolve_hash(<<>> = X,_DB) -> X;
+maybe_resolve_hash(Bin,_DB) when byte_size(Bin) < 32 -> Bin;
+maybe_resolve_hash(Hash, DB) when byte_size(Hash) =:= 32 ->
+    Node = db_get(Hash, DB),
+    Rlp  = aeu_rlp:encode(Node),
+    case byte_size(Rlp) < 32 of
+        true  -> Rlp;
+        false -> Hash
+    end.
+
+%%%===================================================================
+%%% Leaf
+
+-spec leaf(path(), value(), db()) -> {enc_node(), db()}.
+leaf(_Path, <<>>,_DB) ->
+    error(cannot_store_null_in_node);
+leaf(Path, Val, DB) when is_binary(Val); is_list(Val) ->
+    encode_node([encode_path_leaf(Path), Val], DB).
+
+maybe_extension(<<>>, Node, DB) ->
+    {Node, DB};
+maybe_extension(Path, Node, DB) when Path =/= <<>> ->
+    extension(Path, Node, DB).
+
+%%%===================================================================
+%%% Extension
+
+-spec extension(path(), enc_node(), db()) -> {enc_node(), db()}.
+extension(Path, Node, DB) when Path =/= <<>> ->
+    %% Extensions must have a hash as value.
+    {Hash, DB1} = force_encoded_node_to_hash(Node, DB),
+    encode_node([encode_path_ext(Path), Hash], DB1).
+
+update_extension_path({ext,_OldPath, Hash}, NewPath, DB) ->
+    case NewPath =:= <<>> of
+        true ->
+            %% Fall through to the refered value
+            {maybe_resolve_hash(Hash, DB), DB};
+        false ->
+            encode_node([encode_path_ext(NewPath), Hash], DB)
+    end.
+
+%%%===================================================================
+%%% Branch
+
+-define(branch_tuple(___VAL___),
+        { <<>>, <<>>, <<>>, <<>>, <<>>, <<>>, <<>>, <<>>
+        , <<>>, <<>>, <<>>, <<>>, <<>>, <<>>, <<>>, <<>>
+        , Val}).
+
+-spec branch(branch_tuple(), db()) -> {enc_node(), db()}.
+branch(Branch, DB) ->
+    encode_node(tuple_to_list(Branch), DB).
+
+-spec branch([{0..15, enc_node()},...], value(), db()) -> {enc_node(), db()}.
+branch([_|_] = List, Val, DB) ->
+    {true, List} = {length(List) =:= length(lists:ukeysort(1, List)), List},
+    Fun = fun({X, Node}, Acc) -> setelement(X + 1, Acc, Node) end,
+    Branch = lists:foldl(Fun, ?branch_tuple(Val), List),
+    branch(Branch, DB).
+
+branch_next(N, Branch) ->
+    element(N + 1, Branch).
+
+set_branch_next(N, Branch, Node) ->
+    setelement(N + 1, Branch, Node).
+
+branch_value(Branch) ->
+    element(17, Branch).
+
+set_branch_value(Branch, Value) ->
+    setelement(17, Branch, Value).
+
+%%%===================================================================
+%%% DB interface (currently dict)
+%% TODO: Make a local cache, and a proper db interface.
+
+db_get(Hash, DB) ->
+  dict:fetch(Hash, DB).
+
+db_put(Hash, Val, DB) ->
+  dict:store(Hash, Val, DB).
+
+
+%%%===================================================================
+%%% Compact encoding of hex sequence with optional terminator
+%%%
+%%% From: https://github.com/ethereum/wiki/wiki/Patricia-Tree
+%%%
+%%% The flagging of both odd vs. even remaining partial path length and
+%%% leaf vs. extension node as described above reside in the first nibble
+%%% of the partial path of any 2-item node. They result in the following:
+%%%
+%%% hex char    bits    |    node type partial     path length
+%%% ----------------------------------------------------------
+%%%    0        0000    |       extension              even
+%%%    1        0001    |       extension              odd
+%%%    2        0010    |   terminating (leaf)         even
+%%%    3        0011    |   terminating (leaf)         odd
+%%%
+%%% For even remaining path length (0 or 2), another 0 "padding"
+%%% nibble will always follow.
+
+-define(EVEN_EXT,  0).
+-define(ODD_EXT,   1).
+-define(EVEN_LEAF, 2).
+-define(ODD_LEAF , 3).
+
+-spec encode_path_leaf(path()) -> encoded_path().
+encode_path_leaf(Path) ->
+    case bit_size(Path) rem 8 of
+        0 -> <<?EVEN_LEAF:4, 0:4, Path/bits>>;
+        4 -> <<?ODD_LEAF:4, Path/bits>>
+    end.
+
+-spec encode_path_ext(path()) -> encoded_path().
+encode_path_ext(Path) ->
+    case bit_size(Path) rem 8 of
+        0 -> <<?EVEN_EXT:4, 0:4, Path/bits>>;
+        4 -> <<?ODD_EXT:4, Path/bits>>
+    end.
+
+decode_path(<<?EVEN_EXT :4, 0:4, Left/bits>>) -> {ext, Left};
+decode_path(<<?ODD_EXT  :4,      Left/bits>>) -> {ext, Left};
+decode_path(<<?EVEN_LEAF:4, 0:4, Left/bits>>) -> {leaf, Left};
+decode_path(<<?ODD_LEAF :4,      Left/bits>>) -> {leaf, Left}.

--- a/apps/aeutils/src/aeu_rlp.erl
+++ b/apps/aeutils/src/aeu_rlp.erl
@@ -1,0 +1,90 @@
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2017, Aeternity Anstalt
+%%% @doc
+%%%     Implementation of the Recursive Length Prefix.
+%%%
+%%%     https://github.com/ethereum/wiki/wiki/RLP
+%%%
+%%% @end
+%%%-------------------------------------------------------------------
+
+-module(aeu_rlp).
+-export([ decode/1
+	, encode/1
+        ]).
+
+-export_type([ encodable/0
+             , encoded/0
+             ]).
+
+-type encodable() :: [encodable()] | binary().
+-type encoded()   :: <<_:8, _:_*8>>.
+
+-define(UNTAGGED_SIZE_LIMIT , 55).
+-define(UNTAGGED_LIMIT      , 127).
+-define(BYTE_ARRAY_OFFSET   , 128).
+-define(LIST_OFFSET         , 192).
+
+
+-spec encode(encodable()) -> encoded().
+encode(X) ->
+    encode(X, []).
+
+encode(<<B>> = X,_Opts) when B =< ?UNTAGGED_LIMIT ->
+    %% An untagged value
+    X;
+encode(X,_Opts) when is_binary(X) ->
+    %% Byte array
+    add_size(?BYTE_ARRAY_OFFSET, X);
+encode(L, Opts) when is_list(L) ->
+    %% Lists items are encoded and concatenated
+    ByteArray = << << (encode(X, Opts))/binary >> || X <- L >>,
+    add_size(?LIST_OFFSET, ByteArray).
+
+add_size(Offset, X) when byte_size(X) =< ?UNTAGGED_SIZE_LIMIT ->
+    %% The size fits in one tagged byte
+    <<(Offset + byte_size(X)), X/binary>>;
+add_size(Offset, X) when is_binary(X) ->
+    %% The size itself needs to be encoded as a byte array
+    %% Add the tagged size of the size byte array
+    SizeBin    = binary:encode_unsigned(byte_size(X)),
+    TaggedSize = ?UNTAGGED_SIZE_LIMIT + Offset + byte_size(SizeBin),
+    true       = (TaggedSize < 256 ), %% Assert
+    <<TaggedSize, SizeBin/binary, X/binary>>.
+
+-spec decode(encoded()) -> encodable().
+decode(Bin) when is_binary(Bin), byte_size(Bin) > 0 ->
+    case decode_one(Bin) of
+        {X, <<>>} -> X;
+        {X, Left} -> error({trailing, X, Bin, Left})
+    end.
+
+decode_one(<<X, B/binary>>) when X =< ?UNTAGGED_LIMIT ->
+    %% Untagged value
+    {<<X>>, B};
+decode_one(<<L, _/binary>> = B) when L < ?LIST_OFFSET ->
+    %% Byte array
+    {Size, Rest} = decode_size(B, ?BYTE_ARRAY_OFFSET),
+    <<X:Size/binary, Tail/binary>> = Rest,
+    {X, Tail};
+decode_one(<<_/binary>> = B) ->
+    %% List
+    {Size, Rest} = decode_size(B, ?LIST_OFFSET),
+    <<X:Size/binary, Tail/binary>> = Rest,
+    {decode_list(X), Tail}.
+
+decode_size(<<L, B/binary>>, Offset) when L =< Offset + ?UNTAGGED_SIZE_LIMIT->
+    %% One byte tagged size.
+    {L - Offset, B};
+decode_size(<<_, 0, _/binary>>,_Offset) ->
+    error(leading_zeroes_in_size);
+decode_size(<<L, B/binary>>, Offset) ->
+    %% Actual size is in a byte array.
+    BinSize = L - Offset - ?UNTAGGED_SIZE_LIMIT,
+    <<Size:BinSize/unit:8, Rest/binary>> = B,
+    {Size, Rest}.
+
+decode_list(<<>>) -> [];
+decode_list(B) ->
+    {Element, Rest} = decode_one(B),
+    [Element|decode_list(Rest)].

--- a/apps/aeutils/test/aeu_mp_trees_tests.erl
+++ b/apps/aeutils/test/aeu_mp_trees_tests.erl
@@ -1,0 +1,214 @@
+%%%=============================================================================
+%%% @copyright (C) 2017, Aeternity Anstalt
+%%% @doc
+%%%    Unit tests for Merkle Patricia Trees
+%%% @end
+%%%=============================================================================
+-module(aeu_mp_trees_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+basic_test_() ->
+    [ {"Put", fun test_put/0}
+    , {"Lookup", fun test_lookup/0}
+    , {"Delete one", fun test_delete_one_by_one/0}
+    , {"Delete all", fun test_delete_all/0}
+    , {"Missing lookups", fun test_lookup_missing/0}
+    , {"Put rlp values", fun test_put_rlp_vals/0}
+    , {"Collapse extension", fun test_collapse_ext/0}
+    ].
+
+hash_test_() ->
+    [ {"Reversed put", fun test_reversed_put/0}
+    , {"Put and delete", fun test_put_and_delete/0}
+    , {"Merge of ext", fun test_ext_merge_of_paths/0}
+    ].
+
+extension_test_() ->
+    [ {"One step", fun test_extension_one_step/0}
+    , {"Two step", fun test_extension_two_step/0}
+    ].
+
+%%%=============================================================================
+%%% Basic tests
+
+test_put() ->
+    {_Tree,_Vals} = gen_mp_tree({23, 123534, 345345}, 1000),
+    ok.
+
+test_lookup() ->
+    {Tree, Vals} = gen_mp_tree({123, 1234, 1234123}, 1000),
+    [?assertEqual(Y, aeu_mp_trees:get(X, Tree)) || {X, Y} <- Vals],
+    ok.
+
+test_lookup_missing() ->
+    Val = <<0,0,0,0>>,
+    K1 = <<0:4, 0:4>>,
+    K2 = <<0:4, 1:4, 0:4>>,
+    K3 = <<0:4, 0:4, 0:4, 0:4, 0:4>>,
+    K4 = <<0:4, 0:4, 0:4, 0:4, 1:4>>,
+    Keys = [K1, K2, K3, K4],
+    NotPresentLong = [<<K/bits, 15:4>> || K <- Keys],
+    NotPresentShort = [ begin S = bit_size(Key) - 4,
+                              <<X:S/bits, _:4>> = Key,
+                              X
+                        end || Key <- Keys],
+    T = insert_vals([{K1,Val}, {K2, Val}, {K3, Val}, {K4, Val}],
+                    aeu_mp_trees:new()),
+    [?assertEqual(<<>>, aeu_mp_trees:get(Key, T))
+     || Key <- NotPresentShort ++ NotPresentLong].
+
+test_delete_one_by_one() ->
+    {Tree, Vals} = gen_mp_tree({123, 1234, 1234123}, 1000),
+    [begin
+         T = aeu_mp_trees:delete(X, Tree),
+         ?assertEqual(<<>>, aeu_mp_trees:get(X, T))
+     end
+     || {X,_Y} <- Vals],
+    ok.
+
+test_delete_all() ->
+    {Tree, Vals} = gen_mp_tree({123, 1234, 1234123}, 1000),
+    Tree1 = test_delete_all(Vals, Tree),
+    ?assertEqual(aeu_mp_trees:root_hash(aeu_mp_trees:new()),
+                 aeu_mp_trees:root_hash(Tree1)).
+
+test_delete_all([{X, Y}|Left], Tree) ->
+    ?assertEqual(Y, aeu_mp_trees:get(X, Tree)),
+    Tree1 = aeu_mp_trees:delete(X, Tree),
+    ?assertEqual(<<>>, aeu_mp_trees:get(X, Tree1)),
+    ?assertNotEqual(aeu_mp_trees:root_hash(Tree),
+                    aeu_mp_trees:root_hash(Tree1)),
+    test_delete_all(Left, Tree1);
+test_delete_all([], Tree) ->
+    Tree.
+
+test_put_rlp_vals() ->
+    apply_ops([{put, <<7:4>>, [<<0>>]},
+               {put, <<7:4, 0:4>>, <<0>>}
+              ], aeu_mp_trees:new()).
+
+test_collapse_ext() ->
+    T = apply_ops([{put, <<15:4>>, <<0>>},
+                   {put, <<15:4, 13:4, 0:4>>, <<0>>},
+                   {put, <<15:4, 13:4>>, <<0>>}
+                  ], aeu_mp_trees:new()),
+    aeu_mp_trees:pp(T),
+    apply_ops([ {delete, <<15:4>>},
+                {delete, <<15:4, 13:4>>}
+              ], T).
+
+%%%=============================================================================
+%%% Hash tests
+
+test_reversed_put() ->
+    rand:seed(exs1024s, {143, 14132, 4163}),
+    Vals = gen_vals(1000),
+    T0 = aeu_mp_trees:new(),
+    T1 = insert_vals(Vals, T0),
+    T2 = insert_vals(lists:reverse(Vals), T0),
+    ?assertEqual(aeu_mp_trees:root_hash(T1),
+                 aeu_mp_trees:root_hash(T2)).
+
+test_put_and_delete() ->
+    %% From an existing tree, add and delete some nodes and see that
+    %% we arrive at the same hash again.
+    {T0, _} = gen_mp_tree({345, 2345, 1234}, 1000),
+    Vals = gen_vals(1000),
+    ?assertEqual([], [X || {X, _} <- Vals, aeu_mp_trees:get(X, T0) =/= <<>>]),
+    T1 = insert_vals(Vals, T0),
+    T2 = delete_vals(Vals, T1),
+    ?assertEqual(aeu_mp_trees:root_hash(T0), aeu_mp_trees:root_hash(T2)),
+
+    T3 = delete_vals(lists:reverse(Vals), T1),
+    ?assertEqual(aeu_mp_trees:root_hash(T0), aeu_mp_trees:root_hash(T3)),
+    ok.
+
+test_ext_merge_of_paths() ->
+    Val = <<0,0,0,0>>,
+    Key1 = <<81,0:4>>,
+    Key2 = <<81>>,
+    Key3 = <<81,0>>,
+
+    T0 = aeu_mp_trees:new(),
+
+    T1 = apply_ops([ {put, Key1, Val}
+                   , {put, Key2, Val}
+                   , {put, Key3, Val}
+                   , {delete, Key2}
+                   ], T0),
+    T2 = apply_ops([ {put, Key1, Val}
+                   , {put, Key3, Val}
+                   ], T0),
+    ?assertEqual(aeu_mp_trees:root_hash(T1),
+                 aeu_mp_trees:root_hash(T2)).
+
+%%%=============================================================================
+%%% Extension tests
+
+test_extension_one_step() ->
+    rand:seed(exs1024s, {1413, 1432, 413}),
+    test_extension_n_step(1).
+
+test_extension_two_step() ->
+    rand:seed(exs1024s, {141323, 1423432, 415133}),
+    test_extension_n_step(1).
+
+test_extension_n_step(Step) ->
+    Key = random_hexstring(65),
+    Val = random_hexstring(65*2+2),
+    T   = insert_step(Key, Val, 1, aeu_mp_trees:new()),
+    lookup_step(Key, Val, Step, T),
+    ok.
+
+insert_step(Key, Val, Step, T) ->
+    case {Key, Val} of
+        { <<_:Step/unit:4, Key1/bitstring>>
+        , <<_:Step/unit:8, Val1/binary>>} when Key1 =/= <<>> ->
+            T1 = aeu_mp_trees:put(Key1, Val1, T),
+            insert_step(Key1, Val1, Step, T1);
+        {_, _} -> T
+    end.
+
+lookup_step(Key, Val, Step, T) ->
+    case {Key, Val} of
+        { <<_:Step/unit:4, Key1/bitstring>>
+        , <<_:Step/unit:8, Val1/binary>>} when Key1 =/= <<>> ->
+            ?assertEqual(Val1, aeu_mp_trees:get(Key1, T)),
+            lookup_step(Key1, Val1, Step, T);
+        {_, _} -> ok
+    end.
+
+
+%%%=============================================================================
+%%% Test utils
+
+gen_mp_tree(Seed, NofNodes) ->
+    rand:seed(exs1024s, Seed),
+    Vals = gen_vals(NofNodes),
+    ?assertEqual(length(Vals), length(lists:ukeysort(1, Vals))),
+    {insert_vals(Vals, aeu_mp_trees:new()), Vals}.
+
+gen_vals(NofNodes) ->
+    [{random_hexstring(65), random_hexstring(8)}
+     || _ <- lists:seq(1, NofNodes)].
+
+apply_ops([{put, Key, Val}|Left], T) ->
+    apply_ops(Left, aeu_mp_trees:put(Key, Val, T));
+apply_ops([{delete, Key}|Left], T) ->
+    apply_ops(Left, aeu_mp_trees:delete(Key, T));
+apply_ops([], T) ->
+    T.
+
+insert_vals([{X, Y}|Left], T) ->
+    insert_vals(Left, aeu_mp_trees:put(X, Y, T));
+insert_vals([], T) ->
+    T.
+
+delete_vals([{X,_Y}|Left], T) ->
+    delete_vals(Left, aeu_mp_trees:delete(X, T));
+delete_vals([], T) ->
+    T.
+
+random_hexstring(N) when N >= 1 ->
+    << <<(rand:uniform(15)):4>> || _ <- lists:seq(1, N) >>.

--- a/apps/aeutils/test/aeu_rlp_tests.erl
+++ b/apps/aeutils/test/aeu_rlp_tests.erl
@@ -1,0 +1,119 @@
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2017, Aeternity Anstalt
+%%% @doc Tests for Recursive Length Prefix
+%%% @end
+%%%-------------------------------------------------------------------
+
+-module(aeu_rlp_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(UNTAGGED_SIZE_LIMIT , 55).
+-define(UNTAGGED_LIMIT      , 127).
+-define(BYTE_ARRAY_OFFSET   , 128).
+-define(LIST_OFFSET         , 192).
+
+
+rlp_one_byte_test() ->
+    B = <<42>>,
+    B = aeu_rlp:encode(B),
+    B = aeu_rlp:decode(B).
+
+rlp_another_one_byte_test() ->
+    B = <<127>>,
+    B = aeu_rlp:encode(B),
+    B = aeu_rlp:decode(B).
+
+rlp_two_bytes_test() ->
+    B = <<128>>,
+    S = ?BYTE_ARRAY_OFFSET + 1,
+    <<S, B/binary>> = aeu_rlp:encode(B).
+
+rlp_one_byte_size_bytes_test() ->
+    L = 55,
+    S = ?BYTE_ARRAY_OFFSET + L,
+    X = << <<X>> || X <- lists:seq(1,L)>>,
+    E = <<S, X/binary>> = aeu_rlp:encode(X),
+    X = aeu_rlp:decode(E).
+
+rlp_tagged_size_one_byte_bytes_test() ->
+    L = 56,
+    Tag = ?BYTE_ARRAY_OFFSET + ?UNTAGGED_SIZE_LIMIT + 1,
+    X = list_to_binary(lists:duplicate(L, 42)),
+    S = byte_size(X),
+    E = <<Tag, S, X/binary>> = aeu_rlp:encode(X),
+    X = aeu_rlp:decode(E).
+
+rlp_tagged_size_two_bytes_bytes_test() ->
+    L = 256,
+    SizeSize = 2,
+    Tag = ?BYTE_ARRAY_OFFSET + ?UNTAGGED_SIZE_LIMIT + SizeSize,
+    X = list_to_binary(lists:duplicate(L, 42)),
+    S = byte_size(X),
+    E = <<Tag, S:SizeSize/unit:8, X/binary>> = aeu_rlp:encode(X),
+    X = aeu_rlp:decode(E).
+
+rlp_one_byte_list_test() ->
+    L = 1,
+    Tag = ?LIST_OFFSET + L,
+    X = lists:duplicate(L, <<42>>),
+    E = <<Tag, 42>> = aeu_rlp:encode(X),
+    X = aeu_rlp:decode(E).
+
+rlp_byte_array_list_test() ->
+    L = 55,
+    Tag = ?LIST_OFFSET +  L,
+    X = lists:duplicate(L, <<42>>),
+    Y = list_to_binary(X),
+    E = <<Tag, Y/binary>> = aeu_rlp:encode(X),
+    X = aeu_rlp:decode(E).
+
+rlp_byte_array_tagged_size_one_byte_list_test() ->
+    L = 56,
+    SizeSize = 1,
+    Tag = ?LIST_OFFSET + ?UNTAGGED_SIZE_LIMIT + SizeSize,
+    X = lists:duplicate(L, <<42>>),
+    Y = list_to_binary(X),
+    S = byte_size(Y),
+    E = <<Tag, S:SizeSize/unit:8, Y/binary>> = aeu_rlp:encode(X),
+    X = aeu_rlp:decode(E).
+
+rlp_byte_array_tagged_size_two_bytes_list_test() ->
+    L = 256,
+    SizeSize = 2,
+    Tag = ?LIST_OFFSET + ?UNTAGGED_SIZE_LIMIT + SizeSize,
+    X = lists:duplicate(L, <<42>>),
+    Y = list_to_binary(X),
+    S = byte_size(Y),
+    E = <<Tag, S:SizeSize/unit:8, Y/binary>> = aeu_rlp:encode(X),
+    X = aeu_rlp:decode(E).
+
+illegal_size_encoding_list_test() ->
+    %% Ensure we start with somehting legal.
+    L = 56,
+    SizeSize = 1,
+    Tag = ?LIST_OFFSET + ?UNTAGGED_SIZE_LIMIT + SizeSize,
+    X = lists:duplicate(L, <<42>>),
+    Y = list_to_binary(X),
+    S = byte_size(Y),
+    E = <<Tag, S:SizeSize/unit:8, Y/binary>> = aeu_rlp:encode(X),
+    X = aeu_rlp:decode(E),
+
+    %% Add leading zeroes to the size field.
+    E1 = <<(Tag + 1), 0, S:SizeSize/unit:8, Y/binary>>,
+    ?assertError(leading_zeroes_in_size, aeu_rlp:decode(E1)).
+
+illegal_size_encoding_byte_array_test() ->
+    %% Ensure we start with somehting legal.
+    L = 256,
+    SizeSize = 2,
+    Tag = ?BYTE_ARRAY_OFFSET + ?UNTAGGED_SIZE_LIMIT + SizeSize,
+    X = list_to_binary(lists:duplicate(L, 42)),
+    S = byte_size(X),
+    E = <<Tag, S:SizeSize/unit:8, X/binary>> = aeu_rlp:encode(X),
+    X = aeu_rlp:decode(E),
+
+    %% Add leading zeroes to the size field.
+    E1 = <<(Tag + 1), 0, S:SizeSize/unit:8, X/binary>>,
+    ?assertError(leading_zeroes_in_size, aeu_rlp:decode(E1)).
+


### PR DESCRIPTION
This PR adds an implementation of Merkle Patricia Trees as (very vaguely)  defined in https://github.com/ethereum/wiki/wiki/Patricia-Tree with input from the reference implementation at https://github.com/ethereum/go-ethereum/tree/master/trie

This PR also include an implementation of RLP https://github.com/ethereum/wiki/wiki/RLP

The implementation lacks proofs.

Additional testing has been done using Quickcheck https://github.com/Quviq/epoch-eqc
