### PR TITLE
Fix missing libsodium on Circle CI OSX

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,6 +174,7 @@ jobs:
           name: Install required tools
           command: |
             brew update
+            brew install libsodium
             brew install erlang
       - *build_package
       - *test_package


### PR DESCRIPTION
Finishes https://www.pivotaltracker.com/story/show/155124622