### PR TITLE
Pt 155428313 optimize retrieving blocks

### DIFF
--- a/apps/aecore/src/aec_headers.erl
+++ b/apps/aecore/src/aec_headers.erl
@@ -72,7 +72,7 @@ serialize_to_map(H = #header{}) ->
     {ok, Serialized}.
 
 
--spec deserialize_from_map(map()) -> {ok, header()}.
+-spec deserialize_from_map(map()) -> {ok, header()} | {error, deserialize}.
 deserialize_from_map(H = #{}) ->
       #{<<"height">> := Height,
         <<"prev_hash">> := PrevHash,

--- a/apps/aehttp/priv/swagger.json
+++ b/apps/aehttp/priv/swagger.json
@@ -132,6 +132,80 @@
         }
       }
     },
+    "/headers-by-hash" : {
+      "get" : {
+        "tags" : [ "external", "gossip" ],
+        "description" : "Get N headers from hash (down)",
+        "operationId" : "GetHeadersByHash",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "hash",
+          "in" : "query",
+          "description" : "Hash of first block header to fetch",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "number",
+          "in" : "query",
+          "description" : "Number of hashes to fetch",
+          "required" : false,
+          "type" : "integer",
+          "default" : 1
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "The headers found",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/definitions/Header"
+              }
+            }
+          },
+          "400" : {
+            "description" : "Invalid hash or number",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Header(s) not found",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/header-by-height" : {
+      "get" : {
+        "tags" : [ "external", "gossip" ],
+        "description" : "Get a header by its height in the chain",
+        "operationId" : "GetHeaderByHeight",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "height",
+          "in" : "query",
+          "description" : "Height of the header to fetch",
+          "required" : true,
+          "type" : "integer"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "The header found",
+            "schema" : {
+              "$ref" : "#/definitions/Header"
+            }
+          },
+          "400" : {
+            "description" : "Header not found",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
     "/block-by-height" : {
       "get" : {
         "tags" : [ "external", "gossip" ],

--- a/apps/aehttp/src/aehttp_dispatch_ext.erl
+++ b/apps/aehttp/src/aehttp_dispatch_ext.erl
@@ -65,7 +65,6 @@ handle_request('GetBlockByHeight', Req, _Context) ->
     end;
 
 handle_request('GetBlockByHash' = _Method, Req, _Context) ->
-    lager:debug("got ~p; Req = ~p", [_Method, pp(Req)]),
     case aec_base58c:safe_decode(block_hash, maps:get('hash', Req)) of
         {error, _} ->
             {400, [], #{reason => <<"Invalid hash">>}};
@@ -77,8 +76,7 @@ handle_request('GetBlockByHash' = _Method, Req, _Context) ->
                     %% is already encoded to a binary; that's why we use
                     %% aec_blocks:serialize_to_map/1
                     lager:debug("Block = ~p", [pp(Block)]),
-                    Resp =
-                        cleanup_genesis(aec_blocks:serialize_to_map(Block)),
+                    Resp = cleanup_genesis(aec_blocks:serialize_to_map(Block)),
                     lager:debug("Resp = ~p", [pp(Resp)]),
                     {200, [], Resp};
                 error ->
@@ -101,8 +99,41 @@ handle_request('GetHeaderByHash', Req, _Context) ->
                     lager:debug("Resp = ~p", [pp(Resp)]),
                     {200, [], Resp};
                 error ->
-                    {404, [], #{reason => <<"Block not found">>}}
+                    {404, [], #{reason => <<"Header not found">>}}
             end
+    end;
+
+handle_request('GetHeadersByHash', Req, _Context) ->
+    case {aec_base58c:safe_decode(block_hash, maps:get('hash', Req)),
+          maps:get('number', Req, 1)} of
+        {{error, _}, _} ->
+            {400, [], #{reason => <<"Invalid hash">>}};
+        {_, N} when not is_integer(N) orelse N < 1 ->
+            {400, [], #{reason => <<"Invalid number">>}};
+        {{ok, Hash}, N} ->
+            case aec_chain:get_n_headers_from_hash(Hash, N) of
+                {ok, Headers} ->
+                    Resp = [ begin
+                               {ok, HH} = aec_headers:serialize_to_map(Header),
+                               HH
+                             end || Header <- Headers ],
+                    lager:debug("Resp ~p headers = ~p", [N, pp(Resp)]),
+                    {200, [], Resp};
+                error ->
+                    {404, [], #{reason => <<"Header not found">>}}
+            end
+    end;
+
+handle_request('GetHeaderByHeight', Req, _Context) ->
+    Height = maps:get('height', Req),
+    case aec_chain:get_header_by_height(Height) of
+        {ok, Header} ->
+            {ok, HH} = aec_headers:serialize_to_map(Header),
+            Resp = cleanup_genesis(HH),
+            lager:debug("Resp = ~p", [pp(Resp)]),
+            {200, [], Resp};
+        {error, chain_too_short} ->
+            {400, [], #{reason => <<"Chain too short">>}}
     end;
 
 handle_request('GetTxs', _Req, _Context) ->

--- a/apps/aehttp/src/swagger/swagger_api.erl
+++ b/apps/aehttp/src/swagger/swagger_api.erl
@@ -268,6 +268,17 @@ request_params('GetHeaderByHash') ->
         'hash'
     ];
 
+request_params('GetHeaderByHeight') ->
+    [
+        'height'
+    ];
+
+request_params('GetHeadersByHash') ->
+    [
+        'hash',
+        'number'
+    ];
+
 request_params('GetInfo') ->
     [
     ];
@@ -389,6 +400,17 @@ request_params('GetBlockByHeight') ->
 request_params('GetHeaderByHash') ->
     [
         'hash'
+    ];
+
+request_params('GetHeaderByHeight') ->
+    [
+        'height'
+    ];
+
+request_params('GetHeadersByHash') ->
+    [
+        'hash',
+        'number'
     ];
 
 request_params('GetTop') ->
@@ -1337,6 +1359,33 @@ request_param_info('GetHeaderByHash', 'hash') ->
         ]
     };
 
+request_param_info('GetHeaderByHeight', 'height') ->
+    #{
+        source => qs_val  ,
+        rules => [
+            {type, 'integer'},
+            required
+        ]
+    };
+
+request_param_info('GetHeadersByHash', 'hash') ->
+    #{
+        source => qs_val  ,
+        rules => [
+            {type, 'binary'},
+            required
+        ]
+    };
+
+request_param_info('GetHeadersByHash', 'number') ->
+    #{
+        source => qs_val  ,
+        rules => [
+            {type, 'integer'},
+            not_required
+        ]
+    };
+
 request_param_info('GetName', 'name') ->
     #{
         source => qs_val  ,
@@ -1534,6 +1583,33 @@ request_param_info('GetHeaderByHash', 'hash') ->
         rules => [
             {type, 'binary'},
             required
+        ]
+    };
+
+request_param_info('GetHeaderByHeight', 'height') ->
+    #{
+        source => qs_val  ,
+        rules => [
+            {type, 'integer'},
+            required
+        ]
+    };
+
+request_param_info('GetHeadersByHash', 'hash') ->
+    #{
+        source => qs_val  ,
+        rules => [
+            {type, 'binary'},
+            required
+        ]
+    };
+
+request_param_info('GetHeadersByHash', 'number') ->
+    #{
+        source => qs_val  ,
+        rules => [
+            {type, 'integer'},
+            not_required
         ]
     };
 
@@ -2671,6 +2747,18 @@ validate_response('GetHeaderByHash', 400, Body, ValidatorState) ->
 validate_response('GetHeaderByHash', 404, Body, ValidatorState) ->
     validate_response_body('Error', 'Error', Body, ValidatorState);
 
+validate_response('GetHeaderByHeight', 200, Body, ValidatorState) ->
+    validate_response_body('Header', 'Header', Body, ValidatorState);
+validate_response('GetHeaderByHeight', 400, Body, ValidatorState) ->
+    validate_response_body('Error', 'Error', Body, ValidatorState);
+
+validate_response('GetHeadersByHash', 200, Body, ValidatorState) ->
+    validate_response_body('list', 'Header', Body, ValidatorState);
+validate_response('GetHeadersByHash', 400, Body, ValidatorState) ->
+    validate_response_body('Error', 'Error', Body, ValidatorState);
+validate_response('GetHeadersByHash', 404, Body, ValidatorState) ->
+    validate_response_body('Error', 'Error', Body, ValidatorState);
+
 validate_response('GetInfo', 200, Body, ValidatorState) ->
     validate_response_body('Info', 'Info', Body, ValidatorState);
 validate_response('GetInfo', 403, Body, ValidatorState) ->
@@ -2825,6 +2913,18 @@ validate_response('GetHeaderByHash', 200, Body, ValidatorState) ->
 validate_response('GetHeaderByHash', 400, Body, ValidatorState) ->
     validate_response_body('Error', 'Error', Body, ValidatorState);
 validate_response('GetHeaderByHash', 404, Body, ValidatorState) ->
+    validate_response_body('Error', 'Error', Body, ValidatorState);
+
+validate_response('GetHeaderByHeight', 200, Body, ValidatorState) ->
+    validate_response_body('Header', 'Header', Body, ValidatorState);
+validate_response('GetHeaderByHeight', 400, Body, ValidatorState) ->
+    validate_response_body('Error', 'Error', Body, ValidatorState);
+
+validate_response('GetHeadersByHash', 200, Body, ValidatorState) ->
+    validate_response_body('list', 'Header', Body, ValidatorState);
+validate_response('GetHeadersByHash', 400, Body, ValidatorState) ->
+    validate_response_body('Error', 'Error', Body, ValidatorState);
+validate_response('GetHeadersByHash', 404, Body, ValidatorState) ->
     validate_response_body('Error', 'Error', Body, ValidatorState);
 
 validate_response('GetTop', 200, Body, ValidatorState) ->

--- a/apps/aehttp/src/swagger/swagger_external_handler.erl
+++ b/apps/aehttp/src/swagger/swagger_external_handler.erl
@@ -120,6 +120,22 @@ allowed_methods(
 allowed_methods(
     Req,
     State = #state{
+        operation_id = 'GetHeaderByHeight'
+    }
+) ->
+    {[<<"GET">>], Req, State};
+
+allowed_methods(
+    Req,
+    State = #state{
+        operation_id = 'GetHeadersByHash'
+    }
+) ->
+    {[<<"GET">>], Req, State};
+
+allowed_methods(
+    Req,
+    State = #state{
         operation_id = 'GetInfo'
     }
 ) ->
