### PR TITLE
Check locked deps on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,6 +162,7 @@ jobs:
             - _build/default/rebar3_20.2.2_plt
       - run: make dialyzer
       - run: make swagger-check
+      - run: make rebar-lock-check
 
   linux_package:
     <<: *container_config

--- a/Makefile
+++ b/Makefile
@@ -184,6 +184,11 @@ swagger-check:
 $(SWAGGER_CODEGEN_CLI):
 	curl -fsS --create-dirs -o $@ http://central.maven.org/maven2/io/swagger/swagger-codegen-cli/$(SWAGGER_CODEGEN_CLI_V)/swagger-codegen-cli-$(SWAGGER_CODEGEN_CLI_V).jar
 
+rebar-lock-check:
+	./scripts/rebar_lock_check \
+		"$(CURDIR)/rebar3" \
+		"$(CURDIR)"
+
 kill:
 	@echo "Kill all beam processes only from this directory tree"
 	$(shell pkill -9 -f ".*/beam.*-boot `pwd`" || true)
@@ -251,4 +256,5 @@ internal-clean: $$(KIND)
 	test aevm-test-deps\
 	kill killall \
 	clean distclean \
-	swagger swagger-docs swagger-check
+	swagger swagger-docs swagger-check \
+	rebar-lock-check

--- a/rebar.config
+++ b/rebar.config
@@ -39,7 +39,7 @@
         {base58, {git, "https://github.com/aeternity/erl-base58.git", {ref,"7f6e917"}}},
         {eper, ".*", {git, "git://github.com/massemanet/eper.git", {tag, "0.97.6"}}},
         {erlexec, ".*", {git, "https://github.com/saleyn/erlexec.git", {ref, "97a5188"}}},
-        {sha3, {git, "https://github.com/szktty/erlang-sha3"}},
+        {sha3, {git, "https://github.com/szktty/erlang-sha3", {ref, "dbdfd12"}}},
         {sext, {git, "https://github.com/uwiger/sext.git", {ref, "615eebc"}}},
         {idna, {git, "https://github.com/aeternity/erlang-idna", {ref, "24bf647"}}}
        ]}.

--- a/scripts/rebar_lock_check
+++ b/scripts/rebar_lock_check
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+## Check rebar.lock is up-to-date.
+##
+## Copies `rebar.lock` file to temporary directory, then attempts to
+## re-generate it, checks it is the same, finally deletes the
+## temporary directory.
+##
+## The re-generation of the `rebar-lock` file is attempted by:
+## * First running `rebar3 unlock` - so to delete the old lock file;
+## * Then running `rebar3 upgrade` - so to generate a lock file
+##   attempting to minimize contamination by already-fetched
+##   dependencies (e.g. transitive ones) - if any.
+##
+## On failure neither the `rebar.lock` file nor the fetched
+## dependencies are restored.
+
+on_exit() {
+    rm -r "${TmpDir:?}"
+}
+
+set -e
+
+R="${1:?}" ## Absolute path of `rebar3` executable.
+D="${2:?}" ## Directory where `rebar.lock` file is present and from where `rebar3` command is meant to be executed.
+
+## Create temporary directory.  Ensure that on exit the temporary
+## directory is deleted.
+TmpDir="$(mktemp -d)"
+trap on_exit EXIT
+
+## Copy old `rebar.lock` file under version control to temporary
+## directory.
+LP="${D:?}"/rebar.lock ## Lock file path.
+OldLP="${TmpDir:?}"/rebar.lock.backup
+cp -p "${LP:?}" "${OldLP:?}"
+
+## Re-generate `rebar.lock` file.
+( cd "${D:?}" && "${R:?}" unlock && "${R:?}" upgrade; )
+
+## Check that re-generating `rebar.lock` led to same generated file.
+diff -u "${OldLP:?}" "${LP:?}"

--- a/swagger/check
+++ b/swagger/check
@@ -61,8 +61,8 @@ rm -r "${PC:?}"
 ## Re-generate files.
 make "${MT:?}"
 
-## Check that re-generating JSON from YAML lead to same generated JSON.
+## Check that re-generating JSON from YAML led to same generated JSON.
 diff -u "${SJ:?}" "${TmpSJ:?}"
-## Check that re-generating code from YAML lead to same generated code.
+## Check that re-generating code from YAML led to same generated code.
 diff -ru -NB "${ES:?}" "${TmpES:?}"
 diff -ru -NB "${PC:?}" "${TmpPC:?}"


### PR DESCRIPTION
This is the simplest proposal for https://www.pivotaltracker.com/story/show/155326038
Proof that it works: please see [this CI run on branch containing the changes in this PR cherry-picked on tag v0.7.0](https://circleci.com/gh/lucafavatella/epoch/706).

I considered investigating whether it is meaningful/feasible/cheap to rather add a `--dry-run` option to `rebar3 upgrade`, though I ran out of time today so I suggest to review&merge this as it is. It solves the problem of rebar.lock potentially out-of-sync.