### PR TITLE
disable reporter in aecore prep_stop

### DIFF
--- a/apps/aecore/src/aec_metrics.erl
+++ b/apps/aecore/src/aec_metrics.erl
@@ -25,6 +25,7 @@
 %% start phase API
 -export([create_metrics_probes/0]).
 -export([start_reporters/0]).
+-export([prep_stop/1]).
 
 -include_lib("kernel/include/inet.hrl").
 -define(DEFAULT_PORT, 8125).  % default (dog-)statsd port
@@ -101,6 +102,15 @@ start_reporters() ->
         [{module, ?MODULE},
          {intervals, [{default, 10000}]},
          {report_bulk, true}])).
+
+prep_stop(State) ->
+    %% Use disable_reporter/1 instead of remove_reporter/1 since it's
+    %% synchronous. We want to avoid spurious errors due to termination
+    %% order.
+    expect(
+      ok, {?LINE, disable_reporter},
+      exometer_report:disable_reporter(aec_metrics_main)),
+    State.
 
 %%===================================================================
 %% exometer_report_logger callbacks

--- a/apps/aecore/src/aecore_app.erl
+++ b/apps/aecore/src/aecore_app.erl
@@ -5,6 +5,7 @@
 %% Application callbacks
 -export([start/2,
          start_phase/3,
+         prep_stop/1,
          stop/1]).
 -export([check_env/0]).
 
@@ -26,6 +27,8 @@ start_phase(start_reporters, _StartType, _PhaseArgs) ->
     aec_metrics_rpt_dest:check_config(),
     aec_metrics:start_reporters().
 
+prep_stop(State) ->
+    aec_metrics:prep_stop(State).
 
 stop(_State) ->
     ok.


### PR DESCRIPTION
Partial solution to https://www.pivotaltracker.com/story/show/154770099, addressing `badarg` errors accessing `aec_metrics_rpt_dest`.

That ets table is owned by the `aec_metrics_rpt_dest` process in `aecore`, but the metrics reporter accessing it is actually supervised by `exometer_core`, which keeps running even after `aecore` has been stopped. This solution disables the reporter in the `prep_stop` phase in `aecore`, before processes start being terminated. The disable operation is synchronous, which is why it's preferred to the (asynchronous) `remove_reporter/1` call. The reporter will of course terminate soon enough.