### PR TITLE
HTTP Client API: get account's txs

### DIFF
--- a/apps/aecore/src/aec_db.erl
+++ b/apps/aecore/src/aec_db.erl
@@ -49,7 +49,7 @@
 
 %% API for finding transactions related to account key
 -export([transactions_by_account/1,
-         dirty_transactions_by_account/2]).
+         transactions_by_account/2]).
 
 %% indexing callbacks
 -export([ix_acct2tx/3]).
@@ -262,9 +262,9 @@ transactions_by_account(AcctPubKey) ->
     ?t([T || #aec_tx{tx = T}
                  <- mnesia:index_read(aec_tx, AcctPubKey, {acct2tx})]).
 
-dirty_transactions_by_account(AcctPubKey, Filter) ->
-    [T || #aec_tx{tx = T}
-        <- mnesia:dirty_index_read(aec_tx, AcctPubKey, {acct2tx}), Filter(T)].
+transactions_by_account(AcctPubKey, Filter) ->
+    ?t([T || #aec_tx{tx = T}
+        <- mnesia:index_read(aec_tx, AcctPubKey, {acct2tx}), Filter(T)]).
 
 %% start phase hook to load the database
 

--- a/apps/aecore/src/aec_db.erl
+++ b/apps/aecore/src/aec_db.erl
@@ -48,7 +48,8 @@
          delete_tx/2]).
 
 %% API for finding transactions related to account key
--export([transactions_by_account/1]).
+-export([transactions_by_account/1,
+         dirty_transactions_by_account/2]).
 
 %% indexing callbacks
 -export([ix_acct2tx/3]).
@@ -260,6 +261,10 @@ delete_tx_(Hash, Where) ->
 transactions_by_account(AcctPubKey) ->
     ?t([T || #aec_tx{tx = T}
                  <- mnesia:index_read(aec_tx, AcctPubKey, {acct2tx})]).
+
+dirty_transactions_by_account(AcctPubKey, Filter) ->
+    [T || #aec_tx{tx = T}
+        <- mnesia:dirty_index_read(aec_tx, AcctPubKey, {acct2tx}), Filter(T)].
 
 %% start phase hook to load the database
 

--- a/apps/aehttp/priv/swagger.json
+++ b/apps/aehttp/priv/swagger.json
@@ -729,6 +729,78 @@
         }
       }
     },
+    "/account/txs/{account_pubkey}" : {
+      "get" : {
+        "tags" : [ "internal" ],
+        "description" : "Get accounts's transactions included in blocks in the longest chain",
+        "operationId" : "GetAccountTranactions",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "account_pubkey",
+          "in" : "path",
+          "description" : "Account pubkey to show transactions for",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "limit",
+          "in" : "query",
+          "description" : "Maximum transactions count to show",
+          "required" : false,
+          "type" : "integer",
+          "default" : 20,
+          "maximum" : 100,
+          "minimum" : 1
+        }, {
+          "name" : "offset",
+          "in" : "query",
+          "description" : "Offset to start transaction list from",
+          "required" : false,
+          "type" : "integer",
+          "default" : 0,
+          "minimum" : 0
+        }, {
+          "name" : "tx_types",
+          "in" : "query",
+          "description" : "Transactions types to show. Comma separated",
+          "required" : false,
+          "type" : "string"
+        }, {
+          "name" : "exclude_tx_types",
+          "in" : "query",
+          "description" : "Transactions types not to show. Comma separated. If a tx type appears in both tx_types and exclude_tx_types, it is excluded.",
+          "required" : false,
+          "type" : "string"
+        }, {
+          "name" : "tx_encoding",
+          "in" : "query",
+          "description" : "Transactions encoding",
+          "required" : false,
+          "type" : "string",
+          "default" : "message_pack",
+          "enum" : [ "message_pack", "json" ]
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/TxObjects"
+            }
+          },
+          "400" : {
+            "description" : "Invalid account hash",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Account not found",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
     "/balances" : {
       "get" : {
         "tags" : [ "external" ],

--- a/apps/aehttp/priv/swagger.json
+++ b/apps/aehttp/priv/swagger.json
@@ -733,7 +733,7 @@
       "get" : {
         "tags" : [ "internal" ],
         "description" : "Get accounts's transactions included in blocks in the longest chain",
-        "operationId" : "GetAccountTranactions",
+        "operationId" : "GetAccountTransactions",
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "account_pubkey",

--- a/apps/aehttp/src/aehttp_dispatch_int.erl
+++ b/apps/aehttp/src/aehttp_dispatch_int.erl
@@ -863,19 +863,10 @@ get_account_transactions(Account, Req) ->
                   fun({HeaderA, SignedTxA}, {HeaderB, SignedTxB}) ->
                       HeightA = aec_headers:height(HeaderA),
                       HeightB = aec_headers:height(HeaderB),
-                      case HeightA =:= HeightB of
-                          false ->
-                              HeightA > HeightB;
-                          true ->
-                              TxA = aec_tx_sign:data(SignedTxA),
-                              TxB = aec_tx_sign:data(SignedTxB),
-                              case aec_tx:origin(TxA) =:= aec_tx:origin(TxB) of
-                                  true ->
-                                      aec_tx:nonce(TxA) > aec_tx:nonce(TxB);
-                                  false ->
-                                      aec_tx:origin(TxA) > aec_tx:origin(TxB)
-                              end
-                      end
+                      TxA = aec_tx_sign:data(SignedTxA),
+                      TxB = aec_tx_sign:data(SignedTxB),
+                      {HeightA, aec_tx:origin(TxA), aec_tx:nonce(TxA)} >
+                      {HeightB, aec_tx:origin(TxB), aec_tx:nonce(TxB)}
                   end,
                   NonCoinbases ++ Coinbases),
             {ok, offset_and_limit(Req, Res)}

--- a/apps/aehttp/src/aehttp_dispatch_int.erl
+++ b/apps/aehttp/src/aehttp_dispatch_int.erl
@@ -465,7 +465,7 @@ handle_request('GetPeers', _Req, _Context) ->
             {403, [], #{reason => <<"Call not enabled">>}}
     end;
 
-handle_request('GetAccountTranactions', Req, _Context) ->
+handle_request('GetAccountTransactions', Req, _Context) ->
     case aec_base58c:safe_decode(account_pubkey, maps:get('account_pubkey', Req)) of
         {ok, AccountPubkey} ->
             TopBlockHash = aec_conductor:top_block_hash(),

--- a/apps/aehttp/src/swagger/swagger_api.erl
+++ b/apps/aehttp/src/swagger/swagger_api.erl
@@ -94,6 +94,16 @@ request_params('GetAccountBalance') ->
         'hash'
     ];
 
+request_params('GetAccountTranactions') ->
+    [
+        'account_pubkey',
+        'limit',
+        'offset',
+        'tx_types',
+        'exclude_tx_types',
+        'tx_encoding'
+    ];
+
 request_params('GetActiveRegisteredOracles') ->
     [
         'from',
@@ -414,6 +424,64 @@ request_param_info('GetAccountBalance', 'hash') ->
         source => qs_val  ,
         rules => [
             {type, 'binary'},
+            not_required
+        ]
+    };
+
+request_param_info('GetAccountTranactions', 'account_pubkey') ->
+    #{
+        source =>  binding ,
+        rules => [
+            {type, 'binary'},
+            required
+        ]
+    };
+
+request_param_info('GetAccountTranactions', 'limit') ->
+    #{
+        source => qs_val  ,
+        rules => [
+            {type, 'integer'},
+            {max, 100 }, 
+            {min, 1 },
+            not_required
+        ]
+    };
+
+request_param_info('GetAccountTranactions', 'offset') ->
+    #{
+        source => qs_val  ,
+        rules => [
+            {type, 'integer'},
+            {min, 0 },
+            not_required
+        ]
+    };
+
+request_param_info('GetAccountTranactions', 'tx_types') ->
+    #{
+        source => qs_val  ,
+        rules => [
+            {type, 'binary'},
+            not_required
+        ]
+    };
+
+request_param_info('GetAccountTranactions', 'exclude_tx_types') ->
+    #{
+        source => qs_val  ,
+        rules => [
+            {type, 'binary'},
+            not_required
+        ]
+    };
+
+request_param_info('GetAccountTranactions', 'tx_encoding') ->
+    #{
+        source => qs_val  ,
+        rules => [
+            {type, 'binary'},
+            {enum, ['message_pack', 'json'] },
             not_required
         ]
     };
