### PR TITLE
Add CircleCI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,12 +121,13 @@ jobs:
             epmd -daemon
             make eunit
 
-  dialyzer:
+  static_analysis:
     <<: *container_config
     steps:
       - checkout
       - *restore_rebar_cache
       - *restore_build_cache
+      - run: ./rebar3 edoc
       - restore_cache:
           keys:
             - dialyzer-cache-v2-{{ .Branch }}-{{ .Revision }}
@@ -198,7 +199,7 @@ jobs:
 # and all its transitively dependent jobs must also have a filters tags section.
 workflows:
   version: 2
-  build_and_test:
+  build_test_deploy:
     jobs:
       - build:
           requires: ~
@@ -232,7 +233,7 @@ workflows:
             tags:
               only: /^v.*$/
 
-      - dialyzer:
+      - static_analysis:
           requires:
             - build
           filters:
@@ -257,7 +258,7 @@ workflows:
           requires:
             - test
             - eunit
-            - dialyzer
+            - static_analysis
           filters:
             branches:
               only: master
@@ -266,7 +267,7 @@ workflows:
           requires:
             - test
             - eunit
-            - dialyzer
+            - static_analysis
             - linux_package
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,8 +107,6 @@ jobs:
             make test
       - store_artifacts:
           path: _build/test/logs
