### PR TITLE
PT-154994576 pin erlang otp osx

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,7 +179,7 @@ jobs:
           command: |
             brew update
             brew install libsodium
-            brew install file://`pwd`/deployment/erlang.rb
+            brew install file://`pwd`/deployment/homebrew/erlang.rb
       - *build_package
       - *test_package
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,7 +179,7 @@ jobs:
           command: |
             brew update
             brew install libsodium
-            brew install erlang
+            brew install file://`pwd`/deployment/erlang.rb
       - *build_package
       - *test_package
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -302,8 +302,6 @@ workflows:
             - eunit
             - static_analysis
           filters:
-            branches:
-              only: master
             tags:
               only: /^v.*$/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -302,6 +302,8 @@ workflows:
             - eunit
             - static_analysis
           filters:
+            branches:
+              only: master
             tags:
               only: /^v.*$/
 

--- a/ci
+++ b/ci
@@ -26,7 +26,8 @@ case "${1:?}"-"${2:?}" in
             export HOMEBREW_CACHE="$HOME/Library/Caches/Homebrew"
             brew update
             brew install libsodium
-            brew install erlang && export PATH="$(brew --prefix erlang)"/bin:"$PATH"
+            # Install really pinned version of OTP Erlang (See #154994576)
+            brew install file://`pwd`/deployment/homebrew/erlang.rb && export PATH="$(brew --prefix erlang)"/bin:"$PATH"
         elif [ "${TRAVIS_OS_NAME:?}" = "linux" ]; then
             sudo -H pip install -r deployment/ansible/pip-requirements.txt
             wget https://download.libsodium.org/libsodium/releases/libsodium-1.0.16.tar.gz

--- a/deployment/homebrew/erlang.rb
+++ b/deployment/homebrew/erlang.rb
@@ -1,3 +1,30 @@
+=begin
+BSD 2-Clause License
+
+Copyright (c) 2009-present, Homebrew contributors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+=end
 class Erlang < Formula
   desc "Programming language for highly scalable real-time systems"
   homepage "https://www.erlang.org/"

--- a/deployment/homebrew/erlang.rb
+++ b/deployment/homebrew/erlang.rb
@@ -1,0 +1,109 @@
+class Erlang < Formula
+  desc "Programming language for highly scalable real-time systems"
+  homepage "https://www.erlang.org/"
+  # Download tarball from GitHub; it is served faster than the official tarball.
+  url "https://github.com/erlang/otp/archive/OTP-20.2.3.tar.gz"
+  sha256 "d50a7e77a4f0c737c5d6110b92a0aa31bad1c801ff3dccc80c02e3d564242f69"
+  head "https://github.com/erlang/otp.git"
+
+  bottle do
+    cellar :any
+    sha256 "3b2d2f2e70a6860dadf35bca2373d0887a568f4c97446a4ede6dc70adcffefd7" => :high_sierra
+    sha256 "7857f481eb20d51fc3052a287221732143520d184e74b304fd01f794f4e84a24" => :sierra
+    sha256 "e3d2282263cb1552c04f0b2263b02fc101a5acfc4180cfa0a9056433c713031c" => :el_capitan
+  end
+
+  option "without-hipe", "Disable building hipe; fails on various macOS systems"
+  option "with-native-libs", "Enable native library compilation"
+  option "with-dirty-schedulers", "Enable experimental dirty schedulers"
+  option "with-java", "Build jinterface application"
+  option "without-docs", "Do not install documentation"
+
+  deprecated_option "disable-hipe" => "without-hipe"
+  deprecated_option "no-docs" => "without-docs"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "openssl"
+  depends_on "fop" => :optional # enables building PDF docs
+  depends_on :java => :optional
+  depends_on "wxmac" => :recommended # for GUI apps like observer
+
+  resource "man" do
+    url "https://www.erlang.org/download/otp_doc_man_20.2.tar.gz"
+    mirror "https://fossies.org/linux/misc/otp_doc_man_20.2.tar.gz"
+    sha256 "950e088f9e47fc10a98e3f67d6420a990650836c648686a2f5dafe331747cbdf"
+  end
+
+  resource "html" do
+    url "https://www.erlang.org/download/otp_doc_html_20.2.tar.gz"
+    mirror "https://fossies.org/linux/misc/otp_doc_html_20.2.tar.gz"
+    sha256 "7f5e7d4cd0c58e15d7d29231931c2a710f7f5fdfcb0ff8edb8142969520c4256"
+  end
+
+  def install
+    # Unset these so that building wx, kernel, compiler and
+    # other modules doesn't fail with an unintelligable error.
+    %w[LIBS FLAGS AFLAGS ZFLAGS].each { |k| ENV.delete("ERL_#{k}") }
+
+    ENV["FOP"] = "#{HOMEBREW_PREFIX}/bin/fop" if build.with? "fop"
+
+    # Do this if building from a checkout to generate configure
+    system "./otp_build", "autoconf" if File.exist? "otp_build"
+
+    args = %W[
+      --disable-debug
+      --disable-silent-rules
+      --prefix=#{prefix}
+      --enable-kernel-poll
+      --enable-threads
+      --enable-sctp
+      --enable-dynamic-ssl-lib
+      --with-ssl=#{Formula["openssl"].opt_prefix}
+      --enable-shared-zlib
+      --enable-smp-support
+    ]
+
+    args << "--enable-darwin-64bit" if MacOS.prefer_64_bit?
+    args << "--enable-native-libs" if build.with? "native-libs"
+    args << "--enable-dirty-schedulers" if build.with? "dirty-schedulers"
+    args << "--enable-wx" if build.with? "wxmac"
+    args << "--with-dynamic-trace=dtrace" if MacOS::CLT.installed?
+
+    if build.without? "hipe"
+      # HIPE doesn't strike me as that reliable on macOS
+      # https://syntatic.wordpress.com/2008/06/12/macports-erlang-bus-error-due-to-mac-os-x-1053-update/
+      # https://www.erlang.org/pipermail/erlang-patches/2008-September/000293.html
+      args << "--disable-hipe"
+    else
+      args << "--enable-hipe"
+    end
+
+    if build.with? "java"
+      args << "--with-javac"
+    else
+      args << "--without-javac"
+    end
+
+    system "./configure", *args
+    system "make"
+    system "make", "install"
+
+    if build.with? "docs"
+      (lib/"erlang").install resource("man").files("man")
+      doc.install resource("html")
+    end
+  end
+
+  def caveats; <<~EOS
+    Man pages can be found in:
+      #{opt_lib}/erlang/man
+    Access them with `erl -man`, or add this directory to MANPATH.
+    EOS
+  end
+
+  test do
+    system "#{bin}/erl", "-noshell", "-eval", "crypto:start().", "-s", "init", "stop"
+  end
+end


### PR DESCRIPTION
This PR should avoid updating erlang without intending to do so. With homebrew we can only install erlang by choosing the major version, like: `brew install erlang@20`. So as a workaround we have copied the formula as part of our repository and install it only using the formula from the repository.

The installed erlang version is 20.2.3.

The `ci` script has *not* been tested, as I don't know how to execute it. But when I do get it right, it is only used on Travis and will be removed anytime soon.