### PR TITLE
Pt 155517005 api header by hash

### DIFF
--- a/apps/aehttp/priv/swagger.json
+++ b/apps/aehttp/priv/swagger.json
@@ -73,6 +73,41 @@
         }
       }
     },
+    "/header-by-hash" : {
+      "get" : {
+        "tags" : [ "external" ],
+        "description" : "Get a header by hash",
+        "operationId" : "GetHeaderByHash",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "hash",
+          "in" : "query",
+          "description" : "Hash of the block header to fetch",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "The header found",
+            "schema" : {
+              "$ref" : "#/definitions/Header"
+            }
+          },
+          "400" : {
+            "description" : "Invalid hash",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Header not found",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
     "/block-by-height" : {
       "get" : {
         "tags" : [ "external" ],
@@ -2085,6 +2120,17 @@
         "pow" : {
           "$ref" : "#/definitions/Pow"
         }
+      },
+      "example" : {
+        "txs_hash" : null,
+        "state_hash" : null,
+        "prev_hash" : { },
+        "pow" : "",
+        "time" : 5,
+        "nonce" : 1,
+        "version" : 5,
+        "height" : 0,
+        "target" : 6
       }
     },
     "Block" : {

--- a/apps/aehttp/src/swagger/swagger_api.erl
+++ b/apps/aehttp/src/swagger/swagger_api.erl
@@ -50,6 +50,11 @@ request_params('GetCommitmentHash') ->
         'salt'
     ];
 
+request_params('GetHeaderByHash') ->
+    [
+        'hash'
+    ];
+
 request_params('GetInfo') ->
     [
     ];
@@ -420,6 +425,15 @@ request_param_info('GetCommitmentHash', 'salt') ->
         source => qs_val  ,
         rules => [
             {type, 'integer'},
+            required
+        ]
+    };
+
+request_param_info('GetHeaderByHash', 'hash') ->
+    #{
+        source => qs_val  ,
+        rules => [
+            {type, 'binary'},
             required
         ]
     };
@@ -1213,6 +1227,13 @@ validate_response('GetBlockByHeight', 404, Body, ValidatorState) ->
 validate_response('GetCommitmentHash', 200, Body, ValidatorState) ->
     validate_response_body('NameCommitmentHash', 'NameCommitmentHash', Body, ValidatorState);
 validate_response('GetCommitmentHash', 400, Body, ValidatorState) ->
+    validate_response_body('Error', 'Error', Body, ValidatorState);
+
+validate_response('GetHeaderByHash', 200, Body, ValidatorState) ->
+    validate_response_body('Header', 'Header', Body, ValidatorState);
+validate_response('GetHeaderByHash', 400, Body, ValidatorState) ->
+    validate_response_body('Error', 'Error', Body, ValidatorState);
+validate_response('GetHeaderByHash', 404, Body, ValidatorState) ->
     validate_response_body('Error', 'Error', Body, ValidatorState);
 
 validate_response('GetInfo', 200, Body, ValidatorState) ->

--- a/apps/aehttp/src/swagger/swagger_external_handler.erl
+++ b/apps/aehttp/src/swagger/swagger_external_handler.erl
@@ -112,6 +112,14 @@ allowed_methods(
 allowed_methods(
     Req,
     State = #state{
+        operation_id = 'GetHeaderByHash'
+    }
+) ->
+    {[<<"GET">>], Req, State};
+
+allowed_methods(
+    Req,
+    State = #state{
         operation_id = 'GetInfo'
     }
 ) ->
@@ -306,6 +314,7 @@ allowed_methods(Req, State) ->
 
 
 
+
 is_authorized(Req, State) ->
     {true, Req, State}.
 
@@ -388,6 +397,16 @@ valid_content_headers(
     Req0,
     State = #state{
         operation_id = 'GetCommitmentHash'
+    }
+) ->
+    Headers = [],
+    {Result, Req} = validate_headers(Headers, Req0),
+    {Result, Req, State};
+
+valid_content_headers(
+    Req0,
+    State = #state{
+        operation_id = 'GetHeaderByHash'
     }
 ) ->
     Headers = [],

--- a/apps/aehttp/src/swagger/swagger_router.erl
+++ b/apps/aehttp/src/swagger/swagger_router.erl
@@ -90,6 +90,11 @@ get_operations() ->
             method => <<"GET">>,
             handler => 'swagger_external_handler'
         },
+        'GetHeaderByHash' => #{
+            path => "/v2/header-by-hash",
+            method => <<"GET">>,
+            handler => 'swagger_external_handler'
+        },
         'GetInfo' => #{
             path => "/v2/info",
             method => <<"GET">>,

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -485,6 +485,9 @@ block_by_hash(_Config) ->
             ct:log("ExpectedBlockMap ~p, BlockMap: ~p", [ExpectedBlockMap,
                                                          BlockMap]),
             BlockMap = ExpectedBlockMap,
