### PR TITLE
WS integration test infrastructure

### DIFF
--- a/apps/aehttp/src/aehttp_app.erl
+++ b/apps/aehttp/src/aehttp_app.erl
@@ -16,6 +16,9 @@
 %% Application callbacks
 -export([start/2, stop/1]).
 
+%% Tests only
+-export([ws_handlers_queue_max_size/0]).
+
 %%====================================================================
 %% API
 %%====================================================================
@@ -27,7 +30,8 @@ start(_StartType, _StartArgs) ->
     ok = start_swagger_internal(),
     ok = start_websocket_internal(),
     MaxWsHandlers = get_internal_websockets_acceptors(),
-    ok = jobs:add_queue(ws_handlers_queue, [{standard_counter, MaxWsHandlers}]),
+    ok = jobs:add_queue(ws_handlers_queue, [{standard_counter, MaxWsHandlers},
+                                            {max_size, ws_handlers_queue_max_size()}]),
     gproc:reg({n,l,{epoch, app, aehttp}}),
     {ok, Pid}.
 
@@ -91,4 +95,5 @@ get_internal_websockets_acceptors() ->
     aeu_env:user_config_or_env([<<"websocket">>, <<"internal">>, <<"acceptors">>],
                                aehttp, [internal, websocket, handlers], ?INT_ACCEPTORS_POOLSIZE).
 
+ws_handlers_queue_max_size() -> 5.
 

--- a/apps/aehttp/src/ws_handler.erl
+++ b/apps/aehttp/src/ws_handler.erl
@@ -38,7 +38,7 @@ websocket_init(_TransportName, Req, _Opts) ->
               end,
               SubscribeEvents),
             {ok, Req1, JobId};
-        {error, rejected} ->
+        {error, _} ->
             {shutdown, Req1}
     end.
 

