### PR TITLE
Pt 154921144 extend mpt iterator

### DIFF
--- a/apps/aeutils/src/aeu_mp_trees.erl
+++ b/apps/aeutils/src/aeu_mp_trees.erl
@@ -15,7 +15,9 @@
         , delete/2
         , get/2
         , iterator/1
+        , iterator/2
         , iterator_from/2
+        , iterator_from/3
         , iterator_next/1
         , pp/1
         , put/3
@@ -41,11 +43,14 @@
 
 -record(iter, { key  = <<>>          :: <<>> | key()
               , root = <<>>          :: <<>> | hash()
+              , max_length           :: pos_integer() | 'undefined'
               , db   = new_dict_db() :: aeu_mp_trees:db()
               }).
 
 -opaque tree() :: #mpt{}.
 -opaque iterator() :: #iter{}.
+
+-type iterator_opts() :: [{'max_path_length', pos_integer()}].
 
 -type tree_node() :: null() | leaf() | extension() | branch().
 
@@ -159,19 +164,27 @@ verify_proof(Key, Val, Hash, ProofDB) ->
 iterator(#mpt{hash = Hash, db = DB}) ->
     #iter{key = <<>>, root = Hash, db = DB}.
 
+-spec iterator(tree(), iterator_opts()) -> iterator().
+iterator(#mpt{hash = Hash, db = DB}, Opts) ->
+    process_iterator_opts(#iter{key = <<>>, root = Hash, db = DB}, Opts).
+
 %%% @doc Iterator from a key. Key doesn't need to exist. Calling
 %%% iterator_next/1 gives the next value after Key.
 -spec iterator_from(key(), tree()) -> iterator().
 iterator_from(Key, #mpt{hash = Hash, db = DB}) ->
     #iter{key = Key, root = Hash, db = DB}.
 
+-spec iterator_from(key(), tree(), iterator_opts()) -> iterator().
+iterator_from(Key, #mpt{hash = Hash, db = DB}, Opts) ->
+    process_iterator_opts(#iter{key = Key, root = Hash, db = DB}, Opts).
+
 -spec iterator_next(iterator()) ->
                            {key(), value(), iterator()} | '$end_of_table'.
-iterator_next(#iter{key = Key, root = Hash, db = DB} = Iter) ->
+iterator_next(#iter{key = Key, root = Hash, db = DB, max_length = M} = Iter) ->
     Res =
         case Key =:= <<>> of
-            true  -> pick_first(decode_node(Hash, DB), DB);
-            false -> int_iter_next(Key, decode_node(Hash, DB), DB)
+            true  -> pick_first(decode_node(Hash, DB), M, DB);
+            false -> int_iter_next(Key, decode_node(Hash, DB), M, DB)
         end,
     case Res of
         '$end_of_table' -> '$end_of_table';
@@ -473,52 +486,115 @@ int_verify_proof(Path, {Type, NodePath, NodeVal}, Val, ProofDB)
 %%%===================================================================
 %%% Iterator traversal
 
--spec int_iter_next(path(), tree_node(), db()) ->
+process_iterator_opts(Iter, [{max_path_length, X}]) when is_integer(X), X > 0 ->
+    Iter#iter{max_length = X};
+process_iterator_opts(Iter, []) ->
+    Iter;
+process_iterator_opts(_Iter, [X|_]) ->
+    error({illegal_iterator_option, X}).
+
+
+-spec int_iter_next(path(), tree_node(), integer() | 'undefined', db()) ->
                            '$end_of_table' | {path(), value()}.
 
-int_iter_next(_Path, <<>>,_DB) ->
+int_iter_next(_Path, <<>>,_Max,_DB) ->
     '$end_of_table';
-int_iter_next(<<>>, {branch, Branch}, DB) ->
-    pick_first_branch(Branch, 0, DB);
-int_iter_next(<<N:4, Rest/bits>>, {branch, Branch}, DB) ->
-    case int_iter_next(Rest, decode_node(branch_next(N, Branch), DB), DB) of
-        '$end_of_table' -> pick_first_branch(Branch, N + 1, DB);
-        {RestPath, Val} -> {<<N:4, RestPath/bits>>, Val}
+int_iter_next(<<>>, {branch, Branch}, Max, DB) ->
+    case check_iter_path_length(<<0:4>>, Max) of
+        {ok, NewMax} ->
+            pick_first_branch(Branch, 0, NewMax, DB);
+        error ->
+            '$end_of_table'
     end;
-int_iter_next(Path, {leaf, Path, _},_DB) ->
+int_iter_next(<<N:4, Rest/bits>>, {branch, Branch}, Max,  DB) ->
+    case check_iter_path_length(<<N:4>>, Max) of
+        {ok, NewMax} ->
+            Next = decode_node(branch_next(N, Branch), DB),
+            case int_iter_next(Rest, Next, NewMax, DB) of
+                '$end_of_table' -> pick_first_branch(Branch, N + 1, NewMax, DB);
+                {RestPath, Val} -> {<<N:4, RestPath/bits>>, Val}
+            end;
+        error ->
+            '$end_of_table'
+    end;
+int_iter_next(Path, {leaf, Path, _},_Max,_DB) ->
     '$end_of_table';
-int_iter_next(<<>>, {leaf, Path, Val},_DB) ->
-    {Path, Val};
-int_iter_next(<<>>, {ext, NodePath, Hash}, DB) ->
-    {RestPath, Val} = pick_first(decode_node(Hash, DB), DB),
-    {<<NodePath/bits, RestPath/bits>>, Val};
-int_iter_next(Path, {ext, NodePath, Hash}, DB) ->
-    S = bit_size(NodePath),
-    <<NodePath:S/bits, Rest/bits>> = Path,
-    case int_iter_next(Rest, decode_node(Hash, DB), DB) of
-        '$end_of_table' -> '$end_of_table';
-        {RestPath, Val} -> {<<NodePath/bits, RestPath/bits>>, Val}
+int_iter_next(<<>>, {leaf, Path, Val}, Max,_DB) ->
+    case check_iter_path_length(Path, Max) of
+        {ok, _} -> {Path, Val};
+        error   -> '$end_of_table'
+    end;
+int_iter_next(<<>>, {ext, NodePath, Hash}, Max, DB) ->
+    case check_iter_path_length(NodePath, Max) of
+        {ok, NewMax} ->
+            case pick_first(decode_node(Hash, DB), NewMax, DB) of
+                '$end_of_table' -> '$end_of_table';
+                {RestPath, Val} ->
+                    {<<NodePath/bits, RestPath/bits>>, Val}
+            end;
+        error ->
+            '$end_of_table'
+    end;
+int_iter_next(Path, {ext, NodePath, Hash}, Max, DB) ->
+    case check_iter_path_length(NodePath, Max) of
+        {ok, NewMax} ->
+            S = bit_size(NodePath),
+            <<NodePath:S/bits, Rest/bits>> = Path,
+            case int_iter_next(Rest, decode_node(Hash, DB), NewMax, DB) of
+                '$end_of_table' -> '$end_of_table';
+                {RestPath, Val} -> {<<NodePath/bits, RestPath/bits>>, Val}
+            end;
+        error ->
+            '$end_of_table'
     end.
 
-pick_first(<<>>,_DB) ->
+pick_first(<<>>,_Max, _DB) ->
     '$end_of_table';
-pick_first({leaf, Path, Val},_DB) ->
-    {Path, Val};
-pick_first({ext, Path, Hash}, DB) ->
-    {RestPath, Val} = pick_first(decode_node(Hash, DB), DB),
-    {<<Path/bits, RestPath/bits>>, Val};
-pick_first({branch, Branch}, DB) ->
+pick_first({leaf, Path, Val}, Max, _DB) ->
+    case check_iter_path_length(Path, Max) of
+        {ok, _} -> {Path, Val};
+        error   -> '$end_of_table'
+    end;
+pick_first({ext, Path, Hash}, Max, DB) ->
+    case check_iter_path_length(Path, Max) of
+        {ok, NewMax} ->
+            case pick_first(decode_node(Hash, DB), NewMax, DB) of
+                '$end_of_table' ->
+                    '$end_of_table';
+                {RestPath, Val} ->
+                    {<<Path/bits, RestPath/bits>>, Val}
+            end;
+        error ->
+            '$end_of_table'
+    end;
+pick_first({branch, Branch}, Max, DB) ->
     case branch_value(Branch) of
-        <<>> -> pick_first_branch(Branch, 0, DB);
-        Val  -> {<<>>, Val}
+        <<>> ->
+            case check_iter_path_length(<<0:4>>, Max) of
+                {ok, NewMax} -> pick_first_branch(Branch, 0, NewMax, DB);
+                error -> '$end_of_table'
+            end;
+        Val  ->
+            case check_iter_path_length(<<>>, Max) of
+                {ok, _} -> {<<>>, Val};
+                error -> '$end_of_table'
+            end
     end.
 
-pick_first_branch(_Branch, N,_DB) when is_integer(N), N > 15 ->
+pick_first_branch(_Branch, N,_MaxPath,_DB) when is_integer(N), N > 15 ->
     '$end_of_table';
-pick_first_branch(Branch, N, DB) when is_integer(N) ->
-    case pick_first(decode_node(branch_next(N, Branch), DB), DB) of
-        '$end_of_table' -> pick_first_branch(Branch, N + 1, DB);
+pick_first_branch(Branch, N, MaxPath, DB) when is_integer(N) ->
+    case pick_first(decode_node(branch_next(N, Branch), DB), MaxPath, DB) of
+        '$end_of_table' -> pick_first_branch(Branch, N + 1, MaxPath, DB);
         {RestPath, Val} -> {<<N:4, RestPath/bits>>, Val}
+    end.
+
+check_iter_path_length(_Path, undefined) -> {ok, undefined};
+check_iter_path_length(Path, Remaining) ->
+    Length = bit_size(Path) div 4,
+    case Length =< Remaining of
+        true  -> {ok, Remaining - Length};
+        false -> error
     end.
 
 %%%===================================================================

--- a/apps/aeutils/src/aeu_mtrees.erl
+++ b/apps/aeutils/src/aeu_mtrees.erl
@@ -17,7 +17,10 @@
          delete/2,
          get/2,
          insert/3,
+         iterator/1,
+         iterator/2,
          iterator_from/2,
+         iterator_from/3,
          iterator_next/1,
          lookup/2,
          enter/3,
@@ -38,6 +41,7 @@
         ]).
 
 -export_type([iterator/0,
+              iterator_opts/0,
               mtree/0,
               mtree/2,
               root_hash/0,
@@ -52,6 +56,7 @@
 -type mtree() :: mtree(key(), value()).
 
 -opaque iterator() :: aeu_mp_trees:iterator().
+-type iterator_opts() :: aeu_mp_trees:iterator_opts().
 
 %% Enable specification of types of key and value for enabling code
 %% using this module to document types for readability.
@@ -101,9 +106,21 @@ insert(Key, Value, Tree) when ?IS_KEY(Key), ?IS_VALUE(Value) ->
         {value, _} -> error({already_present, Key})
     end.
 
+-spec iterator(mtree()) -> iterator().
+iterator(Tree) ->
+    aeu_mp_trees:iterator(Tree).
+
+-spec iterator(mtree(), iterator_opts()) -> iterator().
+iterator(Tree, Opts) ->
+    aeu_mp_trees:iterator(Tree, Opts).
+
 -spec iterator_from(key(), mtree()) -> iterator().
 iterator_from(Key, Tree) ->
     aeu_mp_trees:iterator_from(Key, Tree).
+
+-spec iterator_from(key(), mtree(), iterator_opts()) -> iterator().
+iterator_from(Key, Tree, Opts) ->
+    aeu_mp_trees:iterator_from(Key, Tree, Opts).
 
 -spec iterator_next(iterator()) ->
                            {key(), value(), iterator()} | '$end_of_table'.

--- a/apps/aeutils/test/aeu_mp_trees_tests.erl
+++ b/apps/aeutils/test/aeu_mp_trees_tests.erl
@@ -25,6 +25,7 @@ basic_test_() ->
     , {"Collapse extension", fun test_collapse_ext/0}
     , {"Iterator test", fun test_iterator/0}
     , {"Iterator depth test", fun test_iterator_depth/0}
+    , {"Iterator from non-existing", fun test_iterator_non_existing/0}
     ].
 
 hash_test_() ->
@@ -172,6 +173,27 @@ test_iterator_depth(_Depth, [],_Tree, Iterator) ->
     ?assertEqual('$end_of_table', aeu_mp_trees:iterator_next(Iterator)),
     ok.
 
+test_iterator_non_existing() ->
+    rand:seed(exs1024s, {1412343, 989132, 44563}),
+    Vals = gen_vals(1000),
+    Sorted = lists:sort(Vals),
+    ?assertEqual(Sorted, lists:ukeysort(1, Sorted)),
+    {Vals1, Vals2} = split_every_other(Sorted, [], []),
+    NonExistingKeys = [X || {X, _} <- Vals1],
+    Tree = insert_vals(Vals2, aeu_mp_trees:new()),
+    test_iterator_non_existing(Vals2, NonExistingKeys, Tree).
+
+split_every_other([X, Y|Left], Acc1, Acc2) ->
+    split_every_other(Left, [X|Acc1], [Y|Acc2]);
+split_every_other([], Acc1, Acc2) ->
+    {lists:reverse(Acc1), lists:reverse(Acc2)}.
+
+test_iterator_non_existing([{Key, Val}|Left1], [NonExisting|Left2], Tree) ->
+    Iterator = aeu_mp_trees:iterator_from(NonExisting, Tree),
+    ?assertMatch({Key, Val, _}, aeu_mp_trees:iterator_next(Iterator)),
+    test_iterator_non_existing(Left1, Left2, Tree);
+test_iterator_non_existing([], [],_Tree) ->
+    ok.
 
 %%%=============================================================================
 %%% Hash tests

--- a/apps/aeutils/test/aeu_mp_trees_tests.erl
+++ b/apps/aeutils/test/aeu_mp_trees_tests.erl
@@ -24,6 +24,7 @@ basic_test_() ->
     , {"Put rlp values", fun test_put_rlp_vals/0}
     , {"Collapse extension", fun test_collapse_ext/0}
     , {"Iterator test", fun test_iterator/0}
+    , {"Iterator depth test", fun test_iterator_depth/0}
     ].
 
 hash_test_() ->
@@ -115,16 +116,62 @@ test_iterator() ->
     {Tree, Vals} = gen_mp_tree({6234, 5234, 9273}, 1000),
     Iterator = aeu_mp_trees:iterator(Tree),
     Sorted = lists:keysort(1, Vals),
-    test_iterator(Iterator, Sorted).
+    test_iterator(Iterator, Tree, Sorted).
 
-test_iterator(Iterator, [{Key, Val}|Left]) ->
+test_iterator(Iterator, Tree, [{Key, Val}|Left]) ->
     {IKey, IVal, Iterator1} = aeu_mp_trees:iterator_next(Iterator),
     ?assertEqual(IKey, Key),
     ?assertEqual(IVal, Val),
-    test_iterator(Iterator1, Left);
-test_iterator(Iterator, []) ->
+    case Left of
+        [{NextKey, NextVal}|_] ->
+            NewIterator = aeu_mp_trees:iterator_from(Key, Tree),
+            ?assertMatch({NextKey, NextVal, _},
+                         aeu_mp_trees:iterator_next(NewIterator));
+        [] ->
+            ok
+    end,
+    test_iterator(Iterator1, Tree, Left);
+test_iterator(Iterator,_Tree, []) ->
     ?assertEqual('$end_of_table', aeu_mp_trees:iterator_next(Iterator)),
     ok.
+
+test_iterator_depth() ->
+    rand:seed(exs1024s, {142343, 132, 4113}),
+    Val = <<"Hello">>,
+    ShortKeys = [random_hexstring(10) || _ <- lists:seq(1,100)],
+    MiddleKeys = [random_hexstring(11) || _ <- lists:seq(1,100)],
+    LongKeys = [random_hexstring(12) || _ <- lists:seq(1,100)],
+    Vals = [{Key, Val} || Key <- ShortKeys ++ MiddleKeys ++ LongKeys],
+    Sorted = lists:sort(Vals),
+    ?assertEqual(Sorted, lists:ukeysort(1, Sorted)),
+    Tree = insert_vals(Vals, aeu_mp_trees:new()),
+    test_iterator_depth(10, Sorted, Tree),
+    test_iterator_depth(11, Sorted, Tree),
+    test_iterator_depth(12, Sorted, Tree).
+
+test_iterator_depth(Depth, Sorted, Tree) ->
+    Iterator = aeu_mp_trees:iterator(Tree, [{max_path_length, Depth}]),
+    Sorted1  = [X || {Key, _} = X <- Sorted, (bit_size(Key) div 4) =< Depth],
+    test_iterator_depth(Depth, Sorted1, Tree, Iterator).
+
+test_iterator_depth(Depth, [{Key, Val}|Left], Tree, Iterator) ->
+    {IKey, IVal, Iterator1} = aeu_mp_trees:iterator_next(Iterator),
+    ?assertEqual(IKey, Key),
+    ?assertEqual(IVal, Val),
+    case Left of
+        [{NextKey, NextVal}|_] ->
+            Opt = [{max_path_length, Depth}],
+            NewIterator = aeu_mp_trees:iterator_from(Key, Tree, Opt),
+            ?assertMatch({NextKey, NextVal, _},
+                         aeu_mp_trees:iterator_next(NewIterator));
+        [] ->
+            ok
+    end,
+    test_iterator_depth(Depth, Left, Tree, Iterator1);
+test_iterator_depth(_Depth, [],_Tree, Iterator) ->
+    ?assertEqual('$end_of_table', aeu_mp_trees:iterator_next(Iterator)),
+    ok.
+
 
 %%%=============================================================================
 %%% Hash tests


### PR DESCRIPTION
Extend MPT (and aeu_mtrees) with iterator for traversing only to a specified path depth.

This is handy for traversing all oracles or all contracts (and not queries/contract_calls).

Also, fixed some corner cases where we couldn't start from a non-existing key in the traversal (as you can in ets/mnesia).

https://www.pivotaltracker.com/n/projects/2124891/stories/154921144