### PR TITLE
move load_database() call [Finishes #154661732]

### DIFF
--- a/apps/aecore/src/aecore.app.src
+++ b/apps/aecore/src/aecore.app.src
@@ -5,7 +5,6 @@
   {registered, []},
   {mod, { aecore_app, []}},
   {start_phases, [
-                  {load_database, []},
                   {create_metrics_probes, []},
                   {start_reporters, []}
                  ]},

--- a/apps/aecore/src/aecore_app.erl
+++ b/apps/aecore/src/aecore_app.erl
@@ -15,11 +15,9 @@
 start(_StartType, _StartArgs) ->
     ok = lager:info("Starting aecore node"),
     ok = application:ensure_started(mnesia),
+    aec_db:load_database(),
     aecore_sup:start_link().
 
-start_phase(load_database, _StartType, _PhaseArgs) ->
-    lager:debug("start_phase(load_database, _, _)", []),
-    aec_db:load_database();
 start_phase(create_metrics_probes, _StartType, _PhaseArgs) ->
     lager:debug("start_phase(create_metrics_probes, _, _)", []),
     aec_metrics:create_metrics_probes();


### PR DESCRIPTION
The `wait_for_tables()` call to mnesia was made too late, causing a possible race condition, note least with the `aec_conductor` process.