@@ -1019,6 +1087,13 @@ validate_response('GetAccountBalance', 200, Body, ValidatorState) ->
 validate_response('GetAccountBalance', 400, Body, ValidatorState) ->
     validate_response_body('Error', 'Error', Body, ValidatorState);
 validate_response('GetAccountBalance', 404, Body, ValidatorState) ->
+    validate_response_body('Error', 'Error', Body, ValidatorState);
+
+validate_response('GetAccountTranactions', 200, Body, ValidatorState) ->
+    validate_response_body('TxObjects', 'TxObjects', Body, ValidatorState);
+validate_response('GetAccountTranactions', 400, Body, ValidatorState) ->
+    validate_response_body('Error', 'Error', Body, ValidatorState);
+validate_response('GetAccountTranactions', 404, Body, ValidatorState) ->
     validate_response_body('Error', 'Error', Body, ValidatorState);
 
 validate_response('GetActiveRegisteredOracles', 200, Body, ValidatorState) ->

--- a/apps/aehttp/src/swagger/swagger_api.erl
+++ b/apps/aehttp/src/swagger/swagger_api.erl
@@ -94,7 +94,7 @@ request_params('GetAccountBalance') ->
         'hash'
     ];
 
-request_params('GetAccountTranactions') ->
+request_params('GetAccountTransactions') ->
     [
         'account_pubkey',
         'limit',
@@ -428,7 +428,7 @@ request_param_info('GetAccountBalance', 'hash') ->
         ]
     };
 
-request_param_info('GetAccountTranactions', 'account_pubkey') ->
+request_param_info('GetAccountTransactions', 'account_pubkey') ->
     #{
         source =>  binding ,
         rules => [
@@ -437,7 +437,7 @@ request_param_info('GetAccountTranactions', 'account_pubkey') ->
         ]
     };
 
-request_param_info('GetAccountTranactions', 'limit') ->
+request_param_info('GetAccountTransactions', 'limit') ->
     #{
         source => qs_val  ,
         rules => [
@@ -448,7 +448,7 @@ request_param_info('GetAccountTranactions', 'limit') ->
         ]
     };
 
-request_param_info('GetAccountTranactions', 'offset') ->
+request_param_info('GetAccountTransactions', 'offset') ->
     #{
         source => qs_val  ,
         rules => [
@@ -458,7 +458,7 @@ request_param_info('GetAccountTranactions', 'offset') ->
         ]
     };
 
-request_param_info('GetAccountTranactions', 'tx_types') ->
+request_param_info('GetAccountTransactions', 'tx_types') ->
     #{
         source => qs_val  ,
         rules => [
@@ -467,7 +467,7 @@ request_param_info('GetAccountTranactions', 'tx_types') ->
         ]
     };
 
-request_param_info('GetAccountTranactions', 'exclude_tx_types') ->
+request_param_info('GetAccountTransactions', 'exclude_tx_types') ->
     #{
         source => qs_val  ,
         rules => [
@@ -476,7 +476,7 @@ request_param_info('GetAccountTranactions', 'exclude_tx_types') ->
         ]
     };
 
