### PR TITLE
Pt 154838110 logging on console

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -44,7 +44,6 @@
       {extra_sinks, [
            {epoch_mining_lager_event, [
              {handlers, [
-               {lager_console_backend, [{level, info}]},
                {lager_file_backend, [
                   {file, "log/epoch_mining.log"},
                   {level, info},
@@ -54,7 +53,6 @@
            ]},
            {epoch_pow_cuckoo_lager_event, [
              {handlers, [
-               {lager_console_backend, [{level, debug}]},
                {lager_file_backend, [
                   {file, "log/epoch_pow_cuckoo.log"},
                   {level, debug},
@@ -64,7 +62,6 @@
            ]},
            {epoch_metrics_lager_event, [
              {handlers, [
-               {lager_console_backend, [{level, info}]},
                {lager_file_backend, [
                   {file, "log/epoch_metrics.log"},
                   {level, info},

--- a/config/sys.config
+++ b/config/sys.config
@@ -36,6 +36,7 @@
   {lager, [
       {error_logger_flush_queue, false},
       {handlers, [
+          {lager_console_backend, [{level, info}]},
           {lager_file_backend,
             [{file, "log/epoch.log"}, {level, debug},
              {size, 4194303}, {date, "$D0"}, {count, 10}]}
@@ -43,6 +44,7 @@
       {extra_sinks, [
            {epoch_mining_lager_event, [
              {handlers, [
+               {lager_console_backend, [{level, info}]},
                {lager_file_backend, [
                   {file, "log/epoch_mining.log"},
                   {level, info},
@@ -52,6 +54,7 @@
            ]},
            {epoch_pow_cuckoo_lager_event, [
              {handlers, [
+               {lager_console_backend, [{level, debug}]},
                {lager_file_backend, [
                   {file, "log/epoch_pow_cuckoo.log"},
                   {level, debug},
@@ -61,6 +64,7 @@
            ]},
            {epoch_metrics_lager_event, [
              {handlers, [
+               {lager_console_backend, [{level, info}]},
                {lager_file_backend, [
                   {file, "log/epoch_metrics.log"},
                   {level, info},


### PR DESCRIPTION
Enable logging on the console, so we can see logs using `docker logs`