### PR TITLE
Fix subtle bug in aeo_query_tx:serialize/1

### DIFF
--- a/apps/aeoracle/src/aeo_query_tx.erl
+++ b/apps/aeoracle/src/aeo_query_tx.erl
@@ -156,8 +156,8 @@ serialize(#oracle_query_tx{sender        = SenderPubKey,
            #{<<"type">>   => QueryTTLType,
              <<"value">>  => QueryTTLValue}},
      #{<<"response_ttl">> =>
-           #{<<"type">>   => delta,
-             <<"value">>  => ResponseTTLValue}}
+           #{<<"type">>   => <<"delta">>,
+             <<"value">>  => ResponseTTLValue}},
      #{<<"fee">>          => Fee}].
 
 deserialize([#{<<"type">>         := ?ORACLE_QUERY_TX_TYPE},
@@ -169,7 +169,7 @@ deserialize([#{<<"type">>         := ?ORACLE_QUERY_TX_TYPE},
              #{<<"query_fee">>    := QueryFee},
              #{<<"query_ttl">>    := #{<<"type">>  := QueryTTLType,
                                        <<"value">> := QueryTTLValue}},
-             #{<<"response_ttl">> := #{<<"type">>  := delta,
+             #{<<"response_ttl">> := #{<<"type">>  := <<"delta">>,
                                        <<"value">> := ResponseTTLValue}},
              #{<<"fee">>          := Fee}]) ->
     #oracle_query_tx{sender        = SenderPubKey,

--- a/deployment/ansible/deploy.yml
+++ b/deployment/ansible/deploy.yml
@@ -40,7 +40,7 @@
           port: 3013
       chain:
         persist: true
-        db_path: "./db19"
+        db_path: "./db20"
       keypair:
         dir: "keys"
         password: "{{ keys_password|default('secret') }}"


### PR DESCRIPTION
Two maps in a list without a comma in between results in one map??!
+ use binaries consistently