### PR TITLE
PT-154313284 Add Naming System HTTP API to compute commitment hash

### DIFF
--- a/apps/aehttp/priv/swagger.json
+++ b/apps/aehttp/priv/swagger.json
@@ -212,6 +212,35 @@
         }
       }
     },
+    "/commitment-hash" : {
+      "get" : {
+        "tags" : [ "external" ],
+        "description" : "Compute commitment hash for a given salt and name",
+        "operationId" : "GetCommitmentHash",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "name",
+          "in" : "query",
+          "description" : "Name to put into the hash",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "salt",
+          "in" : "query",
+          "description" : "Salt to put into the hash",
+          "required" : true,
+          "type" : "integer"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Calculated commitment hash",
+            "schema" : {
+              "$ref" : "#/definitions/NameCommitmentHash"
+            }
+          }
+        }
+      }
+    },
     "/name" : {
       "get" : {
         "tags" : [ "external" ],
@@ -222,7 +251,7 @@
           "name" : "name",
           "in" : "query",
           "description" : "Name to get entry from Naming System",
-          "required" : false,
+          "required" : true,
           "type" : "string"
         } ],
         "responses" : {
@@ -1856,6 +1885,9 @@
         "name" : {
           "type" : "string"
         },
+        "name_hash" : {
+          "type" : "string"
+        },
         "name_ttl" : {
           "type" : "integer",
           "format" : "int64"
@@ -1866,6 +1898,7 @@
       },
       "example" : {
         "name_ttl" : 0,
+        "name_hash" : "name_hash",
         "name" : "name",
         "pointers" : "pointers"
       }

--- a/apps/aehttp/src/swagger/swagger_api.erl
+++ b/apps/aehttp/src/swagger/swagger_api.erl
@@ -39,6 +39,12 @@ request_params('GetBlockByHeight') ->
         'height'
     ];
 
+request_params('GetCommitmentHash') ->
+    [
+        'name',
+        'salt'
+    ];
+
 request_params('GetInfo') ->
     [
     ];
@@ -312,12 +318,30 @@ request_param_info('GetBlockByHeight', 'height') ->
         ]
     };
 
+request_param_info('GetCommitmentHash', 'name') ->
+    #{
+        source => qs_val  ,
+        rules => [
+            {type, 'binary'},
+            required
+        ]
+    };
+
+request_param_info('GetCommitmentHash', 'salt') ->
+    #{
+        source => qs_val  ,
+        rules => [
+            {type, 'integer'},
+            required
+        ]
+    };
+
 request_param_info('GetName', 'name') ->
     #{
         source => qs_val  ,
         rules => [
             {type, 'binary'},
-            not_required
+            required
         ]
     };
 
@@ -926,6 +950,9 @@ validate_response('GetBlockByHeight', 200, Body, ValidatorState) ->
     validate_response_body('Block', 'Block', Body, ValidatorState);
 validate_response('GetBlockByHeight', 404, Body, ValidatorState) ->
     validate_response_body('Error', 'Error', Body, ValidatorState);
+
+validate_response('GetCommitmentHash', 200, Body, ValidatorState) ->
+    validate_response_body('NameCommitmentHash', 'NameCommitmentHash', Body, ValidatorState);
 
 validate_response('GetInfo', 200, Body, ValidatorState) ->
     validate_response_body('Info', 'Info', Body, ValidatorState);

--- a/apps/aehttp/src/swagger/swagger_external_handler.erl
+++ b/apps/aehttp/src/swagger/swagger_external_handler.erl
@@ -96,6 +96,14 @@ allowed_methods(
 allowed_methods(
     Req,
     State = #state{
+        operation_id = 'GetCommitmentHash'
+    }
+) ->
+    {[<<"GET">>], Req, State};
+
+allowed_methods(
+    Req,
+    State = #state{
         operation_id = 'GetInfo'
     }
 ) ->
@@ -180,6 +188,7 @@ allowed_methods(Req, State) ->
 
 
 
