### PR TITLE
Use position in transaction list as key for the transaction root hash

### DIFF
--- a/apps/aecore/include/blocks.hrl
+++ b/apps/aecore/include/blocks.hrl
@@ -1,8 +1,8 @@
 -include("pow.hrl").
 
--define(PROTOCOL_VERSION, 8).
+-define(PROTOCOL_VERSION, 9).
 
--define(GENESIS_VERSION, 8).
+-define(GENESIS_VERSION, 9).
 -define(GENESIS_HEIGHT, 0).
 
 -define(BLOCK_HEADER_HASH_BYTES, 32).

--- a/apps/aecore/src/aec_txs_trees.erl
+++ b/apps/aecore/src/aec_txs_trees.erl
@@ -28,7 +28,7 @@
 
 -spec from_txs([aetx_sign:signed_tx(), ...]) -> txs_tree().
 from_txs(Txs = [_|_]) ->
-    lists:foldl(fun enter_signed_tx/2, empty(), Txs).
+    from_txs(Txs, 0, aeu_mtrees:empty()).
 
 -spec root_hash(txs_tree()) -> {ok, root_hash()}.
 root_hash(TxsTree) ->
@@ -38,13 +38,9 @@ root_hash(TxsTree) ->
 %%% Internal functions
 %%%===================================================================
 
-empty() ->
-    aeu_mtrees:empty().
-
-enter(K, V, T) ->
-    aeu_mtrees:enter(K, V, T).
-
-enter_signed_tx(SignedTx, TxsTree) ->
-    V = aetx_sign:serialize_to_binary(SignedTx),
-    K = aec_hash:hash(signed_tx, V),
-    enter(K, V, TxsTree).
+from_txs([],_Position, Tree) ->
+    Tree;
+from_txs([SignedTx|Left], Position, Tree) ->
+    Key = binary:encode_unsigned(Position),
+    Val = aetx_sign:serialize_to_binary(SignedTx),
+    from_txs(Left, Position + 1, aeu_mtrees:enter(Key, Val, Tree)).

--- a/apps/aecore/test/aec_mining_tests.erl
+++ b/apps/aecore/test/aec_mining_tests.erl
@@ -36,7 +36,7 @@ mine_block_test_() ->
                  % and will invalidate the nonce value below
                  % in order to find a proper nonce for your
                  %let_it_crash = generate_valid_test_data(TopBlock, 100000000000000),
-                 meck:expect(aec_pow, pick_nonce, 0, 11523412447127618300),
+                 meck:expect(aec_pow, pick_nonce, 0, 3907942707503327305),
 
                  {ok, BlockCandidate, Nonce} = ?TEST_MODULE:create_block_candidate(TopBlock, aec_trees:new(), []),
                  HeaderBin = aec_headers:serialize_for_hash(aec_blocks:to_header(BlockCandidate)),

--- a/deployment/ansible/deploy.yml
+++ b/deployment/ansible/deploy.yml
@@ -43,7 +43,7 @@
           port: 3013
       chain:
         persist: true
-        db_path: "./db39"
+        db_path: "./db40"
       keypair:
         dir: "keys"
         password: "{{ vault_keys_password|default('secret') }}"

--- a/docs/release-notes/RELEASE-NOTES-0.10.0.md
+++ b/docs/release-notes/RELEASE-NOTES-0.10.0.md
@@ -4,6 +4,7 @@
 It:
 * Improves chain handling by storing accumulated difficulty in the db rather than recomputing it. This impacts the persisted DB.
 * Enable user configuration of HTTP API acceptors pool
+* Restructure the transaction root hash in the block header for stricter validation. This impacts consensus and the persisted DB.
 * Improves the stability of the node.
 * Does this. This impacts consensus;
 * Does that. This impacts the persisted DB;


### PR DESCRIPTION
This makes the transaction root hash dependent on the order of transactions

https://www.pivotaltracker.com/n/projects/2124891/stories/156130705