### PR TITLE
Index height of headers to make lookup by height faster

### DIFF
--- a/apps/aecore/test/aec_chain_tests.erl
+++ b/apps/aecore/test/aec_chain_tests.erl
@@ -687,6 +687,7 @@ forking_test_() ->
      , {"Fork on shorter chain because of difficulty", fun fork_on_shorter/0}
      , {"Fork on last block", fun fork_on_last_block/0}
      , {"Fork and out of order", fun fork_out_of_order/0}
+     , {"Get by height in forks", fun fork_get_by_height/0}
      ]}.
 
 fork_on_genesis() ->
@@ -772,6 +773,23 @@ fork_out_of_order() ->
                  top_block_hash()),
     ok.
 
+
+fork_get_by_height() ->
+    CommonChain = gen_block_chain_with_state_by_target([?GENESIS_TARGET, 1, 1], 111),
+    EasyChain = blocks_only_chain(extend_chain_with_state(CommonChain, [2], 111)),
+    HardChain = blocks_only_chain(extend_chain_with_state(CommonChain, [1], 222)),
+
+    ok = write_blocks_to_chain(EasyChain),
+    ?assertEqual({ok, block_hash(lists:last(EasyChain))},
+                 aec_chain_state:get_hash_at_height(4)),
+
+    ok = write_blocks_to_chain(HardChain),
+    ?assertEqual({ok, block_hash(lists:last(HardChain))},
+                 aec_chain_state:get_hash_at_height(4)),
+
+    ?assertEqual(error, aec_chain_state:get_hash_at_height(5)),
+
+    ok.
 
 %%%===================================================================
 %%% Blocks time summary tests

--- a/deployment/ansible/deploy.yml
+++ b/deployment/ansible/deploy.yml
@@ -40,7 +40,7 @@
           port: 3013
       chain:
         persist: true
-        db_path: "./db37"
+        db_path: "./db38"
       keypair:
         dir: "keys"
         password: "{{ vault_keys_password|default('secret') }}"

--- a/docs/release-notes/RELEASE-NOTES-0.9.0.md
+++ b/docs/release-notes/RELEASE-NOTES-0.9.0.md
@@ -4,6 +4,7 @@
 It:
 * Improves the stability of the testnet.
 * Eases verification of the coinbase transaction, by including the mining reward in it. This impacts both the consensus and the persisted DB;
+* Makes lookup of blocks/headers by height faster by introducing an index in the DB. This impacts the persisted DB;
 * Does this TODOFILLMEIN. This impacts consensus;
 * Does that TODOFILLMEIN. This impacts the persisted DB;
 * Does that TODOFILLMEIN.


### PR DESCRIPTION
Remove the prev hash index to save one index.

The successor function now use the height index instead.

https://www.pivotaltracker.com/n/projects/2124891/stories/155893232