### PR TITLE
Add tag to rebar plugin repository

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -20,7 +20,7 @@
         {sha3, {git, "https://github.com/szktty/erlang-sha3"}}
        ]}.
 
-{plugins, [{swagger_endpoints, {git, "https://github.com/aeternity/swagger_endpoints", {branch, "master"}}}]}.
+{plugins, [{swagger_endpoints, {git, "https://github.com/aeternity/swagger_endpoints", {tag, "v0.1.0"}}}]}.
 {swagger_endpoints, [{src, "config/swagger.yaml"}, {dst, "apps/aeutils/src/endpoints.erl"}]}.
 
 {relx, [{release, { epoch, "version value comes from VERSION" },


### PR DESCRIPTION
Dependency to master is dangerous, it will read the newest version whatever is pushed there, potentially breaking the build. Test with specific version, tag and then depend is better.