### PR TITLE
Add Status code to return value for further validation

### DIFF
--- a/apps/aeutils/src/aeu_http_client.erl
+++ b/apps/aeutils/src/aeu_http_client.erl
@@ -40,11 +40,11 @@ request(BaseUri, post, Endpoint, Params, Header, HTTPOptions, Options) ->
 process_http_return(R) ->
     case R of
         %% if Body == [] an error is thrown!
-        {ok, {{_,_ReturnCode, _State}, _Head, Body}} ->
+        {ok, {{_, StatusCode, _State}, _Head, Body}} ->
             try
                 Result = jsx:decode(iolist_to_binary(Body), [return_maps]),
                 lager:debug("Decoded response: ~p", [Result]),
-                {ok, Result}
+                {ok, StatusCode, Result}
             catch
                 error:E ->
                     lager:error("http response ~p", [R]),

--- a/apps/aeutils/src/aeu_requests.erl
+++ b/apps/aeutils/src/aeu_requests.erl
@@ -64,7 +64,7 @@ ping(Uri, LocalPingObj) ->
                            },
     Response = process_request(Uri, 'Ping', PingObj),
     case Response of
-        {ok, #{<<"reason">> := Reason}} ->
+        {ok, _, #{<<"reason">> := Reason}} ->
             lager:debug("Got an error return: Reason = ~p", [Reason]),
             aec_events:publish(chain_sync,
                                {sync_aborted, #{uri => Uri,
@@ -76,7 +76,7 @@ ping(Uri, LocalPingObj) ->
                           protocol_violation;
                       _ -> Reason
                     end};
-        {ok, #{ <<"genesis_hash">> := EncRemoteGHash,
+        {ok, 200, #{ <<"genesis_hash">> := EncRemoteGHash,
                 <<"best_hash">> := EncRemoteTopHash} = Map} ->
             case {aec_base58c:safe_decode(block_hash, EncRemoteGHash),
                   aec_base58c:safe_decode(block_hash, EncRemoteTopHash)} of
@@ -92,18 +92,26 @@ ping(Uri, LocalPingObj) ->
                 {error, protocol_violation}
             end;
         {error, _Reason} = Error ->
-            Error
+            Error;
+        _ ->
+            %% Should have been turned to {error, _} by swagger validation
+            lager:debug("unexpected response (~p): ~p", [Uri, Response]),
+            {error, protocol_violation}
     end.
 
 -spec top(http_uri:uri()) -> response(aec_headers:header()).
 top(Uri) ->
     Response = process_request(Uri, 'GetTop', []),
     case Response of
-        {ok, Data} ->
+        {ok, 200, Data} ->
             {ok, Header} = aec_headers:deserialize_from_map(Data),
             {ok, Header};
         {error, _Reason} = Error ->
-            Error
+            Error;
+        _ ->
+            %% Should have been turned to {error, _} by swagger validation
+            lager:debug("unexpected response (~p): ~p", [Uri, Response]),
+            {error, unexpected_response}
     end.
 
 
@@ -112,11 +120,15 @@ get_block(Uri, Hash) ->
     EncHash = aec_base58c:encode(block_hash, Hash),
     Response = process_request(Uri,'GetBlockByHash', [{"hash", EncHash}]),
     case Response of
-        {ok, Data} ->
+        {ok, 200, Data} ->
             {ok, Block} = aec_blocks:deserialize_from_map(Data),
             {ok, Block};
         {error, _Reason} = Error ->
-            Error
+            Error;
+        _ ->
+            %% Should have been turned to {error, _} by swagger validation
+            lager:debug("unexpected response (~p): ~p", [Uri, Response]),
+            {error, unexpected_response}
     end.
 
 -spec transactions(http_uri:uri()) -> response([aec_tx:signed_tx()]).
@@ -141,9 +153,9 @@ transactions(Uri) ->
            end
     end.
 
-tx_response({ok, #{'Transactions' := Txs}}) -> Txs;
-tx_response({ok, [#{<<"tx">> := _}|_] = Txs}) -> Txs;
-tx_response({ok, []}) -> [];
+tx_response({ok, 200, #{'Transactions' := Txs}}) -> Txs;
+tx_response({ok, 200, [#{<<"tx">> := _}|_] = Txs}) -> Txs;
+tx_response({ok, 200, []}) -> [];
 tx_response(_Other) -> bad_result.
 
 
@@ -153,10 +165,14 @@ send_block(Uri, Block) ->
     lager:debug("send_block; serialized: ~p", [pp(BlockSerialized)]),
     Response = process_request(Uri, 'PostBlock', BlockSerialized),
     case Response of
-        {ok, _Map} ->
+        {ok, 200, _Map} ->
             {ok, ok};
         {error, _Reason} = Error ->
-            Error
+            Error;
+        _ ->
+            %% Should have been turned to {error, _} by swagger validation
+            lager:debug("unexpected response (~p): ~p", [Uri, Response]),
+            {error, unexpected_response}
     end.
 
 -spec send_tx(http_uri:uri(), aec_tx:signed_tx()) -> response(ok).
@@ -165,10 +181,14 @@ send_tx(Uri, SignedTx) ->
                      transaction, aec_tx_sign:serialize_to_binary(SignedTx)),
     Response = process_request(Uri, 'PostTx', #{tx => TxSerialized}),
     case Response of
-        {ok, _Map} ->
+        {ok, 200, _Map} ->
             {ok, ok};
         {error, _Reason} = Error ->
-            Error
+            Error;
+        _ ->
+            %% Should have been turned to {error, _} by swagger validation
+            lager:debug("unexpected response (~p): ~p", [Uri, Response]),
+            {error, unexpected_response}
     end.
 
 %% NOTE that this is part of the internal API, thus the standard peer
@@ -181,10 +201,14 @@ new_spend_tx(IntPeer, #{recipient_pubkey := Kr,
             recipient_pubkey, aec_base58c:encode(account_pubkey, Kr), Req0),
     Response = process_request(IntPeer, 'PostSpendTx', Req),
     case Response of
-        {ok, _Map} ->
+        {ok, 200, _Map} ->
             {ok, ok};
         {error, _Reason} = Error ->
-            Error
+            Error;
+        _ ->
+            %% Should have been turned to {error, _} by swagger validation
+            lager:debug("unexpected response (~p): ~p", [IntPeer, Response]),
+            {error, unexpected_response}
     end.
 
 process_request(Uri, OperationId, Params) ->


### PR DESCRIPTION
Since we don't check status code of response, we may mix up bodies with wrong status code with bodies of correct responses. That means, we can interpret {ok, 500, #{}} as {ok, 200, Block}.
Swagger type checking should probably do a better job, but for now, this is a fix to not be crashed by a hostile node that sends us rubish.