### PR TITLE
Include mnesia_rocksdb version with fix for backup

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -25,7 +25,7 @@
 {deps, [{lager, ".*", {git, "https://github.com/aeternity/lager.git", {tag,"3.6.0.ae1"}}},
         {setup, "2.0.2"},
         {parse_trans, "3.1.0"},
-        {mnesia_rocksdb, ".*", {git, "https://github.com/aeternity/mnesia_rocksdb.git", {ref,"43b8612"}}},
+        {mnesia_rocksdb, ".*", {git, "https://github.com/aeternity/mnesia_rocksdb.git", {ref,"618870f"}}},
         {enacl, ".*", {git, "https://github.com/jlouis/enacl.git", {ref, "c8403ab"}}},
         {cowboy, "1.0.4", {git, "https://github.com/ninenines/cowboy.git", {tag, "1.0.4"}}},
         {jsx, {git, "https://github.com/talentdeficit/jsx.git", {tag, "2.8.0"}}},

--- a/rebar.lock
+++ b/rebar.lock
@@ -64,7 +64,7 @@
   2},
  {<<"mnesia_rocksdb">>,
   {git,"https://github.com/aeternity/mnesia_rocksdb.git",
-       {ref,"43b861215ada40cbdaf8144a7fc8ffab78cb9684"}},
+       {ref,"618870f4844b1981eaaa61437b497aae3969a880"}},
   0},
  {<<"msgpack">>,{pkg,<<"msgpack">>,<<"0.7.0">>},0},
  {<<"parse_trans">>,{pkg,<<"parse_trans">>,<<"3.1.0">>},0},


### PR DESCRIPTION
Finishes https://www.pivotaltracker.com/story/show/155748313

TODO:
* [x] Get https://github.com/aeternity/mnesia_rocksdb/pull/5 merged first
* [x] Update rebar.config/lock to merged https://github.com/aeternity/mnesia_rocksdb/pull/5
* [x] Check that actually `mnesia:backup` works