### PR TITLE
Fix epoch image Dockerfile

### DIFF
--- a/docker/Dockerfile-epoch
+++ b/docker/Dockerfile-epoch
@@ -1,12 +1,4 @@
-FROM erlang:20.2 as builder
-
-ENV LIBSODIUM_VERSION=1.0.16
-RUN LIBSODIUM_DOWNLOAD_URL="https://github.com/jedisct1/libsodium/releases/download/${LIBSODIUM_VERSION}/libsodium-${LIBSODIUM_VERSION}.tar.gz" \
-    && curl -fsSL -o libsodium-src.tar.gz "$LIBSODIUM_DOWNLOAD_URL" \
-    && mkdir libsodium-src \
-    && tar -zxf libsodium-src.tar.gz -C libsodium-src --strip-components=1 \
-    && cd libsodium-src \
-    && ./configure && make -j$(nproc) && make install && ldconfig
+FROM aetrnty/builder as builder
 
 ADD . /app
 RUN cd /app && make prod-build
@@ -14,12 +6,17 @@ RUN cd /app && make prod-build
 # Put epoch node in second stage container
 FROM ubuntu:16.04
 
-# OpenSSL is shared lib dependency
-RUN apt-get -qq update && apt-get -qq -y install openssl curl \
-    && rm -rf /var/lib/apt/lists/*
-
 # Deploy application code from builder container
 COPY --from=builder /app/_build/prod/rel/epoch /home/epoch/node
+
+# Copy custom built libs
+# Note the `ldconfig` requirement which is implicitly run by openssl install
+COPY --from=builder /usr/local/lib /usr/local/lib
+
+# OpenSSL is shared lib dependency
+RUN apt-get -qq update && apt-get -qq -y install openssl curl \
+    && ldconfig \
+    && rm -rf /var/lib/apt/lists/*
 
 # Epoch app won't run as root for security reasons
 RUN useradd --shell /bin/bash epoch \


### PR DESCRIPTION
- use aetrnty/builder as builder image
- copy libsodium to epoch image

I think this also addresses [PT 154993662](https://www.pivotaltracker.com/story/show/154993662)