### PR TITLE
Address one Dialyzer warning re language with option `unknown`

### DIFF
--- a/apps/aering/src/aer_syntax.erl
+++ b/apps/aering/src/aer_syntax.erl
@@ -12,6 +12,7 @@
 
 -export_type([ann_line/0, ann_origin/0, ann_format/0, ann/0]).
 -export_type([name/0, id/0, con/0, tvar/0, op/0]).
+-export_type([bin_op/0, un_op/0]).
 -export_type([decl/0, letbind/0, typedef/0]).
 -export_type([arg/0, field_t/0, constructor_t/0]).
 -export_type([type/0, constant/0, expr/0, field/1, stmt/0, alt/0, lvalue/0, pat/0]).


### PR DESCRIPTION
In scope for https://www.pivotaltracker.com/story/show/155400295

----

TODO:
* [ ] `aevm_eeevm_env:get_block_hash/3` - not fixed yet, probably in following PR;
* [x] Other warning is fixed in other PR https://github.com/aeternity/epoch/pull/782/files#diff-c8994b5d88e8ba4eedfb4593900450f3R84