### PR TITLE
Fix implicitly required field in Swagger's definitions

### DIFF
--- a/apps/aehttp/priv/swagger.json
+++ b/apps/aehttp/priv/swagger.json
@@ -2364,7 +2364,7 @@
     },
     "Ping" : {
       "type" : "object",
-      "required" : [ "best_hash", "difficulty", "genesis_hash", "source" ],
+      "required" : [ "best_hash", "difficulty", "genesis_hash", "share", "source" ],
       "properties" : {
         "source" : {
           "type" : "string"

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -1942,6 +1942,7 @@ definitions:
     - genesis_hash
     - best_hash
     - difficulty
+    - share
   Balance:
     type: object
     properties:

--- a/py/tests/swagger_client/models/ping.py
+++ b/py/tests/swagger_client/models/ping.py
@@ -65,8 +65,7 @@ class Ping(object):
         self.genesis_hash = genesis_hash
         self.best_hash = best_hash
         self.difficulty = difficulty
-        if share is not None:
-            self.share = share
+        self.share = share
         if peers is not None:
             self.peers = peers
 
@@ -180,6 +179,8 @@ class Ping(object):
         :param share: The share of this Ping.  # noqa: E501
         :type: int
         """
+        if share is None:
+            raise ValueError("Invalid value for `share`, must not be `None`")  # noqa: E501
         if share is not None and share > 32:  # noqa: E501
             raise ValueError("Invalid value for `share`, must be a value less than or equal to `32`")  # noqa: E501
 


### PR DESCRIPTION
[Pivotal story](https://www.pivotaltracker.com/story/show/155620439)
The `share` field was implictly required but this was not part of its swagger definition so we ended up with strange error responses when it was not around.

I've double checked and this is the only such field.