+
 is_authorized(Req, State) ->
     {true, Req, State}.
 
@@ -242,6 +251,16 @@ valid_content_headers(
     Req0,
     State = #state{
         operation_id = 'GetBlockByHeight'
+    }
+) ->
+    Headers = [],
+    {Result, Req} = validate_headers(Headers, Req0),
+    {Result, Req, State};
+
+valid_content_headers(
+    Req0,
+    State = #state{
+        operation_id = 'GetCommitmentHash'
     }
 ) ->
     Headers = [],

--- a/apps/aehttp/src/swagger/swagger_router.erl
+++ b/apps/aehttp/src/swagger/swagger_router.erl
@@ -80,6 +80,11 @@ get_operations() ->
             method => <<"GET">>,
             handler => 'swagger_external_handler'
         },
+        'GetCommitmentHash' => #{
+            path => "/v2/commitment-hash",
+            method => <<"GET">>,
+            handler => 'swagger_external_handler'
+        },
         'GetInfo' => #{
             path => "/v2/info",
             method => <<"GET">>,

--- a/apps/aens/src/aens.erl
+++ b/apps/aens/src/aens.erl
@@ -1,7 +1,7 @@
 %%%-------------------------------------------------------------------
 %%% @copyright (C) 2018, Aeternity Anstalt
 %%% @doc
-%%%    Resolve registered names
+%%%    Naming System API
 %%% @end
 %%%-------------------------------------------------------------------
 
@@ -9,6 +9,7 @@
 
 %% API
 -export([resolve/3,
+         get_commitment_hash/2,
          get_name_entry/2]).
 
 %%%===================================================================
@@ -45,13 +46,19 @@ resolve(Type, Binary, NSTree) ->
             end
     end.
 
+-spec get_commitment_hash(binary(), integer()) -> aens_hash:commitment_hash().
+get_commitment_hash(Name, Salt) ->
+    aens_hash:commitment_hash(Name, Salt).
+
 -spec get_name_entry(binary(), aens_state_tree:tree()) -> {ok, map()} | {error, name_not_found}.
 get_name_entry(Name, NSTree) ->
     case get_name(Name, NSTree) of
         {ok, #{<<"name">>     := Name,
+               <<"hash">>     := Hash,
                <<"name_ttl">> := TTL,
                <<"pointers">> := Pointers}} ->
             {ok, #{<<"name">>     => Name,
+                   <<"hash">>     => Hash,
                    <<"name_ttl">> => TTL,
                    <<"pointers">> => jsx:encode(Pointers)}};
         {error, name_not_found} = Error ->
@@ -67,6 +74,7 @@ get_name(Name, NSTree) ->
     case aens_state_tree:lookup_name(NameHash, NSTree) of
         {value, N} ->
             {ok, #{<<"name">>     => Name,
+                   <<"hash">>     => NameHash,
                    <<"name_ttl">> => aens_names:ttl(N),
                    <<"pointers">> => aens_names:pointers(N)}};
         none ->

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -181,6 +181,31 @@ paths:
           description: 'Successful operation'
           schema:
             $ref: '#/definitions/Transactions'
+  /commitment-hash:
+    get:
+      tags:
+        - external
+      operationId: GetCommitmentHash
+      description: 'Compute commitment hash for a given salt and name'
+      produces:
+        - application/json
+      parameters:
+        - in: query
+          name: name
+          description: 'Name to put into the hash'
+          required: true
+          type: string
+        - in: query
+          name: salt
+          description: 'Salt to put into the hash'
+          required: true
+          type: integer
+      responses:
+        '200':
+          description: Calculated commitment hash
+          schema:
+            $ref: '#/definitions/NameCommitmentHash'
+      security:
   /name:
     get:
       tags:
@@ -193,6 +218,7 @@ paths:
         - in: query
           name: name
           description: 'Name to get entry from Naming System'
+          required: true
           type : string
       responses:
         '200':
@@ -1488,6 +1514,8 @@ definitions:
     type: object
     properties:
       name:
