### PR TITLE
Add miner reward in the coinbase transaction

### DIFF
--- a/apps/aecore/include/blocks.hrl
+++ b/apps/aecore/include/blocks.hrl
@@ -1,8 +1,8 @@
 -include("pow.hrl").
 
--define(PROTOCOL_VERSION, 7).
+-define(PROTOCOL_VERSION, 8).
 
--define(GENESIS_VERSION, 7).
+-define(GENESIS_VERSION, 8).
 -define(GENESIS_HEIGHT, 0).
 
 -define(BLOCK_HEADER_HASH_BYTES, 32).

--- a/apps/aecore/src/aec_coinbase_tx.erl
+++ b/apps/aecore/src/aec_coinbase_tx.erl
@@ -15,14 +15,16 @@
          signers/1,
          serialize/1,
          deserialize/1,
-         for_client/1]).
+         for_client/1,
+         reward/1]).
 
 -behavior(aetx).
 
 -include("common.hrl").
 
 -record(coinbase_tx, {account       = <<>> :: pubkey(),
-                      block_height  :: non_neg_integer()}).
+                      block_height  :: non_neg_integer(),
+                      reward        :: non_neg_integer()}).
 
 -opaque tx() :: #coinbase_tx{}.
 
@@ -31,6 +33,7 @@
 -spec new(map()) -> {ok, aetx:tx()}.
 new(#{account := AccountPubkey, block_height := Height}) ->
     {ok, aetx:new(?MODULE, #coinbase_tx{account = AccountPubkey,
+                                        reward = aec_governance:block_mine_reward(),
                                         block_height = Height })}.
 
 -spec fee(tx()) -> integer().
