### PR TITLE
PT-154171539 boilerplate for create contract transaction

### DIFF
--- a/apps/aecontract/include/contract_txs.hrl
+++ b/apps/aecontract/include/contract_txs.hrl
@@ -1,24 +1,21 @@
--include_lib("apps/aecore/include/common.hrl").
-
--type amount() :: non_neg_integer().
 
 -record(contract_create_tx, {
-          owner      :: pubkey(),
+          owner      :: aect_contracts:pubkey(),
           nonce      :: non_neg_integer(),
           code       :: binary(),
           vm_version :: byte(),
-          fee        :: amount(),
-          deposit    :: amount(),
-          amount     :: amount(),
-          gas        :: amount(),
-          gas_price  :: amount(),
+          fee        :: aect_contracts:amount(),
+          deposit    :: aect_contracts:amount(),
+          amount     :: aect_contracts:amount(),
+          gas        :: aect_contracts:amount(),
+          gas_price  :: aect_contracts:amount(),
           call_data  :: binary()
         }).
 
 -record(contract_call_tx, {
-          sender   :: pubkey(),
+          sender   :: aect_contracts:pubkey(),
           nonce    :: integer(),
-          contract :: pubkey(),
+          contract :: aect_contracts:pubkey(),
           fee      :: integer()
           }).
 

--- a/apps/aecontract/include/contract_txs.hrl
+++ b/apps/aecontract/include/contract_txs.hrl
@@ -1,9 +1,18 @@
 -include_lib("apps/aecore/include/common.hrl").
 
+-type amount() :: non_neg_integer().
+
 -record(contract_create_tx, {
-          owner :: pubkey(),
-          nonce :: integer(),
-          fee   :: integer()
+          owner      :: pubkey(),
+          nonce      :: non_neg_integer(),
+          code       :: binary(),
+          vm_version :: byte(),
+          fee        :: amount(),
+          deposit    :: amount(),
+          amount     :: amount(),
+          gas        :: amount(),
+          gas_price  :: amount(),
+          call_data  :: binary()
         }).
 
 -record(contract_call_tx, {

--- a/apps/aecontract/src/aect_call_tx.erl
+++ b/apps/aecontract/src/aect_call_tx.erl
@@ -7,6 +7,7 @@
 -module(aect_call_tx).
 
 -include("contract_txs.hrl").
+-include_lib("apps/aecore/include/common.hrl").
 -include_lib("apps/aecore/include/trees.hrl").
 
 -behavior(aetx).

--- a/apps/aecontract/src/aect_contracts.erl
+++ b/apps/aecontract/src/aect_contracts.erl
@@ -23,6 +23,8 @@
 %%% Types
 %%%===================================================================
 
+-type amount() :: non_neg_integer().
+
 -record(contract, { owner   :: pubkey()
                   , account :: pubkey()
                   }).
@@ -30,6 +32,8 @@
 -opaque contract() :: #contract{}.
 
 -export_type([ contract/0
+             , pubkey/0
+             , amount/0
              ]).
 
 -define(PUB_SIZE, 65).

--- a/apps/aecontract/src/aect_create_tx.erl
+++ b/apps/aecontract/src/aect_create_tx.erl
@@ -7,6 +7,7 @@
 -module(aect_create_tx).
 
 -include("contract_txs.hrl").
+-include_lib("apps/aecore/include/common.hrl").
 -include_lib("apps/aecore/include/trees.hrl").
 
 -behavior(aetx).
@@ -38,6 +39,8 @@
 -define(CONTRACT_CREATE_TX_TYPE, <<"contract_create">>).
 -define(CONTRACT_CREATE_TX_VSN, 1).
 -define(CONTRACT_CREATE_TX_FEE, 4).
+
+-type amount() :: aect_contracts:amount().
 
 -opaque create_tx() :: #contract_create_tx{}.
 

--- a/apps/aecontract/src/aect_create_tx.erl
+++ b/apps/aecontract/src/aect_create_tx.erl
@@ -26,7 +26,14 @@
         ]).
 
 %% Additional getters
--export([owner/1]).
+-export([owner/1,
+         code/1,
+         vm_version/1,
+         deposit/1,
+         amount/1,
+         gas/1,
+         gas_price/1,
+         call_data/1]).
 
 -define(CONTRACT_CREATE_TX_TYPE, <<"contract_create">>).
 -define(CONTRACT_CREATE_TX_VSN, 1).
