### PR TITLE
Python transaction signing

### DIFF
--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -2324,22 +2324,22 @@ definitions:
     - data_schema
   SingleTxJSON:
     allOf:
-      - $ref: '#/definitions/SingleTxObject'
-      - type: object
-        properties:
-          transaction:
-            $ref: '#/definitions/SignedTxJSON'
-        required:
-        - transaction
+    - $ref: '#/definitions/SingleTxObject'
+    - type: object
+      properties:
+        transaction:
+          $ref: '#/definitions/SignedTxJSON'
+      required:
+      - transaction
   SingleTxMsgPack:
     allOf:
-      - $ref: '#/definitions/SingleTxObject'
-      - type: object
-        properties:
-          transaction:
-            $ref: '#/definitions/Tx'
-        required:
-        - transaction
+    - $ref: '#/definitions/SingleTxObject'
+    - type: object
+      properties:
+        transaction:
+          $ref: '#/definitions/Tx'
+      required:
+      - transaction
   SignedTxJSON:
     type: object
     properties:

--- a/py/requirements.txt
+++ b/py/requirements.txt
@@ -1,6 +1,7 @@
 base58==0.2.5
 certifi==2017.7.27.1
 chardet==3.0.4
+ecdsa==0.13
 idna==2.5
 msgpack==0.5.4
 nose==1.3.7

--- a/py/tests/integration/common.py
+++ b/py/tests/integration/common.py
@@ -124,6 +124,10 @@ def encode_signed_tx(encoded_tx, signatures):
     str = base58.b58encode_check(msgpack.packb(["sig_tx", 1, encoded_tx, signatures], use_bin_type=True))
     return "tx$" + str
 
+def encode_pubkey(pubkey):
+    str = base58.b58encode_check(pubkey)
+    return "ak$" + str
+
 def unpack_tx(tx):
     return msgpack.unpackb(tx)
 

--- a/py/tests/integration/keys.py
+++ b/py/tests/integration/keys.py
@@ -1,0 +1,37 @@
+import ecdsa
+from ecdsa import SigningKey, VerifyingKey
+from ecdsa.der import remove_sequence
+from hashlib import sha256
+
+import common
+
+def new_private():
+    return SigningKey.generate(curve=ecdsa.SECP256k1, hashfunc=sha256) 
+
+def private_from_bytearray(arr):
+    return SigningKey.from_string(arr, curve=ecdsa.SECP256k1, hashfunc=sha256) 
+
+def public_key(private_key):
+    return private_key.get_verifying_key()
+
+def public_from_bytearray(arr):
+    return VerifyingKey.from_string(arr, curve=ecdsa.SECP256k1, hashfunc=sha256) 
+
+def address(public_key):
+    arr = bytearray([0x04] + map(ord, list(public_key.to_string())))
+    return common.encode_pubkey(str(arr))
+
+def sign(message, private_key):
+    return private_key.sign(message, sigencode=ecdsa.util.sigencode_der)
+
+def sign_verify_encode_tx(msgpacked_tx, unpacked_tx, private_key, public_key):
+    signature = sign(msgpacked_tx, private_key)
+    assert verify(signature, msgpacked_tx, public_key)
+    signed_encoded = common.encode_signed_tx(unpacked_tx, [bytearray(signature)]) 
+    return signed_encoded
+
+def verify(signature, message, public_key):
+    return public_key.verify(signature, message, sigdecode=ecdsa.util.sigdecode_der)
+
+def to_string(key):
+    return str(map(ord, list(key.to_string())))

--- a/py/tests/integration/setup.yaml
+++ b/py/tests/integration/setup.yaml
@@ -104,7 +104,6 @@ tests: # test specific settings
         node: dev1
       blocks_to_mine: 3
       alice:
-        pubkey: ak$3Kfn4zPmFVHc6ZtSVRWYwouYTtEPvzN1c8mhvSLxjaDC2YnTPFR9eBSGhofzx8jwwFhrMqU2PkU4MAbpHYc8eMxzbdQnUV
         amount: 20
         fee: 1
       create_contract:
@@ -116,17 +115,14 @@ tests: # test specific settings
         gas_price: 1
         fee: 11
         call_data: "0x0000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000002a00000000000000000000000000000000000000000000000000000000000000046d61696e00000000000000000000000000000000000000000000000000000000"