+            {ok, 200, HeaderMap} = get_header_by_hash(Hash),
+            %% Equal upto transactions.
+            HeaderMap = maps:without([<<"transactions">>], ExpectedBlockMap),
             #{<<"height">> := Height} = BlockMap
         end,
         lists:seq(0, BlocksToCheck)), % from genesis
@@ -2768,6 +2771,10 @@ get_block_by_height(Height) ->
 get_block_by_hash(Hash) ->
     Host = external_address(),
     http_request(Host, get, "block-by-hash", [{hash, Hash}]).
+
+get_header_by_hash(Hash) ->
+    Host = external_address(),
+    http_request(Host, get, "header-by-hash", [{hash, Hash}]).
 
 get_transactions() ->
     Host = external_address(),

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -65,6 +65,34 @@ paths:
           schema:
             $ref: '#/definitions/Top'
       security:
+  /header-by-hash:
+    get:
+      tags:
+        - external
+      operationId: GetHeaderByHash
+      description: 'Get a header by hash'
+      produces:
+        - application/json
+      parameters:
+        - in: query
+          name: hash
+          description: 'Hash of the block header to fetch'
+          required: true
+          type : string
+      responses:
+        '200':
+          description: The header found
+          schema:
+            $ref: '#/definitions/Header'
+        '400':
+          description: Invalid hash
+          schema:
+            $ref: '#/definitions/Error'
+        '404':
+          description: Header not found
+          schema:
+            $ref: '#/definitions/Error'
+      security:
   /block-by-height:
     get:
       tags:

--- a/py/tests/swagger_client/api/external_api.py
+++ b/py/tests/swagger_client/api/external_api.py
@@ -710,6 +710,101 @@ class ExternalApi(object):
             _request_timeout=params.get('_request_timeout'),
             collection_formats=collection_formats)
 
+    def get_header_by_hash(self, hash, **kwargs):  # noqa: E501
+        """get_header_by_hash  # noqa: E501
+
+        Get a header by hash  # noqa: E501
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.get_header_by_hash(hash, async=True)
+        >>> result = thread.get()
+
+        :param async bool
+        :param str hash: Hash of the block header to fetch (required)
+        :return: Header
+                 If the method is called asynchronously,
+                 returns the request thread.
+        """
+        kwargs['_return_http_data_only'] = True
+        if kwargs.get('async'):
+            return self.get_header_by_hash_with_http_info(hash, **kwargs)  # noqa: E501
+        else:
+            (data) = self.get_header_by_hash_with_http_info(hash, **kwargs)  # noqa: E501
+            return data
+
+    def get_header_by_hash_with_http_info(self, hash, **kwargs):  # noqa: E501
+        """get_header_by_hash  # noqa: E501
+
+        Get a header by hash  # noqa: E501
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.get_header_by_hash_with_http_info(hash, async=True)
+        >>> result = thread.get()
+
+        :param async bool
+        :param str hash: Hash of the block header to fetch (required)
+        :return: Header
+                 If the method is called asynchronously,
+                 returns the request thread.
+        """
+
+        all_params = ['hash']  # noqa: E501
+        all_params.append('async')
+        all_params.append('_return_http_data_only')
+        all_params.append('_preload_content')
+        all_params.append('_request_timeout')
+
+        params = locals()
+        for key, val in six.iteritems(params['kwargs']):
+            if key not in all_params:
+                raise TypeError(
+                    "Got an unexpected keyword argument '%s'"
+                    " to method get_header_by_hash" % key
+                )
+            params[key] = val
+        del params['kwargs']
+        # verify the required parameter 'hash' is set
+        if ('hash' not in params or
+                params['hash'] is None):
+            raise ValueError("Missing the required parameter `hash` when calling `get_header_by_hash`")  # noqa: E501
+
+        collection_formats = {}
+
+        path_params = {}
+
+        query_params = []
+        if 'hash' in params:
+            query_params.append(('hash', params['hash']))  # noqa: E501
+
+        header_params = {}
+
+        form_params = []
+        local_var_files = {}
+
+        body_params = None
+        # HTTP header `Accept`
+        header_params['Accept'] = self.api_client.select_header_accept(
+            ['application/json'])  # noqa: E501
+
+        # Authentication setting
+        auth_settings = []  # noqa: E501
+
+        return self.api_client.call_api(
+            '/header-by-hash', 'GET',
+            path_params,
+            query_params,
+            header_params,
+            body=body_params,
+            post_params=form_params,
+            files=local_var_files,
+            response_type='Header',  # noqa: E501
+            auth_settings=auth_settings,
+            async=params.get('async'),
+            _return_http_data_only=params.get('_return_http_data_only'),
+            _preload_content=params.get('_preload_content', True),
+            _request_timeout=params.get('_request_timeout'),
+            collection_formats=collection_formats)
+
     def get_info(self, **kwargs):  # noqa: E501
         """get_info  # noqa: E501
 


### PR DESCRIPTION
Add an API to get the header instead of the block for a specific hash.

This is needed to build the chain backward when we synchronize with a node that is ahead of us.