-request_param_info('GetAccountTranactions', 'tx_encoding') ->
+request_param_info('GetAccountTransactions', 'tx_encoding') ->
     #{
         source => qs_val  ,
         rules => [
@@ -1089,11 +1089,11 @@ validate_response('GetAccountBalance', 400, Body, ValidatorState) ->
 validate_response('GetAccountBalance', 404, Body, ValidatorState) ->
     validate_response_body('Error', 'Error', Body, ValidatorState);
 
-validate_response('GetAccountTranactions', 200, Body, ValidatorState) ->
+validate_response('GetAccountTransactions', 200, Body, ValidatorState) ->
     validate_response_body('TxObjects', 'TxObjects', Body, ValidatorState);
-validate_response('GetAccountTranactions', 400, Body, ValidatorState) ->
+validate_response('GetAccountTransactions', 400, Body, ValidatorState) ->
     validate_response_body('Error', 'Error', Body, ValidatorState);
-validate_response('GetAccountTranactions', 404, Body, ValidatorState) ->
+validate_response('GetAccountTransactions', 404, Body, ValidatorState) ->
     validate_response_body('Error', 'Error', Body, ValidatorState);
 
 validate_response('GetActiveRegisteredOracles', 200, Body, ValidatorState) ->

--- a/apps/aehttp/src/swagger/swagger_external_handler.erl
+++ b/apps/aehttp/src/swagger/swagger_external_handler.erl
@@ -197,6 +197,7 @@ allowed_methods(Req, State) ->
 
 
 
+
 is_authorized(Req, State) ->
     {true, Req, State}.
 

--- a/apps/aehttp/src/swagger/swagger_internal_handler.erl
+++ b/apps/aehttp/src/swagger/swagger_internal_handler.erl
@@ -64,7 +64,7 @@ allowed_methods(
 allowed_methods(
     Req,
     State = #state{
-        operation_id = 'GetAccountTranactions'
+        operation_id = 'GetAccountTransactions'
     }
 ) ->
     {[<<"GET">>], Req, State};
@@ -373,7 +373,7 @@ valid_content_headers(
 valid_content_headers(
     Req0,
     State = #state{
-        operation_id = 'GetAccountTranactions'
+        operation_id = 'GetAccountTransactions'
     }
 ) ->
     Headers = [],

--- a/apps/aehttp/src/swagger/swagger_internal_handler.erl
+++ b/apps/aehttp/src/swagger/swagger_internal_handler.erl
@@ -64,6 +64,14 @@ allowed_methods(
 allowed_methods(
     Req,
     State = #state{
+        operation_id = 'GetAccountTranactions'
+    }
+) ->
+    {[<<"GET">>], Req, State};
+
+allowed_methods(
+    Req,
+    State = #state{
         operation_id = 'GetActiveRegisteredOracles'
     }
 ) ->
@@ -333,6 +341,7 @@ allowed_methods(Req, State) ->
 
 
 
+
 is_authorized(Req, State) ->
     {true, Req, State}.
 
@@ -355,6 +364,16 @@ valid_content_headers(
     Req0,
     State = #state{
         operation_id = 'GetAccountBalance'
+    }
+) ->
+    Headers = [],
+    {Result, Req} = validate_headers(Headers, Req0),
+    {Result, Req, State};
+
+valid_content_headers(
+    Req0,
+    State = #state{
+        operation_id = 'GetAccountTranactions'
     }
 ) ->
     Headers = [],

--- a/apps/aehttp/src/swagger/swagger_router.erl
+++ b/apps/aehttp/src/swagger/swagger_router.erl
@@ -135,7 +135,7 @@ get_operations() ->
             method => <<"GET">>,
             handler => 'swagger_internal_handler'
         },
-        'GetAccountTranactions' => #{
+        'GetAccountTransactions' => #{
             path => "/v2/account/txs/:account_pubkey",
             method => <<"GET">>,
             handler => 'swagger_internal_handler'

--- a/apps/aehttp/src/swagger/swagger_router.erl
+++ b/apps/aehttp/src/swagger/swagger_router.erl
@@ -135,6 +135,11 @@ get_operations() ->
             method => <<"GET">>,
             handler => 'swagger_internal_handler'
         },
+        'GetAccountTranactions' => #{
+            path => "/v2/account/txs/:account_pubkey",
+            method => <<"GET">>,
+            handler => 'swagger_internal_handler'
+        },
         'GetActiveRegisteredOracles' => #{
             path => "/v2/oracles",
             method => <<"GET">>,

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -615,6 +615,64 @@ paths:
           description: Block or account not found
           schema:
             $ref: '#/definitions/Error'
+  /account/txs/{account_pubkey}:
+    get:
+      tags:
+        - internal
+      operationId: GetAccountTranactions
+      description: 'Get accounts''s transactions included in blocks in the longest chain'
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: account_pubkey
+          description: 'Account pubkey to show transactions for'
+          required: true
+          type: string
+        - in: query
+          name: limit
+          description: 'Maximum transactions count to show'
+          required: false
+          type: integer
+          default: 20
+          maximum: 100
+          minimum: 1
+        - in: query
+          name: offset 
+          description: 'Offset to start transaction list from'
+          required: false
+          type: integer
+          default: 0
+          minimum: 0
+        - in: query
+          name: tx_types
+          description: 'Transactions types to show. Comma separated'
+          required: false
+          type : string
+        - in: query
+          name: exclude_tx_types
+          description: 'Transactions types not to show. Comma separated. If a tx type appears in both tx_types and exclude_tx_types, it is excluded.'
+          required: false
+          type : string
+        - in: query
+          name: tx_encoding
+          description: 'Transactions encoding'
+          type: string
+          enum: [message_pack, json]
+          default: message_pack
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            $ref: '#/definitions/TxObjects'
+        '400':
+          description: Invalid account hash
+          schema:
+            $ref: '#/definitions/Error'
+        '404':
+          description: Account not found
+          schema:
+            $ref: '#/definitions/Error'
 
 ## CAUTION: debug endpoints, implementation may be inefficient
   /balances:

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -619,7 +619,7 @@ paths:
     get:
       tags:
         - internal
-      operationId: GetAccountTranactions
+      operationId: GetAccountTransactions
       description: 'Get accounts''s transactions included in blocks in the longest chain'
       produces:
         - application/json

--- a/py/tests/swagger_client/api/internal_api.py
+++ b/py/tests/swagger_client/api/internal_api.py
@@ -136,6 +136,127 @@ class InternalApi(object):
             _request_timeout=params.get('_request_timeout'),
             collection_formats=collection_formats)
 
