### PR TITLE
Python UAT: Alice sends tokens to bob.aet

### DIFF
--- a/py/tests/integration/common.py
+++ b/py/tests/integration/common.py
@@ -128,6 +128,10 @@ def encode_pubkey(pubkey):
     str = base58.b58encode_check(pubkey)
     return "ak$" + str
 
+def encode_name(name):
+    str = base58.b58encode_check(name)
+    return "nm$" + str
+
 def unpack_tx(tx):
     return msgpack.unpackb(tx)
 

--- a/py/tests/integration/keys.py
+++ b/py/tests/integration/keys.py
@@ -24,6 +24,12 @@ def address(public_key):
 def sign(message, private_key):
     return private_key.sign(message, sigencode=ecdsa.util.sigencode_der)
 
+def sign_encode_tx(msgpacked_tx, private_key):
+    unpacked_tx = common.unpack_tx(msgpacked_tx)
+    signature = sign(msgpacked_tx, private_key)
+    signed_encoded = common.encode_signed_tx(unpacked_tx, [bytearray(signature)]) 
+    return signed_encoded
+
 def sign_verify_encode_tx(msgpacked_tx, unpacked_tx, private_key, public_key):
     signature = sign(msgpacked_tx, private_key)
     assert verify(signature, msgpacked_tx, public_key)

--- a/py/tests/integration/setup.yaml
+++ b/py/tests/integration/setup.yaml
@@ -88,6 +88,19 @@ tests: # test specific settings
         alice_pubkey: ak$v6kQV2Z6uXv2PsUJdv955gE
         amount: 1000
         fee: 20
+    test_send_by_name:
+    # Bob registers a name 'bob.aet'
+    # Alice should be able to send tokens to Bob using that name
+      nodes:
+        miner: dev1
+      blocks_to_mine: 3
+      send_tokens:
+        alice: 10
+        bob: 10
+      name_register:
+        name: "bob.aet"
+      spend_tx:
+        amount: 7
   test_contracts:
     test_compile_id:
       nodes:

--- a/py/tests/integration/test_spend_tx.py
+++ b/py/tests/integration/test_spend_tx.py
@@ -202,7 +202,10 @@ def test_send_by_name():
     print("Alice balance is " + str(alice_balance2))
     print("Bob balance is " + str(bob_balance2))
 
+    # Alice's balance should be decresed by the amount being send and the fee (1)
     assert_equals(alice_balance2, alice_balance0 - tokens_to_send - 1)
+
+    # Bob's balance should be incresed by the amount being send
     assert_equals(bob_balance2, bob_balance1 + tokens_to_send)
 
     # stop node
@@ -257,10 +260,10 @@ def register_name(name, address, external_api, private_key):
     commitment = external_api.get_commitment_hash(name, salt).commitment
 
     # preclaim
