### PR TITLE
Do not unnecessarily close socket if HTTP request invalid

### DIFF
--- a/apps/aehttp/src/aehttp_api_middleware.erl
+++ b/apps/aehttp/src/aehttp_api_middleware.erl
@@ -16,7 +16,8 @@ execute(Req0, Env0) ->
                     {ok, Req1, [{handler_opts, HandlerOpts} | Env1]};
                 {error, Reason, Req1} ->
                     error_logger:error_msg("Unable to process params for ~p: ~p", [OperationId, Reason]),
-                    {error, 400, Req1}
+                    {ok, Req2} = cowboy_req:reply(400, Req1),
+                    {halt, Req2}
             end;
         _ ->
             {error, 405, Req0}


### PR DESCRIPTION
Please refer to commit message for details.

In scope of https://www.pivotaltracker.com/story/show/155582602

----

Currently triple checking this:
* [CI running each HTTP GET request in integration suite 100 times](https://circleci.com/workflow-run/bb4fc671-4905-4c4e-9d43-11c0bfb939a9) - still without httpc fix for server sending response with `Connection: close`
  * FAILED - probably for lack of httpc fix for server sending response with `Connection: close`
* [CI running each HTTP GET request in integration suite 10 times](https://circleci.com/workflow-run/b0d71ef8-a2ca-4a85-b0ab-c5eb55b3f641) - still without httpc fix for server sending response with `Connection: close`
  * FAILED - probably for lack of httpc fix for server sending response with `Connection: close`
* Local test running each HTTP GET request in integration suite 10 times (`pkill epmd rebar3 run_erl beam; make clean; epmd -daemon && make test SUITE=apps/aehttp/test/aehttp_integration GROUP=internal_endpoints`)
  * PASSED