### PR TITLE
Fixed bug in spend_tx, do spend followed by earn

### DIFF
--- a/apps/aecore/src/aec_spend_tx.erl
+++ b/apps/aecore/src/aec_spend_tx.erl
@@ -81,12 +81,11 @@ process(#spend_tx{sender = SenderPubkey,
     AccountsTrees0 = aec_trees:accounts(Trees0),
 
     {value, SenderAccount0} = aec_accounts_trees:lookup(SenderPubkey, AccountsTrees0),
-    {value, RecipientAccount0} = aec_accounts_trees:lookup(RecipientPubkey, AccountsTrees0),
-
     {ok, SenderAccount} = aec_accounts:spend(SenderAccount0, Amount + Fee, Nonce, Height),
-    {ok, RecipientAccount} = aec_accounts:earn(RecipientAccount0, Amount, Height),
-
     AccountsTrees1 = aec_accounts_trees:enter(SenderAccount, AccountsTrees0),
+
+    {value, RecipientAccount0} = aec_accounts_trees:lookup(RecipientPubkey, AccountsTrees1),
+    {ok, RecipientAccount} = aec_accounts:earn(RecipientAccount0, Amount, Height),
     AccountsTrees2 = aec_accounts_trees:enter(RecipientAccount, AccountsTrees1),
 
     Trees = aec_trees:set_accounts(Trees0, AccountsTrees2),

--- a/deployment/ansible/deploy.yml
+++ b/deployment/ansible/deploy.yml
@@ -40,7 +40,7 @@
           port: 3013
       chain:
         persist: true
-        db_path: "./db20"
+        db_path: "./db21"
       keypair:
         dir: "keys"
         password: "{{ keys_password|default('secret') }}"


### PR DESCRIPTION
Previously we fetched both sender and receiver from the state tree and
updated the accounts separately. If sender == receiver we overwrote the
sender update.