@@ -36,21 +43,69 @@
 
 -export_type([create_tx/0]).
 
+%%%===================================================================
+%%% Getters
+
 -spec owner(create_tx()) -> pubkey().
 owner(#contract_create_tx{owner = OwnerPubKey}) ->
     OwnerPubKey.
+
+-spec code(create_tx()) -> binary().
+code(#contract_create_tx{code = X}) ->
+    X.
+
+-spec vm_version(create_tx()) -> non_neg_integer().
+vm_version(#contract_create_tx{vm_version = X}) ->
+    X.
+
+-spec deposit(create_tx()) -> amount().
+deposit(#contract_create_tx{deposit = X}) ->
+    X.
+
+-spec amount(create_tx()) -> amount().
+amount(#contract_create_tx{amount = X}) ->
+    X.
+
+-spec gas(create_tx()) -> amount().
+gas(#contract_create_tx{gas = X}) ->
+    X.
+
+-spec gas_price(create_tx()) -> amount().
+gas_price(#contract_create_tx{gas_price = X}) ->
+    X.
+
+-spec call_data(create_tx()) -> binary().
+call_data(#contract_create_tx{call_data = X}) ->
+    X.
+
+%%%===================================================================
+%%% Behavior API
 
 -spec fee(create_tx()) -> integer().
 fee(#contract_create_tx{fee = Fee}) ->
     Fee.
 
 -spec new(map()) -> {ok, create_tx()}.
-new(#{owner := OwnerPubKey,
-      nonce := Nonce,
-      fee   := Fee}) ->
-    {ok, #contract_create_tx{owner = OwnerPubKey,
-                             nonce = Nonce,
-                             fee   = Fee}}.
+new(#{owner      := OwnerPubKey,
+      nonce      := Nonce,
+      code       := Code,
+      vm_version := VmVersion,
+      deposit    := Deposit,
+      amount     := Amount,
+      gas        := Gas,
+      gas_price  := GasPrice,
+      call_data  := CallData,
+      fee        := Fee}) ->
+    {ok, #contract_create_tx{owner      = OwnerPubKey,
+                             nonce      = Nonce,
+                             code       = Code,
+                             vm_version = VmVersion,
+                             deposit    = Deposit,
+                             amount     = Amount,
+                             gas        = Gas,
+                             gas_price  = GasPrice,
+                             call_data  = CallData,
+                             fee        = Fee}}.
 
 -spec nonce(create_tx()) -> non_neg_integer().
 nonce(#contract_create_tx{nonce = Nonce}) ->
@@ -83,23 +138,77 @@ process(#contract_create_tx{owner = _OwnerPubKey,
     %% PLACEHOLDER
     {ok, Trees}.
 
-serialize(#contract_create_tx{owner = OwnerPubKey,
-                              nonce = Nonce,
-                              fee   = Fee}) ->
-    [#{<<"type">>  => type()},
-     #{<<"vsn">>   => version()},
-     #{<<"owner">> => OwnerPubKey},
-     #{<<"nonce">> => Nonce},
-     #{<<"fee">>   => Fee}].
+serialize(#contract_create_tx{owner      = OwnerPubKey,
+                              nonce      = Nonce,
+                              code       = Code,
+                              vm_version = VmVersion,
+                              fee        = Fee,
+                              deposit    = Deposit,
+                              amount     = Amount,
+                              gas        = Gas,
+                              gas_price  = GasPrice,
+                              call_data  = CallData}) ->
+    [#{<<"type">>       => type()},
+     #{<<"vsn">>        => version()},
+     #{<<"owner">>      => OwnerPubKey},
+     #{<<"nonce">>      => Nonce},
+     #{<<"code">>       => Code},
+     #{<<"vm_version">> => VmVersion},
+     #{<<"fee">>        => Fee},
+     #{<<"deposit">>    => Deposit},
+     #{<<"amount">>     => Amount},
+     #{<<"gas">>        => Gas},
+     #{<<"gas_price">>  => GasPrice},
+     #{<<"call_data">>  => CallData}].
 
-deserialize([#{<<"type">>  := ?CONTRACT_CREATE_TX_TYPE},
-             #{<<"vsn">>   := ?CONTRACT_CREATE_TX_VSN},
-             #{<<"owner">> := OwnerPubKey},
-             #{<<"nonce">> := Nonce},
-             #{<<"fee">>   := Fee}]) ->
-    #contract_create_tx{owner = OwnerPubKey,
-                        nonce = Nonce,
-                        fee   = Fee}.
+deserialize([#{<<"type">>       := ?CONTRACT_CREATE_TX_TYPE},
+             #{<<"vsn">>        := ?CONTRACT_CREATE_TX_VSN},
+             #{<<"owner">>      := OwnerPubKey},
+             #{<<"nonce">>      := Nonce},
+             #{<<"code">>       := Code},
+             #{<<"vm_version">> := VmVersion},
+             #{<<"fee">>        := Fee},
+             #{<<"deposit">>    := Deposit},
+             #{<<"amount">>     := Amount},
+             #{<<"gas">>        := Gas},
+             #{<<"gas_price">>  := GasPrice},
+             #{<<"call_data">>  := CallData}]) ->
+    #contract_create_tx{owner      = OwnerPubKey,
+                        nonce      = Nonce,
+                        code       = Code,
+                        vm_version = VmVersion,
+                        fee        = Fee,
+                        deposit    = Deposit,
+                        amount     = Amount,
+                        gas        = Gas,
+                        gas_price  = GasPrice,
+                        call_data  = CallData}.
+
+for_client(#contract_create_tx{ owner      = OwnerPubKey,
+                                nonce      = Nonce,
+                                code       = Code,
+                                vm_version = VmVersion,
+                                fee        = Fee,
+                                deposit    = Deposit,
+                                amount     = Amount,
+                                gas        = Gas,
+                                gas_price  = GasPrice,
+                                call_data  = CallData}) ->
+    #{<<"type">>       => <<"ContractCreateTxObject">>, % swagger schema name
+      <<"vsn">>        => version(),
+      <<"owner">>      => aec_base58c:encode(account_pubkey, OwnerPubKey),
+      <<"nonce">>      => Nonce,
+      <<"code">>       => hex_bytes(Code),
+      <<"vm_version">> => hex_byte(VmVersion),
+      <<"fee">>        => Fee,
+      <<"deposit">>    => Deposit,
+      <<"amount">>     => Amount,
+      <<"gas">>        => Gas,
+      <<"gas_price">>  => GasPrice,
+      <<"call_data">>  => hex_bytes(CallData)}.
+
+%%%===================================================================
+%%% Internal functions
 
 -spec type() -> binary().
 type() ->
@@ -109,12 +218,11 @@ type() ->
 version() ->
     ?CONTRACT_CREATE_TX_VSN.
 
-for_client(#contract_create_tx{ owner = OwnerPubKey,
-                                nonce = Nonce,
-                                fee   = Fee}) ->
-    #{<<"type">>  => <<"ContractCreateTxObject">>, % swagger schema name
-      <<"vsn">>   => version(),
-      <<"owner">> => aec_base58c:encode(account_pubkey, OwnerPubKey),
-      <<"nonce">> => Nonce,
-      <<"fee">>   => Fee}.
+-spec hex_byte(byte()) -> string().
+hex_byte(N) ->
+    hex_bytes(<<N:8>>).
+
+-spec hex_bytes(binary()) -> string().
+hex_bytes(Bin) ->
+    lists:flatten("0x" ++ [io_lib:format("~2.16.0B", [B]) || <<B:8>> <= Bin]).
 

--- a/apps/aecontract/src/aect_state_tree.erl
+++ b/apps/aecontract/src/aect_state_tree.erl
@@ -7,4 +7,30 @@
 
 -module(aect_state_tree).
 
-%% PLACEHOLDER
+%% API
+-export([empty/0, insert_contract/2]).
+
+-export_type([tree/0]).
+
+%%%===================================================================
+%%% Types
+%%%===================================================================
+
+-record(contract_tree, {}).
+
+-opaque tree() :: #contract_tree{}.
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+-spec empty() -> tree().
+empty() ->
+    %% PLACEHOLDER
+    #contract_tree{}.
+
+-spec insert_contract(aect_contracts:contract(), tree()) -> tree().
+insert_contract(_Contract, Tree) ->
+    %% PLACEHOLDER
+    Tree.
+

--- a/apps/aecontract/test/aecontract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_SUITE.erl
@@ -44,15 +44,53 @@ groups() ->
 %%%===================================================================
 
 create_contract_negative(_Cfg) ->
-    %% PLACEHOLDER
+    {PubKey, S1} = aect_test_utils:setup_new_account(aect_test_utils:new_state()),
+    Trees        = aect_test_utils:trees(S1),
+    PrivKey      = aect_test_utils:priv_key(PubKey, S1),
+    CurrHeight   = 1,
+
+    %% Test creating a bogus account
+    {BadPubKey, BadS} = aect_test_utils:setup_new_account(aect_test_utils:new_state()),
+    BadPrivKey        = aect_test_utils:priv_key(BadPubKey, BadS),
+    RTx1      = aect_test_utils:create_tx(BadPubKey, S1),
+    {_, [], S1}  = sign_and_apply_transaction(RTx1, BadPrivKey, S1),
+    {error, account_not_found} = aect_create_tx:check(RTx1, Trees, CurrHeight),
+
+    %% Insufficient funds
+    S2     = aect_test_utils:set_account_balance(PubKey, 0, S1),
+    Trees2 = aect_test_utils:trees(S2),
+    RTx2   = aect_test_utils:create_tx(PubKey, S2),
+    {_, [], S2}  = sign_and_apply_transaction(RTx2, PrivKey, S2),
+    {error, insufficient_funds} =
+        aect_create_tx:check(RTx2, Trees2, CurrHeight),
+
+    %% Test too high account nonce
+    RTx3 = aect_test_utils:create_tx(PubKey, #{nonce => 0}, S1),
+    {_, [], S1}  = sign_and_apply_transaction(RTx3, PrivKey, S1),
+    {error, account_nonce_too_high} =
+        aect_create_tx:check(RTx3, Trees, CurrHeight),
+
     ok.
 
 create_contract(_Cfg) ->
-    %% PLACEHOLDER
-    ok.
+    {PubKey, S1} = aect_test_utils:setup_new_account(aect_test_utils:new_state()),
+    Tx           = aect_test_utils:create_tx(PubKey, #{}, S1),
+    PrivKey      = aect_test_utils:priv_key(PubKey, S1),
+
+    %% Test that the create transaction is accepted
+    {SignedTx, [SignedTx], S2} = sign_and_apply_transaction(Tx, PrivKey, S1),
+    {PubKey, S2}.
+
+sign_and_apply_transaction(Tx, PrivKey, S1) ->
+    SignedTx = aec_tx_sign:sign(Tx, PrivKey),
+    Trees    = aect_test_utils:trees(S1),
+    Height   = 1,
+    {ok, AcceptedTxs, Trees1} = aec_tx:apply_signed([SignedTx], Trees, Height),
+    S2       = aect_test_utils:set_trees(Trees1, S1),
+    {SignedTx, AcceptedTxs, S2}.
 
 %%%===================================================================
-%%% Query contract
+%%% Call contract
 %%%===================================================================
 
 call_contract_negative(_Cfg) ->

--- a/apps/aecontract/test/aect_contracts_tests.erl
+++ b/apps/aecontract/test/aect_contracts_tests.erl
@@ -13,6 +13,7 @@
                         , id/1
                         , new/2
                         , owner/1
+                        , account/1
                         , serialize/1
                         , set_owner/2
                         ]).
@@ -24,18 +25,22 @@ basic_test_() ->
     ].
 
 basic_serialize() ->
-    C = aect_contracts:new(create_tx(), 1),
+    ContractPubKey = <<12345:65/unit:8>>,
+    C = aect_contracts:new(ContractPubKey, create_tx(), 1),
     ?assertEqual(C, deserialize(serialize(C))),
     ok.
 
 basic_getters() ->
-    C = aect_contracts:new(create_tx(), 1),
+    ContractPubKey = <<12345:65/unit:8>>,
+    C = aect_contracts:new(ContractPubKey, create_tx(), 1),
     ?assert(is_binary(id(C))),
     ?assert(is_binary(owner(C))),
+    ?assert(is_binary(account(C))),
     ok.
 
 basic_setters() ->
-    C = aect_contracts:new(create_tx(), 1),
+    ContractPubKey = <<12345:65/unit:8>>,
+    C = aect_contracts:new(ContractPubKey, create_tx(), 1),
     ?assertError({illegal, _, _}, set_owner(<<4711:64/unit:8>>, C)),
     _ = set_owner(<<42:65/unit:8>>, C),
     ok.

--- a/apps/aecontract/test/aect_contracts_tests.erl
+++ b/apps/aecontract/test/aect_contracts_tests.erl
@@ -45,9 +45,16 @@ create_tx() ->
     create_tx(#{}).
 
 create_tx(Override) ->
-    Map = #{ owner => <<4711:65/unit:8>>
-           , nonce => 42
-           , fee   => 10
+    Map = #{ owner      => <<4711:65/unit:8>>
+           , nonce      => 42
+           , code       => <<"THIS IS NOT ACTUALLY PROPER BYTE CODE">>
+           , vm_version => 1
+           , fee        => 10
+           , deposit    => 100
+           , amount     => 50
+           , gas        => 100
+           , gas_price  => 5
+           , call_data  => <<"NOT ENCODED ACCORDING TO ABI">>
            },
     Map1 = maps:merge(Map, Override),
     {ok, R} = aect_create_tx:new(Map1),

--- a/apps/aecore/include/trees.hrl
+++ b/apps/aecore/include/trees.hrl
@@ -1,6 +1,7 @@
 -record(trees, {
-          accounts :: aec_accounts_trees:tree(),
-          oracles  :: aeo_state_tree:tree()}).
+          accounts  :: aec_accounts_trees:tree(),
+          oracles   :: aeo_state_tree:tree(),
+          contracts :: aect_state_tree:tree()}).
 -type(trees() :: #trees{}).
 
 %% Placeholder to define state Merkle trees

--- a/apps/aecore/src/aec_trees.erl
+++ b/apps/aecore/src/aec_trees.erl
@@ -14,9 +14,11 @@
          hash/1,
          new/0,
          oracles/1,
+         contracts/1,
          perform_pre_transformations/2,
          set_accounts/2,
-         set_oracles/2
+         set_oracles/2,
+         set_contracts/2
         ]).
 
 %%%%=============================================================================
@@ -25,8 +27,9 @@
 
 -spec new() -> trees().
 new() ->
-    #trees{accounts = aec_accounts_trees:empty(),
-           oracles  = aeo_state_tree:empty()
+    #trees{accounts  = aec_accounts_trees:empty(),
+           oracles   = aeo_state_tree:empty(),
+           contracts = aect_state_tree:empty()
           }.
 
 hash(Trees) ->