@@ -333,6 +349,8 @@ allowed_methods(Req, State) ->
 
 
 
+
+
 is_authorized(Req, State) ->
     {true, Req, State}.
 
@@ -425,6 +443,26 @@ valid_content_headers(
     Req0,
     State = #state{
         operation_id = 'GetHeaderByHash'
+    }
+) ->
+    Headers = [],
+    {Result, Req} = validate_headers(Headers, Req0),
+    {Result, Req, State};
+
+valid_content_headers(
+    Req0,
+    State = #state{
+        operation_id = 'GetHeaderByHeight'
+    }
+) ->
+    Headers = [],
+    {Result, Req} = validate_headers(Headers, Req0),
+    {Result, Req, State};
+
+valid_content_headers(
+    Req0,
+    State = #state{
+        operation_id = 'GetHeadersByHash'
     }
 ) ->
     Headers = [],

--- a/apps/aehttp/src/swagger/swagger_gossip_handler.erl
+++ b/apps/aehttp/src/swagger/swagger_gossip_handler.erl
@@ -80,6 +80,22 @@ allowed_methods(
 allowed_methods(
     Req,
     State = #state{
+        operation_id = 'GetHeaderByHeight'
+    }
+) ->
+    {[<<"GET">>], Req, State};
+
+allowed_methods(
+    Req,
+    State = #state{
+        operation_id = 'GetHeadersByHash'
+    }
+) ->
+    {[<<"GET">>], Req, State};
+
+allowed_methods(
+    Req,
+    State = #state{
         operation_id = 'GetTop'
     }
 ) ->
