### PR TITLE
Update dialyzer cache plt version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,7 +173,7 @@ jobs:
       - save_cache:
           key: dialyzer-cache-v2-{{ .Branch }}-{{ .Revision }}
           paths:
-            - _build/default/rebar3_20.2.2_plt
+            - _build/default/rebar3_20.2.3_plt
       - run: make dialyzer
       - run: make swagger-check
       - run: make rebar-lock-check


### PR DESCRIPTION
Unfortunately it seems CircleCI does not support wildcards in path.


https://www.pivotaltracker.com/story/show/155250917