### PR TITLE
Make `./rebar3 eunit --module=aec_db` work

### DIFF
--- a/apps/aecore/test/aec_db_tests.erl
+++ b/apps/aecore/test/aec_db_tests.erl
@@ -1,4 +1,4 @@
--module(aec_persistence_tests).
+-module(aec_db_tests).
 
 -include_lib("eunit/include/eunit.hrl").
 -include("common.hrl").


### PR DESCRIPTION
... following deletion of `aec_persistence` module.

Finishes https://www.pivotaltracker.com/story/show/154958070