@@ -50,6 +53,14 @@ set_oracles(Trees, Oracles) ->
 
 perform_pre_transformations(Trees, Height) ->
     set_oracles(Trees, aeo_state_tree:prune(Height, oracles(Trees))).
+
+-spec contracts(trees()) -> aect_state_tree:tree().
+contracts(Trees) ->
+    Trees#trees.contracts.
+
+-spec set_contracts(trees(), aect_state_tree:tree()) -> trees().
+set_contracts(Trees, Contracts) ->
+    Trees#trees{contracts = Contracts}.
 
 %%%=============================================================================
 %%% Internal functions

--- a/apps/aecore/src/aec_tx_dispatcher.erl
+++ b/apps/aecore/src/aec_tx_dispatcher.erl
@@ -4,11 +4,16 @@
 
 -include("core_txs.hrl").
 -include_lib("apps/aeoracle/include/oracle_txs.hrl").
+-include_lib("apps/aecontract/include/contract_txs.hrl").
 
 handler(#coinbase_tx{}) ->
     aec_coinbase_tx;
 handler(#spend_tx{}) ->
     aec_spend_tx;
+handler(#contract_create_tx{}) ->
+    aect_create_tx;
+handler(#contract_call_tx{}) ->
+    aect_call_tx;
 handler(#oracle_register_tx{}) ->
     aeo_register_tx;
 handler(#oracle_query_tx{}) ->
@@ -20,6 +25,10 @@ handler_by_type(<<"coinbase">>) ->
     aec_coinbase_tx;
 handler_by_type(<<"spend">>) ->
     aec_spend_tx;
+handler_by_type(<<"contract_create">>) ->
+    aect_create_tx;
+handler_by_type(<<"contract_call">>) ->
+    aect_call_tx;
 handler_by_type(<<"oracle_register">>) ->
     aeo_register_tx;
 handler_by_type(<<"oracle_query">>) ->

--- a/apps/aecore/src/aecore.app.src
+++ b/apps/aecore/src/aecore.app.src
@@ -32,7 +32,8 @@
     erlexec,
     aecuckoo,
     aetx,
-    aeoracle
+    aeoracle,
+    aecontract
    ]},
   {env, [
          {exometer_predefined,


### PR DESCRIPTION
This PR adds the appropriate fields to the create contract transaction, and sets up the infrastructure for building and applying such transactions.

Note that this doesn't close the ticket, this part is pure boilerplate and doesn't do anything interesting with the data in the transaction. That will be added once we have contract state trees in place.