### PR TITLE
Use merge pull/checkout for pull requests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ references:
         if [ -n "$CIRCLE_PULL_REQUEST" ]; then
           git fetch origin +refs/pull/${CIRCLE_PULL_REQUEST##*/}/merge
           git checkout -qf FETCH_HEAD
+          git rev-parse HEAD
         fi
 
   rebar_cache_key: &rebar_cache_key rebar-cache-{{ checksum "rebar.lock" }}-{{ checksum "rebar.config" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,15 @@ references:
         user: builder
     working_directory: ~/epoch
 
+  merge_checkout: &merge_checkout
+    run:
+      name: Checkout merged master
+      command: |
+        if [ -n "$CIRCLE_PR_NUMBER" ]; then
+          git fetch origin +refs/pull/${CIRCLE_PR_NUMBER}/merge
+          git checkout -qf FETCH_HEAD
+        fi
+
   rebar_cache_key: &rebar_cache_key rebar-cache-{{ checksum "rebar.lock" }}-{{ checksum "rebar.config" }}
   restore_rebar_cache: &restore_rebar_cache
     restore_cache:
@@ -97,6 +106,7 @@ jobs:
     <<: *container_config
     steps:
       - checkout
+      - *merge_checkout
       - *restore_rebar_cache
       - run:
           name: Build
@@ -117,6 +127,7 @@ jobs:
     <<: *container_config
     steps:
       - checkout
+      - *merge_checkout
       - *restore_rebar_cache
       - *restore_build_cache
       - run:
@@ -133,6 +144,7 @@ jobs:
     <<: *container_config
     steps:
       - checkout
+      - *merge_checkout
       - *restore_rebar_cache
       - *restore_build_cache
       - run:
@@ -145,6 +157,7 @@ jobs:
     <<: *container_config
     steps:
       - checkout
+      - *merge_checkout
       - *restore_rebar_cache
       - *restore_build_cache
       - run: ./rebar3 edoc
@@ -168,6 +181,7 @@ jobs:
     <<: *container_config
     steps:
       - checkout
+      - *merge_checkout
       - *set_package_path
       - *build_package
       - *test_package

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,8 +14,8 @@ references:
     run:
       name: Checkout merged master
       command: |
-        if [ -n "$CIRCLE_PR_NUMBER" ]; then
-          git fetch origin +refs/pull/${CIRCLE_PR_NUMBER}/merge
+        if [ -n "$CIRCLE_PULL_REQUEST" ]; then
+          git fetch origin +refs/pull/${CIRCLE_PULL_REQUEST##*/}/merge
           git checkout -qf FETCH_HEAD
         fi
 


### PR DESCRIPTION
Using the same behaviour as Travis - use merge checkout (GH feature) of each PR. See below comments for examples and details.

Examples:
- [branch only build](https://circleci.com/workflow-run/d3838a0a-2b48-4189-b47e-ca66e76e47ea) - merged master checkout should *not* kick in
- [PR build](https://circleci.com/workflow-run/2a51e7ea-b0aa-4f5f-8862-f16ab5dbc3ea) - merged master checkout should kick in

*EDIT*: updated builds URLs

[PT 155429174](https://www.pivotaltracker.com/story/show/155429174)