### PR TITLE
Improve CircleCI job dependancies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,5 @@
 version: 2
 
-
 references:
   container_config: &container_config
     setup_remote_docker:
@@ -308,7 +307,6 @@ workflows:
   build_test_deploy:
     jobs:
       - build:
-          requires: ~
           filters:
             branches:
               ignore:
@@ -316,6 +314,7 @@ workflows:
                 - env/dev2
             tags:
               only: /^v.*$/
+
       - deploy_api_docs:
           requires:
             - static_analysis
@@ -324,7 +323,6 @@ workflows:
               ignore: /.*/
             tags:
               only: /^v.*$/
-
 
       - test:
           requires:
@@ -365,10 +363,6 @@ workflows:
               only: /^v.*$/
 
       - osx_package:
-          requires:
-            - test
-            - eunit
-            - static_analysis
           filters:
             branches:
               only: master
@@ -409,6 +403,9 @@ workflows:
 
       - deploy_uat:
           requires:
+            - test
+            - eunit
+            - static_analysis
             - linux_package
             - hodl
           filters:
@@ -419,6 +416,9 @@ workflows:
 
       - github_release_linux:
           requires:
+            - test
+            - eunit
+            - static_analysis
             - linux_package
             - hodl
           filters:
@@ -429,6 +429,9 @@ workflows:
 
       - github_release_osx:
           requires:
+            - test
+            - eunit
+            - static_analysis
             - osx_package
             - hodl
           filters:


### PR DESCRIPTION
- make sure UAT and GitHub release are not deployed until all tests
success
- run OSX package in parallel to other build jobs

Examples:
- [master build](https://circleci.com/workflow-run/9a310c6e-40ab-4a67-a9b6-b2bed187acfa)
- [tag build](https://circleci.com/workflow-run/5cd281df-93e0-4c7b-963e-f3d8931672e0)


[PT 155030952](https://www.pivotaltracker.com/story/show/155030952)