-        signature: "48,69,2,32,71,171,200,76,208,92,100,158,72,126,90,164,254,28,6,0,104,57,73,83,197,251,95,119,16,166,100,225,59,247,252,43,2,33,0,129,128,218,245,11,37,127,197,165,232,78,217,210,130,25,44,123,161,122,123,241,133,245,47,245,221,214,219,52,107,197,116"
     test_contract_call:
       nodes:
         node: dev1
       blocks_to_mine: 7
       alice:
-        pubkey: ak$3Kfn4zPmFVHc6ZtSVRWYwouYTtEPvzN1c8mhvSLxjaDC2YnTPFR9eBSGhofzx8jwwFhrMqU2PkU4MAbpHYc8eMxzbdQnUV
         amount: 50
         fee: 1
       contract_call:
-        contract: ak$foHWQQpfLNhav7CahBuP6phCtdRvLNQngQuzNRvUi2Zxe1wEGALHRyXottSmLbxbiY1VjhX3QMoZfnk643hDptbKXre8bP 
         vm_version: 1
         fee: 1
         amount: 10
@@ -135,4 +131,14 @@ tests: # test specific settings
         data:
           function: main
           argument: "42"
-        signature: "48,69,2,33,0,207,85,190,252,133,96,24,144,99,155,120,250,12,237,145,186,24,90,103,20,207,171,85,145,78,100,178,255,239,20,184,220,2,32,17,255,106,140,202,211,39,221,71,99,126,119,112,123,105,100,42,230,7,227,245,114,130,207,11,176,219,33,26,242,212,175"
+    test_spend:
+      nodes:
+        node: dev1
+      blocks_to_mine: 7
+      alice:
+        amount: 50
+        fee: 1
+      spend_tx:
+        amount: 13
+        fee: 1
+        recipient: ak$3WkBeo6uZn


