### PR TITLE
Teach CI to check generated Swagger code in git repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,6 +140,7 @@ jobs:
           paths:
             - _build/default/rebar3_20.2.2_plt
       - run: make dialyzer
+      - run: make swagger-check
 
   linux_package:
     <<: *container_config

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,7 +140,6 @@ jobs:
           paths:
             - _build/default/rebar3_20.2.2_plt
       - run: make dialyzer
-      - run: make swagger-check
 
   linux_package:
     <<: *container_config

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ apps/*/doc/edoc-info
 apps/*/doc/erlang.png
 apps/*/doc/stylesheet.css
 otp_patches/*.erl
+swagger/swagger-codegen-cli-*.jar

--- a/Makefile
+++ b/Makefile
@@ -236,4 +236,5 @@ internal-clean: $$(KIND)
 	dialyzer \
 	test aevm-test-deps\
 	kill killall \
-	clean distclean
+	clean distclean \
+	swagger swagger-docs

--- a/Makefile
+++ b/Makefile
@@ -160,9 +160,9 @@ SWAGGER_CODEGEN = java -jar $(SWAGGER_CODEGEN_CLI)
 swagger: config/swagger.yaml $(SWAGGER_CODEGEN_CLI)
 	@$(SWAGGER_CODEGEN) generate -i $< -l erlang-server -o $(SWTEMP)
 	@echo "Swagger tempdir: $(SWTEMP)"
-	@cp $(SWTEMP)/priv/swagger.json $(HTTP_APP)/priv/
+	@( mkdir -p $(HTTP_APP)/priv && cp $(SWTEMP)/priv/swagger.json $(HTTP_APP)/priv/; )
 	@( cd $(HTTP_APP) && $(MAKE) updateswagger; )
-	@cp $(SWTEMP)/src/*.erl $(HTTP_APP)/src/swagger
+	@( mkdir -p $(HTTP_APP)/src/swagger && cp $(SWTEMP)/src/*.erl $(HTTP_APP)/src/swagger; )
 	@rm -fr $(SWTEMP)
 	@./rebar3 swagger_endpoints
 	@$(SWAGGER_CODEGEN) generate -i $< -l python -o $(SWTEMP)

--- a/Makefile
+++ b/Makefile
@@ -173,6 +173,14 @@ swagger: config/swagger.yaml $(SWAGGER_CODEGEN_CLI)
 swagger-docs:
 	(cd ./apps/aehttp && $(MAKE) swagger-docs);
 
+swagger-check:
+	./swagger/check \
+		"$(CURDIR)/config/swagger.yaml" \
+		"swagger" \
+		"$(CURDIR)/apps/aehttp/priv/swagger.json" \
+		"$(CURDIR)/apps/aehttp/src/swagger" \
+		"$(CURDIR)/py/tests/swagger_client"
+
 $(SWAGGER_CODEGEN_CLI):
 	curl -fsS --create-dirs -o $@ http://central.maven.org/maven2/io/swagger/swagger-codegen-cli/$(SWAGGER_CODEGEN_CLI_V)/swagger-codegen-cli-$(SWAGGER_CODEGEN_CLI_V).jar
 
@@ -243,4 +251,4 @@ internal-clean: $$(KIND)
 	test aevm-test-deps\
 	kill killall \
 	clean distclean \
-	swagger swagger-docs
+	swagger swagger-docs swagger-check

--- a/Makefile
+++ b/Makefile
@@ -153,15 +153,19 @@ python-single-uat:
 python-release-test:
 	( cd $(PYTHON_DIR) && TARBALL=$(TARBALL) VER=$(VER) $(MAKE) release-test; )
 
-swagger: config/swagger.yaml
-	@swagger-codegen generate -i $< -l erlang-server -o $(SWTEMP)
+SWAGGER_CODEGEN_CLI_V = 2.3.1
+SWAGGER_CODEGEN_CLI = swagger/swagger-codegen-cli-$(SWAGGER_CODEGEN_CLI_V).jar
+SWAGGER_CODEGEN = java -jar $(SWAGGER_CODEGEN_CLI)
+
+swagger: config/swagger.yaml $(SWAGGER_CODEGEN_CLI)
+	@$(SWAGGER_CODEGEN) generate -i $< -l erlang-server -o $(SWTEMP)
 	@echo "Swagger tempdir: $(SWTEMP)"
 	@cp $(SWTEMP)/priv/swagger.json $(HTTP_APP)/priv/
 	@( cd $(HTTP_APP) && $(MAKE) updateswagger; )
 	@cp $(SWTEMP)/src/*.erl $(HTTP_APP)/src/swagger
 	@rm -fr $(SWTEMP)
 	@./rebar3 swagger_endpoints
-	@swagger-codegen generate -i $< -l python -o $(SWTEMP)
+	@$(SWAGGER_CODEGEN) generate -i $< -l python -o $(SWTEMP)
 	@echo "Swagger python tempdir: $(SWTEMP)"
 	@cp -r $(SWTEMP)/swagger_client $(PYTHON_TESTS)
 	@rm -fr $(SWTEMP)
@@ -169,6 +173,8 @@ swagger: config/swagger.yaml
 swagger-docs:
 	(cd ./apps/aehttp && $(MAKE) swagger-docs);
 
+$(SWAGGER_CODEGEN_CLI):
+	curl -fsS --create-dirs -o $@ http://central.maven.org/maven2/io/swagger/swagger-codegen-cli/$(SWAGGER_CODEGEN_CLI_V)/swagger-codegen-cli-$(SWAGGER_CODEGEN_CLI_V).jar
 
 kill:
 	@echo "Kill all beam processes only from this directory tree"

--- a/ci
+++ b/ci
@@ -45,6 +45,7 @@ case "${1:?}"-"${2:?}" in
     script-static_analysis)
         ./rebar3 edoc
         make dialyzer
+        make swagger-check
         ;;
     script-package)
         make prod-package

--- a/swagger/check
+++ b/swagger/check
@@ -1,0 +1,51 @@
+#!/bin/sh
+
+## Check Swagger-generated files under version control are up-to-date.
+##
+## Moves Swagger-generated files under version control to temporary
+## directory, then attempts to re-generate them, finally checks that
+## they are the same.
+##
+## On failure, it leaves the working directory without the generated
+## files - as previously moved to a temporary directory.
+
+set -e
+set -x
+
+SY="${1:?}" ## Swagger schema YAML file
+
+## Make target for generating Swagger-related files under version
+## control.  Assumptions:
+## * Make file is in current working directory;
+## * Make file is named so that make finds it without specifying
+##   additional arguments.
+MT="${2:?}"
+
+## Generated Swagger-related files under version control.
+SJ="${3:?}" ## Swagger schema JSON file - generated
+ES="${4:?}" ## Erlang server code directory - generated
+PC="${5:?}" ## Python client code directory - generated
+
+## Move old generated files under version control to temporary
+## directory.
+TmpDir="$(mktemp -d)"
+TmpSJ="${TmpDir:?}"/sj.backup
+TmpES="${TmpDir:?}"/es.backup
+TmpPC="${TmpDir:?}"/pc.backup
+mv "${SJ:?}" "${TmpSJ:?}"
+mv "${ES:?}" "${TmpES:?}"
+mv "${PC:?}" "${TmpPC:?}"
+
+## Re-generate files.
+make "${MT:?}"
+
+## Check that re-generating JSON from YAML lead to same generated JSON.
+diff "${SJ:?}" "${TmpSJ:?}"
+## Check that re-generating code from YAML lead to same generated code.
+diff -r -N "${ES:?}" "${TmpES:?}"
+diff -r -N "${PC:?}" "${TmpPC:?}"
+
+## On success, as re-generated files are the same of the old generated
+## files, delete the temporary directory containing the olf generated
+## files.
+rm -r "${TmpDir:?}"


### PR DESCRIPTION
Finishes [PT-154799594](https://www.pivotaltracker.com/story/show/154799594).
Supersedes #663 .

* Sample [CI failure](https://travis-ci.org/lucafavatella/epoch/jobs/336234841#L1765) for spurious manual change in Erlang file;
* Sample [CI failure](https://travis-ci.org/lucafavatella/epoch/jobs/336234506#L1763) for spurious removal of Python file;
* Observed [failure on Circle CI](https://circleci.com/gh/lucafavatella/epoch/18) for missing `java` - hence Circle CI disabled.