-      - store_artifacts:
-          path: _build/test/logs/latest.sync/*/log/*.log
 
   eunit:
     <<: *container_config

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,9 +12,10 @@ references:
     restore_cache:
       key: *rebar_cache_key
 
+  build_cache_key: &build_cache_key build-cache-v1-{{ .Revision }}
   restore_build_cache: &restore_build_cache
     restore_cache:
-      key: build-cache-v1
+      key: *build_cache_key
 
   packages_workspace: &packages_workspace /tmp/packages
   build_package: &build_package
@@ -82,7 +83,7 @@ jobs:
           name: Build
           command: ./rebar3 as test do release
       - save_cache:
-          key: build-cache-v1
+          key: *build_cache_key
           paths:
             - "_build"
             - "apps/aecuckoo/c_src"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -263,6 +263,8 @@ workflows:
           filters:
             branches:
               only: master
+            tags:
+              only: /^v.*$/
 
       - deploy_integration:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ references:
         if [ "$(uname -s)" == "Darwin" ]; then
             PKG_SUFFIX="osx-$(sw_vers -productVersion)"
         elif [ "$(uname -s)" == "Linux" ]; then
-            PKG_SUFFIX="linux"
+            PKG_SUFFIX="ubuntu"
         fi
         make prod-package
         mkdir ${PACKAGES_DIR:?}
@@ -41,7 +41,7 @@ references:
         if [ "$(uname -s)" == "Darwin" ]; then
             PKG_SUFFIX="osx-$(sw_vers -productVersion)"
         elif [ "$(uname -s)" == "Linux" ]; then
-            PKG_SUFFIX="linux"
+            PKG_SUFFIX="ubuntu"
         fi
         epmd -daemon
         make python-env
@@ -65,7 +65,7 @@ references:
         environment:
           PACKAGES_DIR: *packages_workspace
         command: |
-          export PACKAGE=${PACKAGES_DIR:?}/epoch-$(cat VERSION)-linux.tar.gz
+          export PACKAGE=${PACKAGES_DIR:?}/epoch-$(cat VERSION)-ubuntu.tar.gz
           cd deployment/ansible
           ansible-playbook -i inventory/openstack.yml --limit="epoch:&${DEPLOY_ENV:?}" \
             --extra-vars "package=${PACKAGE:?} env=${DEPLOY_ENV:?} \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ references:
         fi
         make prod-package
         mkdir ${PACKAGES_DIR:?}
-        cp _build/prod/rel/epoch/epoch-$(cat VERSION).tar.gz ${PACKAGES_DIR:?}/epoch-$(cat VERSION)-${PKG_SUFFIX}.tar.gz
+        mv _build/prod/rel/epoch/epoch-$(cat VERSION).tar.gz ${PACKAGES_DIR:?}/epoch-$(cat VERSION)-${PKG_SUFFIX}.tar.gz
 
   test_package: &test_package
     run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,305 @@
+version: 2
+
+references:
+  container_config: &container_config
+    docker:
+      - image: aetrnty/builder
+        user: builder
+    working_directory: ~/epoch
+
+  rebar_cache_key: &rebar_cache_key rebar-cache-{{ checksum "rebar.lock" }}-{{ checksum "rebar.config" }}
+  restore_rebar_cache: &restore_rebar_cache
+    restore_cache:
+      key: *rebar_cache_key
+
+  restore_build_cache: &restore_build_cache
+    restore_cache:
+      key: build-cache-v1
+
+  packages_workspace: &packages_workspace /tmp/packages
+  build_package: &build_package
+    run:
+      name: Build Package Tarball
+      environment:
+        PACKAGES_DIR: *packages_workspace
+      command: |
+        if [ "$(uname -s)" == "Darwin" ]; then
+            PKG_SUFFIX="osx-$(sw_vers -productVersion)"
+        elif [ "$(uname -s)" == "Linux" ]; then
+            PKG_SUFFIX="linux"
+        fi
+        make prod-package
+        mkdir ${PACKAGES_DIR:?}
+        cp _build/prod/rel/epoch/epoch-$(cat VERSION).tar.gz ${PACKAGES_DIR:?}/epoch-$(cat VERSION)-${PKG_SUFFIX}.tar.gz
+
+  test_package: &test_package
+    run:
+      name: Test Package Tarball
+      environment:
+        PACKAGES_DIR: *packages_workspace
+      command: |
+        if [ "$(uname -s)" == "Darwin" ]; then
+            PKG_SUFFIX="osx-$(sw_vers -productVersion)"
+        elif [ "$(uname -s)" == "Linux" ]; then
+            PKG_SUFFIX="linux"
+        fi
+        epmd -daemon
+        make python-env
+        make python-release-test TARBALL=${PACKAGES_DIR:?}/epoch-$(cat VERSION)-${PKG_SUFFIX}.tar.gz
+
+  store_package_artifacts: &store_package_artifacts
+    store_artifacts:
+      path: *packages_workspace
+      destination: /
+
+  deploy_steps: &deploy_steps
+    - checkout
+    - attach_workspace:
+        at: *packages_workspace
+    - run:
+        name: Install PIP Requirements
+        command: |
+          pip install --user -r deployment/ansible/pip-requirements.txt
+    - run:
+        name: Deploy
+        environment:
+          PACKAGES_DIR: *packages_workspace
+        command: |
+          export PACKAGE=${PACKAGES_DIR:?}/epoch-$(cat VERSION)-linux.tar.gz
+          cd deployment/ansible
+          ansible-playbook -i inventory/openstack.yml --limit="epoch:&${DEPLOY_ENV:?}" \
+            --extra-vars "package=${PACKAGE:?} env=${DEPLOY_ENV:?} \
+              tester_keys_password='${tester_keys_password:?}' datadog_api_key=${datadog_api_key:?} datadog_app_key=${datadog_app_key:?}" \
+            deploy.yml
+
+jobs:
+  build:
+    <<: *container_config
+    steps:
+      - checkout
+      - *restore_rebar_cache
+      - run:
+          name: Build
+          command: ./rebar3 as test do release
+      - save_cache:
+          key: build-cache-v1
+          paths:
+            - "_build"
+            - "apps/aecuckoo/c_src"
+            - "apps/aecuckoo/priv/bin"
+            - "apps/aecuckoo/priv/lib"
+      - save_cache:
+          key: *rebar_cache_key
+          paths:
+            - .cache/rebar3
+
+  test:
+    <<: *container_config
+    steps:
+      - checkout
+      - *restore_rebar_cache
+      - *restore_build_cache
+      - run:
+          name: Test
+          command: |
+            epmd -daemon
+            make test
+      - store_artifacts:
+          path: _build/test/logs
+      - store_artifacts:
+          path: _build/test/logs/latest.sync/*/log/*.log
+
+  eunit:
+    <<: *container_config
+    steps:
+      - checkout
+      - *restore_rebar_cache
+      - *restore_build_cache
+      - run:
+          name: Test
+          command: |
+            epmd -daemon
+            make eunit
+
+  dialyzer:
+    <<: *container_config
+    steps:
+      - checkout
+      - *restore_rebar_cache
+      - *restore_build_cache
+      - restore_cache:
+          keys:
+            - dialyzer-cache-v2-{{ .Branch }}-{{ .Revision }}
+            - dialyzer-cache-v2-{{ .Branch }}-
+            - dialyzer-cache-v2-
+      - run:
+          name: Update dialyzer PLT
+          command: make dialyzer-install
+      - save_cache:
+          key: dialyzer-cache-v2-{{ .Branch }}-{{ .Revision }}
+          paths:
+            - _build/default/rebar3_20.2.2_plt
+      - run: make dialyzer
+
+  linux_package:
+    <<: *container_config
+    steps:
+      - checkout
+      - run: id
+      - *build_package
+      - *test_package
+      - *store_package_artifacts
+      - persist_to_workspace:
+          root: *packages_workspace
+          paths:
+            - "*.tar.gz"
+
+  osx_package:
+    macos:
+      xcode: "9.0"
+    working_directory: ~/epoch
+    steps:
+      - checkout
+      - run:
+          name: Install required tools
+          command: |
+            brew update
+            brew install erlang
+      - *build_package
+      - *test_package
+      - *store_package_artifacts
+
+  deploy_integration:
+    <<: *container_config
+    environment:
+      - DEPLOY_ENV: integration
+    steps: *deploy_steps
+
+  deploy_dev1:
+    <<: *container_config
+    environment:
+      - DEPLOY_ENV: dev1
+    steps: *deploy_steps
+
+  deploy_dev2:
+    <<: *container_config
+    environment:
+      - DEPLOY_ENV: dev2
+    steps: *deploy_steps
+
+  deploy_uat:
+    <<: *container_config
+    environment:
+      - DEPLOY_ENV: uat
+    steps: *deploy_steps
+
+# CircleCI skips a job for a tag by default.
+# A job must have a filters tags section to run as a part of a tag push
+# and all its transitively dependent jobs must also have a filters tags section.
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - build:
+          requires: ~
+          filters:
+            branches:
+              ignore:
+                - env/dev1
+                - env/dev2
+            tags:
+              only: /^v.*$/
+
+      - test:
+          requires:
+            - build
+          filters:
+            branches:
+              ignore:
+                - env/dev1
+                - env/dev2
+            tags:
+              only: /^v.*$/
+
+      - eunit:
+          requires:
+            - build
+          filters:
+            branches:
+              ignore:
+                - env/dev1
+                - env/dev2
+            tags:
+              only: /^v.*$/
+
+      - dialyzer:
+          requires:
+            - build
+          filters:
+            branches:
+              ignore:
+                - env/dev1
+                - env/dev2
+            tags:
+              only: /^v.*$/
+
+      - linux_package:
+          filters:
+            branches:
+              only:
+                - master
+                - env/dev1
+                - env/dev2
+            tags:
+              only: /^v.*$/
+
+      - osx_package:
+          requires:
+            - test
+            - eunit
+            - dialyzer
+          filters:
+            branches:
+              only: master
+
+      - deploy_integration:
+          requires:
+            - test
+            - eunit
+            - dialyzer
+            - linux_package
+          filters:
+            branches:
+              only: master
+
+      - deploy_dev1:
+          requires:
+            - linux_package
+          filters:
+            branches:
+              only: env/dev1
+
+      - deploy_dev2:
+          requires:
+            - linux_package
+          filters:
+            branches:
+              only: env/dev2
+
+      - hodl:
+          type: approval
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*$/
+
+      - deploy_uat:
+          requires:
+            - linux_package
+            - hodl
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -264,44 +264,44 @@ workflows:
             tags:
               only: /^v.*$/
 
-      - deploy_integration:
-          requires:
-            - test
-            - eunit
-            - static_analysis
-            - linux_package
-          filters:
-            branches:
-              only: master
+      # - deploy_integration:
+      #     requires:
+      #       - test
+      #       - eunit
+      #       - static_analysis
+      #       - linux_package
+      #     filters:
+      #       branches:
+      #         only: master
 
-      - deploy_dev1:
-          requires:
-            - linux_package
-          filters:
-            branches:
-              only: env/dev1
+      # - deploy_dev1:
+      #     requires:
+      #       - linux_package
+      #     filters:
+      #       branches:
+      #         only: env/dev1
 
-      - deploy_dev2:
-          requires:
-            - linux_package
-          filters:
-            branches:
-              only: env/dev2
+      # - deploy_dev2:
+      #     requires:
+      #       - linux_package
+      #     filters:
+      #       branches:
+      #         only: env/dev2
 
-      - hodl:
-          type: approval
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*$/
+      # - hodl:
+      #     type: approval
+      #     filters:
+      #       branches:
+      #         ignore: /.*/
+      #       tags:
+      #         only: /^v.*$/
 
