### PR TITLE
Bump db_path to db19

### DIFF
--- a/deployment/ansible/deploy.yml
+++ b/deployment/ansible/deploy.yml
@@ -40,7 +40,7 @@
           port: 3013
       chain:
         persist: true
-        db_path: "./db18"
+        db_path: "./db19"
       keypair:
         dir: "keys"
         password: "{{ keys_password|default('secret') }}"


### PR DESCRIPTION
It looks like #617 introduces BC break in the persistence layer but db_path version was not bumped.