+    def get_account_tranactions(self, account_pubkey, **kwargs):  # noqa: E501
+        """get_account_tranactions  # noqa: E501
+
+        Get accounts's transactions included in blocks in the longest chain  # noqa: E501
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.get_account_tranactions(account_pubkey, async=True)
+        >>> result = thread.get()
+
+        :param async bool
+        :param str account_pubkey: Account pubkey to show transactions for (required)
+        :param int limit: Maximum transactions count to show
+        :param int offset: Offset to start transaction list from
+        :param str tx_types: Transactions types to show. Comma separated
+        :param str exclude_tx_types: Transactions types not to show. Comma separated. If a tx type appears in both tx_types and exclude_tx_types, it is excluded.
+        :param str tx_encoding: Transactions encoding
+        :return: TxObjects
+                 If the method is called asynchronously,
+                 returns the request thread.
+        """
+        kwargs['_return_http_data_only'] = True
+        if kwargs.get('async'):
+            return self.get_account_tranactions_with_http_info(account_pubkey, **kwargs)  # noqa: E501
+        else:
+            (data) = self.get_account_tranactions_with_http_info(account_pubkey, **kwargs)  # noqa: E501
+            return data
+
+    def get_account_tranactions_with_http_info(self, account_pubkey, **kwargs):  # noqa: E501
+        """get_account_tranactions  # noqa: E501
+
+        Get accounts's transactions included in blocks in the longest chain  # noqa: E501
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.get_account_tranactions_with_http_info(account_pubkey, async=True)
+        >>> result = thread.get()
+
+        :param async bool
+        :param str account_pubkey: Account pubkey to show transactions for (required)
+        :param int limit: Maximum transactions count to show
+        :param int offset: Offset to start transaction list from
+        :param str tx_types: Transactions types to show. Comma separated
+        :param str exclude_tx_types: Transactions types not to show. Comma separated. If a tx type appears in both tx_types and exclude_tx_types, it is excluded.
+        :param str tx_encoding: Transactions encoding
+        :return: TxObjects
+                 If the method is called asynchronously,
+                 returns the request thread.
+        """
+
+        all_params = ['account_pubkey', 'limit', 'offset', 'tx_types', 'exclude_tx_types', 'tx_encoding']  # noqa: E501
+        all_params.append('async')
+        all_params.append('_return_http_data_only')
+        all_params.append('_preload_content')
+        all_params.append('_request_timeout')
+
+        params = locals()
+        for key, val in six.iteritems(params['kwargs']):
+            if key not in all_params:
+                raise TypeError(
+                    "Got an unexpected keyword argument '%s'"
+                    " to method get_account_tranactions" % key
+                )
+            params[key] = val
+        del params['kwargs']
+        # verify the required parameter 'account_pubkey' is set
+        if ('account_pubkey' not in params or
+                params['account_pubkey'] is None):
+            raise ValueError("Missing the required parameter `account_pubkey` when calling `get_account_tranactions`")  # noqa: E501
+
+        if 'limit' in params and params['limit'] > 100:  # noqa: E501
+            raise ValueError("Invalid value for parameter `limit` when calling `get_account_tranactions`, must be a value less than or equal to `100`")  # noqa: E501
+        if 'limit' in params and params['limit'] < 1:  # noqa: E501
+            raise ValueError("Invalid value for parameter `limit` when calling `get_account_tranactions`, must be a value greater than or equal to `1`")  # noqa: E501
+        if 'offset' in params and params['offset'] < 0:  # noqa: E501
+            raise ValueError("Invalid value for parameter `offset` when calling `get_account_tranactions`, must be a value greater than or equal to `0`")  # noqa: E501
+        collection_formats = {}
+
+        path_params = {}
+        if 'account_pubkey' in params:
+            path_params['account_pubkey'] = params['account_pubkey']  # noqa: E501
+
+        query_params = []
+        if 'limit' in params:
+            query_params.append(('limit', params['limit']))  # noqa: E501
+        if 'offset' in params:
+            query_params.append(('offset', params['offset']))  # noqa: E501
+        if 'tx_types' in params:
+            query_params.append(('tx_types', params['tx_types']))  # noqa: E501
+        if 'exclude_tx_types' in params:
+            query_params.append(('exclude_tx_types', params['exclude_tx_types']))  # noqa: E501
+        if 'tx_encoding' in params:
+            query_params.append(('tx_encoding', params['tx_encoding']))  # noqa: E501
+
+        header_params = {}
+
+        form_params = []
+        local_var_files = {}
+
+        body_params = None
+        # HTTP header `Accept`
+        header_params['Accept'] = self.api_client.select_header_accept(
+            ['application/json'])  # noqa: E501
+
+        # Authentication setting
+        auth_settings = []  # noqa: E501
+
+        return self.api_client.call_api(
+            '/account/txs/{account_pubkey}', 'GET',
+            path_params,
+            query_params,
+            header_params,
+            body=body_params,
+            post_params=form_params,
+            files=local_var_files,
+            response_type='TxObjects',  # noqa: E501
+            auth_settings=auth_settings,
+            async=params.get('async'),
+            _return_http_data_only=params.get('_return_http_data_only'),
+            _preload_content=params.get('_preload_content', True),
+            _request_timeout=params.get('_request_timeout'),
+            collection_formats=collection_formats)
+
     def get_active_registered_oracles(self, **kwargs):  # noqa: E501
         """get_active_registered_oracles  # noqa: E501
 

--- a/py/tests/swagger_client/api/internal_api.py
+++ b/py/tests/swagger_client/api/internal_api.py
@@ -136,13 +136,13 @@ class InternalApi(object):
             _request_timeout=params.get('_request_timeout'),
             collection_formats=collection_formats)
 
-    def get_account_tranactions(self, account_pubkey, **kwargs):  # noqa: E501
-        """get_account_tranactions  # noqa: E501
+    def get_account_transactions(self, account_pubkey, **kwargs):  # noqa: E501
+        """get_account_transactions  # noqa: E501
 
         Get accounts's transactions included in blocks in the longest chain  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_account_tranactions(account_pubkey, async=True)
+        >>> thread = api.get_account_transactions(account_pubkey, async=True)
         >>> result = thread.get()
 
         :param async bool
@@ -158,18 +158,18 @@ class InternalApi(object):
         """
         kwargs['_return_http_data_only'] = True
         if kwargs.get('async'):