-      - deploy_uat:
-          requires:
-            - linux_package
-            - hodl
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*$/
+      # - deploy_uat:
+      #     requires:
+      #       - linux_package
+      #       - hodl
+      #     filters:
+      #       branches:
+      #         ignore: /.*/
+      #       tags:
+      #         only: /^v.*$/

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -1,0 +1,26 @@
+FROM ubuntu:16.04
+
+RUN apt-get -qq update \
+    && apt-get -qq -y install git curl \
+        autoconf build-essential ncurses-dev libssl-dev \
+        python-pip python-dev software-properties-common \
+    && apt-add-repository ppa:ansible/ansible \
+    && apt-get -qq update \
+    && apt-get -qq -y install ansible \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV OTP_VERSION="20.2.2"
+RUN OTP_DOWNLOAD_URL="https://github.com/erlang/otp/archive/OTP-${OTP_VERSION}.tar.gz" \
+    && curl -fsSL -o otp-src.tar.gz "$OTP_DOWNLOAD_URL" \
+    && mkdir otp-src \
+    && tar -zxf otp-src.tar.gz -C otp-src --strip-components=1 \
+    && cd otp-src \
+    && export ERL_TOP=`pwd` \
+    && ./otp_build autoconf && ./configure && make -j$(nproc) && make install
+
+RUN pip install virtualenv
+
+# Add non-root user in case some app won't run as root
+RUN useradd --shell /bin/bash builder --create-home
+
+ENV SHELL=/bin/bash

