### PR TITLE
Auto-unblock peers after 15 minutes and don’t block trusted peers

### DIFF
--- a/apps/aecore/src/aec_peers.erl
+++ b/apps/aecore/src/aec_peers.erl
@@ -23,6 +23,7 @@
 
 %% API
 -export([add_and_ping_peers/1,
+         add_and_ping_peers/2,
          block_peer/1,
          unblock_peer/1,
          is_blocked/1,
@@ -52,6 +53,11 @@
 -define(MIN_PING_INTERVAL,   3000).
 -define(MAX_PING_INTERVAL, 120000).
 
+-ifdef(TEST).
+-define(UNBLOCK_INTERVAL, 3000).
+-else.
+-define(UNBLOCK_INTERVAL, 15 * 60 * 1000).
+-endif.
 
 %% We parse the uri's with http_uri, therefore we use types from that module.
 -record(peer, {
@@ -62,7 +68,8 @@
           path              :: http_uri:path(),
           last_seen = 0     :: integer(), % Erlang system time (POSIX time)
           last_pings = []   :: [integer()], % Erlang system time
-          ping_tref         :: reference() | undefined
+          ping_tref         :: reference() | undefined,
+          trusted = false   :: boolean() % Is it a pre-configured peer
          }).
 
 -type peer() :: #peer{}.
@@ -98,13 +105,22 @@ add(Uri, Connect) when is_boolean(Connect) ->
                    end).
 
 %%------------------------------------------------------------------------------
-%% Add peer by url or supplying full peer() record. Connect if `Connect==true`
+%% Add peers by uri.
 %%------------------------------------------------------------------------------
 -spec add_and_ping_peers([http_uri:uri()]) -> ok.
 add_and_ping_peers(Uris) ->
+    add_and_ping_peers(Uris, false).
+
+%%------------------------------------------------------------------------------
+%% Add peers by uri. Indicate whether they are trusted (i.e. pre-configured) or
+%% not.
+%%------------------------------------------------------------------------------
+-spec add_and_ping_peers([http_uri:uri()], boolean()) -> ok.
+add_and_ping_peers(Uris, Trusted) ->
     case valid_uris(Uris) of
         [] -> ok;
-        Peers when is_list(Peers) ->
+        Peers0 when is_list(Peers0) ->
+            Peers = [ P#peer{ trusted = Trusted } || P <- Peers0 ],
             gen_server:cast(?MODULE, {add_and_ping, Peers})
     end.
 
@@ -239,6 +255,10 @@ check_ping_interval_env() ->
           end,
     application:set_env(aecore, ping_interval_limits, {Min, Max}).
 
+-ifdef(TEST).
+unblock_all() ->
+    gen_server:call(?MODULE, unblock_all).
+-endif.
 
 %%%=============================================================================
 %%% gen_server functions
@@ -248,7 +268,8 @@ check_ping_interval_env() ->
 -record(state, {peers :: gb_trees:tree(binary(), peer()),
                 blocked = gb_sets:new() :: gb_sets:set(http_uri:uri()),
                 errored = gb_sets:new() :: gb_sets:set(http_uri:uri()),
-                local_peer :: peer()  %% for universal handling of URIs
+                local_peer :: peer(),  %% for universal handling of URIs
+                last_unblock = 0 :: integer() %% Erlang timestamp in ms.
                }).
 
 start_link() ->
@@ -264,19 +285,23 @@ handle_call({set_local_peer_uri, Peer}, _From, State) ->
     {reply, ok, State#state{local_peer = Peer}};
 handle_call(get_local_peer_uri, _From, State) ->
     {reply, uri_of_peer(State#state.local_peer), State};
-handle_call({is_blocked, Peer}, _From, State) ->
+handle_call({is_blocked, Peer}, _From, State0) ->
+    State = maybe_unblock(State0),
     {reply, is_blocked(Peer, State), State};
-handle_call({block, Peer}, _From, #state{peers = Peers,
-                                  blocked = Blocked} = State) ->
+handle_call({block, Peer}, _From, State0) ->
+    State = maybe_unblock(State0),
+    #state{peers = Peers, blocked = Blocked} = State,
     Uri = uri_of_peer(Peer),
-    Key = hash_uri(Uri),
-    NewState = 
-        case gb_sets:is_element(Uri, Blocked) of
-            true -> State;
-            false ->
-               aec_events:publish(peers, {blocked, Uri}),
-               State#state{peers   = gb_trees:delete_any(Key, Peers),
-                           blocked = gb_sets:add_element(Uri, Blocked)}
+    NewState =
+        case lookup_peer(Uri, State) of
+            {value, _Key, #peer{ trusted = true }} -> State;
+            {value, Key, _} ->
+                aec_events:publish(peers, {blocked, Uri}),
+                State#state{peers   = gb_trees:delete_any(Key, Peers),
+                            blocked = gb_sets:add_element(Uri, Blocked)};
+            none ->
+                aec_events:publish(peers, {blocked, Uri}),
+                State#state{blocked = gb_sets:add_element(Uri, Blocked)}
         end,
     {reply, ok, NewState};
 handle_call({unblock, Peer}, _From, #state{blocked = Blocked} = State) ->
@@ -289,6 +314,9 @@ handle_call({unblock, Peer}, _From, #state{blocked = Blocked} = State) ->
                 State#state{blocked = gb_sets:del_element(Uri, Blocked)}
         end,
     {reply, ok, NewState};
+%% unblock_all is only available for test
+handle_call(unblock_all, _From, State) ->
+    {reply, ok, State#state{blocked = gb_sets:new(), last_unblock = timestamp()}};
 handle_call(all, _From, State) ->
     Uris = [ uri_of_peer(Peer) || Peer <- gb_trees:values(State#state.peers) ],
     {reply, Uris, State};
@@ -364,7 +392,8 @@ handle_cast({add, Peer, Connect}, State0) ->
             lager:debug("Will not add peer ~p", [Uri]),
             {noreply, State0}
     end;
-handle_cast({add_and_ping, Peers}, State) ->
+handle_cast({add_and_ping, Peers}, State0) ->
+    State = maybe_unblock(State0),
     lager:debug("add and ping peers ~p", [Peers]),
     State1 = 
         lists:foldl(
@@ -428,6 +457,15 @@ metrics(#state{peers = Peers, blocked = Blocked,
     aec_metrics:try_update([ae,epoch,aecore,peers,errored],
                            gb_sets:size(Errored)),
     State.
+
+maybe_unblock(State = #state{ last_unblock = 0 }) ->
+    State#state{ last_unblock = timestamp() };
+maybe_unblock(State = #state{ last_unblock = T0 }) ->
+    case timestamp() - T0 > ?UNBLOCK_INTERVAL of
+        false -> State;
+        true  -> State#state{ blocked = gb_sets:new(),
+                              last_unblock = timestamp() }
+    end.
 
 %% Updates if already exists.
 enter_peer(#peer{} = P, Peers) ->

--- a/apps/aecore/src/aec_sync.erl
+++ b/apps/aecore/src/aec_sync.erl
@@ -140,7 +140,7 @@ init([]) ->
     Peers = application:get_env(aecore, peers, []),
     BlockedPeers = application:get_env(aecore, blocked_peers, []),
     [aec_peers:block_peer(P) || P <- BlockedPeers],
-    aec_peers:add_and_ping_peers(Peers),
+    aec_peers:add_and_ping_peers(Peers, true),
     {ok, #state{}}.
 
 handle_call(_, _From, State) ->

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -19,6 +19,8 @@
     % pings
     broken_pings/1,
     blocked_ping/1,
+    not_blocked_ping/1,
+    auto_unblocked_peer/1,
     correct_ping/1,
 
     % get block-s
@@ -123,6 +125,8 @@ groups() ->
         % pings
         broken_pings,
         blocked_ping,
+        not_blocked_ping,
+        auto_unblocked_peer,
         correct_ping,
 
         % get block-s
@@ -294,6 +298,43 @@ blocked_ping(_Config) ->
         post_ping(maps:put(<<"source">>, Peer, PingObj)),
     rpc(aec_peers, remove, [Peer]),
     ok.
+
+not_blocked_ping(_Config) ->
+    %% Use one of the "trusted" peers, it shouldn't get blocked!
+    Peer = <<"http://localhost:3023">>,
+    PingObj = rpc(aec_sync, local_ping_object, []),
+    WrongGenHashPing = maps:merge(PingObj, #{<<"source">> => Peer,
+                                             <<"genesis_hash">> => <<"foo">>}),
+    {ok, 409, _} = post_ping(WrongGenHashPing),
+    % node shouldn't be blocked despite sending garbage...
+    {ok, 409, #{<<"reason">> := <<"Different genesis blocks">>}} =
+        post_ping(WrongGenHashPing),
+    rpc(aec_peers, remove, [Peer]),
+    ok.
+
+auto_unblocked_peer(_Config) ->
+    Peer = unique_peer(),
+    PingObj = rpc(aec_sync, local_ping_object, []),
+    WrongGenHashPing = maps:merge(PingObj, #{<<"source">> => Peer,
+                                             <<"genesis_hash">> => <<"foo">>}),
+    %% Reset the blocking
+    rpc(aec_peers, unblock_all, []),
+    {ok, 409, #{<<"reason">> := <<"Different genesis blocks">>}} =
+        post_ping(WrongGenHashPing),
+
+    % After 1s the peer should still be blocked.
+    timer:sleep(1000),
+    {ok, 403, #{<<"reason">> := <<"Not allowed">>}} =
+        post_ping(WrongGenHashPing),
+
+    %% Nodes should be unblocked after 3s
+    timer:sleep(2000),
+    {ok, 409, #{<<"reason">> := <<"Different genesis blocks">>}} =
+        post_ping(WrongGenHashPing),
+
+    rpc(aec_peers, remove, [Peer]),
+    ok.
+
 
 get_top_empty_chain(_Config) ->
     ok = rpc(aec_conductor, reinit_chain, []),


### PR DESCRIPTION
While contemplating more advanced peer handling strategies, this should solve the current problems with integration network, etc. in a lightweight way.