### PR TITLE
 Push docker "epoch" image to DockerHub from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -376,6 +376,7 @@ workflows:
               ignore:
                 - env/dev1
                 - env/dev2
+                - master
 
       - deploy_api_docs:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -297,9 +297,9 @@ jobs:
           name: Build and push Docker image to DockerHub
           command: |
             ~/bin/docker login -u $DOCKER_USER -p $DOCKER_PASS
-            ~/bin/docker build -t ${DOCKERHUB_REPO:?}:${CIRCLE_TAG:?} .
-            ~/bin/docker tag ${DOCKERHUB_REPO:?}:latest ${DOCKERHUB_REPO:?}:${CIRCLE_TAG:?}
+            ~/bin/docker build -t ${DOCKERHUB_REPO:?}:${CIRCLE_TAG:?} -t ${DOCKERHUB_REPO:?}:latest .
             ~/bin/docker push ${DOCKERHUB_REPO:?}:${CIRCLE_TAG:?}
+            ~/bin/docker push ${DOCKERHUB_REPO:?}:latest
 
   docker_push_dev:
     <<: *container_config

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ references:
     working_directory: ~/epoch
     environment:
       DOCKER_CLIENT_VERSION: "17.09.0-ce"
+      DOCKERHUB_REPO: aetrnty/epoch
 
   setup_remote_docker: &setup_remote_docker
     setup_remote_docker:
@@ -24,12 +25,6 @@ references:
           https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_CLIENT_VERSION:?}.tgz
         tar -xz -C /tmp -f /tmp/docker-${DOCKER_CLIENT_VERSION:?}.tgz
         mkdir ~/bin && mv /tmp/docker/docker ~/bin
-
-  docker_build: &docker_build
-    run:
-      name: Build Docker image
-      command: |
-        ~/bin/docker build .
 
   merge_checkout: &merge_checkout
     run:
@@ -287,7 +282,50 @@ jobs:
       - checkout
       - *setup_remote_docker
       - *install_docker_client
-      - *docker_build
+      - run:
+          name: Build Docker image
+          command: |
+            ~/bin/docker build .
+
+  docker_push_tag:
+    <<: *container_config
+    steps:
+      - checkout
+      - *setup_remote_docker
+      - *install_docker_client
+      - run:
+          name: Build and push Docker image to DockerHub
+          command: |
+            ~/bin/docker login -u $DOCKER_USER -p $DOCKER_PASS
+            ~/bin/docker build -t ${DOCKERHUB_REPO:?}:${CIRCLE_TAG:?} .
+            ~/bin/docker tag ${DOCKERHUB_REPO:?}:latest ${DOCKERHUB_REPO:?}:${CIRCLE_TAG:?}
+            ~/bin/docker push ${DOCKERHUB_REPO:?}:dev
+
+  docker_push_dev:
+    <<: *container_config
+    steps:
+      - checkout
+      - *setup_remote_docker
+      - *install_docker_client
+      - run:
+          name: Build and push Docker image to DockerHub
+          command: |
+            ~/bin/docker login -u $DOCKER_USER -p $DOCKER_PASS
+            ~/bin/docker build -t ${DOCKERHUB_REPO:?}:dev .
+            ~/bin/docker push ${DOCKERHUB_REPO:?}:dev
+
+  docker_push_test:
+    <<: *container_config
+    steps:
+      - checkout
+      - *setup_remote_docker
+      - *install_docker_client
+      - run:
+          name: Build and push Docker image to DockerHub
+          command: |
+            ~/bin/docker login -u $DOCKER_USER -p $DOCKER_PASS
+            ~/bin/docker build -t ${DOCKERHUB_REPO:?}:test .
+            ~/bin/docker push ${DOCKERHUB_REPO:?}:test
 
   deploy_integration:
     <<: *container_config
@@ -476,6 +514,13 @@ workflows:
               ignore: /.*/
             tags:
               only: /^v.*$/
+
+      - docker_push_test:
+          filters:
+            branches:
+              ignore:
+                - env/dev1
+                - env/dev2
 
   nightly:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -314,19 +314,6 @@ jobs:
             ~/bin/docker build -t ${DOCKERHUB_REPO:?}:dev .
             ~/bin/docker push ${DOCKERHUB_REPO:?}:dev
 
-  docker_push_test:
-    <<: *container_config
-    steps:
-      - checkout
-      - *setup_remote_docker
-      - *install_docker_client
-      - run:
-          name: Build and push Docker image to DockerHub
-          command: |
-            ~/bin/docker login -u $DOCKER_USER -p $DOCKER_PASS
-            ~/bin/docker build -t ${DOCKERHUB_REPO:?}:test .
-            ~/bin/docker push ${DOCKERHUB_REPO:?}:test
-
   deploy_integration:
     <<: *container_config
     environment:
@@ -454,6 +441,15 @@ workflows:
             branches:
               only: master
 
+      - docker_push_dev:
+          requires:
+            - test
+            - eunit
+            - static_analysis
+          filters:
+            branches:
+              only: master
+
       - deploy_dev1:
           requires:
             - linux_package
@@ -515,12 +511,17 @@ workflows:
             tags:
               only: /^v.*$/
 
-      - docker_push_test:
+      - docker_push_tag:
+          requires:
+            - test
+            - eunit
+            - static_analysis
+            - hodl
           filters:
             branches:
-              ignore:
-                - env/dev1
-                - env/dev2
+              ignore: /.*/
+            tags:
+              only: /^v.*$/
 
   nightly:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -299,7 +299,7 @@ jobs:
             ~/bin/docker login -u $DOCKER_USER -p $DOCKER_PASS
             ~/bin/docker build -t ${DOCKERHUB_REPO:?}:${CIRCLE_TAG:?} .
             ~/bin/docker tag ${DOCKERHUB_REPO:?}:latest ${DOCKERHUB_REPO:?}:${CIRCLE_TAG:?}
-            ~/bin/docker push ${DOCKERHUB_REPO:?}:dev
+            ~/bin/docker push ${DOCKERHUB_REPO:?}:${CIRCLE_TAG:?}
 
   docker_push_dev:
     <<: *container_config


### PR DESCRIPTION
After this change we'll push docker images to DockerHub from CircleCI.
- on master build we push `aetrnty/epoch:dev`
- on tag build we push `aetrnty/epoch:latest` and `aetrnty/epoch:$TAG`
- each PR build is still building the docker image without push

[example build](https://circleci.com/workflow-run/0a266b5e-3985-46ea-946e-5b27b6d77a0e) that pushed the [`aetrnty/epoch:test`](https://hub.docker.com/r/aetrnty/epoch/tags/)

[PT 155366081](https://www.pivotaltracker.com/story/show/155366081)