@@ -118,6 +134,8 @@ allowed_methods(Req, State) ->
         Req :: cowboy_req:req(),
         State :: state()
     }.
+
+
 
 
 
@@ -168,6 +186,26 @@ valid_content_headers(
     Req0,
     State = #state{
         operation_id = 'GetHeaderByHash'
+    }
+) ->
+    Headers = [],
+    {Result, Req} = validate_headers(Headers, Req0),
+    {Result, Req, State};
+
+valid_content_headers(
+    Req0,
+    State = #state{
+        operation_id = 'GetHeaderByHeight'
+    }
+) ->
+    Headers = [],
+    {Result, Req} = validate_headers(Headers, Req0),
+    {Result, Req, State};
+
+valid_content_headers(
+    Req0,
+    State = #state{
+        operation_id = 'GetHeadersByHash'
     }
 ) ->
     Headers = [],

--- a/apps/aehttp/src/swagger/swagger_router.erl
+++ b/apps/aehttp/src/swagger/swagger_router.erl
@@ -285,6 +285,16 @@ get_operations() ->
             method => <<"GET">>,
             handler => 'swagger_external_handler'
         },
+        'GetHeaderByHeight' => #{
+            path => "/v2/header-by-height",
+            method => <<"GET">>,
+            handler => 'swagger_external_handler'
+        },
+        'GetHeadersByHash' => #{
+            path => "/v2/headers-by-hash",
+            method => <<"GET">>,
+            handler => 'swagger_external_handler'
+        },
         'GetInfo' => #{
             path => "/v2/info",
             method => <<"GET">>,