--- a/apps/aehttp/test/aehttp_ws_test_utils.erl
+++ b/apps/aehttp/test/aehttp_ws_test_utils.erl
@@ -1,0 +1,169 @@
+-module(aehttp_ws_test_utils).
+-behaviour(websocket_client).
+
+%% API
+-export([start_link/2,
+         send/4,
+         register_test_for_event/3,
+         unregister_test_for_event/3,
+         wait_for_event/2,
+         wait_for_event/3,
+         stop/1]).
+
+%% behaviour exports
+-export([
+         init/1,
+         onconnect/2,
+         ondisconnect/2,
+         websocket_handle/3,
+         websocket_info/3,
+         websocket_terminate/3
+        ]).
+
+-define(DEFAULT_EVENT_TIMEOUT, 5000).
+-define(DEFAULT_SUB_TIMEOUT, 1000).
+
+start_link(Host, Port) ->
+    WsAddress = "ws://" ++ Host ++ ":" ++ integer_to_list(Port) ++ "/websocket",
+    ct:log("connecting to ~p", [WsAddress]),
+    {ok, Pid} = websocket_client:start_link(WsAddress, ?MODULE, self()),
+    case wait_for_event(websocket, connected, ?DEFAULT_SUB_TIMEOUT) of
+        ok ->
+            {ok, Pid};
+        timeout ->
+            {error, timeout}
+    end.
+    
+
+stop(ConnPid) ->
+    ok = websocket_client:stop(ConnPid).
+
+send(ConnPid, Target, Action, Payload) ->
+    Msg0 = #{target => Target,
+             action => Action},
+    Msg =
+        case Payload == [] orelse Payload == #{} of
+            true -> Msg0;
+            false -> maps:put(payload, Payload, Msg0)
+        end,
+    ct:log("Sending to server ~p", [Msg]),
+    websocket_client:cast(ConnPid, {text, jsx:encode(Msg)}),
+    ok.
+
+%% when an WS event occours, the registered process will receive a message in
+%% the mailbox. Message structure will be:
+%% {websocket_event, Origin::atom(), Action::atom()}
+%% {websocket_event, Origin::atom(), Action::atom(), Payload::map()}
+%% where the Origin and Action are the same as the ones for which the process
+%% had registered. This message is consumed by wait_for_event/2,3
+register_test_for_event(ConnPid, Origin, Action) ->
+    Event = {Origin, Action},
+    ConnPid ! {register_test, self(), Event},
+    ok = wait_for_event(registered_test, Event, ?DEFAULT_SUB_TIMEOUT),
+    ok.
+
+unregister_test_for_event(ConnPid, Origin, Action) ->
+    Event = {Origin, Action},
+    ConnPid ! {unregister_test, self(), Event},
+    ok = wait_for_event(unregistered_test, Event, ?DEFAULT_SUB_TIMEOUT),
+    ok.
+    
+
+%% consumes messages from the mailbox:
+%% {websocket_event, Origin::atom(), Action::atom()}
+%% {websocket_event, Origin::atom(), Action::atom(), Payload::map()}
+-spec wait_for_event(atom(), atom()) -> ok | {ok, map()} | timeout.
+wait_for_event(Origin, Action) ->
+    wait_for_event(Origin, Action, ?DEFAULT_EVENT_TIMEOUT).
+
+-spec wait_for_event(atom(), atom(), integer()) -> ok | {ok, map()} | timeout.
+wait_for_event(Origin, Action, Timeout) ->
+    receive
+        {websocket_event, Origin, Action, Payload} ->
+            {ok, Payload};
+        {websocket_event, Origin, Action} ->
+            ok
+    after Timeout ->
+        timeout
+    end.
+          
+inform_registered(RegisteredPid, Origin, Action) ->
+    inform_registered(RegisteredPid, Origin, Action, []).
+
+inform_registered(RegisteredPid, Origin, Action, Payload) ->
+    case Payload == [] orelse Payload == #{} of
+        true ->
+            RegisteredPid ! {websocket_event, Origin, Action};
+        false ->
+            RegisteredPid ! {websocket_event, Origin, Action, Payload}
+    end.
+
+init(WaitingPid) ->
+    Regs = put_registration(WaitingPid, waiting_connected, #{}),
+    {once, Regs}.
+
+onconnect(_WSReq, Regs) ->
+    ct:log("Ws connected"),
+    [WaitingPid] = get_registered(waiting_connected, Regs),
+    Regs1 = delete_registered(WaitingPid, waiting_connected, Regs),
+    inform_registered(WaitingPid, websocket, connected),
+    {ok, Regs1}.
+
+ondisconnect({remote, closed}, Regs) ->
+    ct:log("Connection closed, reconnecting"),
+    {reconnect, Regs}.
+
+websocket_handle({pong, _}, _ConnState, Regs) ->
+    {ok, Regs};
+websocket_handle({text, MsgBin}, _ConnState, Regs) ->
+    Msg = jsx:decode(MsgBin, [return_maps]), 
+    ct:log("Received msg ~p~n", [Msg]),
+    Origin = binary_to_existing_atom(maps:get(<<"origin">>, Msg), utf8),
+    Action = binary_to_existing_atom(maps:get(<<"action">>, Msg), utf8),
+    Payload = maps:get(<<"payload">>, Msg, []),
+    Registered = get_registered({Origin, Action}, Regs),
+    lists:foreach(
+        fun(Pid) -> inform_registered(Pid, Origin, Action, Payload) end,
+        Registered),
+
+    % for easier debugging
+    case Registered == [] of
+        true -> ct:log("No test registered for this event");
+        false -> pass
+    end,
+    {ok, Regs}.
+
+websocket_info(stop, _ConnState, _Regs) ->
+    {close, <<>>, "stopped"};
+websocket_info({register_test, RegisteredPid, Event}, _ConnState, Regs0) ->
+    Regs = put_registration(RegisteredPid, Event, Regs0),
+    inform_registered(RegisteredPid, registered_test, Event),
+    {ok, Regs};
+websocket_info({unregister_test, RegisteredPid, Event}, _ConnState, Regs0) ->
+    Regs = delete_registered(RegisteredPid, Event, Regs0),
+    inform_registered(RegisteredPid, unregistered_test, Event),
+    {ok, Regs}.
+
+websocket_terminate(Reason, _ConnState, Regs) ->
+    ct:log("Websocket closed in state ~p wih reason ~p~n",
+              [Regs, Reason]),
+    ok.
+
+get_registered(Event, Regs) ->
+    maps:get(Event, Regs, []).
+
+put_registration(RegPid, Event, Regs) ->
+    Pids0 = get_registered(Event, Regs),
+    false = lists:member(RegPid, Pids0), % assert there is no double registration 
+    maps:put(Event, [RegPid | Pids0], Regs).
+
+delete_registered(RegPid, Event, Regs) ->
+    PidsLeft =
+        lists:filter(
+            fun(Pid) -> Pid =/= RegPid end,
+            get_registered(Event, Regs)),
+    case PidsLeft == [] of
+        true -> maps:remove(Event, Regs);
+        false -> maps:put(Event, PidsLeft, Regs)
+    end.
+

--- a/rebar.config
+++ b/rebar.config
@@ -78,7 +78,10 @@
                             {vm_args, "./config/dev1/vm.args"}]},
                     {dist_node, [{setcookie, 'epoch_cookie'},
                                  {sname, epoch_ct}]},
