### PR TITLE
PT-154885468:  Use cowboy to handle http api requests

### DIFF
--- a/apps/aehttp/src/aehttp_api_handler.erl
+++ b/apps/aehttp/src/aehttp_api_handler.erl
@@ -1,0 +1,50 @@
+-module(aehttp_api_handler).
+
+-export([allowed_methods/2]).
+-export([init/3]).
+-export([rest_init/2]).
+-export([content_types_accepted/2]).
+-export([content_types_provided/2]).
+-export([delete_resource/2]).
+-export([handle_request_json/2]).
+
+-record(state, {
+    operation_id :: atom(),
+    operation_params :: #{},
+    allowed_methods :: [binary()],
+    logic_handler :: atom()
+}).
+
+init(_Transport, Req, Opts) ->
+    {upgrade, protocol, cowboy_rest, Req, Opts}.
+
+rest_init(Req, {OperationId, AllowedMethods, LogicHandler, Params}) ->
+    State = #state{
+        operation_id = OperationId,
+        operation_params = Params,
+        allowed_methods = AllowedMethods,
+        logic_handler = LogicHandler
+    },
+    {ok, Req, State}.
+
+allowed_methods(Req, State = #state{ allowed_methods = Methods }) ->
+    {Methods, Req, State}.
+
+content_types_accepted(Req, State) ->
+    {[{<<"application/json">>, handle_request_json}], Req, State}.
+
+content_types_provided(Req, State) ->
+    {[{<<"application/json">>, handle_request_json}], Req, State}.
+
+delete_resource(Req, State) ->
+    handle_request_json(Req, State).
+
+handle_request_json(Req0, State = #state{
+        operation_id = OperationId,
+        operation_params = Params,
+        logic_handler = LogicHandler
+    }) ->
+    Context = #{},
+    {Code, Headers, Body} = LogicHandler:handle_request(OperationId, Params, Context),
+    {ok, Req} = cowboy_req:reply(Code, Headers, jsx:encode(Body), Req0),
+    {halt, Req, State}.

--- a/apps/aehttp/src/aehttp_api_middleware.erl
+++ b/apps/aehttp/src/aehttp_api_middleware.erl
@@ -1,0 +1,23 @@
+-module(aehttp_api_middleware).
+-behaviour(cowboy_middleware).
+
+-export([execute/2]).
+
+execute(Req0, Env0) ->
+    {Operations, LogicHandler, ValidatorState} = proplists:get_value(handler_opts, Env0),
+
+    {Method, Req} = cowboy_req:method(Req0),
+    case maps:get(Method, Operations, undefined) of
+        undefined -> {error, 405, Req};
+        OperationId ->
+            case swagger_api:populate_request(OperationId, Req, ValidatorState) of
+                {ok, Params, Req1} ->
+                    Env1 = proplists:delete(handler_opts, Env0),
+                    AllowedMethods = maps:keys(Operations),
+                    HandlerOpts = {OperationId, AllowedMethods, LogicHandler, Params},
+                    {ok, Req1, [{handler_opts, HandlerOpts} | Env1]};
+                {error, Reason, Req1} ->
+                    error_logger:error_msg("Unable to process params for ~p: ~p", [OperationId, Reason]),
+                    {error, 400, Req1}
+            end
+    end.

--- a/apps/aehttp/src/aehttp_app.erl
+++ b/apps/aehttp/src/aehttp_app.erl
@@ -29,8 +29,7 @@
 start(_StartType, _StartArgs) ->
     {ok, Pid} = aehttp_sup:start_link(),
     {ok, _} = ws_task_worker_sup:start_link(),