-    unsinged_preclaim = common.base58_decode(\
+    unsigned_preclaim = common.base58_decode(\
         external_api.post_name_preclaim(\
             NamePreclaimTx(commitment=commitment, fee=1, account=address)).tx)
-    signed_preclaim = keys.sign_encode_tx(unsinged_preclaim, private_key)
+    signed_preclaim = keys.sign_encode_tx(unsigned_preclaim, private_key)
 
     external_api.post_tx(Tx(tx=signed_preclaim))
     top = external_api.get_top()
@@ -268,10 +271,10 @@ def register_name(name, address, external_api, private_key):
 
     # claim
     encoded_name = common.encode_name(name)
-    unsinged_claim = common.base58_decode(\
+    unsigned_claim = common.base58_decode(\
         external_api.post_name_claim(\
             NameClaimTx(name=encoded_name, name_salt=salt, fee=1, account=address)).tx)
-    signed_claim = keys.sign_encode_tx(unsinged_claim, private_key)
+    signed_claim = keys.sign_encode_tx(unsigned_claim, private_key)
 
     external_api.post_tx(Tx(tx=signed_claim))
     top = external_api.get_top()
@@ -281,11 +284,11 @@ def register_name(name, address, external_api, private_key):
 
     # set pointers
     pointers_str = json.dumps({'account_pubkey': address})
-    unsinged_update = common.base58_decode(\
+    unsigned_update = common.base58_decode(\
         external_api.post_name_update(\
             NameUpdateTx(name_hash=name_entry0.name_hash, name_ttl=600000, ttl=50,\
                 pointers=pointers_str, fee=1, account=address)).tx)
-    signed_update = keys.sign_encode_tx(unsinged_update, private_key)
+    signed_update = keys.sign_encode_tx(unsigned_update, private_key)
 
     external_api.post_tx(Tx(tx=signed_update))
     top = external_api.get_top()
@@ -299,10 +302,10 @@ def send_tokens_to_name(name, tokens, sender_address, private_key, external_api)
     resolved_address = json.loads(name_entry.pointers)['account_pubkey']
     print("Name " + name + " resolved to address " + resolved_address)
 
-    unsinged_spend = common.base58_decode(\
+    unsigned_spend = common.base58_decode(\
         external_api.post_spend(\
             SpendTx(sender=sender_address, recipient_pubkey=resolved_address, amount=tokens, fee=1)).tx)
-    signed_spend = keys.sign_encode_tx(unsinged_spend, private_key)
+    signed_spend = keys.sign_encode_tx(unsigned_spend, private_key)
 
     external_api.post_tx(Tx(tx=signed_spend))
     top = external_api.get_top()

--- a/py/tests/integration/test_spend_tx.py
+++ b/py/tests/integration/test_spend_tx.py
@@ -6,10 +6,17 @@ import shutil
 import time
 from nose.tools import assert_equals, assert_not_equals, with_setup
 import common
+import json
 from waiting import wait
 from swagger_client.models.ping import Ping 
+from swagger_client.models.tx import Tx
 from swagger_client.models.spend_tx import SpendTx
+from swagger_client.models.name_preclaim_tx import NamePreclaimTx
+from swagger_client.models.name_claim_tx import NameClaimTx
+from swagger_client.models.name_update_tx import NameUpdateTx
 from swagger_client.rest import ApiException
+
+import keys
 
 settings = common.test_settings(__name__.split(".")[-1])
 
@@ -143,6 +150,64 @@ def test_not_enough_tokens():
     common.stop_node(bob_node)
     shutil.rmtree(root_dir)
 
+def test_send_by_name():
+    # Bob registers a name 'bob.aet'
+    # Alice should be able to send tokens to Bob using that name
+    test_settings = settings["test_send_by_name"]
+    coinbase_reward = common.coinbase_reward() 
+    (root_dir, node, ext_api, top) = setup_node_with_tokens(test_settings, "miner") 
+    int_api = common.internal_api(node)
+
+    alice_private_key = keys.new_private()
+    alice_public_key = keys.public_key(alice_private_key)
+    alice_address = keys.address(alice_public_key)
+
+    bob_private_key = keys.new_private()
+    bob_public_key = keys.public_key(bob_private_key)
+    bob_address = keys.address(bob_public_key)
+
+    # initial balances - amounts that the miner should send them
+    alice_init_balance = test_settings["send_tokens"]["alice"]
+    bob_init_balance = test_settings["send_tokens"]["bob"]
+
+    # populate accounts with tokens
+    miner_send_tokens(alice_address, alice_init_balance, int_api, ext_api)
+    miner_send_tokens(bob_address, bob_init_balance, int_api, ext_api)
+
+    # validate balances
+    alice_balance0 = common.get_account_balance(int_api, pub_key=alice_address).balance
+    bob_balance0 = common.get_account_balance(int_api, pub_key=bob_address).balance
+
+    assert_equals(alice_balance0, alice_init_balance)
+    assert_equals(bob_balance0, bob_init_balance)
+    print("Alice balance is " + str(alice_balance0))
+    print("Bob balance is " + str(bob_balance0))
+    print("Bob address is " + bob_address)
+
+    bob_name = test_settings["name_register"]["name"]
+    register_name(bob_name, bob_address, ext_api, bob_private_key)
+
+    print("Bob has registered " + bob_name)
+    bob_balance1 = common.get_account_balance(int_api, pub_key=bob_address).balance
+    print("Bob balance is " + str(bob_balance1))
+
+    tokens_to_send = test_settings["spend_tx"]["amount"]
+    print("Alice is about to send " + str(tokens_to_send) + " to " + bob_name)
+    send_tokens_to_name(bob_name, tokens_to_send, alice_address, alice_private_key, ext_api)
+
+    # validate balances
+    alice_balance2 = common.get_account_balance(int_api, pub_key=alice_address).balance
+    bob_balance2 = common.get_account_balance(int_api, pub_key=bob_address).balance
+
+    print("Alice balance is " + str(alice_balance2))
+    print("Bob balance is " + str(bob_balance2))
+
+    assert_equals(alice_balance2, alice_balance0 - tokens_to_send - 1)
+    assert_equals(bob_balance2, bob_balance1 + tokens_to_send)
+
+    # stop node
+    common.stop_node(node)
+    shutil.rmtree(root_dir)
 
 def make_mining_config(root_dir, file_name):
     sys_config = os.path.join(root_dir, file_name)
@@ -175,4 +240,70 @@ def setup_node_with_tokens(test_settings, node_name):
 
     return (root_dir, node, api, top)
 
+def miner_send_tokens(address, amount, internal_api, external_api): 
+    spend_tx_obj = SpendTx(
+        recipient_pubkey=address,
+        amount=amount,
+        fee=1)
 
+    # populate account
+    internal_api.post_spend_tx(spend_tx_obj)
+
+    top = external_api.get_top()
+    common.wait_until_height(external_api, top.height + 3)
+
+def register_name(name, address, external_api, private_key):
+    salt = 42
+    commitment = external_api.get_commitment_hash(name, salt).commitment
+
+    # preclaim
+    unsinged_preclaim = common.base58_decode(\
+        external_api.post_name_preclaim(\
+            NamePreclaimTx(commitment=commitment, fee=1, account=address)).tx)
+    signed_preclaim = keys.sign_encode_tx(unsinged_preclaim, private_key)
+
+    external_api.post_tx(Tx(tx=signed_preclaim))
+    top = external_api.get_top()
+    common.wait_until_height(external_api, top.height + 3)
+
+    # claim
+    encoded_name = common.encode_name(name)
+    unsinged_claim = common.base58_decode(\
+        external_api.post_name_claim(\
+            NameClaimTx(name=encoded_name, name_salt=salt, fee=1, account=address)).tx)
+    signed_claim = keys.sign_encode_tx(unsinged_claim, private_key)
+
+    external_api.post_tx(Tx(tx=signed_claim))
+    top = external_api.get_top()
+    common.wait_until_height(external_api, top.height + 3)
+    name_entry0 = external_api.get_name(name)
+    print("Name " + name_entry0.name + " has been claimed and has hash " + name_entry0.name_hash)
+
+    # set pointers
+    pointers_str = json.dumps({'account_pubkey': address})
+    unsinged_update = common.base58_decode(\
+        external_api.post_name_update(\
+            NameUpdateTx(name_hash=name_entry0.name_hash, name_ttl=600000, ttl=50,\
+                pointers=pointers_str, fee=1, account=address)).tx)
+    signed_update = keys.sign_encode_tx(unsinged_update, private_key)
+
+    external_api.post_tx(Tx(tx=signed_update))
+    top = external_api.get_top()
+    common.wait_until_height(external_api, top.height + 3)
+    name_entry = external_api.get_name(name)
+    received_pointers = json.loads(name_entry.pointers)
+    assert_equals(address, received_pointers['account_pubkey'])
+
+def send_tokens_to_name(name, tokens, sender_address, private_key, external_api):
+    name_entry = external_api.get_name(name)
+    resolved_address = json.loads(name_entry.pointers)['account_pubkey']
+    print("Name " + name + " resolved to address " + resolved_address)
+
+    unsinged_spend = common.base58_decode(\
+        external_api.post_spend(\
+            SpendTx(sender=sender_address, recipient_pubkey=resolved_address, amount=tokens, fee=1)).tx)
+    signed_spend = keys.sign_encode_tx(unsinged_spend, private_key)
+
+    external_api.post_tx(Tx(tx=signed_spend))
+    top = external_api.get_top()
+    common.wait_until_height(external_api, top.height + 3)

--- a/py/tests/integration/test_unsigned_tx.py
+++ b/py/tests/integration/test_unsigned_tx.py
@@ -239,7 +239,7 @@ def send_tokens_to_user(user, test_settings, internal_api, external_api):
     spend_tx_obj = SpendTx(
         recipient_pubkey=test_settings[user]["pubkey"],
         amount=test_settings[user]["amount"],
-        fee=test_settings[user]["amount"])
+        fee=test_settings[user]["fee"])
 
     # populate Alice's account
     internal_api.post_spend_tx(spend_tx_obj)


### PR DESCRIPTION
[Pivotal story](https://www.pivotaltracker.com/story/show/154277512)
UAT test to verify that Bob can register a name, using this name Alice can resolve Bob's address and send tokens to that address.

Test steps:
1. Setup
1.1 Generate pub-priv pair and public address for Alice and Bob
1.2 Node is started, miner mines some blocks and sends tokens to Alice and Bob (so both of them have accounts in the chain and tokens to spend)
2. Bob registers the name `bob.aet`
2.1 Using a `salt` and the name, Bob prepares a `commitement_hash`.
2.2 Bob prepares a `aens_preclaim_tx`, signes it and posts it to the node. Waits a couple of blocks so it is included. Bob has a `name_hash`
2.3 Using the `salt` from 2.1 and the `name_hash` of 2.2, Bob prepares a `aens_claim_tx`, signes it and posts it to the node. Waits a couple of blocks so it is included. Bob now has registered the name but it still doesn't have any address related to it.
2.4 Bob prepares `aens_update_tx` in which he sets his address in the `pointers`, signes it and posts it to the node. Waits a couple of blocks so it is included.
2.5 Bob validates his name is in the nameservice
3. Alice sends to bob.aet
3.1 Alice resolves the name and gets Bob's address from the `pointers` attached to that name
3.2 Alice sends tokens to that address
4. Validation
4.1 Alice's balance is updated
4.1 Bob's balance is updated
