### PR TITLE
Abort node start if an unexpected persisted genesis block is found

### DIFF
--- a/apps/aecore/src/aec_db.erl
+++ b/apps/aecore/src/aec_db.erl
@@ -133,9 +133,19 @@ persisted_valid_genesis_block() ->
         false ->
             true;
         true ->
-            LoadedGH = aec_db:get_genesis_hash(),
             {ok, ExpectedGH} = aec_headers:hash_header(aec_block_genesis:genesis_header()),
-            LoadedGH =:= undefined orelse LoadedGH =:= ExpectedGH
+            case aec_db:get_genesis_hash() of
+                undefined ->
+                    lager:info("Loaded empty persisted chain"),
+                    true;
+                ExpectedGH ->
+                    true;
+                LoadedGH ->
+                    lager:warning("Expected genesis block hash ~p, persisted genesis block hash ~p",
+                                  [ExpectedGH, LoadedGH]),
+                    false
+            end
+              
     end.
 
 transaction(Fun) when is_function(Fun, 0) ->

--- a/apps/aecore/src/aec_db.erl
+++ b/apps/aecore/src/aec_db.erl
@@ -1,10 +1,11 @@
 -module(aec_db).
 
--export([check_db/0,           % called from setup hook
-         initialize_db/1,      % assumes mnesia started
-         load_database/0,      % called in aecore app start phase
-         tables/1,             % for e.g. test database setup
-         clear_db/0            % mostly for test purposes
+-export([check_db/0,                    % called from setup hook
+         initialize_db/1,               % assumes mnesia started
+         load_database/0,               % called in aecore app start phase
+         tables/1,                      % for e.g. test database setup
+         clear_db/0,                    % mostly for test purposes
+         persisted_valid_genesis_block/0
         ]).
 
 -export([transaction/1,
@@ -126,6 +127,16 @@ clear_table(Tab) ->
            [delete(Tab, K) || K <- Keys],
            ok
        end).
+
+persisted_valid_genesis_block() ->
+    case application:get_env(aecore, persist, false) of
+        false ->
+            true;
+        true ->
+            LoadedGH = aec_db:get_genesis_hash(),
+            {ok, ExpectedGH} = aec_headers:hash_header(aec_block_genesis:genesis_header()),
+            LoadedGH =:= undefined orelse LoadedGH =:= ExpectedGH
+    end.
 
 transaction(Fun) when is_function(Fun, 0) ->
     mnesia:activity(transaction, Fun).

--- a/apps/aecore/src/aecore_app.erl
+++ b/apps/aecore/src/aecore_app.erl
@@ -17,7 +17,14 @@ start(_StartType, _StartArgs) ->
     ok = lager:info("Starting aecore node"),
     ok = application:ensure_started(mnesia),
     aec_db:load_database(),
-    aecore_sup:start_link().
+    case aec_db:persisted_valid_genesis_block() of
+        true ->
+            aecore_sup:start_link();
+        false ->
+            lager:error("Persisted chain has a different genesis block than "
+                        ++ "the one being expected. Aborting", []),
+            {error, inconsistent_database}
+    end.
 
 start_phase(create_metrics_probes, _StartType, _PhaseArgs) ->
     lager:debug("start_phase(create_metrics_probes, _, _)", []),

--- a/apps/aecore/test/aec_db_tests.erl
+++ b/apps/aecore/test/aec_db_tests.erl
@@ -191,3 +191,41 @@ restart_test_() ->
                ok
        end}
      ]}.
+
+persisted_valid_gen_block_test_() ->
+    {foreach,
+     fun() ->
+             TmpDir = aec_test_utils:aec_keys_setup(),
+             aec_test_utils:mock_genesis(),
+             meck:new(aec_db, [passthrough]),
+             TmpDir
+     end,
+     fun(TmpDir) ->
+             aec_test_utils:unmock_genesis(),
+             aec_test_utils:aec_keys_cleanup(TmpDir),
+             meck:unload(aec_db),
+             application:set_env(aecore, persist, false)
+     end,
+     [{"Check persisted validation of genesis block, persistence OFF",
+       fun() ->
+            application:set_env(aecore, persist, false),
+            ?assertEqual(true, aec_db:persisted_valid_genesis_block())
+       end},
+      {"Check persisted validation of genesis block, persistence ON",
+       fun() ->
+            application:set_env(aecore, persist, true),
+
+            meck:expect(aec_db, get_genesis_hash, 0, undefined),
+            ?assertEqual(true, aec_db:persisted_valid_genesis_block()),
+
+            {ok, ExpectedGH} = aec_headers:hash_header(aec_block_genesis:genesis_header()),
+
+            meck:expect(aec_db, get_genesis_hash, 0, ExpectedGH),
+            ?assertEqual(true, aec_db:persisted_valid_genesis_block()),
+
+            meck:expect(aec_db, get_genesis_hash, 0, <<"invalid genesis block hash">>),
+            ?assertEqual(false, aec_db:persisted_valid_genesis_block()),
+            ok
+       end}
+     ]}.
+

--- a/apps/aecore/test/aecore_app_tests.erl
+++ b/apps/aecore/test/aecore_app_tests.erl
@@ -1,0 +1,34 @@
+-module(aecore_app_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("common.hrl").
+-include("blocks.hrl").
+
+persisted_valid_gen_block_test_() ->
+    {foreach,
+     fun() ->
+             meck:new(aec_db, [passthrough]),
+             meck:expect(aec_db, load_database, 0, ok),
+             meck:new(aecore_sup, [passthrough]),
+             meck:expect(aecore_sup, start_link, 0, {ok, pid}),
+             lager:start(),
+             ok
+     end,
+     fun(ok) ->
+             ok = application:stop(lager),
+             ok = application:stop(mnesia),
+             meck:unload(aecore_sup),
+             meck:unload(aec_db)
+     end,
+     [{"Check persisted genesis block",
+       fun() ->
+            meck:expect(aec_db, persisted_valid_genesis_block, 0, false),
+            ?assertEqual({error, inconsistent_database},
+                         aecore_app:start(normal, [])),
+
+            meck:expect(aec_db, persisted_valid_genesis_block, 0, true),
+            ?assertEqual({ok, pid}, aecore_app:start(normal, [])),
+            ok
+       end}
+     ]}.
+

--- a/docs/release-notes/RELEASE-NOTES-0.10.0.md
+++ b/docs/release-notes/RELEASE-NOTES-0.10.0.md
@@ -4,6 +4,7 @@
 It:
 * Improves chain handling by storing accumulated difficulty in the db rather than recomputing it. This impacts the persisted DB.
 * Enable user configuration of HTTP API acceptors pool
+* Improves the stability of the node.
 * Does this. This impacts consensus;
 * Does that. This impacts the persisted DB;
 * Does that;


### PR DESCRIPTION
[Pivotal story](https://www.pivotaltracker.com/story/show/155656097)
While starting a node, if persistence is `on` and node loads an unexpected genesis block from the persisted chain - the start is aborted and there is a proper message in the logs.