-                    {deps, [{meck, ".*", {git, "git://github.com/eproxus/meck.git", {tag, "0.8.6"}}}
+                    {deps, [{meck, ".*", {git, "git://github.com/eproxus/meck.git", {tag, "0.8.6"}}},
+                            {websocket_client, ".*", {git,
+                            "git://github.com/aeternity/websocket_client",
+                            {ref, "e88797c"}}}
                            ]}
                    ]},
             {prod, [{relx, [{dev_mode, false},


### PR DESCRIPTION
[Pivotal story](https://www.pivotaltracker.com/story/show/154081975)
### Description
Added an utils file (`apps/aehttp/test/aehttp_ws_test_utils.erl`) for handling all the client's websocket logic. This includes some wrappers around the WS client - since by nature WS are async and this does not fit really well in tests - the functions that needed to be synchronous are sync, and the others are left async. Currently it has the support for:

* start a websocket client (sync)

* stop a websocket client (async)

* send message (async)

* subscribe/unsubscribe the test process for an event (described bellow) (sync)

* wait for a certain event (sync)

### Arguments
The main concern had been not letting race conditions inside tests. The work flow is the following:
1. Subscribe the test for certain events
2. Do something
3. Wait for the expected event

Since 1 and 3 are sync calls to the WS client process, this guarantees us that no events are lost due to races.

### Example
from ws_block_mined test
```
    ok = ?WS:subscribe_for_event(ConnPid, miner, mined_block),
    aecore_suite_utils:mine_blocks(aecore_suite_utils:node_name(?NODE), 1),
    {ok, #{<<"height">> := _Height, <<"hash">> := _Hash}} = ?WS:wait_for_event(miner, mined_block),
    ok = ?WS:unsubscribe_for_event(ConnPid, miner, mined_block),
```
We subscribe the test process to event with origin `miner` and action `mined_block`, then we mine a block and wait for the message from the WS process to arrive (default timeout is 5s).

### TODO
~~Move the starting and stopping of a WS client (being boiler plate) to the `init_per_testcase/2` and `init_per_testcase/2` respectively~~

- [x] A WS connection can subscribe to certain events (for example _this_ oracle events). This functionality is not implemented yet in the test client. This would also require some renaming - we need to distinguish test subscribes to expected events with WS connection's subscriptions. Probably test's subscribtions would be renamed to registering or something like that. Comments are welcome.
- [x] Write some WS tests to cover the current functionality