### PR TITLE
HTTP Endpoint for getting transaction by tx_hash

### DIFF
--- a/apps/aecore/test/aec_tx_pool_tests.erl
+++ b/apps/aecore/test/aec_tx_pool_tests.erl
@@ -19,13 +19,18 @@ tx_pool_test_() ->
              %% Start `aec_keys` merely for generating realistic test
              %% signed txs - as a node would do.
              ets:new(?TAB, [public, ordered_set, named_table]),
+             meck:new(aec_db, [passthrough]),
+             meck:expect(aec_db, write_tx, 3, ok),
+             meck:expect(aec_db, delete_tx, 2, ok),
              TmpKeysDir
      end,
      fun(TmpKeysDir) ->
              ok = aec_test_utils:aec_keys_cleanup(TmpKeysDir),
              ok = application:stop(gproc),
              ets:delete(?TAB),
-             ok = aec_tx_pool:stop()
+             ok = aec_tx_pool:stop(),
+             meck:unload(aec_db),
+             ok
      end,
      [{"No txs in mempool",
        fun() ->

--- a/apps/aehttp/priv/swagger.json
+++ b/apps/aehttp/priv/swagger.json
@@ -233,7 +233,7 @@
     "/tx/{tx_hash}" : {
       "get" : {
         "tags" : [ "external" ],
-        "description" : "Post a new transaction",
+        "description" : "Get a transaction by hash",
         "operationId" : "GetTx",
         "produces" : [ "application/json" ],
         "parameters" : [ {

--- a/apps/aehttp/priv/swagger.json
+++ b/apps/aehttp/priv/swagger.json
@@ -230,6 +230,49 @@
         }
       }
     },
+    "/tx/{tx_hash}" : {
+      "get" : {
+        "tags" : [ "external" ],
+        "description" : "Post a new transaction",
+        "operationId" : "GetTx",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "tx_hash",
+          "in" : "path",
+          "description" : "Hash of the transaction to get",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "tx_encoding",
+          "in" : "query",
+          "description" : "Transaction encoding",
+          "required" : false,
+          "type" : "string",
+          "default" : "message_pack",
+          "enum" : [ "message_pack", "json" ]
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "The transaction found",
+            "schema" : {
+              "$ref" : "#/definitions/SingleTxObject"
+            }
+          },
+          "400" : {
+            "description" : "Invalid transaction",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Transaction not found",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
     "/tx/contract/create" : {
       "post" : {
         "tags" : [ "external" ],

--- a/apps/aehttp/src/aehttp_dispatch_ext.erl
+++ b/apps/aehttp/src/aehttp_dispatch_ext.erl
@@ -463,7 +463,7 @@ handle_request('EncodeCalldata', Req, _Context) ->
 
 handle_request('GetTx', Req, _Context) ->
     ParseFuns = [read_required_params([tx_hash]),
-                 read_optional_params([{tx_encoding, tx_encoding, <<"message_pack">>}]),
+                 read_optional_params([{tx_encoding, tx_encoding, message_pack}]),
                  parse_tx_encoding(tx_encoding),
                  base58_decode([{tx_hash, tx_hash, tx_hash}]),
                  get_transaction(tx_hash, tx),

--- a/apps/aehttp/src/aehttp_dispatch_ext.erl
+++ b/apps/aehttp/src/aehttp_dispatch_ext.erl
@@ -7,6 +7,7 @@
 -import(aeu_debug, [pp/1]).
 -import(aehttp_helpers, [ process_request/2
                         , read_required_params/1
+                        , read_optional_params/1
                         , parse_map_to_atom_keys/0
                         , base58_decode/1
                         , hexstrings_decode/1
@@ -18,9 +19,12 @@
                         , verify_oracle_query_existence/2
                         , verify_name/1
                         , ttl_decode/1
+                        , parse_tx_encoding/1
                         , compute_contract_call_data/0
                         , relative_ttl_decode/1
                         , unsigned_tx_response/1
+                        , get_transaction/2
+                        , encode_transaction/3
                         , ok_response/1
                         ]).
 
@@ -457,6 +461,20 @@ handle_request('EncodeCalldata', Req, _Context) ->
         _ -> {403, [], #{reason => <<"Bad request">>}}
     end;
 
+handle_request('GetTx', Req, _Context) ->
+    ParseFuns = [read_required_params([tx_hash]),
+                 read_optional_params([{tx_encoding, tx_encoding, <<"message_pack">>}]),
+                 parse_tx_encoding(tx_encoding),
+                 base58_decode([{tx_hash, tx_hash, tx_hash}]),
+                 get_transaction(tx_hash, tx),
+                 encode_transaction(tx, tx_encoding, encoded_tx),
+                 ok_response(
+                    fun(#{encoded_tx := #{tx := Tx, schema := Schema}}) ->
+                        #{transaction => Tx,
+                          data_schema => Schema}
+                    end)
+                ],
+    process_request(ParseFuns, Req);
 
 handle_request(OperationID, Req, Context) ->
     error_logger:error_msg(

--- a/apps/aehttp/src/aehttp_helpers.erl
+++ b/apps/aehttp/src/aehttp_helpers.erl
@@ -3,9 +3,11 @@
 -export([ process_request/2
         , parse_map_to_atom_keys/0
         , read_required_params/1
+        , read_optional_params/1
         , base58_decode/1
         , hexstrings_decode/1
         , ttl_decode/1
+        , parse_tx_encoding/1
         , relative_ttl_decode/1
         , nameservice_pointers_decode/1
         , get_nonce/1
@@ -15,6 +17,10 @@
         , verify_oracle_query_existence/2
         , verify_name/1
         , compute_contract_call_data/0
+        ]).
+
+-export([ get_transaction/2
+        , encode_transaction/3
         ]).
 
 -export([ ok_response/1
@@ -45,6 +51,20 @@ read_required_params(ParamNames) ->
                 undefined -> error;
                 Val -> {ok, Val}
             end
+        end,
+        "Not found").
+
+read_optional_params(Params) ->
+    params_read_fun(Params,
+        fun({Name, DefaultValue}, Req, _) ->
+            Val =
+                %% swagger puts an 'undefined' value for missing not reqired
+                %% params
+                case maps:get(Name, Req) of
+                    undefined -> DefaultValue;
+                    V -> V
+                end,
+            {ok, Val}
         end,
         "Not found").
 
@@ -288,3 +308,57 @@ compute_contract_call_data() ->
                 {error, {400, [], #{<<"reason">> => Reason}}}
         end
     end.
+
+get_transaction(TxKey, TxStateKey) ->
+    fun(_Req, State) ->
+        TxHash = maps:get(TxKey, State),
+        case aec_db:read_tx(TxHash) of
+            [] ->
+                {error, {404, [], #{<<"reason">> => <<"Transaction not found">>}}};
+            [{Block0, Tx}] ->
+                BlockHash =
+                    case Block0 of
+                        mempool -> mempool;
+                        BH when is_binary(BH) -> BH
+                    end,
+                {ok, maps:put(TxStateKey, #{tx => Tx,
+                                            tx_block_hash => BlockHash},
+                             State)}
+        end
+    end.
+
+parse_tx_encoding(TxEncodingKey) ->
+    fun(_Req, State) ->
+        TxEncoding =
+            case maps:get(TxEncodingKey, State) of
+                message_pack -> message_pack;
+                <<"message_pack">> -> message_pack;
+                json -> json;
+                <<"json">> -> json
+            end,
+        {ok, maps:put(TxEncodingKey, TxEncoding, State)}
+    end.
+    
+encode_transaction(TxKey, TxEncodingKey, EncodedTxKey) ->
+    fun(_Req, State) ->
+        #{tx := Tx,
+          tx_block_hash := BlockHash} = maps:get(TxKey, State),
+        TxEncoding = maps:get(TxEncodingKey, State),
+        DataSchema =
+            case TxEncoding of
+                json ->
+                    <<"SingleTxJSON">>;
+                message_pack ->
+                    <<"SingleTxMsgPack">>
+            end,
+        T =
+            case BlockHash of
+                mempool ->
+                    aetx_sign:serialize_for_client_pending(TxEncoding, Tx);
+                _ when is_binary(BlockHash) -> 
+                    H = aec_db:get_header(BlockHash),
+                    aetx_sign:serialize_for_client(TxEncoding, H, Tx)
+            end,
+        {ok, maps:put(EncodedTxKey, #{tx => T, schema => DataSchema}, State)}
+    end.
+

--- a/apps/aehttp/src/aehttp_helpers.erl
+++ b/apps/aehttp/src/aehttp_helpers.erl
@@ -329,14 +329,13 @@ get_transaction(TxKey, TxStateKey) ->
 
 parse_tx_encoding(TxEncodingKey) ->
     fun(_Req, State) ->
-        TxEncoding =
-            case maps:get(TxEncodingKey, State) of
-                message_pack -> message_pack;
-                <<"message_pack">> -> message_pack;
-                json -> json;
-                <<"json">> -> json
-            end,
-        {ok, maps:put(TxEncodingKey, TxEncoding, State)}
+        TxEncoding = maps:get(TxEncodingKey, State),
+        case lists:member(TxEncoding, [message_pack, json]) of
+            true ->
+                {ok, maps:put(TxEncodingKey, TxEncoding, State)};
+            false ->
+                {error, {400, [], #{reason => <<"Unsupported transaction encoding">>}}}
+        end
     end.
     
 encode_transaction(TxKey, TxEncodingKey, EncodedTxKey) ->

--- a/apps/aehttp/src/swagger/swagger_api.erl
+++ b/apps/aehttp/src/swagger/swagger_api.erl
@@ -68,6 +68,12 @@ request_params('GetTop') ->
     [
     ];
 
+request_params('GetTx') ->
+    [
+        'tx_hash',
+        'tx_encoding'
+    ];
+
 request_params('GetTxs') ->
     [
     ];
@@ -454,6 +460,25 @@ request_param_info('GetName', 'name') ->
         rules => [
             {type, 'binary'},
             required
+        ]
+    };
+
+request_param_info('GetTx', 'tx_hash') ->
+    #{
+        source =>  binding ,
+        rules => [
+            {type, 'binary'},
+            required
+        ]
+    };
+
+request_param_info('GetTx', 'tx_encoding') ->
+    #{
+        source => qs_val  ,
+        rules => [
+            {type, 'binary'},
+            {enum, ['message_pack', 'json'] },
+            not_required
         ]
     };
 
@@ -1278,6 +1303,13 @@ validate_response('GetName', 404, Body, ValidatorState) ->
 
 validate_response('GetTop', 200, Body, ValidatorState) ->
     validate_response_body('Top', 'Top', Body, ValidatorState);
+
+validate_response('GetTx', 200, Body, ValidatorState) ->
+    validate_response_body('SingleTxObject', 'SingleTxObject', Body, ValidatorState);
+validate_response('GetTx', 400, Body, ValidatorState) ->
+    validate_response_body('Error', 'Error', Body, ValidatorState);
+validate_response('GetTx', 404, Body, ValidatorState) ->
+    validate_response_body('Error', 'Error', Body, ValidatorState);
 
 validate_response('GetTxs', 200, Body, ValidatorState) ->
     validate_response_body('Transactions', 'Transactions', Body, ValidatorState);

--- a/apps/aehttp/src/swagger/swagger_external_handler.erl
+++ b/apps/aehttp/src/swagger/swagger_external_handler.erl
@@ -144,6 +144,14 @@ allowed_methods(
 allowed_methods(
     Req,
     State = #state{
+        operation_id = 'GetTx'
+    }
+) ->
+    {[<<"GET">>], Req, State};
+
+allowed_methods(
+    Req,
+    State = #state{
         operation_id = 'GetTxs'
     }
 ) ->
@@ -446,6 +454,16 @@ valid_content_headers(
     Req0,
     State = #state{
         operation_id = 'GetTop'
+    }
+) ->
+    Headers = [],
+    {Result, Req} = validate_headers(Headers, Req0),
+    {Result, Req, State};
+
+valid_content_headers(
+    Req0,
+    State = #state{
+        operation_id = 'GetTx'
     }
 ) ->
     Headers = [],

--- a/apps/aehttp/src/swagger/swagger_router.erl
+++ b/apps/aehttp/src/swagger/swagger_router.erl
@@ -110,6 +110,11 @@ get_operations() ->
             method => <<"GET">>,
             handler => 'swagger_external_handler'
         },
+        'GetTx' => #{
+            path => "/v2/tx/:tx_hash",
+            method => <<"GET">>,
+            handler => 'swagger_external_handler'
+        },
         'GetTxs' => #{
             path => "/v2/transactions",
             method => <<"GET">>,

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -195,6 +195,40 @@ paths:
           schema:
             $ref: '#/definitions/Error'
       security:
+  /tx/{tx_hash}:
+    get:
+      tags:
+        - external
+      operationId: GetTx
+      description: 'Post a new transaction'
+      produces:
+        - application/json
+      parameters:
+        - in: path 
+          name: tx_hash
+          description: Hash of the transaction to get
+          required: true
+          type: string
+        - in: query
+          name: tx_encoding
+          description: 'Transaction encoding'
+          type: string
+          enum: [message_pack, json]
+          default: message_pack
+      responses:
+        '200':
+          description: The transaction found
+          schema:
+            $ref: '#/definitions/SingleTxObject'
+        '400':
+          description: Invalid transaction
+          schema:
+            $ref: '#/definitions/Error'
+        '404':
+          description: Transaction not found
+          schema:
+            $ref: '#/definitions/Error'
+      security:
   /tx/contract/create:
     post:
       tags:

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -200,7 +200,7 @@ paths:
       tags:
         - external
       operationId: GetTx
-      description: 'Post a new transaction'
+      description: 'Get a transaction by hash'
       produces:
         - application/json
       parameters:

--- a/py/tests/swagger_client/api/external_api.py
+++ b/py/tests/swagger_client/api/external_api.py
@@ -1077,7 +1077,7 @@ class ExternalApi(object):
     def get_tx(self, tx_hash, **kwargs):  # noqa: E501
         """get_tx  # noqa: E501
 
-        Post a new transaction  # noqa: E501
+        Get a transaction by hash  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async=True
         >>> thread = api.get_tx(tx_hash, async=True)
@@ -1100,7 +1100,7 @@ class ExternalApi(object):
     def get_tx_with_http_info(self, tx_hash, **kwargs):  # noqa: E501
         """get_tx  # noqa: E501
 
-        Post a new transaction  # noqa: E501
+        Get a transaction by hash  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async=True
         >>> thread = api.get_tx_with_http_info(tx_hash, async=True)

--- a/py/tests/swagger_client/api/external_api.py
+++ b/py/tests/swagger_client/api/external_api.py
@@ -1074,6 +1074,105 @@ class ExternalApi(object):
             _request_timeout=params.get('_request_timeout'),
             collection_formats=collection_formats)
 
+    def get_tx(self, tx_hash, **kwargs):  # noqa: E501
+        """get_tx  # noqa: E501
+
+        Post a new transaction  # noqa: E501
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.get_tx(tx_hash, async=True)
+        >>> result = thread.get()
+
+        :param async bool
+        :param str tx_hash: Hash of the transaction to get (required)
+        :param str tx_encoding: Transaction encoding
+        :return: SingleTxObject
+                 If the method is called asynchronously,
+                 returns the request thread.
+        """
+        kwargs['_return_http_data_only'] = True
+        if kwargs.get('async'):
+            return self.get_tx_with_http_info(tx_hash, **kwargs)  # noqa: E501
+        else:
+            (data) = self.get_tx_with_http_info(tx_hash, **kwargs)  # noqa: E501
+            return data
+
+    def get_tx_with_http_info(self, tx_hash, **kwargs):  # noqa: E501
+        """get_tx  # noqa: E501
+
+        Post a new transaction  # noqa: E501
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.get_tx_with_http_info(tx_hash, async=True)
+        >>> result = thread.get()
+
+        :param async bool
+        :param str tx_hash: Hash of the transaction to get (required)
+        :param str tx_encoding: Transaction encoding
+        :return: SingleTxObject
+                 If the method is called asynchronously,
+                 returns the request thread.
+        """
+
+        all_params = ['tx_hash', 'tx_encoding']  # noqa: E501
+        all_params.append('async')
+        all_params.append('_return_http_data_only')
+        all_params.append('_preload_content')
+        all_params.append('_request_timeout')
+
+        params = locals()
+        for key, val in six.iteritems(params['kwargs']):
+            if key not in all_params:
+                raise TypeError(
+                    "Got an unexpected keyword argument '%s'"
+                    " to method get_tx" % key
+                )
+            params[key] = val
+        del params['kwargs']
+        # verify the required parameter 'tx_hash' is set
+        if ('tx_hash' not in params or
+                params['tx_hash'] is None):
+            raise ValueError("Missing the required parameter `tx_hash` when calling `get_tx`")  # noqa: E501
+
+        collection_formats = {}
+
+        path_params = {}
+        if 'tx_hash' in params:
+            path_params['tx_hash'] = params['tx_hash']  # noqa: E501
+
+        query_params = []
+        if 'tx_encoding' in params:
+            query_params.append(('tx_encoding', params['tx_encoding']))  # noqa: E501
+
+        header_params = {}
+
+        form_params = []
+        local_var_files = {}
+
+        body_params = None
+        # HTTP header `Accept`
+        header_params['Accept'] = self.api_client.select_header_accept(
+            ['application/json'])  # noqa: E501
+
+        # Authentication setting
+        auth_settings = []  # noqa: E501
+
+        return self.api_client.call_api(
+            '/tx/{tx_hash}', 'GET',
+            path_params,
+            query_params,
+            header_params,
+            body=body_params,
+            post_params=form_params,
+            files=local_var_files,
+            response_type='SingleTxObject',  # noqa: E501
+            auth_settings=auth_settings,
+            async=params.get('async'),
+            _return_http_data_only=params.get('_return_http_data_only'),
+            _preload_content=params.get('_preload_content', True),
+            _request_timeout=params.get('_request_timeout'),
+            collection_formats=collection_formats)
+
     def get_txs(self, **kwargs):  # noqa: E501
         """get_txs  # noqa: E501
 


### PR DESCRIPTION
[Pivotal story](https://www.pivotaltracker.com/story/show/154658289)
[Github issue](https://github.com/aeternity/protocol/issues/26) (already closed)

Get a transaction by its hash. Works both for transaction included in a block or pending ones. If the transaction is pending (not yet included in a block) its block height is -1 and block hash is "none".
CT log examples:

#### Transaction in block (16)
```
*** User 2018-02-27 14:40:43.109 ***
GET "http://127.0.0.1:3013/v2/tx/th$ujvJtee7SQXz3koe6rzLSgyBc8NESfSJ56Uyf8QKyYWLQptMq?tx_encoding=json"


Return code 200, Body "{\"data_schema\":\"SingleTxJSON\",\"transaction\":{\"block_hash\":\"bh$2VQRNNxqR1iUsU3WrMKFi7t1CrVFuNVtnAhb4J81eUzFjtiTwV\",\"block_height\":16,\"hash\":\"th$ujvJtee7SQXz3koe6rzLSgyBc8NESfSJ56Uyf8QKyYWLQptMq\",\"signatures\":[\"sg$24GJCUfrEpSTbcErnBfU3DBPxugTDJxAbPyVm9HZ37neDQ2BoDPayp77KUzEs1sv6WnCVWEa8bmVXG8F7J1QNSemfc1dh9QWfMcWu9H\"],\"tx\":{\"amount\":1,\"data_schema\":\"SpendTxJSON\",\"fee\":1,\"nonce\":9,\"recipient\":\"ak$2EDiLTme2T59G4LaFtE9BRhXjbc28Xz5QKR3NKzHvmAnxR8q8H\",\"sender\":\"ak$3hZVCRddNv2wiomdnkasYp4vnz2NkunVoZs8fpP2wDvjz8xef84dPBYhqnJpa9NU1PMZ7FBupb2YqMXA93EbpyrrfddniZ\",\"type\":\"aec_spend_tx\",\"vsn\":1}}}"
```

#### Transaction in mempool
Block height is `-1` and block hash is `none`
```
GET "http://127.0.0.1:3013/v2/tx/th$227PwRyDUWWVe85Zcf2irxxAupgLAeAA3ygnHoeEJResKiGRBA?tx_encoding=json"

Return code 200, Body "{\"data_schema\":\"SingleTxJSON\",\"transaction\":{\"block_hash\":\"none\",\"block_height\":-1,\"hash\":\"th$227PwRyDUWWVe85Zcf2irxxAupgLAeAA3ygnHoeEJResKiGRBA\",\"signatures\":[\"sg$24GJCVPdPmeRa3tusgkbjF2jGTeH6LHXU4cgYtPLsptCjGHmVKcmBJq1m3thS5YJmxUeC576ZFYtbs1CJUsgkxVrWW6cuj3i9hW5oyz\"],\"tx\":{\"amount\":2,\"data_schema\":\"SpendTxJSON\",\"fee\":1,\"nonce\":10,\"recipient\":\"ak$jtK2pvy2YeSTDeQtGVf5rZE3HcZ1v3hRnXdRhZfyaRdJNXtPk\",\"sender\":\"ak$3hZVCRddNv2wiomdnkasYp4vnz2NkunVoZs8fpP2wDvjz8xef84dPBYhqnJpa9NU1PMZ7FBupb2YqMXA93EbpyrrfddniZ\",\"type\":\"aec_spend_tx\",\"vsn\":1}}}"
```
Optional param is `tx_encoding` with values `message_pack` or `json` (`message_pack` is the default one)