### PR TITLE
Add more flexibility to deploy playbook

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,8 +104,8 @@ references:
         command: |
           export PACKAGE=${PACKAGES_DIR:?}/epoch-$(cat VERSION)-ubuntu.tar.gz
           cd deployment/ansible
-          ansible-playbook -i inventory/openstack.yml --limit="epoch:&${DEPLOY_ENV:?}" \
-            --extra-vars "package=${PACKAGE:?} env=${DEPLOY_ENV:?}" \
+          ansible-playbook --limit="tag_role_epoch:&tag_env_${DEPLOY_ENV:?}" \
+            --extra-vars "package=${PACKAGE:?} hosts_group=tag_env_${DEPLOY_ENV:?} env=${DEPLOY_ENV:?}" \
             deploy.yml
 
   upload_github_release_asset: &upload_github_release_asset

--- a/deployment/ansible/ansible.cfg
+++ b/deployment/ansible/ansible.cfg
@@ -1,7 +1,7 @@
 [defaults]
 callback_whitelist = profile_tasks
 host_key_checking = False
-inventory = inventory/openstack.yml
+inventory = inventory/
 timeout = 30
 vault_password_file = vault-env
 

--- a/deployment/ansible/deploy.yml
+++ b/deployment/ansible/deploy.yml
@@ -3,8 +3,8 @@
 # This is required to allow deploying on fraction of group hosts
 # For example rolling updates and deploying only to single hosts of a group
 #
-# For example below command will deploy only to ae-dev2-epoch-n0 host in dev2 group
-# ansible-playbook --limit="ae-dev2-epoch-n0" --extra-vars "env=dev2" deploy.yml
+# For example below command will deploy only to ae-dev2-epoch-n0 host in tag_env_dev2 group
+# ansible-playbook --limit="ae-dev2-epoch-n0" --extra-vars "hosts_group=tag_env_dev2" deploy.yml
 
 - name: Facts setup
   hosts: all
@@ -12,12 +12,12 @@
   # Executor facts will be gathered anyway in the task below
   gather_facts: no
   tasks:
-    - name: Gather facts from all hosts in {{ env }} group
+    - name: Gather facts from all hosts in {{ hosts_group }} group
       setup:
       run_once: yes
       delegate_to: "{{ item }}"
       delegate_facts: yes
-      with_items: "{{ groups[env] }}"
+      with_items: "{{ groups[hosts_group] }}"
 
 - name: Deploy epoch package
   hosts: all
@@ -32,7 +32,10 @@
     genesis_accounts_path: "{{ project_root }}/data/aecore/.genesis/accounts.json"
     is_remote_package: false
 
+    # Label used for datadog tagging and ENV file planting
     env: unknown
+    # Group of the hosts used to configure node peers
+    hosts_group: unknown
     config:
       http:
         external:

--- a/deployment/ansible/templates/epoch.yaml.j2
+++ b/deployment/ansible/templates/epoch.yaml.j2
@@ -1,6 +1,6 @@
 ---
 peers:
-    {% for host in groups[env] | difference([inventory_hostname]) %}
+    {% for host in groups[hosts_group] | difference([inventory_hostname]) %}
 - "http://{{ hostvars[host]['ansible_default_ipv4']['address'] }}:3013/"
     {% endfor %}
 


### PR DESCRIPTION
Add additional hosts_group variable so that "env" var can be used only
as label.

Depends on https://github.com/aeternity/infrastructure/pull/27

in context of [PT 155784885](https://www.pivotaltracker.com/story/show/155784885)