### PR TITLE
upgrade setup [Fixes #154990570]

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,7 +3,7 @@
                                  epoch_metrics]}]}.
 
 {deps, [{lager, ".*", {git, "https://github.com/aeternity/lager.git", {tag,"3.6.0.ae1"}}},
-        {setup, "2.0.0"},
+        {setup, "2.0.2"},
         {parse_trans, "3.1.0"},
         {cowboy, "1.0.4", {git, "https://github.com/ninenines/cowboy.git", {tag, "1.0.4"}}},
         {jsx, {git, "https://github.com/talentdeficit/jsx.git", {tag, "2.8.0"}}},

--- a/rebar.lock
+++ b/rebar.lock
@@ -65,7 +65,7 @@
   {git,"git://github.com/andreineculau/rfc3339.git",
        {ref,"dcc77d66430490620677de8140a3415dfbd3fa61"}},
   1},
- {<<"setup">>,{pkg,<<"setup">>,<<"2.0.0">>},0},
+ {<<"setup">>,{pkg,<<"setup">>,<<"2.0.2">>},0},
  {<<"sha3">>,
   {git,"https://github.com/szktty/erlang-sha3",
        {ref,"dbdfd12ace2fc7e530e697fef81e1e72e90740f9"}},
@@ -79,6 +79,6 @@
  {<<"msgpack">>, <<"128AE0A2227C7E7A2847C0F0F73551C268464F8C1EE96BFFB920BC0A5712B295">>},
  {<<"parse_trans">>, <<"1BAD3B959941CC53FFD6F4769A5D2666F9CDF179B2D62826636497D3FBAD9EC0">>},
  {<<"poolboy">>, <<"6B46163901CFD0A1B43D692657ED9D7E599853B3B21B95AE5AE0A777CF9B6CA8">>},
- {<<"setup">>, <<"DE842FBC4F6610BDEF95B107D04DBC9715229E34058AD540C665ECD31B052C91">>},
+ {<<"setup">>, <<"1203F4CDA11306C2E34434244576DED0A7BBFB0908D9A572356C809BD0CDF085">>},
  {<<"yamerl">>, <<"6EC55A5D830F6F0D65A4030F5C5DB24B0E72B813DFBDE32FEA44B4951ED9417C">>}]}
 ].


### PR DESCRIPTION
> A crash has been observed in testing, as the setup application tries to patch in the sasl application. This is a minor bug in the setup app, fixed in version 2.0.1.

Example crash:
```
%%% aecore_sync_SUITE ==> {{badmatch,
     {badrpc,
         {'EXIT',
             {function_clause,
                 [{filename,join,[[]],[{file,"filename.erl"},{line,399}]},
                  {setup,'-roots_of/1-fun-0-',2,
                      [{file,
                           "/home/builder/epoch/_build/default/lib/setup/src/setup.erl"},
                       {line,733}]},
```

The bug in setup was triggered by the addition of the patch path `"patches/ebin"`.