### PR TITLE
Pt 156003774 get successor hashes when fetching a long chain

### DIFF
--- a/apps/aehttp/priv/swagger.json
+++ b/apps/aehttp/priv/swagger.json
@@ -135,7 +135,7 @@
     "/headers-by-hash" : {
       "get" : {
         "tags" : [ "external", "gossip" ],
-        "description" : "Get N headers from hash (down)",
+        "description" : "Get N headers from hash",
         "operationId" : "GetHeadersByHash",
         "produces" : [ "application/json" ],
         "parameters" : [ {
@@ -151,6 +151,12 @@
           "required" : false,
           "type" : "integer",
           "default" : 1
+        }, {
+          "name" : "direction",
+          "in" : "query",
+          "description" : "Towards top = forward, towards genesis = backward",
+          "required" : false,
+          "default" : "backward"
         } ],
         "responses" : {
           "200" : {

--- a/apps/aehttp/src/swagger/swagger_api.erl
+++ b/apps/aehttp/src/swagger/swagger_api.erl
@@ -276,7 +276,8 @@ request_params('GetHeaderByHeight') ->
 request_params('GetHeadersByHash') ->
     [
         'hash',
-        'number'
+        'number',
+        'direction'
     ];
 
 request_params('GetInfo') ->
@@ -410,7 +411,8 @@ request_params('GetHeaderByHeight') ->
 request_params('GetHeadersByHash') ->
     [
         'hash',
-        'number'
+        'number',
+        'direction'
     ];
 
 request_params('GetTop') ->
@@ -1386,6 +1388,15 @@ request_param_info('GetHeadersByHash', 'number') ->
         ]
     };
 
+request_param_info('GetHeadersByHash', 'direction') ->
+    #{
+        source => qs_val  ,
+        rules => [
+            {type, 'binary'},
+            not_required
+        ]
+    };
+
 request_param_info('GetName', 'name') ->
     #{
         source => qs_val  ,
@@ -1609,6 +1620,15 @@ request_param_info('GetHeadersByHash', 'number') ->
         source => qs_val  ,
         rules => [
             {type, 'integer'},
+            not_required
+        ]
+    };
+
+request_param_info('GetHeadersByHash', 'direction') ->
+    #{
+        source => qs_val  ,
+        rules => [
+            {type, 'binary'},
             not_required
         ]
     };

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -118,7 +118,7 @@ paths:
         - external
         - gossip
       operationId: GetHeadersByHash
-      description: 'Get N headers from hash (down)'
+      description: 'Get N headers from hash'
       produces:
         - application/json
       parameters:
@@ -132,6 +132,13 @@ paths:
           description: 'Number of hashes to fetch'
           type: integer
           default: 1
+        - in: query
+          name: direction
+          description: 'Towards top = forward, towards genesis = backward'
+          schema:
+            type: string
+            enum: [forward, backward]
+          default: backward
       responses:
         '200':
           description: The headers found

--- a/py/tests/swagger_client/api/external_api.py
+++ b/py/tests/swagger_client/api/external_api.py
@@ -903,7 +903,7 @@ class ExternalApi(object):
     def get_headers_by_hash(self, hash, **kwargs):  # noqa: E501
         """get_headers_by_hash  # noqa: E501
 
-        Get N headers from hash (down)  # noqa: E501
+        Get N headers from hash  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async=True
         >>> thread = api.get_headers_by_hash(hash, async=True)
@@ -912,6 +912,7 @@ class ExternalApi(object):
         :param async bool
         :param str hash: Hash of first block header to fetch (required)
         :param int number: Number of hashes to fetch
+        :param str direction: Towards top = forward, towards genesis = backward
         :return: list[Header]
                  If the method is called asynchronously,
                  returns the request thread.
@@ -926,7 +927,7 @@ class ExternalApi(object):
     def get_headers_by_hash_with_http_info(self, hash, **kwargs):  # noqa: E501
         """get_headers_by_hash  # noqa: E501
 
-        Get N headers from hash (down)  # noqa: E501
+        Get N headers from hash  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async=True
         >>> thread = api.get_headers_by_hash_with_http_info(hash, async=True)
@@ -935,12 +936,13 @@ class ExternalApi(object):
         :param async bool
         :param str hash: Hash of first block header to fetch (required)
         :param int number: Number of hashes to fetch
+        :param str direction: Towards top = forward, towards genesis = backward
         :return: list[Header]
                  If the method is called asynchronously,
                  returns the request thread.
         """
 
-        all_params = ['hash', 'number']  # noqa: E501
+        all_params = ['hash', 'number', 'direction']  # noqa: E501
         all_params.append('async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
@@ -969,6 +971,8 @@ class ExternalApi(object):
             query_params.append(('hash', params['hash']))  # noqa: E501
         if 'number' in params:
             query_params.append(('number', params['number']))  # noqa: E501
+        if 'direction' in params:
+            query_params.append(('direction', params['direction']))  # noqa: E501
 
         header_params = {}
 

--- a/py/tests/swagger_client/api/gossip_api.py
+++ b/py/tests/swagger_client/api/gossip_api.py
@@ -416,7 +416,7 @@ class GossipApi(object):
     def get_headers_by_hash(self, hash, **kwargs):  # noqa: E501
         """get_headers_by_hash  # noqa: E501
 
-        Get N headers from hash (down)  # noqa: E501
+        Get N headers from hash  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async=True
         >>> thread = api.get_headers_by_hash(hash, async=True)
@@ -425,6 +425,7 @@ class GossipApi(object):
         :param async bool
         :param str hash: Hash of first block header to fetch (required)
         :param int number: Number of hashes to fetch
+        :param str direction: Towards top = forward, towards genesis = backward
         :return: list[Header]
                  If the method is called asynchronously,
                  returns the request thread.
@@ -439,7 +440,7 @@ class GossipApi(object):
     def get_headers_by_hash_with_http_info(self, hash, **kwargs):  # noqa: E501
         """get_headers_by_hash  # noqa: E501
 
-        Get N headers from hash (down)  # noqa: E501
+        Get N headers from hash  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async=True
         >>> thread = api.get_headers_by_hash_with_http_info(hash, async=True)
@@ -448,12 +449,13 @@ class GossipApi(object):
         :param async bool
         :param str hash: Hash of first block header to fetch (required)
         :param int number: Number of hashes to fetch
+        :param str direction: Towards top = forward, towards genesis = backward
         :return: list[Header]
                  If the method is called asynchronously,
                  returns the request thread.
         """
 
-        all_params = ['hash', 'number']  # noqa: E501
+        all_params = ['hash', 'number', 'direction']  # noqa: E501
         all_params.append('async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
@@ -482,6 +484,8 @@ class GossipApi(object):
             query_params.append(('hash', params['hash']))  # noqa: E501
         if 'number' in params:
             query_params.append(('number', params['number']))  # noqa: E501
+        if 'direction' in params:
+            query_params.append(('direction', params['direction']))  # noqa: E501
 
         header_params = {}
 


### PR DESCRIPTION
With new function we can now get the headers on top of a certain hash. We use this instead of re-implementing this functionality.

Experiment on 500 blocks chain:
At the moment we can fetch 10 blocks per second when talking to 2 nodes to fetch from, more nodes, quicker fetching. We only fetch what we need, no duplications.