### PR TITLE
Comment why we use erlexec

### DIFF
--- a/apps/aecore/src/aec_pow_cuckoo.erl
+++ b/apps/aecore/src/aec_pow_cuckoo.erl
@@ -5,6 +5,16 @@
 %%%    Using (as an independent OS process) the C/C++ Cuckoo Cycle implementation of
 %%%    John Tromp:  https://github.com/tromp/cuckoo
 %%%    White paper: https://github.com/tromp/cuckoo/blob/master/doc/cuckoo.pdf?raw=true
+%%%
+%%%    We use erlexec to start an OS process that runs this C code.
+%%%    The reasons for using erlexec over os:cmd are:
+%%%    -  os:cmd is insufficient because cuckoo miner program streams solutions on stdout as it finds them, 
+%%%       while the program returns only when whole possibilities are explored. 
+%%%       So integration with cuckoo needs to stream stdout.
+%%%    - Erlang port is closed implicitly by erlang VM closing stdin of spawned process, on the assumption 
+%%%      that spawned program will eventual read from stdin and hence terminate. 
+%%%      The cuckoo program does not read from stdin
+%%%
 %%% @end
 %%%-------------------------------------------------------------------
 -module(aec_pow_cuckoo).


### PR DESCRIPTION
Instead of documenting improtant design decisions in slack, the code may be a better place to remember it.