+        type: string
+      name_hash:
         type: string
       name_ttl:
         type: integer

--- a/py/tests/swagger_client/api/external_api.py
+++ b/py/tests/swagger_client/api/external_api.py
@@ -508,6 +508,109 @@ class ExternalApi(object):
             _request_timeout=params.get('_request_timeout'),
             collection_formats=collection_formats)
 
+    def get_commitment_hash(self, name, salt, **kwargs):  # noqa: E501
+        """get_commitment_hash  # noqa: E501
+
+        Compute commitment hash for a given salt and name  # noqa: E501
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.get_commitment_hash(name, salt, async=True)
+        >>> result = thread.get()
+
+        :param async bool
+        :param str name: Name to put into the hash (required)
+        :param int salt: Salt to put into the hash (required)
+        :return: NameCommitmentHash
+                 If the method is called asynchronously,
+                 returns the request thread.
+        """
+        kwargs['_return_http_data_only'] = True
+        if kwargs.get('async'):
+            return self.get_commitment_hash_with_http_info(name, salt, **kwargs)  # noqa: E501
+        else:
+            (data) = self.get_commitment_hash_with_http_info(name, salt, **kwargs)  # noqa: E501
+            return data
+
+    def get_commitment_hash_with_http_info(self, name, salt, **kwargs):  # noqa: E501
+        """get_commitment_hash  # noqa: E501
+
+        Compute commitment hash for a given salt and name  # noqa: E501
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.get_commitment_hash_with_http_info(name, salt, async=True)
+        >>> result = thread.get()
+
+        :param async bool
+        :param str name: Name to put into the hash (required)
+        :param int salt: Salt to put into the hash (required)
+        :return: NameCommitmentHash
+                 If the method is called asynchronously,
+                 returns the request thread.
+        """
+
+        all_params = ['name', 'salt']  # noqa: E501
+        all_params.append('async')
+        all_params.append('_return_http_data_only')
+        all_params.append('_preload_content')
+        all_params.append('_request_timeout')
+
+        params = locals()
+        for key, val in six.iteritems(params['kwargs']):
+            if key not in all_params:
+                raise TypeError(
+                    "Got an unexpected keyword argument '%s'"
+                    " to method get_commitment_hash" % key
+                )
+            params[key] = val
+        del params['kwargs']
+        # verify the required parameter 'name' is set
+        if ('name' not in params or
+                params['name'] is None):
+            raise ValueError("Missing the required parameter `name` when calling `get_commitment_hash`")  # noqa: E501
+        # verify the required parameter 'salt' is set
+        if ('salt' not in params or
+                params['salt'] is None):
+            raise ValueError("Missing the required parameter `salt` when calling `get_commitment_hash`")  # noqa: E501
+
+        collection_formats = {}
+
+        path_params = {}
+
+        query_params = []
+        if 'name' in params:
+            query_params.append(('name', params['name']))  # noqa: E501
+        if 'salt' in params:
+            query_params.append(('salt', params['salt']))  # noqa: E501
+
+        header_params = {}
+
+        form_params = []
+        local_var_files = {}
+
+        body_params = None
+        # HTTP header `Accept`
+        header_params['Accept'] = self.api_client.select_header_accept(
+            ['application/json'])  # noqa: E501
+
+        # Authentication setting
+        auth_settings = []  # noqa: E501
+
+        return self.api_client.call_api(
+            '/commitment-hash', 'GET',
+            path_params,
+            query_params,
+            header_params,
+            body=body_params,
+            post_params=form_params,
+            files=local_var_files,
+            response_type='NameCommitmentHash',  # noqa: E501
+            auth_settings=auth_settings,
+            async=params.get('async'),
+            _return_http_data_only=params.get('_return_http_data_only'),
+            _preload_content=params.get('_preload_content', True),
+            _request_timeout=params.get('_request_timeout'),
+            collection_formats=collection_formats)
+
     def get_info(self, **kwargs):  # noqa: E501
         """get_info  # noqa: E501
 
@@ -595,39 +698,39 @@ class ExternalApi(object):
             _request_timeout=params.get('_request_timeout'),
             collection_formats=collection_formats)
 
-    def get_name(self, **kwargs):  # noqa: E501
+    def get_name(self, name, **kwargs):  # noqa: E501
         """get_name  # noqa: E501
 
         Get name entry from Naming System  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_name(async=True)
