### PR TITLE
HTTP Client API: Add transaction hash in tx related API endpoints

### DIFF
--- a/apps/aecore/src/aec_base58c.erl
+++ b/apps/aecore/src/aec_base58c.erl
@@ -8,6 +8,7 @@
                     | block_tx_hash
                     | block_state_hash
                     | transaction
+                    | tx_hash
                     | oracle_pubkey
                     | oracle_query_id
                     | account_pubkey
@@ -71,6 +72,7 @@ type2pfx(block_hash)       -> <<"bh">>;
 type2pfx(block_tx_hash)    -> <<"bx">>;
 type2pfx(block_state_hash) -> <<"bs">>;
 type2pfx(transaction)      -> <<"tx">>;
+type2pfx(tx_hash)          -> <<"th">>;
 type2pfx(oracle_pubkey)    -> <<"ok">>;
 type2pfx(oracle_query_id)  -> <<"oq">>;
 type2pfx(account_pubkey)   -> <<"ak">>;
@@ -82,6 +84,7 @@ pfx2type(<<"bh">>) -> block_hash;
 pfx2type(<<"bx">>) -> block_tx_hash;
 pfx2type(<<"bs">>) -> block_state_hash;
 pfx2type(<<"tx">>) -> transaction;
+pfx2type(<<"th">>) -> tx_hash;
 pfx2type(<<"ok">>) -> oracle_pubkey;
 pfx2type(<<"oq">>) -> oracle_query_id;
 pfx2type(<<"ak">>) -> account_pubkey;

--- a/apps/aecore/src/aec_tx.erl
+++ b/apps/aecore/src/aec_tx.erl
@@ -186,3 +186,4 @@ grant_fee_to_miner(SignedTxs, Trees0, TotalFee, Height) ->
             Trees = aec_trees:set_accounts(Trees0, AccountsTrees),
             Trees
     end.
+

--- a/apps/aehttp/priv/swagger.json
+++ b/apps/aehttp/priv/swagger.json
@@ -2126,7 +2126,10 @@
           "type" : "integer"
         },
         "block_hash" : {
-          "$ref" : "#/definitions/JSONTx"
+          "$ref" : "#/definitions/EncodedHash"
+        },
+        "hash" : {
+          "$ref" : "#/definitions/EncodedHash"
         },
         "signatures" : {
           "type" : "array",

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -2093,14 +2093,17 @@ block_to_endpoint_map(Block, Options) ->
     BlockHeight = aec_blocks:height(Block),
     {ok, BlockHash} = aec_blocks:hash_internal_representation(Block),
     lists:foreach(
-        fun(EncodedTx) ->
+        fun({EncodedTx, SignedTx}) ->
             #{block_hash := TxBlockHash,
-              block_height := TxBlockHeight} =
-                  aec_tx_sign:meta_data_from_client_serialized(Encoding, EncodedTx),
+              block_height := TxBlockHeight,
+              hash := Hash} =
+                  aec_tx_sign:meta_data_from_client_serialized(Encoding, EncodedTx), 
             {BlockHeight, TxBlockHeight} = {TxBlockHeight, BlockHeight},
-            {BlockHash, TxBlockHash} = {TxBlockHash, BlockHash}
+            {BlockHash, TxBlockHash} = {TxBlockHash, BlockHash},
+            TxHash = aec_tx:hash_tx(aec_tx_sign:data(SignedTx)),
+            {Hash, TxHash} = {TxHash, Hash}
         end,
-        ExpectedTxs),
+        lists:zip(ExpectedTxs, aec_blocks:txs(Block))),
     Expected.
 
 %% misbehaving peers get blocked so we need unique ones

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -1635,7 +1635,9 @@ definitions:
       block_height:
         type: integer
       block_hash:
-        $ref: '#/definitions/JSONTx'
+        $ref: '#/definitions/EncodedHash'
+      hash:
+        $ref: '#/definitions/EncodedHash'
       signatures:
         type: array
         minItems: 1

--- a/py/tests/swagger_client/models/signed_tx_json.py
+++ b/py/tests/swagger_client/models/signed_tx_json.py
@@ -16,6 +16,7 @@ import re  # noqa: F401
 
 import six
 
+from swagger_client.models.encoded_hash import EncodedHash  # noqa: F401,E501
 from swagger_client.models.json_tx import JSONTx  # noqa: F401,E501
 
 
@@ -35,7 +36,8 @@ class SignedTxJSON(object):
     swagger_types = {
         'tx': 'JSONTx',
         'block_height': 'int',
-        'block_hash': 'JSONTx',
+        'block_hash': 'EncodedHash',
+        'hash': 'EncodedHash',
         'signatures': 'list[str]'
     }
 
@@ -43,15 +45,17 @@ class SignedTxJSON(object):
         'tx': 'tx',
         'block_height': 'block_height',
         'block_hash': 'block_hash',
+        'hash': 'hash',
         'signatures': 'signatures'
     }
 
-    def __init__(self, tx=None, block_height=None, block_hash=None, signatures=None):  # noqa: E501
+    def __init__(self, tx=None, block_height=None, block_hash=None, hash=None, signatures=None):  # noqa: E501
         """SignedTxJSON - a model defined in Swagger"""  # noqa: E501
 
         self._tx = None
         self._block_height = None
         self._block_hash = None
+        self._hash = None
         self._signatures = None
         self.discriminator = None
 
@@ -61,6 +65,8 @@ class SignedTxJSON(object):
             self.block_height = block_height
         if block_hash is not None:
             self.block_hash = block_hash
+        if hash is not None:
+            self.hash = hash
         if signatures is not None:
             self.signatures = signatures
 
@@ -112,7 +118,7 @@ class SignedTxJSON(object):
 
 
         :return: The block_hash of this SignedTxJSON.  # noqa: E501
-        :rtype: JSONTx
+        :rtype: EncodedHash
         """
         return self._block_hash
 
@@ -122,10 +128,31 @@ class SignedTxJSON(object):
 
 
         :param block_hash: The block_hash of this SignedTxJSON.  # noqa: E501
-        :type: JSONTx
+        :type: EncodedHash
         """
 
         self._block_hash = block_hash
+
+    @property
+    def hash(self):
+        """Gets the hash of this SignedTxJSON.  # noqa: E501
+
+
+        :return: The hash of this SignedTxJSON.  # noqa: E501
+        :rtype: EncodedHash
+        """
+        return self._hash
+
+    @hash.setter
+    def hash(self, hash):
+        """Sets the hash of this SignedTxJSON.
+
+
+        :param hash: The hash of this SignedTxJSON.  # noqa: E501
+        :type: EncodedHash
+        """
+
+        self._hash = hash
 
     @property
     def signatures(self):


### PR DESCRIPTION
[Pivotal story](https://www.pivotaltracker.com/story/show/154658152)
[Github issue](https://github.com/aeternity/protocol/issues/25)

Added a transaction's hash to all Client APIs returning transactions.