--- a/deployment/ansible/pip-requirements.txt
+++ b/deployment/ansible/pip-requirements.txt
@@ -1,4 +1,5 @@
 ansible ~= 2.4
 python-openstackclient ~= 3.12
 shade ~= 1.24
+pyyaml ~= 3.12
 datadog ~= 0.17


### PR DESCRIPTION
- each commit is build then test dialyzer and eunit in parallel
- master branch is build, test, dialyzer, eunit and deployed to
integration in the end. It also generates package artifacts for both
linux and osx
- env/dev1 and env/dev2 are just packaged and deployed
- tags with format /^v.*$/ are build, tested and deployed to UAT with
manual approval
- test job stores the build logs for further inspection

The new Dockerfile is used to build the builder image [aetrnty/builder](https://hub.docker.com/r/aetrnty/builder/) used in the CI.

Examples:
- [Commit build](https://circleci.com/workflow-run/68ac0637-b849-4054-8ef1-97657491b1c8)
- [Dev environment deploy](https://circleci.com/workflow-run/2466f455-16d5-49e5-83b6-709e3d0aae77)
- [Master branch](https://circleci.com/workflow-run/19dfd816-6265-409f-990f-7921b9a97a7a)
- [Tag build (deploy to UAT)](https://circleci.com/workflow-run/52c64f0c-4f8d-4b8e-8e8d-3db8f0da5c58)

Possible future improvements:
- [Getting more containers](https://circleci.com/pricing/)
- [Docker layer caching](https://circleci.com/docs/2.0/docker-layer-caching/)
- [Better resource class](https://circleci.com/docs/2.0/configuration-reference/#resource_class)
- [JUnit test summary](https://circleci.com/docs/2.0/collect-test-data/)

Todo:
- [x] [Setup CircleCI environment](https://circleci.com/gh/aeternity/epoch/edit#env-vars)
- [x] [Add CircleCI deploy key to epoch servers](https://github.com/aeternity/infrastructure/pull/19)
- [x] Temporary disable deploys until we disable travis deploys