-            return self.get_account_tranactions_with_http_info(account_pubkey, **kwargs)  # noqa: E501
+            return self.get_account_transactions_with_http_info(account_pubkey, **kwargs)  # noqa: E501
         else:
-            (data) = self.get_account_tranactions_with_http_info(account_pubkey, **kwargs)  # noqa: E501
+            (data) = self.get_account_transactions_with_http_info(account_pubkey, **kwargs)  # noqa: E501
             return data
 
-    def get_account_tranactions_with_http_info(self, account_pubkey, **kwargs):  # noqa: E501
-        """get_account_tranactions  # noqa: E501
+    def get_account_transactions_with_http_info(self, account_pubkey, **kwargs):  # noqa: E501
+        """get_account_transactions  # noqa: E501
 
         Get accounts's transactions included in blocks in the longest chain  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_account_tranactions_with_http_info(account_pubkey, async=True)
+        >>> thread = api.get_account_transactions_with_http_info(account_pubkey, async=True)
         >>> result = thread.get()
 
         :param async bool
@@ -195,21 +195,21 @@ class InternalApi(object):
             if key not in all_params:
                 raise TypeError(
                     "Got an unexpected keyword argument '%s'"
-                    " to method get_account_tranactions" % key
+                    " to method get_account_transactions" % key
                 )
             params[key] = val
         del params['kwargs']
         # verify the required parameter 'account_pubkey' is set
         if ('account_pubkey' not in params or
                 params['account_pubkey'] is None):
-            raise ValueError("Missing the required parameter `account_pubkey` when calling `get_account_tranactions`")  # noqa: E501
+            raise ValueError("Missing the required parameter `account_pubkey` when calling `get_account_transactions`")  # noqa: E501
 
         if 'limit' in params and params['limit'] > 100:  # noqa: E501
-            raise ValueError("Invalid value for parameter `limit` when calling `get_account_tranactions`, must be a value less than or equal to `100`")  # noqa: E501
+            raise ValueError("Invalid value for parameter `limit` when calling `get_account_transactions`, must be a value less than or equal to `100`")  # noqa: E501
         if 'limit' in params and params['limit'] < 1:  # noqa: E501
-            raise ValueError("Invalid value for parameter `limit` when calling `get_account_tranactions`, must be a value greater than or equal to `1`")  # noqa: E501
+            raise ValueError("Invalid value for parameter `limit` when calling `get_account_transactions`, must be a value greater than or equal to `1`")  # noqa: E501
         if 'offset' in params and params['offset'] < 0:  # noqa: E501
-            raise ValueError("Invalid value for parameter `offset` when calling `get_account_tranactions`, must be a value greater than or equal to `0`")  # noqa: E501
+            raise ValueError("Invalid value for parameter `offset` when calling `get_account_transactions`, must be a value greater than or equal to `0`")  # noqa: E501
         collection_formats = {}
 
         path_params = {}