@@ -407,6 +417,16 @@ get_operations() ->
         },
         'GetHeaderByHash' => #{
             path => "/v2/header-by-hash",
+            method => <<"GET">>,
+            handler => 'swagger_gossip_handler'
+        },
+        'GetHeaderByHeight' => #{
+            path => "/v2/header-by-height",
+            method => <<"GET">>,
+            handler => 'swagger_gossip_handler'
+        },
+        'GetHeadersByHash' => #{
+            path => "/v2/headers-by-hash",
             method => <<"GET">>,
             handler => 'swagger_gossip_handler'
         },

--- a/apps/aeutils/src/aeu_http_client.erl
+++ b/apps/aeutils/src/aeu_http_client.erl
@@ -7,10 +7,10 @@
 request(BaseUri, OperationId, Params) ->
     Timeout = aeu_env:user_config_or_env(
                 [<<"http">>, <<"external">>,<<"request_timeout">>],
-                aehttp, http_request_timeout, 1000),
+                aehttp, http_request_timeout, 5000),
     CTimeout = aeu_env:user_config_or_env(
                  [<<"http">>, <<"external">>, <<"connect_timeout">>],
-                 aehttp, http_connect_timeout, min(Timeout, 1000)),
+                 aehttp, http_connect_timeout, max(Timeout, 1000)),
     HTTPOptions = [{timeout, Timeout}, {connect_timeout, CTimeout}],
     %% we support only one method at the moment
     [Method|_] = maps:keys(endpoints:operation(OperationId)),

