### PR TITLE
Add docker docs how to change config file

### DIFF
--- a/docs/docker-testnet.md
+++ b/docs/docker-testnet.md
@@ -66,7 +66,7 @@ docker run -d -p 3013:3013 -e PEERS_ADDRESS_0=http://31.13.248.103:3013/ aetrnty
 
 ### Changing the configuration file
 
-Assuming the new configuration file is in current working directory and named `myepoch.yaml`:
+Assuming the new configuration file location is `~/.aeternity/myepoch.yaml`:
 
 ```bash
 docker run -d -p 3013:3013 \

--- a/docs/docker-testnet.md
+++ b/docs/docker-testnet.md
@@ -70,7 +70,7 @@ Assuming the new configuration file is in current working directory and named `m
 
 ```bash
 docker run -d -p 3013:3013 \
-    -v $(pwd)/myepoch.yaml:/home/epoch/myepoch.yaml \
+    -v ~/.aeternity/myepoch.yaml:/home/epoch/myepoch.yaml \
     -e EPOCH_CONFIG=/home/epoch/myepoch.yaml \
     aetrnty/epoch
 ```

--- a/docs/docker-testnet.md
+++ b/docs/docker-testnet.md
@@ -64,6 +64,17 @@ Docker image has packaged the address of one of the testnet nodes in the configu
 docker run -d -p 3013:3013 -e PEERS_ADDRESS_0=http://31.13.248.103:3013/ aetrnty/epoch
 ```
 
+### Changing the configuration file
+
+Assuming the new configuration file is in current working directory and named `myepoch.yaml`:
+
+```bash
+docker run -d -p 3013:3013 \
+    -v $(pwd)/myepoch.yaml:/home/epoch/myepoch.yaml \
+    -e EPOCH_CONFIG=/home/epoch/myepoch.yaml \
+    aetrnty/epoch
+```
+
 ## Persisting Data
 
 To persist blockchain data and node keys between container runs, use [Docker volumes](https://docs.docker.com/engine/admin/volumes/volumes/). Replace `~/.aeternity/db` with location of your choice.


### PR DESCRIPTION
Better example would be:

```bash
docker run -d -p 3013:3013 \
    -v ~/.aeternity/epoch.yaml:/home/epoch/node/epoch.yaml \
    aetrnty/epoch
```

However, it does not seems that bind mount works the same way as with directories to hide the container (target) file.

[PT-154764969](https://www.pivotaltracker.com/n/projects/2124891/stories/154764969)