@@ -57,11 +60,10 @@ check(#coinbase_tx{account = AccountPubkey}, Trees, Height) ->
 %% Amount from all the fees of transactions included in the block
 %% is added to miner's account in aec_trees:apply_signed_txs/3.
 -spec process(tx(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()}.
-process(#coinbase_tx{account = AccountPubkey}, Trees0, Height) ->
+process(#coinbase_tx{account = AccountPubkey, reward = Reward}, Trees0, Height) ->
     AccountsTrees0 = aec_trees:accounts(Trees0),
     {value, Account0} = aec_accounts_trees:lookup(AccountPubkey, AccountsTrees0),
 
-    Reward = aec_governance:block_mine_reward(),
     {ok, Account} = aec_accounts:earn(Account0, Reward, Height),
 
     AccountsTrees = aec_accounts_trees:enter(Account, AccountsTrees0),
@@ -77,22 +79,29 @@ signers(#coinbase_tx{account = AccountPubkey}) -> [AccountPubkey].
 -define(CB_TX_VSN, 1).
 
 -spec serialize(tx()) -> [map()].
-serialize(#coinbase_tx{account = Account, block_height = Height}) ->
+serialize(#coinbase_tx{account = Account, block_height = Height, reward = Reward}) ->
     [#{<<"vsn">> => version()},
      #{<<"acct">> => Account},
-     #{<<"h">> => Height}].
+     #{<<"h">> => Height},
+     #{<<"r">> => Reward}].
 
 -spec deserialize([map()]) -> tx().
 deserialize([#{<<"vsn">>  := ?CB_TX_VSN},
              #{<<"acct">> := Account},
-             #{<<"h">> := Height}]) ->
-    #coinbase_tx{account = Account, block_height = Height}.
+             #{<<"h">> := Height},
+             #{<<"r">> := Reward}]) ->
+    #coinbase_tx{account = Account, block_height = Height, reward = Reward}.
 
-for_client(#coinbase_tx{account = Account, block_height = Height}) ->
+for_client(#coinbase_tx{account = Account, block_height = Height, reward = Reward}) ->
     #{<<"account">> => aec_base58c:encode(account_pubkey,Account),
       <<"data_schema">> => <<"CoinbaseTxJSON">>, % swagger schema name
       <<"block_height">> => Height,
+      <<"reward">> => Reward,
       <<"vsn">> => ?CB_TX_VSN}.
 
 version() ->
     ?CB_TX_VSN.
+
+reward(#coinbase_tx{reward = Reward}) ->
+    Reward.
+

--- a/apps/aecore/src/aec_coinbase_tx.erl
+++ b/apps/aecore/src/aec_coinbase_tx.erl
@@ -53,8 +53,14 @@ origin(#coinbase_tx{}) ->
 check(#coinbase_tx{block_height = CBHeight}, _Trees, Height)
     when CBHeight =/= Height ->
     {error, wrong_height};
-check(#coinbase_tx{account = AccountPubkey}, Trees, Height) ->
-    aec_trees:ensure_account_at_height(AccountPubkey, Trees, Height).
+check(#coinbase_tx{account = AccountPubkey, reward = Reward}, Trees, Height) ->
+    ExpectedReward = aec_governance:block_mine_reward(),
+    case Reward =:= ExpectedReward of
+        true ->
+            aec_trees:ensure_account_at_height(AccountPubkey, Trees, Height);
+        false ->
+            {error, wrong_reward}
+    end.
 
 %% Only aec_governance:block_mine_reward() is granted to miner's account here.
 %% Amount from all the fees of transactions included in the block

--- a/apps/aecore/test/aec_coinbase_tx_tests.erl
+++ b/apps/aecore/test/aec_coinbase_tx_tests.erl
@@ -52,13 +52,29 @@ coinbase_tx_existing_account_test_() ->
       fun({PubKey, Trees0}) ->
               {"Check coinbase trx with existing account, but with wrong block height",
                fun() ->
-                        Height = 9,
+                       Height = 9,
                        {ok, CoinbaseTx} = aec_coinbase_tx:new(#{account => PubKey,
                                                                 block_height => Height}),
                        ?assertEqual({error, wrong_height},
                                     aetx:check(CoinbaseTx, Trees0, Height - 1)),
                        ?assertEqual({error, wrong_height},
                                     aetx:check(CoinbaseTx, Trees0, Height + 1))
+               end}
+      end,
+      fun({PubKey, Trees0}) ->
+              {"Check coinbase trx with existing account, but with wrong reward",
+               fun() ->
+                       Reward = aec_governance:block_mine_reward(),
+                       Height = 42,
+                       %% no other way of setting a erronous reward
+                       CoinbaseTxBiggerReward = {aetx, aec_coinbase_tx,
+                                      {coinbase_tx, PubKey, Height, Reward + 1}},
+                       CoinbaseTxSmallerReward = {aetx, aec_coinbase_tx,
+                                      {coinbase_tx, PubKey, Height, Reward - 1}},
+                       ?assertEqual({error, wrong_reward},
+                                    aetx:check(CoinbaseTxBiggerReward, Trees0, Height)),
+                       ?assertEqual({error, wrong_reward},
+                                    aetx:check(CoinbaseTxSmallerReward, Trees0, Height))
                end}
       end,
       fun({PubKey, Trees0}) ->

--- a/apps/aecore/test/aec_coinbase_tx_tests.erl
+++ b/apps/aecore/test/aec_coinbase_tx_tests.erl
@@ -71,7 +71,11 @@ coinbase_tx_existing_account_test_() ->
                        AccountsTree = aec_trees:accounts(Trees),
                        {value, Account} = aec_accounts_trees:lookup(PubKey, AccountsTree),
                        ?assertEqual(PubKey, aec_accounts:pubkey(Account)),
-                       ?assertEqual(23 + 10, aec_accounts:balance(Account)), %% block reward = 10
+
+                       {_, CbTx} = aetx:specialize_type(CoinbaseTx),
+                       Reward = aec_coinbase_tx:reward(CbTx),
+                       ?assertEqual(Reward, aec_governance:block_mine_reward()),
+                       ?assertEqual(23 + Reward, aec_accounts:balance(Account)),
                        ?assertEqual(9, aec_accounts:height(Account))
                end}
       end

--- a/apps/aecore/test/aec_mining_tests.erl
+++ b/apps/aecore/test/aec_mining_tests.erl
@@ -15,13 +15,11 @@
 
 -define(TEST_MODULE, aec_mining).
 -define(LOWEST_TARGET_SCI, 16#01010000).
--define(TEST_PUB, <<4,94,128,206,55,62,168,73,150,204,73,
-                    91,104,62,51,55,157,144,3,185,127,129,
-                    152,105,238,172,232,250,124,52,57,83,
-                    214,253,227,65,225,150,54,203,2,77,179,
-                    110,238,243,104,31,88,220,217,49,139,
-                    215,140,228,209,85,119,11,221,117,185,
-                    126,17>>).
+-define(TEST_PUB, <<4,176,10,241,172,223,229,80,244,222,165,8,198,46,
+                    167,128,25,34,151,180,162,192,72,103,185,62,161,12,
+                    117,147,72,68,194,188,89,248,81,212,197,21,193,74,
+                    115,216,210,123,239,69,164,128,164,122,116,151,23,
+                    22,56,146,73,13,29,198,110,162,145>>).
 
 mine_block_test_() ->
     {foreach,
@@ -38,7 +36,7 @@ mine_block_test_() ->
                  % and will invalidate the nonce value below
                  % in order to find a proper nonce for your
                  %let_it_crash = generate_valid_test_data(TopBlock, 100000000000000),
-                 meck:expect(aec_pow, pick_nonce, 0, 5323613534633545025),
+                 meck:expect(aec_pow, pick_nonce, 0, 12829721440654966408),
 
                  {ok, BlockCandidate, Nonce} = ?TEST_MODULE:create_block_candidate(TopBlock, aec_trees:new(), []),
                  HeaderBin = aec_headers:serialize_for_hash(aec_blocks:to_header(BlockCandidate)),
@@ -167,13 +165,12 @@ setup() ->
     meck:new(aeu_time, [passthrough]),
     meck:expect(aeu_time, now_in_msecs, 0, 1519659148405),
     {ok, _} = aec_tx_pool:start_link(),
-    SignedTx = {signed_tx,{aetx, aec_coinbase_tx, {coinbase_tx, ?TEST_PUB, 1}},
-                         [<<48,70,2,33,0,247,96,99,204,37,44,253,86,102,
-                            233,172,140,93,187,16,5,16,48,200,208,94,8,
-                            23,59,135,39,126,108,43,152,66,171,2,33,0,
-                            197,245,135,154,3,78,30,207,216,164,203,102,
-                            212,186,232,187,66,202,202,64,203,0,171,2,
-                            109,11,237,130,23,161,104,8>>]},
+    SignedTx = {signed_tx,{aetx, aec_coinbase_tx, {coinbase_tx, ?TEST_PUB, 1, 10}},
+                         [<<48,69,2,33,0,151,160,64,156,110,97,161,160,237,140,
+                            18,232,182,37,68,99,200,144,40,65,103,163,173,53,90,
+                            247,6,157,166,84,220,124,2,32,80,201,195,212,6,205,
+                            220,250,64,226,125,99,147,224,227,56,197,82,7,211,9,
+                            129,211,75,78,174,188,130,254,42,200,229>>]},
     Trees =
     aec_test_utils:create_state_tree_with_account(aec_accounts:new(?TEST_PUB, 0, 0)),
     meck:expect(aec_trees, hash, 1, <<>>),

--- a/apps/aecore/test/aec_mining_tests.erl
+++ b/apps/aecore/test/aec_mining_tests.erl
@@ -36,7 +36,7 @@ mine_block_test_() ->
                  % and will invalidate the nonce value below
                  % in order to find a proper nonce for your
                  %let_it_crash = generate_valid_test_data(TopBlock, 100000000000000),
-                 meck:expect(aec_pow, pick_nonce, 0, 12829721440654966408),
+                 meck:expect(aec_pow, pick_nonce, 0, 11523412447127618300),
 
                  {ok, BlockCandidate, Nonce} = ?TEST_MODULE:create_block_candidate(TopBlock, aec_trees:new(), []),
                  HeaderBin = aec_headers:serialize_for_hash(aec_blocks:to_header(BlockCandidate)),

--- a/apps/aehttp/priv/swagger.json
+++ b/apps/aehttp/priv/swagger.json
@@ -3098,7 +3098,21 @@
       "allOf" : [ {
         "$ref" : "#/definitions/JSONTx"
       }, {
-        "type" : "object"
+        "type" : "object",
+        "required" : [ "account", "height", "reward" ],
+        "properties" : {
+          "account" : {
+            "$ref" : "#/definitions/EncodedHash"
+          },
+          "height" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "reward" : {
+            "type" : "integer",
+            "format" : "int64"
+          }
+        }
       } ]
     },
     "SpendTxJSON" : {

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -2373,9 +2373,18 @@ definitions:
       - $ref: '#/definitions/JSONTx'
       - type: object
         properties:
-          account: string
+          account:
+            $ref: '#/definitions/EncodedHash'
+          height:
+            type: integer
+            format: int64
+          reward:
+            type: integer
+            format: int64
         required:
         - account
+        - height
+        - reward
   SpendTxJSON:
     allOf:
       - $ref: '#/definitions/JSONTx'

--- a/deployment/ansible/deploy.yml
+++ b/deployment/ansible/deploy.yml
@@ -40,7 +40,7 @@
           port: 3013
       chain:
         persist: true
-        db_path: "./db36"
+        db_path: "./db37"
       keypair:
         dir: "keys"
         password: "{{ vault_keys_password|default('secret') }}"

--- a/docs/release-notes/RELEASE-NOTES-0.9.0.md
+++ b/docs/release-notes/RELEASE-NOTES-0.9.0.md
@@ -3,6 +3,7 @@
 [This release][this-release] is focused on TODOFILLMEIN.
 It:
 * Improves the stability of the testnet.
+* Eases verification of the coinbase transaction, by including the mining reward in it. This impacts both the consensus and the persisted DB;
 * Does this TODOFILLMEIN. This impacts consensus;
 * Does that TODOFILLMEIN. This impacts the persisted DB;
 * Does that TODOFILLMEIN.

--- a/py/tests/swagger_client/models/coinbase_tx_json.py
+++ b/py/tests/swagger_client/models/coinbase_tx_json.py
@@ -16,6 +16,7 @@ import re  # noqa: F401
 
 import six
 
+from swagger_client.models.encoded_hash import EncodedHash  # noqa: F401,E501
 from swagger_client.models.json_tx import JSONTx  # noqa: F401,E501
 
 
@@ -33,14 +34,97 @@ class CoinbaseTxJSON(object):
                             and the value is json key in definition.
     """
     swagger_types = {
+        'account': 'EncodedHash',
+        'height': 'int',
+        'reward': 'int'
     }
 
     attribute_map = {
+        'account': 'account',
+        'height': 'height',
+        'reward': 'reward'
     }
 
-    def __init__(self):  # noqa: E501
+    def __init__(self, account=None, height=None, reward=None):  # noqa: E501
         """CoinbaseTxJSON - a model defined in Swagger"""  # noqa: E501
+
+        self._account = None
+        self._height = None
+        self._reward = None
         self.discriminator = None
+
+        self.account = account
+        self.height = height
+        self.reward = reward
+
+    @property
+    def account(self):
+        """Gets the account of this CoinbaseTxJSON.  # noqa: E501
+
+
+        :return: The account of this CoinbaseTxJSON.  # noqa: E501
+        :rtype: EncodedHash
+        """
+        return self._account
+
+    @account.setter
+    def account(self, account):
+        """Sets the account of this CoinbaseTxJSON.
+
+
+        :param account: The account of this CoinbaseTxJSON.  # noqa: E501
+        :type: EncodedHash
+        """
+        if account is None:
+            raise ValueError("Invalid value for `account`, must not be `None`")  # noqa: E501
+
+        self._account = account
+
+    @property
+    def height(self):
+        """Gets the height of this CoinbaseTxJSON.  # noqa: E501
+
+
+        :return: The height of this CoinbaseTxJSON.  # noqa: E501
+        :rtype: int
+        """
+        return self._height
+
+    @height.setter
+    def height(self, height):
+        """Sets the height of this CoinbaseTxJSON.
+
+
+        :param height: The height of this CoinbaseTxJSON.  # noqa: E501
+        :type: int
+        """
+        if height is None:
+            raise ValueError("Invalid value for `height`, must not be `None`")  # noqa: E501
+
+        self._height = height
+
+    @property
+    def reward(self):
+        """Gets the reward of this CoinbaseTxJSON.  # noqa: E501
+
+
+        :return: The reward of this CoinbaseTxJSON.  # noqa: E501
+        :rtype: int
+        """
+        return self._reward
+
+    @reward.setter
+    def reward(self, reward):
+        """Sets the reward of this CoinbaseTxJSON.
+
+
+        :param reward: The reward of this CoinbaseTxJSON.  # noqa: E501
+        :type: int
+        """
+        if reward is None:
+            raise ValueError("Invalid value for `reward`, must not be `None`")  # noqa: E501
+
+        self._reward = reward
 
     def to_dict(self):
         """Returns the model properties as a dict"""


### PR DESCRIPTION
[Pivotal story](https://www.pivotaltracker.com/story/show/155740802)

Currently the knowledge for the amount of the miner reward in the coinbase transaction is present only in the code. This should be verifiable outside the node. Since this will be a subject to governance - it will change so we must provide a mechanism for getting the miner reward at a certain height.

This PR adds the reward as being part of the coinbase transaction itself.