--- a/apps/aeutils/src/aeu_requests.erl
+++ b/apps/aeutils/src/aeu_requests.erl
@@ -37,6 +37,7 @@
 -export([ping/2,
          top/1,
          get_header_by_hash/2,
+         get_n_hashes/3,
          get_header_by_height/2,
          get_block_by_height/2,
          get_block/2,
@@ -142,15 +143,23 @@ get_header_by_hash(Uri, Hash) ->
             {error, unexpected_response}
     end.
 
-
-%% Add API for header later... now use block
--spec get_header_by_height(http_uri_uri(), non_neg_integer()) -> response(aec_headers:header()).
-get_header_by_height(Uri, Height) when is_integer(Height) ->
-    Response = process_request(Uri, 'GetBlockByHeight', [{"height", integer_to_list(Height)}]),
+-spec get_n_hashes(http_uri_uri(),  binary(), non_neg_integer()) -> response([{integer(), binary()}]).
+get_n_hashes(Uri, Hash, N) when is_integer(N) ->
+    EncHash = aec_base58c:encode(block_hash, Hash),
+    Response = process_request(Uri, 'GetHeadersByHash', [{"hash", EncHash}, {"number", integer_to_list(N)}]),
     case Response of
-        {ok, 200, Data} ->
-            {ok, Block} = aec_blocks:deserialize_from_map(Data),  %% needs to be headers later
-            {ok, aec_blocks:to_header(Block)};
+        {ok, 200, Data} when is_list(Data) ->
+            %% Keep them in order, oldest block is first!
+            {ok, lists:foldr(fun(Header, Acc) ->
+                            case aec_headers:deserialize_from_map(Header) of
+                                {ok, H} ->
+                                    {ok, HH} = aec_headers:hash_header(H),
+                                    [ {aec_headers:height(H), HH} | Acc ];
+                                 _ ->
+                                    lager:info("Got bad block hash from ~p", [Uri]),
+                                    Acc
+                            end
+                        end, [], Data)};
         {error, _Reason} = Error ->
             Error;
         _ ->
@@ -159,12 +168,32 @@ get_header_by_height(Uri, Height) when is_integer(Height) ->
             {error, unexpected_response}
     end.
 
+%% Add API for header later... now use block
+-spec get_header_by_height(http_uri_uri(), non_neg_integer()) -> response(aec_headers:header()).
+get_header_by_height(Uri, Height) when is_integer(Height) ->
+    Response = process_request(Uri, 'GetHeaderByHeight', [{"height", integer_to_list(Height)}]),
+    case Response of
+        {ok, 200, Data} ->
+            {ok, _Header} = aec_headers:deserialize_from_map(Data);
+        {ok, 400, Reason} ->
+            lager:debug("Header not found ~p", [Reason]),
+            {error, chain_too_short};
+        _ ->
+            %% Should have been turned to {error, _} by swagger validation
+            lager:debug("unexpected response (~p): ~p", [Uri, Response]),
+            {error, unexpected_response}
+    end.
+
+
+
 -spec get_block_by_height(http_uri_uri(), non_neg_integer()) -> response(aec_headers:header()).
 get_block_by_height(Uri, Height) when is_integer(Height) ->
     Response = process_request(Uri, 'GetBlockByHeight', [{"height", integer_to_list(Height)}]),
     case Response of
         {ok, 200, Data} ->
-            {ok, Block} = aec_blocks:deserialize_from_map(Data);
+            {ok, _Block} = aec_blocks:deserialize_from_map(Data);
+        {ok, 404, #{reason := <<"Chain too short">>}} ->
+            {error, chain_too_short};
         {error, _Reason} = Error ->
             Error;
         _ ->

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -97,7 +97,7 @@ paths:
           name: hash
           description: 'Hash of the block header to fetch'
           required: true
-          type : string
+          type: string
       responses:
         '200':
           description: The header found
@@ -108,6 +108,67 @@ paths:
           schema:
             $ref: '#/definitions/Error'
         '404':
+          description: Header not found
+          schema:
+            $ref: '#/definitions/Error'
+      security:
+  /headers-by-hash:
+    get:
+      tags:
+        - external
+        - gossip
+      operationId: GetHeadersByHash
+      description: 'Get N headers from hash (down)'
+      produces:
+        - application/json
+      parameters:
+        - in: query
+          name: hash
+          description: 'Hash of first block header to fetch'
+          required: true
+          type: string
+        - in: query
+          name: number
+          description: 'Number of hashes to fetch'
+          type: integer
+          default: 1
+      responses:
+        '200':
+          description: The headers found
+          schema:
+            type: array 
+            items:
+              $ref: '#/definitions/Header'
+        '400':
+          description: Invalid hash or number
+          schema:
+            $ref: '#/definitions/Error'
+        '404':
+          description: Header(s) not found
+          schema:
+            $ref: '#/definitions/Error'
+      security:
+  /header-by-height:
+    get:
+      tags:
+        - external
+        - gossip
+      operationId: GetHeaderByHeight
+      description: 'Get a header by its height in the chain'
+      produces:
+        - application/json
+      parameters:
+        - in: query
+          name: height
+          description: 'Height of the header to fetch'
+          required: true
+          type: integer
+      responses:
+        '200':
+          description: The header found
+          schema:
+            $ref: '#/definitions/Header'
+        '400':
           description: Header not found
           schema:
             $ref: '#/definitions/Error'

--- a/py/tests/swagger_client/api/external_api.py
+++ b/py/tests/swagger_client/api/external_api.py
@@ -805,6 +805,200 @@ class ExternalApi(object):
             _request_timeout=params.get('_request_timeout'),
             collection_formats=collection_formats)
 
+    def get_header_by_height(self, height, **kwargs):  # noqa: E501
+        """get_header_by_height  # noqa: E501
+
+        Get a header by its height in the chain  # noqa: E501
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.get_header_by_height(height, async=True)
+        >>> result = thread.get()
+
+        :param async bool
+        :param int height: Height of the header to fetch (required)
+        :return: Header
+                 If the method is called asynchronously,
+                 returns the request thread.
+        """
+        kwargs['_return_http_data_only'] = True
+        if kwargs.get('async'):
+            return self.get_header_by_height_with_http_info(height, **kwargs)  # noqa: E501
+        else:
+            (data) = self.get_header_by_height_with_http_info(height, **kwargs)  # noqa: E501
+            return data
+
+    def get_header_by_height_with_http_info(self, height, **kwargs):  # noqa: E501
+        """get_header_by_height  # noqa: E501
+
+        Get a header by its height in the chain  # noqa: E501
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.get_header_by_height_with_http_info(height, async=True)
+        >>> result = thread.get()
+
+        :param async bool
+        :param int height: Height of the header to fetch (required)
+        :return: Header
+                 If the method is called asynchronously,
+                 returns the request thread.
+        """
+
+        all_params = ['height']  # noqa: E501
+        all_params.append('async')
+        all_params.append('_return_http_data_only')
+        all_params.append('_preload_content')
+        all_params.append('_request_timeout')
+
+        params = locals()
+        for key, val in six.iteritems(params['kwargs']):
+            if key not in all_params:
+                raise TypeError(
+                    "Got an unexpected keyword argument '%s'"
+                    " to method get_header_by_height" % key
+                )
+            params[key] = val
+        del params['kwargs']
+        # verify the required parameter 'height' is set
+        if ('height' not in params or
+                params['height'] is None):
+            raise ValueError("Missing the required parameter `height` when calling `get_header_by_height`")  # noqa: E501
+
+        collection_formats = {}
+
+        path_params = {}
+
+        query_params = []
+        if 'height' in params:
+            query_params.append(('height', params['height']))  # noqa: E501
+
+        header_params = {}
+
+        form_params = []
+        local_var_files = {}
+
+        body_params = None
+        # HTTP header `Accept`
+        header_params['Accept'] = self.api_client.select_header_accept(
+            ['application/json'])  # noqa: E501
+
+        # Authentication setting
+        auth_settings = []  # noqa: E501
+
+        return self.api_client.call_api(
+            '/header-by-height', 'GET',
+            path_params,
+            query_params,
+            header_params,
+            body=body_params,
+            post_params=form_params,
+            files=local_var_files,
+            response_type='Header',  # noqa: E501
+            auth_settings=auth_settings,
+            async=params.get('async'),
+            _return_http_data_only=params.get('_return_http_data_only'),
+            _preload_content=params.get('_preload_content', True),
+            _request_timeout=params.get('_request_timeout'),
+            collection_formats=collection_formats)
+
+    def get_headers_by_hash(self, hash, **kwargs):  # noqa: E501
+        """get_headers_by_hash  # noqa: E501
+
+        Get N headers from hash (down)  # noqa: E501
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.get_headers_by_hash(hash, async=True)
+        >>> result = thread.get()
+
+        :param async bool
+        :param str hash: Hash of first block header to fetch (required)
+        :param int number: Number of hashes to fetch
+        :return: list[Header]
+                 If the method is called asynchronously,
+                 returns the request thread.
+        """
+        kwargs['_return_http_data_only'] = True
+        if kwargs.get('async'):
+            return self.get_headers_by_hash_with_http_info(hash, **kwargs)  # noqa: E501
+        else:
+            (data) = self.get_headers_by_hash_with_http_info(hash, **kwargs)  # noqa: E501
+            return data
+
+    def get_headers_by_hash_with_http_info(self, hash, **kwargs):  # noqa: E501
+        """get_headers_by_hash  # noqa: E501
+
+        Get N headers from hash (down)  # noqa: E501
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.get_headers_by_hash_with_http_info(hash, async=True)
+        >>> result = thread.get()
+
+        :param async bool
+        :param str hash: Hash of first block header to fetch (required)
+        :param int number: Number of hashes to fetch
+        :return: list[Header]
+                 If the method is called asynchronously,
+                 returns the request thread.
+        """
+
+        all_params = ['hash', 'number']  # noqa: E501
+        all_params.append('async')
+        all_params.append('_return_http_data_only')
+        all_params.append('_preload_content')
+        all_params.append('_request_timeout')
+
+        params = locals()
+        for key, val in six.iteritems(params['kwargs']):
+            if key not in all_params:
+                raise TypeError(
+                    "Got an unexpected keyword argument '%s'"
+                    " to method get_headers_by_hash" % key
+                )
+            params[key] = val
+        del params['kwargs']
+        # verify the required parameter 'hash' is set
+        if ('hash' not in params or
+                params['hash'] is None):
+            raise ValueError("Missing the required parameter `hash` when calling `get_headers_by_hash`")  # noqa: E501
+
+        collection_formats = {}
+
+        path_params = {}
+
+        query_params = []
+        if 'hash' in params:
+            query_params.append(('hash', params['hash']))  # noqa: E501
+        if 'number' in params:
+            query_params.append(('number', params['number']))  # noqa: E501
+
+        header_params = {}
+
+        form_params = []
+        local_var_files = {}
+
+        body_params = None
+        # HTTP header `Accept`
+        header_params['Accept'] = self.api_client.select_header_accept(
+            ['application/json'])  # noqa: E501
+
+        # Authentication setting
+        auth_settings = []  # noqa: E501
+
+        return self.api_client.call_api(
+            '/headers-by-hash', 'GET',
+            path_params,
+            query_params,
+            header_params,
+            body=body_params,
+            post_params=form_params,
+            files=local_var_files,
+            response_type='list[Header]',  # noqa: E501
+            auth_settings=auth_settings,
+            async=params.get('async'),
+            _return_http_data_only=params.get('_return_http_data_only'),
+            _preload_content=params.get('_preload_content', True),
+            _request_timeout=params.get('_request_timeout'),
+            collection_formats=collection_formats)
+
     def get_info(self, **kwargs):  # noqa: E501
         """get_info  # noqa: E501
 

--- a/py/tests/swagger_client/api/gossip_api.py
+++ b/py/tests/swagger_client/api/gossip_api.py
@@ -318,6 +318,200 @@ class GossipApi(object):
             _request_timeout=params.get('_request_timeout'),
             collection_formats=collection_formats)
 
+    def get_header_by_height(self, height, **kwargs):  # noqa: E501
+        """get_header_by_height  # noqa: E501
+
+        Get a header by its height in the chain  # noqa: E501
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.get_header_by_height(height, async=True)
+        >>> result = thread.get()
+
+        :param async bool
+        :param int height: Height of the header to fetch (required)
+        :return: Header
+                 If the method is called asynchronously,
+                 returns the request thread.
+        """
+        kwargs['_return_http_data_only'] = True
+        if kwargs.get('async'):
+            return self.get_header_by_height_with_http_info(height, **kwargs)  # noqa: E501
+        else:
+            (data) = self.get_header_by_height_with_http_info(height, **kwargs)  # noqa: E501
+            return data
+
+    def get_header_by_height_with_http_info(self, height, **kwargs):  # noqa: E501
+        """get_header_by_height  # noqa: E501
+
+        Get a header by its height in the chain  # noqa: E501
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.get_header_by_height_with_http_info(height, async=True)
+        >>> result = thread.get()
+
+        :param async bool
+        :param int height: Height of the header to fetch (required)
+        :return: Header
+                 If the method is called asynchronously,
+                 returns the request thread.
+        """
+
+        all_params = ['height']  # noqa: E501
+        all_params.append('async')
+        all_params.append('_return_http_data_only')
+        all_params.append('_preload_content')
+        all_params.append('_request_timeout')
+
+        params = locals()
+        for key, val in six.iteritems(params['kwargs']):
+            if key not in all_params:
+                raise TypeError(
+                    "Got an unexpected keyword argument '%s'"
+                    " to method get_header_by_height" % key
+                )
+            params[key] = val
+        del params['kwargs']
+        # verify the required parameter 'height' is set
+        if ('height' not in params or
+                params['height'] is None):
+            raise ValueError("Missing the required parameter `height` when calling `get_header_by_height`")  # noqa: E501
+
+        collection_formats = {}
+
+        path_params = {}
+
+        query_params = []
+        if 'height' in params:
+            query_params.append(('height', params['height']))  # noqa: E501
+
+        header_params = {}
+
+        form_params = []
+        local_var_files = {}
+
+        body_params = None
+        # HTTP header `Accept`
+        header_params['Accept'] = self.api_client.select_header_accept(
+            ['application/json'])  # noqa: E501
+
+        # Authentication setting
+        auth_settings = []  # noqa: E501
+
+        return self.api_client.call_api(
+            '/header-by-height', 'GET',
+            path_params,
+            query_params,
+            header_params,
+            body=body_params,
+            post_params=form_params,
+            files=local_var_files,
+            response_type='Header',  # noqa: E501
+            auth_settings=auth_settings,
+            async=params.get('async'),
+            _return_http_data_only=params.get('_return_http_data_only'),
+            _preload_content=params.get('_preload_content', True),
+            _request_timeout=params.get('_request_timeout'),
+            collection_formats=collection_formats)
+
+    def get_headers_by_hash(self, hash, **kwargs):  # noqa: E501
+        """get_headers_by_hash  # noqa: E501
+
+        Get N headers from hash (down)  # noqa: E501
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.get_headers_by_hash(hash, async=True)
+        >>> result = thread.get()
+
+        :param async bool
+        :param str hash: Hash of first block header to fetch (required)
+        :param int number: Number of hashes to fetch
+        :return: list[Header]
+                 If the method is called asynchronously,
+                 returns the request thread.
+        """
+        kwargs['_return_http_data_only'] = True
+        if kwargs.get('async'):
+            return self.get_headers_by_hash_with_http_info(hash, **kwargs)  # noqa: E501
+        else:
+            (data) = self.get_headers_by_hash_with_http_info(hash, **kwargs)  # noqa: E501
+            return data
+
+    def get_headers_by_hash_with_http_info(self, hash, **kwargs):  # noqa: E501
+        """get_headers_by_hash  # noqa: E501
+
+        Get N headers from hash (down)  # noqa: E501
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.get_headers_by_hash_with_http_info(hash, async=True)
+        >>> result = thread.get()
+
+        :param async bool
+        :param str hash: Hash of first block header to fetch (required)
+        :param int number: Number of hashes to fetch
+        :return: list[Header]
+                 If the method is called asynchronously,
+                 returns the request thread.
+        """
+
+        all_params = ['hash', 'number']  # noqa: E501
+        all_params.append('async')
+        all_params.append('_return_http_data_only')
+        all_params.append('_preload_content')
+        all_params.append('_request_timeout')
+
+        params = locals()
+        for key, val in six.iteritems(params['kwargs']):
+            if key not in all_params:
+                raise TypeError(
+                    "Got an unexpected keyword argument '%s'"
+                    " to method get_headers_by_hash" % key
+                )
+            params[key] = val
+        del params['kwargs']
+        # verify the required parameter 'hash' is set
+        if ('hash' not in params or
+                params['hash'] is None):
+            raise ValueError("Missing the required parameter `hash` when calling `get_headers_by_hash`")  # noqa: E501
+
+        collection_formats = {}
+
+        path_params = {}
+
+        query_params = []
+        if 'hash' in params:
+            query_params.append(('hash', params['hash']))  # noqa: E501
+        if 'number' in params:
+            query_params.append(('number', params['number']))  # noqa: E501
+
+        header_params = {}
+
+        form_params = []
+        local_var_files = {}
+
+        body_params = None
+        # HTTP header `Accept`
+        header_params['Accept'] = self.api_client.select_header_accept(
+            ['application/json'])  # noqa: E501
+
+        # Authentication setting
+        auth_settings = []  # noqa: E501
+
+        return self.api_client.call_api(
+            '/headers-by-hash', 'GET',
+            path_params,
+            query_params,
+            header_params,
+            body=body_params,
+            post_params=form_params,
+            files=local_var_files,
+            response_type='list[Header]',  # noqa: E501
+            auth_settings=auth_settings,
+            async=params.get('async'),
+            _return_http_data_only=params.get('_return_http_data_only'),
+            _preload_content=params.get('_preload_content', True),
+            _request_timeout=params.get('_request_timeout'),
+            collection_formats=collection_formats)
+
     def get_top(self, **kwargs):  # noqa: E501
         """get_top  # noqa: E501
 


### PR DESCRIPTION
We now fetch blocks from below and in parallel

```erlang
%% When we Ping a node with at least as much difficulty as we have, 
%% then we are going to sync with it.
%% We already agree upon the genesis block and need to find the highest common
%% block we agree upon. We use a binary search to find out.
%% From the height we agree upon, we start asking for blocks to add to the chain.
%% 
%% When an additional Ping arrives for which we agree upon genesis, we have
%% the following possibilities:
%% 1. It has worst top hash than our node, do not include in sync
%% 2. It has better top hash than our node
%%    We binary search for a node that we agree upon (could be genesis) 
%% We add new node to sync pool to sync agreed node upto top of new
%% 1. If we are already synchronizing, we ignore it,
%%    the ongoing sync will pick that up later
%% 2. If we are not already synchronizing, we start doing so.
%% 
%% We sync with several nodes at the same time and use as strategy 
%% to pick a random hash from the hashes in the pool.
```