+        >>> thread = api.get_name(name, async=True)
         >>> result = thread.get()
 
         :param async bool
-        :param str name: Name to get entry from Naming System
+        :param str name: Name to get entry from Naming System (required)
         :return: NameEntry
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
         if kwargs.get('async'):
-            return self.get_name_with_http_info(**kwargs)  # noqa: E501
+            return self.get_name_with_http_info(name, **kwargs)  # noqa: E501
         else:
-            (data) = self.get_name_with_http_info(**kwargs)  # noqa: E501
+            (data) = self.get_name_with_http_info(name, **kwargs)  # noqa: E501
             return data
 
-    def get_name_with_http_info(self, **kwargs):  # noqa: E501
+    def get_name_with_http_info(self, name, **kwargs):  # noqa: E501
         """get_name  # noqa: E501
 
         Get name entry from Naming System  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_name_with_http_info(async=True)
+        >>> thread = api.get_name_with_http_info(name, async=True)
         >>> result = thread.get()
 
         :param async bool
-        :param str name: Name to get entry from Naming System
+        :param str name: Name to get entry from Naming System (required)
         :return: NameEntry
                  If the method is called asynchronously,
                  returns the request thread.
@@ -648,6 +751,10 @@ class ExternalApi(object):
                 )
             params[key] = val
         del params['kwargs']
+        # verify the required parameter 'name' is set
+        if ('name' not in params or
+                params['name'] is None):
+            raise ValueError("Missing the required parameter `name` when calling `get_name`")  # noqa: E501
 
         collection_formats = {}
 

--- a/py/tests/swagger_client/models/name_entry.py
+++ b/py/tests/swagger_client/models/name_entry.py
@@ -32,26 +32,31 @@ class NameEntry(object):
     """
     swagger_types = {
         'name': 'str',
+        'name_hash': 'str',
         'name_ttl': 'int',
         'pointers': 'str'
     }
 
     attribute_map = {
         'name': 'name',
+        'name_hash': 'name_hash',
         'name_ttl': 'name_ttl',
         'pointers': 'pointers'
     }
 
-    def __init__(self, name=None, name_ttl=None, pointers=None):  # noqa: E501
+    def __init__(self, name=None, name_hash=None, name_ttl=None, pointers=None):  # noqa: E501
         """NameEntry - a model defined in Swagger"""  # noqa: E501
 
         self._name = None
+        self._name_hash = None
         self._name_ttl = None
         self._pointers = None
         self.discriminator = None
 
         if name is not None:
             self.name = name
+        if name_hash is not None:
+            self.name_hash = name_hash
         if name_ttl is not None:
             self.name_ttl = name_ttl
         if pointers is not None:
@@ -77,6 +82,27 @@ class NameEntry(object):
         """
 
         self._name = name
+
+    @property
+    def name_hash(self):
+        """Gets the name_hash of this NameEntry.  # noqa: E501
+
+
+        :return: The name_hash of this NameEntry.  # noqa: E501
+        :rtype: str
+        """
+        return self._name_hash
+
+    @name_hash.setter
+    def name_hash(self, name_hash):
+        """Sets the name_hash of this NameEntry.
+
+
+        :param name_hash: The name_hash of this NameEntry.  # noqa: E501
+        :type: str
+        """
+
+        self._name_hash = name_hash
 
     @property
     def name_ttl(self):


### PR DESCRIPTION
* Add hash to `GET /name` returned payload

This is reflected and used in https://github.com/aeternity/protocol/pull/47.

[Delivers #154313284]