### PR DESCRIPTION
UAT test for unsigned transactions is updated to sign the transactions. There is a new utils module for the keys and signatures management.
The test now generates a new keys pair and corresponding public address for each test; using this address the miner populates it with some tokens (and creates the address on chain). Then the address is used to create an unsigned transaction, the key pair is used to sign it (and validate it); the produced signed transaction is posted to the node and included in a block.
Example output of a test run
```
$ make python-single-uat TEST_NAME=unsigned_tx
( cd py && TEST_NAME=unsigned_tx make single-uat; )
make[1]: Entering directory '/home/vlz/projects/aeternity/epoch/py'
nose.config: INFO: Ignoring files matching ['^\\.', '^_', '^setup\\.py$']
integration.test_unsigned_tx.test_contract_create ... 
Node dev1 starting
Alice's balance is now 20
Unsigned encoded transaction: tx$4njwjur6uPpN7oun48ZfKmjPXTS6igWhGH2A5caRedgVxWYyEqGKjn4CDAANMtHdNGbWpdcnsQUtDkKxCHnVL4M93bRFWKxCEGugXBtfFX42brBMttE8EyVqNGtkDk37Kg9oDfJYo25bNxL7KoMWsCA2JFrGPGzosNWoiLHuotLyiQGTzrymZAPf3ePq1BrG5XAjg1NcaPhfB2Q2eiXwtz4FQ5LyiEaa4i4m24AFYGEPDvmE2J8dix8T4CapPCqd5D11Rb1YtqdzWoRqGMTVkRsxyJwoc8YS3DVFkXeHFCbNsjxe1iLRG41jsQ55Sqhq7SWyS7ZJomfc8cmRgq7T4AdRmLFX7v3Pq41vdv973Wm1bCnUbR4yHMboeqEWKYWTNMrW7vveHmEc6gTP15WH1aSwSEtYsrPLqd1P7dm4sTuU9zCGuPtfeUgcnpy8MGf8hccLB6JGaK2Pz9K4A7aFNfKu7P8FMsCgRsuevHg5unUeKumNoLgj6YvHuqyZmSjgShgd6bjPFXdAg6s7hzdfbGQbvVmXHxHmLPybTgrqAS8eFFkxGSJrfviw4Ch1VbWbL28P4m2x2KDNfDzh1t8JkJ5UGXz2HfNTK1r
Contract address: C0DE5CDA1598A57D7AD06759B82DAF1EF93605BAFC53D122FACD50E0DE1951FDE
Unsigned decoded transaction: {'nonce': 1, 'code': '6`\x00\x807b\x00\x00!`\x00\x80\x80\x80Q\x80Q`\x04\x14b\x00\x000WP[P`\x01\x19Q\x00[`\x00R` `\x00\xf3[\x80\x90P\x90V[` \x01Q\x7fmain\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x14b\x00\x00aWb\x00\x00\x1aV[` \x01Q\x90P\x80\x91PPb\x00\x00*V', 'vm_version': 1, 'call_data': '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00*\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x04main\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00', 'gas': 1000, 'amount': 1, 'fee': 11, 'deposit': 1, 'owner': '\x04\x81X\xea\xd2~-\x1dQl\x9br\xf4=6\xb3a\xe3\xd4\xfa\xd9\xb9Y2\xdb\x8bVP\xbf\xb9\xb7,u\x7f?.B\xbd\xe2\x1f>A\x903[\xdfa0\x84\xb9\xcawl\x06\xce\x14\x18\x02\xbbB\xf7A\x15\x0b\x83', 'gas_price': 1, 'type': 'aect_create_tx', 'vsn': 1}
Signed transaction tx$28joyMuDixJbXf3r7AVCdVKXn2yp6kGYjs476aSwg1usm3XnJmN5mxGSE8EuKoPCQ6bfZXBcHbcZUgpjQR9S33R3sR1KmwrUGAgbUZMZVvwCvaRvpgrmAU8ZAycGsrZ8bQZBuZeGSh1euVvGxJTg9r7xDTf73te6rgB5GGxoGwLLLYZeX8b5jZf6H9ddMzzWEWxPEKeeJhCnpdZGchk5LbXzywbX1Ae64nciUfWnKc6TKJsWHKGGHhyJLe2RN3fBHCbWVhSXAGuQcBJQ3DT4CU6YxbKdjgqDM76bFvtCVwVb2ZJFn5eaiXqPPVYM32rRpAKCBj72AhdnXuX4mpE5P6KvCd6NVCSPt6AU8wMWXnQFC6xzFqS4rDsWifzwzJ4ETtRRHwEYBusNBfL3ARB6iEWXggaEh1hLRDSUCHyXbEjNDuPgFiEYqM1sb1JbG2BMUvv4Sb7iSNyXvvZcaw2bFw2GmzembPm4dAJ8UwtDPD5P7if3RqmeGBApKmToebHZzGv7QYKQM25GNskkAQ6AgyBmatAM8SQzmUbqP92yqN9huYbqPxt9ZFYMNiWZg6jCNUB5JV7p6MxHCTc77yDUzzEP2EbGepeHYxY27r1SkUnHzfvLNaj8VCkwQoHbtVW5eZZbAFSYTVwa4bnNYh7ih2mGWUpTbpDrtt8BvYXzcXWzeUyLQD1xs1sMT1oAZuf8pVuHbwPxnA2W7jNogdmtHJ
Fee was consumed, transaction is part of the chain
Node dev1 stopping
ok
integration.test_unsigned_tx.test_contract_call ... 
Node dev1 starting
Alice's balance is now 50
Unsigned encoded transaction: tx$24ffVCAXKA8UHntFhXb8fXCqCC6Nh1orB591rRKD8tAsLBphg3K91t5hxsRchYbeAD4ARWrh6Twx3uJmHJE4CBrFndg37KMMj12zdkJHuE7JtPu1s76AHD4dG7mBrBdFJ5koyZmxsvQkL1RrpenY4mzKS8NvKmr3LRfszNka9LSvQPXmsTDD5veNSFfzgxpdRnVpGxcz7EhSmyCKiQMAR4VqsHd57bFitkYDxoswBK6HtHm8dr4gtZHeXZX6eFZKige47vH55ek6CQQ4B6htGWR9xdXmNnyEmcP5w5i4CepPdMbVC3H1e1A9c2i1ot2pjwEtoJDrVwBx7hp8ppPbEURmnv9Mfy4r6cXgW7cBHmeiAC71hQAmDbbw87yLcCJ2tUF2MFuhcwU69haEr
Unsigned decoded transaction: {'nonce': 2, 'fee': 1, 'vm_version': 1, 'call_data': '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00*', 'caller': '\x04`\xd2O\xec9\xd1\xa6\x82\xfa\xee\xde$\x95T\xdd\t\xca\xb8\xd2\xa9\x05\x02\n\x8910vE\xa8B\x92\x8bc\x97\x7f5a\xa4\x1b\x16\xc1<o<[;\xadG\xd9A\x9cG\xd6\xa3\xce\x07R\xac\x1fq\xd6m\x07\x07', 'gas': 10, 'contract': 'C0DE4E0F463C584937034CD91D113C71B029E0BD6AE45AFDE95CD746BEA83A7FA', 'amount': 10, 'gas_price': 1, 'type': 'aect_call_tx', 'vsn': 1}
Signed transaction: tx$KZtJZM5bcRmQAnToHDixKXYmTCBjQT1Y1GRpBe8Qyj4GPm1Qh8mvc6UHJEP6Vb2av8i2ss7behN5SkWnB5PbrtqFmi18UF2PtzpddCsrsU6BerVYecdAD65cBwuajj8n7f799AmX4t7VtMxqNBC49o2D23aX3Uik51ZqaES3ogjMXmyhQ4FgSaw4wbsP4xBpEkQReQREb6dmrWaDMjrYoM47W4oQRyy7HGTZ1BdjGW6EzAh345DASP26uEvtH8C6gLUrqaR4LWaokWztWUdDuPFv9TDJbQaiuEBG5sMy18igdczbNa4AtaYe5jhwY1y6PeMbcAZrM6pDMahX11hYA8ACqH2CUZPenbCN9QbmSguRvC7pyehNm6wwuxL8GD436LzPCaYuuwacSPM67tt2wzK6V9JtRuxxqCDFtQsc5jFs4BbokHEb8HBfXZwuTCA6oboATXnKWc9TBQa7dtzKbJHmHWSMuKUm2ia22Hbv1oL4R1kEDZLXcLyTRY6EwaLJ6S6
Fee was consumed, transaction is part of the chain
Node dev1 stopping
ok
integration.test_unsigned_tx.test_spend ... 
Node dev1 starting
Alice's balance is now 50
Tx {'nonce': 1, 'amount': 13, 'fee': 1, 'sender': '\x04]g\xea\xdf\xab\xc9F\x147\x95\xaf\xeb\xe6\xea\xbe\x8d\xf2\x8fY\x82\xf8Mbm-L\xc9\xbe\x97n|\xd0\x05\x8d\xef\xe5\xbe\xef\xde\x99\x8a\xe28\xb1N\x8b\x9ay)\xe6\xe2)\xa5\x0b\xb7M\x01$8\x82\xaf\x8c9\xf1', 'type': 'aec_spend_tx', 'recipient': 'BOB', 'vsn': 1}
Signed transaction tx$9WYDUWgFvgWFMjmBJB9ZfLhf81Lz4Gc1MdCrmTPtV6B6RQAmeDvmHGy1pA8ijxD8XmygnP5PYKhd8RDkKvTDBFjk9LZYgPZDxtaTTsqAEGTHhamfQFBb8MmChoBoxenGHkDNNrTFXvGE48haBPP7pQWzLrStY2jpGisoby1L3jbHMvbwyFmUr7QVmg8dbd9wcQihHpEr84gUXjnMbkb4S2CGhTgtbn24CYPVzUcGM5H1rAKezV1pVUyejM7q9QaQBAj426wE5FY535UyHmYw6TAj6GatJREEGARYzFCcBAUYkHkCxMfaxxHpKMbTb13bqgUP
Tx hash th$2kZcvVKfkLJAPcJ7DSDmCasC9fu61eG6mgKzG2LwcDgnthGHAF
Alice balance now is 36
Bob balance now is 13
Balances are updated, transaction has been executed
Node dev1 stopping
ok

----------------------------------------------------------------------
XML: nosetests.xml
----------------------------------------------------------------------
Ran 3 tests in 34.713s

OK
```