### PR TITLE
Make aec_chain_state use database rather than a functional state

### DIFF
--- a/apps/aecore/src/aec_blocks.erl
+++ b/apps/aecore/src/aec_blocks.erl
@@ -17,6 +17,7 @@
          set_target/2,
          new/3,
          new_with_state/3,
+         from_header_and_txs/2,
          to_header/1,
          serialize_for_store/1,
          deserialize_from_store/1,
@@ -132,6 +133,27 @@ to_header(#block{height = Height,
             time = Time,
             pow_evidence = Evd,
             version = Version}.
+
+from_header_and_txs(#header{height = Height,
+                            prev_hash = PrevHash,
+                            txs_hash = TxsHash,
+                            root_hash = RootHash,
+                            target = Target,
+                            nonce = Nonce,
+                            time = Time,
+                            pow_evidence = Evd,
+                            version = Version}, Txs) ->
+    #block{height = Height,
+           prev_hash = PrevHash,
+           txs_hash = TxsHash,
+           root_hash = RootHash,
+           target = Target,
+           nonce = Nonce,
+           time = Time,
+           version = Version,
+           pow_evidence = Evd,
+           txs = Txs
+          }.
 
 serialize_client_readable(Encoding, B) ->
     serialize_to_map(B,

--- a/apps/aecore/test/aec_db_tests.erl
+++ b/apps/aecore/test/aec_db_tests.erl
@@ -73,11 +73,11 @@ write_chain_test_() ->
                ?compareBlockResults(GB, Block),
 
                %% Genesis should be top header
-               Header = aec_db:get_top_header(),
+               Header = aec_db:get_top_header_hash(),
                ?assertEqual(Header, Hash),
 
                %% Genesis should be top block
-               TopBlockHash = aec_db:get_top_block(),
+               TopBlockHash = aec_db:get_top_block_hash(),
                ?assertEqual(Header, TopBlockHash),
 
                ok
@@ -99,26 +99,26 @@ write_chain_test_() ->
                ?compareBlockResults(GB, Block),
 
                %% BH2 should be top header
-               Header = aec_db:get_top_header(),
+               Header = aec_db:get_top_header_hash(),
                B2Hash = header_hash(BH2),
                ?assertEqual(B2Hash, Header),
 
                %% Genesis should be top block
-               TopBlockHash = aec_db:get_top_block(),
+               TopBlockHash = aec_db:get_top_block_hash(),
                ?assertEqual(GHash, TopBlockHash),
 
                %% Add one block corresponding to a header already in the chain.
                ?assertEqual(ok, aec_conductor:post_block(B2)),
 
                %% GB should still be top block
-               NewTopBlockHash = aec_db:get_top_block(),
+               NewTopBlockHash = aec_db:get_top_block_hash(),
                ?assertEqual(GHash, NewTopBlockHash),
 
                %% Add missing block corresponding to a header already in the chain.
                ?assertEqual(ok, aec_conductor:post_block(B1)),
 
                %% Now B2 should be the top block
-               LastTopBlockHash = aec_db:get_top_block(),
+               LastTopBlockHash = aec_db:get_top_block_hash(),
                ?assertEqual(B2Hash, LastTopBlockHash),
 
                ok
@@ -156,7 +156,7 @@ restart_test_() ->
                ?assertEqual(ok, aec_conductor:post_block(B1)),
                ?assertEqual(ok, aec_conductor:post_block(B2)),
                %% Now B2 should be the top block
-               TopBlockHash = aec_db:get_top_block(),
+               TopBlockHash = aec_db:get_top_block_hash(),
                B2Hash = header_hash(BH2),
                ?assertEqual(B2Hash, TopBlockHash),
                ChainTop1 = aec_conductor:top(),
@@ -174,7 +174,7 @@ restart_test_() ->
                %% Kill chain server
 
                kill_and_restart_conductor(),
-               NewTopBlockHash = aec_db:get_top_block(),
+               NewTopBlockHash = aec_db:get_top_block_hash(),
                ?assertEqual(B2Hash, NewTopBlockHash),
 
                ChainTop2 = aec_conductor:top(),

--- a/deployment/ansible/deploy.yml
+++ b/deployment/ansible/deploy.yml
@@ -40,7 +40,7 @@
           port: 3013
       chain:
         persist: true
-        db_path: "./db26"
+        db_path: "./db27"
       keypair:
         dir: "keys"
         password: "{{ vault_keys_password|default('secret') }}"


### PR DESCRIPTION
* Blocks and headers are stored unless they are blatantly malformed.
* Blocks are stored in db as headers + transactions
* Previous hash is indexed in db
* The top block hash is driving top header hash rather than the opposite
* Avoid giving error messages for other nodes than the one currently added
* Add stricter checking before adding state to db
* If a node has a stored state in the db, it needs no more checking
* Better restart from persisted states

https://www.pivotaltracker.com/n/projects/2124891/stories/153442321
https://www.pivotaltracker.com/n/projects/2124891/stories/154877787
