### PR TITLE
Update dockerhub org name to aeternity

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,12 +5,12 @@ references:
     setup_remote_docker:
       docker_layer_caching: true
     docker:
-      - image: aetrnty/builder
+      - image: aeternity/builder
         user: builder
     working_directory: ~/epoch
     environment:
       DOCKER_CLIENT_VERSION: "17.09.0-ce"
-      DOCKERHUB_REPO: aetrnty/epoch
+      DOCKERHUB_REPO: aeternity/epoch
 
   setup_remote_docker: &setup_remote_docker
     setup_remote_docker:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM aetrnty/builder as builder
+FROM aeternity/builder as builder
 
 # Add required files to download and compile only the dependencies
 ADD rebar.config rebar.lock Makefile rebar3 rebar.config.script VERSION /app/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   node1:
     build: .
-    image: aetrnty/epoch
+    image: aeternity/epoch
     hostname: node1
     environment:
       EPOCH_CONFIG: /home/epoch/epoch.yaml
@@ -14,7 +14,7 @@ services:
       - node1_keys:/home/epoch/node/keys
 
   node2:
-    image: aetrnty/epoch
+    image: aeternity/epoch
     hostname: node2
     environment:
       EPOCH_CONFIG: /home/epoch/epoch.yaml
@@ -25,7 +25,7 @@ services:
       - node2_keys:/home/epoch/node/keys
 
   node3:
-    image: aetrnty/epoch
+    image: aeternity/epoch
     hostname: node3
     environment:
       EPOCH_CONFIG: /home/epoch/epoch.yaml

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -10,19 +10,19 @@ You must have [docker installed](https://docs.docker.com/engine/installation/) o
 
 ### Docker Image
 
-Docker image is automatically build and published on [DockerHub](https://hub.docker.com/r/aetrnty/epoch/). All tagged source code versions have their own docker image tag as well. Latest tagged ("stable") version is tagged with `latest`.
+Docker image is automatically build and published on [DockerHub](https://hub.docker.com/r/aeternity/epoch/). All tagged source code versions have their own docker image tag as well. Latest tagged ("stable") version is tagged with `latest`.
 Master branch of the source code is tagged as `dev`.
 
 To pull the latest "stable" image run:
 ```bash
-docker pull aetrnty/epoch
+docker pull aeternity/epoch
 ```
 
 ### Start a Node
 
 To start a docker node and join the testnet run:
 ```bash
-docker run -d --name epoch_node0 -p 3013:3013 aetrnty/epoch
+docker run -d --name epoch_node0 -p 3013:3013 aeternity/epoch
 ```
 
 Verify the node is running:
@@ -34,7 +34,7 @@ curl localhost:3013/v2/top
 
 Arguments can also be passed to epoch node, for example to enable API debug endpoints:
 ```bash
-docker run -d --name epoch_node0 -p 3013:3013 aetrnty/epoch -aehttp enable_debug_endpoints true
+docker run -d --name epoch_node0 -p 3013:3013 aeternity/epoch -aehttp enable_debug_endpoints true
 ```
 
 ### Stop a Node
@@ -66,7 +66,7 @@ Make sure you have a working port forwarding setup on your firewall to be able t
 Docker environment variable `EXTERNAL_PEER_ADDRESS` may be used in case external peer address shall be changed e.g. different port mapping or different inbound IP:
 
 ```bash
-docker run -d -p 3013:3013 -e EXTERNAL_PEER_ADDRESS=http://1.2.3.4:3013/ aetrnty/epoch
+docker run -d -p 3013:3013 -e EXTERNAL_PEER_ADDRESS=http://1.2.3.4:3013/ aeternity/epoch
 ```
 
 #### Peer addresses
@@ -74,7 +74,7 @@ docker run -d -p 3013:3013 -e EXTERNAL_PEER_ADDRESS=http://1.2.3.4:3013/ aetrnty
 Docker image has packaged the address of one of the testnet nodes in the configuration. This can be changed by setting `PEERS_ADDRESS_0` Docker environment variable:
 
 ```bash
-docker run -d -p 3013:3013 -e PEERS_ADDRESS_0=http://31.13.249.0:3013/ aetrnty/epoch
+docker run -d -p 3013:3013 -e PEERS_ADDRESS_0=http://31.13.249.0:3013/ aeternity/epoch
 ```
 
 #### Changing the configuration file
@@ -85,7 +85,7 @@ Assuming the new configuration file location is `~/.aeternity/myepoch.yaml`:
 docker run -d -p 3013:3013 \
     -v ~/.aeternity/myepoch.yaml:/home/epoch/myepoch.yaml \
     -e EPOCH_CONFIG=/home/epoch/myepoch.yaml \
-    aetrnty/epoch
+    aeternity/epoch
 ```
 
 ### Persisting Data
@@ -97,7 +97,7 @@ To persist blockchain data and node keys between container runs, use [Docker vol
 docker run -d -p 3013:3013 --hostname node0 \
     -v ~/.aeternity/db:/home/epoch/node/data/mnesia \
     -v ~/.aeternity/keys:/home/epoch/node/keys \
-    aetrnty/epoch
+    aeternity/epoch
 ```
 
 **Note: make sure `hostname` option is set when reusing the mnesia data directory**
@@ -144,7 +144,7 @@ More details can be found in [`docker-compose` documentation](https://docs.docke
 
 ### Image Version
 
-Docker compose uses the `aetrnty/epoch:latest` image, it will be pulled from [docker hub](https://hub.docker.com/r/aetrnty/epoch/) if it's not found locally.
+Docker compose uses the `aeternity/epoch:latest` image, it will be pulled from [docker hub](https://hub.docker.com/r/aeternity/epoch/) if it's not found locally.
 To create a network with the source code in this repository, one should build a local image beforehand:
 
 ```bash

--- a/docs/release-notes/RELEASE-NOTES-0.10.0.md
+++ b/docs/release-notes/RELEASE-NOTES-0.10.0.md
@@ -8,6 +8,7 @@ It:
 * Does that. This impacts the persisted DB;
 * Does that;
 * Improves the stability of the testnet.
+* Changes the DockerHub organization to `aeternity`
 
 [this-release]: https://github.com/aeternity/epoch/releases/tag/v0.10.0
 
@@ -27,7 +28,7 @@ The instructions below describe:
 
 You can run a node by using either:
 * The published [release binary][this-release] corresponding to your platform; or
-* The published [Docker image `aetrnty/epoch`][docker].
+* The published [Docker image `aeternity/epoch`][docker].
 
 [docker]: https://github.com/aeternity/epoch/blob/v0.10.0/docs/docker.md
 


### PR DESCRIPTION
The [builder image](https://hub.docker.com/r/aeternity/builder/tags/) is already pushed under the new org.
I also copied the `latest` and `v0.9.0` [docker images](https://hub.docker.com/r/aeternity/epoch/tags/) to the new org.

In scope of https://www.pivotaltracker.com/story/show/155940263