### PR TITLE
Update idna lib in rebar.lock considering rebar.config

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -43,7 +43,7 @@
   1},
  {<<"idna">>,
   {git,"https://github.com/aeternity/erlang-idna",
-       {ref,"b452d8fe4c15be8146f5ca15d4f0c08720a98be4"}},
+       {ref,"24bf647c9b63f4521351896398edecf56f4843a8"}},
   0},
  {<<"jesse">>,
   {git,"https://github.com/for-GET/jesse.git",


### PR DESCRIPTION
It means that before this commit ["fix app.src"](https://github.com/aeternity/erlang-idna/commit/24bf647c9b63f4521351896398edecf56f4843a8) was missing.