-    ok = start_swagger_external(),
-    ok = start_swagger_internal(),
+    ok = start_http_api(),
     ok = start_websocket_internal(),
     MaxWsHandlers = get_internal_websockets_acceptors(),
     ok = jobs:add_queue(ws_handlers_queue, [{standard_counter, MaxWsHandlers},
@@ -47,28 +46,27 @@ stop(_State) ->
 %%====================================================================
 %% Internal functions
 %%====================================================================
-start_swagger_external() ->
-    Port = get_external_port(),
-    ListenAddress = get_external_listen_address(),
-    Spec = swagger_server:child_spec(swagger_ext, #{
-                                       ip => ListenAddress,
-                                       port => Port,
-                                       net_opts => [],
-                                       logic_handler => aehttp_dispatch_ext
-                                      }),
-    {ok, _} = supervisor:start_child(aehttp_sup, Spec),
-    ok.
 
-start_swagger_internal() ->
-    Port = get_internal_port(),
-    ListenAddress = get_internal_listen_address(),
-    Spec = swagger_server:child_spec(swagger_int, #{
-                                       ip => ListenAddress,
-                                       port => Port,
-                                       net_opts => [],
-                                       logic_handler => aehttp_dispatch_int
-                                      }),
-    {ok, _} = supervisor:start_child(aehttp_sup, Spec),
+start_http_api() ->
+    ok = start_http_api(external, aehttp_dispatch_ext, swagger_external_handler),
+    ok = start_http_api(internal, aehttp_dispatch_int, swagger_internal_handler).
+
+start_http_api(Target, LogicHandler, SwaggerHandler) ->
+    PoolSize = get_http_api_acceptors(Target),
+    Port = get_http_api_port(Target),
+    ListenAddress = get_http_api_listen_address(Target),
+
+    [{'_', Paths0}] = swagger_router:get_paths(LogicHandler),
+    Paths = [{Path, aehttp_api_handler, Args}
+             || {Path, TmpSwaggerHandler, Args} <- Paths0,
+                TmpSwaggerHandler == SwaggerHandler
+            ],
+    Dispatch = cowboy_router:compile([{'_', Paths}]),
+
+    {ok, _} = cowboy:start_http(Target, PoolSize, [{port, Port}, {ip, ListenAddress}], [
+            {env, [ {dispatch, Dispatch} ]},
+            {middlewares, [cowboy_router, aehttp_api_middleware, cowboy_handler]}
+        ]),
     ok.
 
 start_websocket_internal() ->
@@ -90,19 +88,20 @@ get_and_parse_ip_address_from_config_or_env(CfgKey, App, EnvKey, Default) ->
     {ok, IpAddress} = inet:parse_address(binary_to_list(Config)),
     IpAddress.
 
-get_external_port() ->
+get_http_api_acceptors(_) -> ?INT_ACCEPTORS_POOLSIZE.
+
+get_http_api_port(external) ->
     aeu_env:user_config_or_env([<<"http">>, <<"external">>, <<"port">>],
-                               aehttp, swagger_port_external, ?DEFAULT_SWAGGER_EXTERNAL_PORT).
-
-get_external_listen_address() ->
-    get_and_parse_ip_address_from_config_or_env([<<"http">>, <<"external">>, <<"listen_address">>],
-                                                aehttp, [http, websocket, listen_address], ?DEFAULT_SWAGGER_EXTERNAL_LISTEN_ADDRESS).
-
-get_internal_port() ->
+                               aehttp, swagger_port_external, ?DEFAULT_SWAGGER_EXTERNAL_PORT);
+get_http_api_port(internal) ->
     aeu_env:user_config_or_env([<<"http">>, <<"internal">>, <<"port">>],
                                aehttp, [internal, swagger_port], ?DEFAULT_SWAGGER_INTERNAL_PORT).
 
-get_internal_listen_address() ->
+
+get_http_api_listen_address(external) ->
+    get_and_parse_ip_address_from_config_or_env([<<"http">>, <<"external">>, <<"listen_address">>],
+                                                aehttp, [http, websocket, listen_address], ?DEFAULT_SWAGGER_EXTERNAL_LISTEN_ADDRESS);
+get_http_api_listen_address(internal) ->
     get_and_parse_ip_address_from_config_or_env([<<"http">>, <<"internal">>, <<"listen_address">>],
                                                 aehttp, [http, websocket, listen_address], ?DEFAULT_SWAGGER_INTERNAL_LISTEN_ADDRESS).
 


### PR DESCRIPTION
General TODOs:
- use configuration for http acceptors pool 
- add tests for requests with wrong http method

Following steps (in order): 
1. use custom validation instead of swagger's one (reuse: https://github.com/aeternity/epoch/commit/f68db7625e9243c1d05456af6254750749279bf4)
2. validate `aehttp_dispatch_{ext,int}` response 
3. validate http client request (ref: https://github.com/aeternity/epoch/commit/f68db7625e9243c1d05456af6254750749279bf4)
4. ...
5. remove swagger generated code