### PR DESCRIPTION
[Pivotal story](https://www.pivotaltracker.com/story/show/154658088)
[Github issue](https://github.com/aeternity/protocol/issues/24)
### Description
List all transactions related to an account

### Endpoint
```
GET /account/txs/{account_public_key}
```
#### Query params
*  **limit** (*integer*) - maximum transactions to show (1 < limit < 100, default 20)
*  **offset** (*integer*) - offset from where to start the list of tx (default 0)
* **tx_encoding** (`message_pack` or `json`) - how to encode transactions. Options are [MessagePack](https://msgpack.org/) or as a JSON objects. Since MessagePack is more compact it is expected that it would be used for client apps. Default: `message_pack`
* **tx_types** (`coinbase`, `spend`, `oracle_query`, etc.) - filter on transaction's type. Use this to get **only** these specified transaction types. If more than one type is specified - the types are comma separated. By default all transaction types are returned.
* **exclude_tx_types** (`coinbase`, `spend`, `oracle_query`, etc.) - filter on transaction's type. Use this to get **all but** these specified transaction types. If more than one type is specified - the types are comma separated. By default none transaction types are filtered out.

### Examples
##### Last 10 txs
limit=10, tx_encoding=json
```
curl -G 'http://127.0.0.1:3113/v2/account/txs/ak$3XXadWA4rQemrWkx4gJpf36HkPeDZE7Zj933cv5YaqfschtuWbCXqc7vhvvLhCdoePEXsC92sBMY6em7SvZvkSZEEqZzZq' --data-urlencode 'tx_encoding=json' --data-urlencode 'limit=10'
{
   "data_schema":"JSONTxs",
   "transactions":[
      {
         "block_hash":"bh$AMVA9FB7HfDsUpVNoDzTr4cws1rSbjTFQy9RkwfNgcLSSZz5V",
         "block_height":23,
         "hash":"th$27bXQjbWb6pjPKLb3bkVTqHNeEkdRgKNSX2f2xYpLS59hAM8qD",
         "signatures":[
            "sg$EsykzDr7aCkmVnL9gjXVDkgZso1DrNdJBoZwWxoMxXzXMsXHKNiFdL1Ecn9pWNSkfQo6PnGSwrpnL2vFneZb2z6dHDa4BaTLSYN8e"
         ],
         "tx":{
            "account":"ak$3XXadWA4rQemrWkx4gJpf36HkPeDZE7Zj933cv5YaqfschtuWbCXqc7vhvvLhCdoePEXsC92sBMY6em7SvZvkSZEEqZzZq",
            "data_schema":"CoinbaseTxJSON",
            "type":"coinbase",
            "vsn":1
         }
      },
      {
         "block_hash":"bh$9WbANDzy8WeRT3uYPjuZMj93z4mp29Z7bbJqV6CuL1KNcX1vL",
         "block_height":22,
         "hash":"th$27bXQjbWb6pjPKLb3bkVTqHNeEkdRgKNSX2f2xYpLS59hAM8qD",
         "signatures":[
            "sg$5fRnXJUGNDitZWoCu3mn5rhyZduCuqsWRzU89nweddmFDMqmKjM8EYKd1wGVZU13huYSrYC787EGc2YV5af7jXmSJeEF3MHX6JWCjsJQ"
         ],
         "tx":{
            "account":"ak$3XXadWA4rQemrWkx4gJpf36HkPeDZE7Zj933cv5YaqfschtuWbCXqc7vhvvLhCdoePEXsC92sBMY6em7SvZvkSZEEqZzZq",
            "data_schema":"CoinbaseTxJSON",
            "type":"coinbase",
            "vsn":1
         }
      },
      {
         "block_hash":"bh$2E4XkEFvq3RrkHYpkvVy3EBcC1ytfwAeEv4fSzPHCKjXLNQeY6",
         "block_height":21,
         "hash":"th$27bXQjbWb6pjPKLb3bkVTqHNeEkdRgKNSX2f2xYpLS59hAM8qD",
         "signatures":[
            "sg$5fRnXJUEhEY4LmVaxDBLRo9ctJmSTwSC4xzeUk6AqioJhAkAB5ZY5VwaEFwjwKCkAyUyXpD2XD1DSh34sfu1ATMQpD9uXCejEQ7vbokB"
         ],
         "tx":{
            "account":"ak$3XXadWA4rQemrWkx4gJpf36HkPeDZE7Zj933cv5YaqfschtuWbCXqc7vhvvLhCdoePEXsC92sBMY6em7SvZvkSZEEqZzZq",
            "data_schema":"CoinbaseTxJSON",
            "type":"coinbase",
            "vsn":1
         }
      },
      {
         "block_hash":"bh$iqUaerFKYgcr4azr6LCQWDTCM2zjif7rfCKa5VcEMS95hwSAA",
         "block_height":20,
         "hash":"th$27bXQjbWb6pjPKLb3bkVTqHNeEkdRgKNSX2f2xYpLS59hAM8qD",
         "signatures":[
            "sg$24GJCVPdxPDZErbfz2fxy8GytSaTS6x5fgXHkPGXb6QKnD49dR6eYWRwv9AB7MwMY2f8v7gAY8V3f9n7yaZqC9mtYQh8yUsmkbjqUqf"
         ],
         "tx":{
            "account":"ak$3XXadWA4rQemrWkx4gJpf36HkPeDZE7Zj933cv5YaqfschtuWbCXqc7vhvvLhCdoePEXsC92sBMY6em7SvZvkSZEEqZzZq",
            "data_schema":"CoinbaseTxJSON",
            "type":"coinbase",
            "vsn":1
         }
      },
      {
         "block_hash":"bh$qbQanVKmTzDyVd8SfNV5UGkU4gYxE32s6CdUTfNqdbh6JVjoY",
         "block_height":19,
         "hash":"th$27bXQjbWb6pjPKLb3bkVTqHNeEkdRgKNSX2f2xYpLS59hAM8qD",
         "signatures":[
            "sg$5fRnXJUCZzwgj3jEbHKwHGfwFwhjfrsp9YdDheWFED11xTWE8HB3UFY3TGJipW23adsWrH9XMRZu2nTpDTwZPzvsRZXAbiw6byUbiMgb"
         ],
         "tx":{
            "account":"ak$3XXadWA4rQemrWkx4gJpf36HkPeDZE7Zj933cv5YaqfschtuWbCXqc7vhvvLhCdoePEXsC92sBMY6em7SvZvkSZEEqZzZq",
            "data_schema":"CoinbaseTxJSON",
            "type":"coinbase",
            "vsn":1
         }
      },
      {
         "block_hash":"bh$2kerMFwQx3YXRYhycZhn94tLrgc9VRqBvf5CWb314bJSNu6VAF",
         "block_height":18,
         "hash":"th$27bXQjbWb6pjPKLb3bkVTqHNeEkdRgKNSX2f2xYpLS59hAM8qD",
         "signatures":[
            "sg$24GJCUidxHnXnvx4pG4GHgySiFKz145r9bAGzpAqD8PhFPxqRFCd5vtoQhAZ4183ixjFowiGS1kEfVt8P6DowSRPsxRRKkemG9wKpaY"
         ],
         "tx":{
            "account":"ak$3XXadWA4rQemrWkx4gJpf36HkPeDZE7Zj933cv5YaqfschtuWbCXqc7vhvvLhCdoePEXsC92sBMY6em7SvZvkSZEEqZzZq",
            "data_schema":"CoinbaseTxJSON",
            "type":"coinbase",
            "vsn":1
         }
      },
      {
         "block_hash":"bh$26Kp8nKkGdjhNcFppcyVsVpQ9gyjXQLSuA4b1CF7MLpuqKD541",
         "block_height":17,
         "hash":"th$27bXQjbWb6pjPKLb3bkVTqHNeEkdRgKNSX2f2xYpLS59hAM8qD",
         "signatures":[
            "sg$EsykzGiNgVzrTm5D5VT2gkqA6ZjZiAAVqTjMATcsfYFLkKxfaoJEvpiCMgvS63fyefvVXNXVXFLztFyFYDPe3DvSpA1AP4wsfFqyz"
         ],
         "tx":{
            "account":"ak$3XXadWA4rQemrWkx4gJpf36HkPeDZE7Zj933cv5YaqfschtuWbCXqc7vhvvLhCdoePEXsC92sBMY6em7SvZvkSZEEqZzZq",
            "data_schema":"CoinbaseTxJSON",
            "type":"coinbase",
            "vsn":1
         }
      },
      {
         "block_hash":"bh$26Kp8nKkGdjhNcFppcyVsVpQ9gyjXQLSuA4b1CF7MLpuqKD541",
         "block_height":17,
         "hash":"th$DXN2vW5fVfAGsvqiHMwwxeAJv38QnZJF8FpGsHyrdnhfTZtYk",
         "signatures":[
            "sg$EsykzDjxMJPThsksU6mPneFfDSLLBGfTndqxEyxcCnxjD1kVNcgAStUf6Z4WtCWDA6cFeXRNepEFz1LtKwXcAYpAyTMFk7ZnvFTjQ"
         ],
         "tx":{
            "amount":42,
            "data_schema":"SpendTxJSON",
            "fee":2,
            "nonce":4,
            "recipient":"ak$3kj9ijauBtf2SZQdJm1f1",
            "sender":"ak$3XXadWA4rQemrWkx4gJpf36HkPeDZE7Zj933cv5YaqfschtuWbCXqc7vhvvLhCdoePEXsC92sBMY6em7SvZvkSZEEqZzZq",
            "type":"spend",
            "vsn":1
         }
      },
      {
         "block_hash":"bh$1D8cAaQwoG6UTz7EZPg2inDY7r1GUHjr3A4tq2Ckr36XtdgTN",
         "block_height":16,
         "hash":"th$27bXQjbWb6pjPKLb3bkVTqHNeEkdRgKNSX2f2xYpLS59hAM8qD",
         "signatures":[
            "sg$EsykzFHYGhNzD1SmUkFmrfwnJu9pzzuPbLD1RRGqEcs3K8o3aiz2EFEKZbiXAvyGRe19rUtp3g4MDWd8sn1Y3p2Vt5R8ZrG3f8kGT"
         ],
         "tx":{
            "account":"ak$3XXadWA4rQemrWkx4gJpf36HkPeDZE7Zj933cv5YaqfschtuWbCXqc7vhvvLhCdoePEXsC92sBMY6em7SvZvkSZEEqZzZq",
            "data_schema":"CoinbaseTxJSON",
            "type":"coinbase",
            "vsn":1
         }
      },
      {
         "block_hash":"bh$224UnTozG2ZTAFFjafFBZSdB68aS6w7XwSFgRwi8ZrUmkEqtNj",
         "block_height":15,
         "hash":"th$27bXQjbWb6pjPKLb3bkVTqHNeEkdRgKNSX2f2xYpLS59hAM8qD",
         "signatures":[
            "sg$24GJCUiSA4a8Auw8D5qgGiiRZDJzJtE5Ky45HtcYpdsouCAUjy7jbQDPVvNsWGMMAkAyzwVWvbtiwqCeGWk9J2KMKNsBJYfhbDZEmZY"
         ],
         "tx":{
            "account":"ak$3XXadWA4rQemrWkx4gJpf36HkPeDZE7Zj933cv5YaqfschtuWbCXqc7vhvvLhCdoePEXsC92sBMY6em7SvZvkSZEEqZzZq",
            "data_schema":"CoinbaseTxJSON",
            "type":"coinbase",
            "vsn":1
         }
      }
   ]
}
```

#### Last 10 spends
limit=10, tx_encoding=json, tx_types=spend
```
curl -G 'http://127.0.0.1:3113/v2/account/txs/ak$3XXadWA4rQemrWkx4gJpf36HkPeDZE7Zj933cv5YaqfschtuWbCXqc7vhvvLhCdoePEXsC92sBMY6em7SvZvkSZEEqZzZq' --data-urlencode 'tx_encoding=json' --data-urlencode 'limit=10' --data-urlencode 'tx_types=spend'
{
   "data_schema":"JSONTxs",
   "transactions":[
      {
         "block_hash":"bh$26Kp8nKkGdjhNcFppcyVsVpQ9gyjXQLSuA4b1CF7MLpuqKD541",
         "block_height":17,
         "hash":"th$DXN2vW5fVfAGsvqiHMwwxeAJv38QnZJF8FpGsHyrdnhfTZtYk",
         "signatures":[
            "sg$EsykzDjxMJPThsksU6mPneFfDSLLBGfTndqxEyxcCnxjD1kVNcgAStUf6Z4WtCWDA6cFeXRNepEFz1LtKwXcAYpAyTMFk7ZnvFTjQ"
         ],
         "tx":{
            "amount":42,
            "data_schema":"SpendTxJSON",
            "fee":2,
            "nonce":4,
            "recipient":"ak$3kj9ijauBtf2SZQdJm1f1",
            "sender":"ak$3XXadWA4rQemrWkx4gJpf36HkPeDZE7Zj933cv5YaqfschtuWbCXqc7vhvvLhCdoePEXsC92sBMY6em7SvZvkSZEEqZzZq",
            "type":"spend",
            "vsn":1
         }
      },
      {
         "block_hash":"bh$unRkMoYf4qUZmAomLMzzpaJeWXkq4mJZ7C3KgURM6fcNsyJrk",
         "block_height":13,
         "hash":"th$22PNegeQcrDeu14Y8Ek8U9DmQdMG9o3bkres87m2W3WtEwf4BH",
         "signatures":[
            "sg$EsykzJ6JMtvaKoMTEpRbdnzyu627gjjXM3dYCsZjBPmV9U2fbvEavFAhQTiiC2e8h5SD9uQCSyATGpTSFm7eDN8k5nNRsoBay1Nc6"
         ],
         "tx":{
            "amount":42,
            "data_schema":"SpendTxJSON",
            "fee":2,
            "nonce":3,
            "recipient":"ak$3kj9ijauBtf2SZQdJm1f1",
            "sender":"ak$3XXadWA4rQemrWkx4gJpf36HkPeDZE7Zj933cv5YaqfschtuWbCXqc7vhvvLhCdoePEXsC92sBMY6em7SvZvkSZEEqZzZq",
            "type":"spend",
            "vsn":1
         }
      },
      {
         "block_hash":"bh$EaRAvymmLNnKvmzvSxZynXVA3ZNWY1jqfdB4xUgTDCPT2Jwwk",
         "block_height":9,
         "hash":"th$qu3GxSgHMpRhmC9XtQVqgKBTjCcbLZkRNEYPh1D3oPiVR9gZp",
         "signatures":[
            "sg$24GJCUkr3XeGTLYfznH7o1cdiYXjNdJyJkWh96UzPgWbk7BjBwg73yJN3tQZdvqXyGxV6GPCtKesp81518Xp9SXa19ZD1wa3cdL8EMH"
         ],
         "tx":{
            "amount":42,
            "data_schema":"SpendTxJSON",
            "fee":2,
            "nonce":2,
            "recipient":"ak$3kj9ijauBtf2SZQdJm1f1",
            "sender":"ak$3XXadWA4rQemrWkx4gJpf36HkPeDZE7Zj933cv5YaqfschtuWbCXqc7vhvvLhCdoePEXsC92sBMY6em7SvZvkSZEEqZzZq",
            "type":"spend",
            "vsn":1
         }
      },
      {
         "block_hash":"bh$EaRAvymmLNnKvmzvSxZynXVA3ZNWY1jqfdB4xUgTDCPT2Jwwk",
         "block_height":9,
         "hash":"th$AKP9GfshNYF7jKK679CptHwT4q7rJkWCJnHyrT9ZWkf5kCdqa",
         "signatures":[
            "sg$5fRnXJURkhnS5euEoDnLty5XodEy5X5CjLAM9WMJ6E2z41u2qKDaMiqLaqmCruwDXVox1AfiQ86EFZGB3TWQMwtDYMntAaRZyRQAtXWC"
         ],
         "tx":{
            "amount":42,
            "data_schema":"SpendTxJSON",
            "fee":2,
            "nonce":1,
            "recipient":"ak$3kj9ijauBtf2SZQdJm1f1",
            "sender":"ak$3XXadWA4rQemrWkx4gJpf36HkPeDZE7Zj933cv5YaqfschtuWbCXqc7vhvvLhCdoePEXsC92sBMY6em7SvZvkSZEEqZzZq",
            "type":"spend",
            "vsn":1
         }
      }
   ]
}
```

#### 10 spends before the last one
limit=10, tx_encoding=json, tx_types=spend, offset=1
```
curl -G 'http://127.0.0.1:3113/v2/account/txs/ak$3XXadWA4rQemrWkx4gJpf36HkPeDZE7Zj933cv5YaqfschtuWbCXqc7vhvvLhCdoePEXsC92sBMY6em7SvZvkSZEEqZzZq' --data-urlencode 'tx_encoding=json' --data-urlencode 'limit=10' --data-urlencode 'tx_types=spend' --data-urlencode 'offset=1'
{
   "data_schema":"JSONTxs",
   "transactions":[
      {
         "block_hash":"bh$unRkMoYf4qUZmAomLMzzpaJeWXkq4mJZ7C3KgURM6fcNsyJrk",
         "block_height":13,
         "hash":"th$22PNegeQcrDeu14Y8Ek8U9DmQdMG9o3bkres87m2W3WtEwf4BH",
         "signatures":[
            "sg$EsykzJ6JMtvaKoMTEpRbdnzyu627gjjXM3dYCsZjBPmV9U2fbvEavFAhQTiiC2e8h5SD9uQCSyATGpTSFm7eDN8k5nNRsoBay1Nc6"
         ],
         "tx":{
            "amount":42,
            "data_schema":"SpendTxJSON",
            "fee":2,
            "nonce":3,
            "recipient":"ak$3kj9ijauBtf2SZQdJm1f1",
            "sender":"ak$3XXadWA4rQemrWkx4gJpf36HkPeDZE7Zj933cv5YaqfschtuWbCXqc7vhvvLhCdoePEXsC92sBMY6em7SvZvkSZEEqZzZq",
            "type":"spend",
            "vsn":1
         }
      },
      {
         "block_hash":"bh$EaRAvymmLNnKvmzvSxZynXVA3ZNWY1jqfdB4xUgTDCPT2Jwwk",
         "block_height":9,
         "hash":"th$qu3GxSgHMpRhmC9XtQVqgKBTjCcbLZkRNEYPh1D3oPiVR9gZp",
         "signatures":[
            "sg$24GJCUkr3XeGTLYfznH7o1cdiYXjNdJyJkWh96UzPgWbk7BjBwg73yJN3tQZdvqXyGxV6GPCtKesp81518Xp9SXa19ZD1wa3cdL8EMH"
         ],
         "tx":{
            "amount":42,
            "data_schema":"SpendTxJSON",
            "fee":2,
            "nonce":2,
            "recipient":"ak$3kj9ijauBtf2SZQdJm1f1",
            "sender":"ak$3XXadWA4rQemrWkx4gJpf36HkPeDZE7Zj933cv5YaqfschtuWbCXqc7vhvvLhCdoePEXsC92sBMY6em7SvZvkSZEEqZzZq",
            "type":"spend",
            "vsn":1
         }
      },
      {
         "block_hash":"bh$EaRAvymmLNnKvmzvSxZynXVA3ZNWY1jqfdB4xUgTDCPT2Jwwk",
         "block_height":9,
         "hash":"th$AKP9GfshNYF7jKK679CptHwT4q7rJkWCJnHyrT9ZWkf5kCdqa",
         "signatures":[
            "sg$5fRnXJURkhnS5euEoDnLty5XodEy5X5CjLAM9WMJ6E2z41u2qKDaMiqLaqmCruwDXVox1AfiQ86EFZGB3TWQMwtDYMntAaRZyRQAtXWC"
         ],
         "tx":{
            "amount":42,
            "data_schema":"SpendTxJSON",
            "fee":2,
            "nonce":1,
            "recipient":"ak$3kj9ijauBtf2SZQdJm1f1",
            "sender":"ak$3XXadWA4rQemrWkx4gJpf36HkPeDZE7Zj933cv5YaqfschtuWbCXqc7vhvvLhCdoePEXsC92sBMY6em7SvZvkSZEEqZzZq",
            "type":"spend",
            "vsn":1
         }
      }
   ]
}
```