### PR TITLE
HTTP NS endpoint polish

### DIFF
--- a/apps/aehttp/priv/swagger.json
+++ b/apps/aehttp/priv/swagger.json
@@ -769,7 +769,7 @@
     "/commitment-hash" : {
       "get" : {
         "tags" : [ "external" ],
-        "description" : "Compute commitment hash for a given salt and name",
+        "description" : "Compute commitment hash for a given salt and name. Commitment hash must be computed client side. This endpoint is for verifying client's implementations.",
         "operationId" : "GetCommitmentHash",
         "produces" : [ "application/json" ],
         "parameters" : [ {

--- a/apps/aehttp/src/aehttp_dispatch_int.erl
+++ b/apps/aehttp/src/aehttp_dispatch_int.erl
@@ -31,7 +31,7 @@ handle_request('PostSpendTx', #{'SpendTx' := SpendTxObj}, _Context) ->
                     {404, [], #{reason => <<"Invalid key">>}}
             end;
         {error, account_not_found} ->
-            {404, [], #{reason => <<"No funds in an account">>}};
+            {404, [], #{reason => <<"Account not found">>}};
         {error, key_not_found} ->
             {404, [], #{reason => <<"Keys not configured">>}}
     end;
@@ -60,7 +60,7 @@ handle_request('PostOracleRegisterTx', #{'OracleRegisterTx' := OracleRegisterTxO
             {200, [], #{oracle_id => aec_base58c:encode(oracle_pubkey, Pubkey),
                         tx_hash => aec_base58c:encode(tx_hash, TxHash)}};
         {error, account_not_found} ->
-            {404, [], #{reason => <<"No funds in an account">>}};
+            {404, [], #{reason => <<"Account not found">>}};
         {error, key_not_found} ->
             {404, [], #{reason => <<"Keys not configured">>}}
     end;
@@ -83,7 +83,7 @@ handle_request('PostOracleExtendTx', #{'OracleExtendTx' := OracleExtendTxObj}, _
             {200, [], #{oracle_id => aec_base58c:encode(oracle_pubkey, Pubkey),
                         tx_hash => aec_base58c:encode(tx_hash, TxHash)}};
         {error, account_not_found} ->
-            {404, [], #{reason => <<"No funds in an account">>}};
+            {404, [], #{reason => <<"Account not found">>}};
         {error, key_not_found} ->
             {404, [], #{reason => <<"Keys not configured">>}}
     end;
@@ -122,7 +122,7 @@ handle_request('PostOracleQueryTx', #{'OracleQueryTx' := OracleQueryTxObj}, _Con
                     {404, [], #{reason => <<"Invalid key">>}}
             end;
         {error, account_not_found} ->
-            {404, [], #{reason => <<"No funds in an account">>}};
+            {404, [], #{reason => <<"Account not found">>}};
         {error, key_not_found} ->
             {404, [], #{reason => <<"Keys not configured">>}}
     end;
@@ -150,7 +150,7 @@ handle_request('PostOracleResponseTx', #{'OracleResponseTx' := OracleResponseTxO
                     {404, [], #{reason => <<"Invalid Query Id">>}}
             end;
         {error, account_not_found} ->
-            {404, [], #{reason => <<"No funds in an account">>}};
+            {404, [], #{reason => <<"Account not found">>}};
         {error, key_not_found} ->
             {404, [], #{reason => <<"Keys not configured">>}}
     end;
@@ -222,7 +222,7 @@ handle_request('PostNamePreclaimTx', #{'NamePreclaimTx' := NamePreclaimTxObj}, _
                     {400, [], #{reason => <<"Invalid commitment hash">>}}
             end;
         {error, account_not_found} ->
-            {404, [], #{reason => <<"No funds in an account">>}};
+            {404, [], #{reason => <<"Account not found">>}};
         {error, key_not_found} ->
             {400, [], #{reason => <<"Keys not configured">>}}
     end;
@@ -249,7 +249,7 @@ handle_request('PostNameClaimTx', #{'NameClaimTx' := NameClaimTxObj}, _Context) 
                     {400, [], #{reason => <<"Name validation failed with a reason: ", ReasonBin/binary>>}}
             end;
         {error, account_not_found} ->
-            {404, [], #{reason => <<"No funds in an account">>}};
+            {404, [], #{reason => <<"Account not found">>}};
         {error, key_not_found} ->
             {400, [], #{reason => <<"Keys not configured">>}}
     end;
@@ -279,7 +279,7 @@ handle_request('PostNameUpdateTx', #{'NameUpdateTx' := NameUpdateTxObj}, _Contex
                     {400, [], #{reason => <<"Invalid name hash">>}}
             end;
         {error, account_not_found} ->
-            {404, [], #{reason => <<"No funds in an account">>}};
+            {404, [], #{reason => <<"Account not found">>}};
         {error, key_not_found} ->
             {400, [], #{reason => <<"Keys not configured">>}}
     end;
@@ -310,7 +310,7 @@ handle_request('PostNameTransferTx', #{'NameTransferTx' := NameTransferTxObj}, _
                     {400, [], #{reason => <<"Invalid name hash">>}}
             end;
         {error, account_not_found} ->
-            {404, [], #{reason => <<"No funds in an account">>}};
+            {404, [], #{reason => <<"Account not found">>}};
         {error, key_not_found} ->
             {400, [], #{reason => <<"Keys not configured">>}}
     end;
@@ -334,7 +334,7 @@ handle_request('PostNameRevokeTx', #{'NameRevokeTx' := NameRevokeTxObj}, _Contex
                     {400, [], #{reason => <<"Invalid name hash">>}}
             end;
         {error, account_not_found} ->
-            {404, [], #{reason => <<"No funds in an account">>}};
+            {404, [], #{reason => <<"Account not found">>}};
         {error, key_not_found} ->
             {400, [], #{reason => <<"Keys not configured">>}}
     end;

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -2216,15 +2216,15 @@ naming_system_broken_txs(_Config) ->
         get_commitment_hash(<<"abcd.badregistrar">>, 123),
     {ok, 400, #{<<"reason">> := <<"Name validation failed with a reason: registrar_unknown">>}} =
         get_name(<<"abcd.badregistrar">>),
-    {ok, 404, #{<<"reason">> := <<"No funds in an account">>}} =
+    {ok, 404, #{<<"reason">> := <<"Account not found">>}} =
         post_name_preclaim_tx(CHash, Fee),
-    {ok, 404, #{<<"reason">> := <<"No funds in an account">>}} =
+    {ok, 404, #{<<"reason">> := <<"Account not found">>}} =
         post_name_claim_tx(Name, NameSalt, Fee),
-    {ok, 404, #{<<"reason">> := <<"No funds in an account">>}} =
+    {ok, 404, #{<<"reason">> := <<"Account not found">>}} =
         post_name_update_tx(NHash, 5, <<"pointers">>, 5, Fee),
-    {ok, 404, #{<<"reason">> := <<"No funds in an account">>}} =
+    {ok, 404, #{<<"reason">> := <<"Account not found">>}} =
         post_name_transfer_tx(NHash, random_hash(), Fee),
-    {ok, 404, #{<<"reason">> := <<"No funds in an account">>}} =
+    {ok, 404, #{<<"reason">> := <<"Account not found">>}} =
         post_name_revoke_tx(NHash, Fee),
 
     %% Check mempool still empty

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -616,7 +616,7 @@ paths:
       tags:
         - external
       operationId: GetCommitmentHash
-      description: 'Compute commitment hash for a given salt and name'
+      description: 'Compute commitment hash for a given salt and name. Commitment hash must be computed client side. This endpoint is for verifying client''s implementations.'
       produces:
         - application/json
       parameters:

--- a/py/tests/swagger_client/api/external_api.py
+++ b/py/tests/swagger_client/api/external_api.py
@@ -610,7 +610,7 @@ class ExternalApi(object):
     def get_commitment_hash(self, name, salt, **kwargs):  # noqa: E501
         """get_commitment_hash  # noqa: E501
 
-        Compute commitment hash for a given salt and name  # noqa: E501
+        Compute commitment hash for a given salt and name. Commitment hash must be computed client side. This endpoint is for verifying client's implementations.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async=True
         >>> thread = api.get_commitment_hash(name, salt, async=True)
@@ -633,7 +633,7 @@ class ExternalApi(object):
     def get_commitment_hash_with_http_info(self, name, salt, **kwargs):  # noqa: E501
         """get_commitment_hash  # noqa: E501
 
-        Compute commitment hash for a given salt and name  # noqa: E501
+        Compute commitment hash for a given salt and name. Commitment hash must be computed client side. This endpoint is for verifying client's implementations.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async=True
         >>> thread = api.get_commitment_hash_with_http_info(name, salt, async=True)


### PR DESCRIPTION
[Pivotal story](https://www.pivotaltracker.com/story/show/155705837)

* Updated commitement hash's swagger description not to be misleading that the endpoint should be used in real life scenarios

* As requested by AEpps team, updated response message on posting a tx when no account is present yet