### PR TITLE
PT-154173362 VM/chain API

### DIFF
--- a/apps/aecontract/include/contract_txs.hrl
+++ b/apps/aecontract/include/contract_txs.hrl
@@ -21,6 +21,9 @@
           amount     :: aect_contracts:amount(),
           gas        :: aect_contracts:amount(),
           gas_price  :: aect_contracts:amount(),
-          call_data  :: binary()
+          call_data  :: binary(),
+          call_stack = [] :: [non_neg_integer()]
+            %% addresses (the pubkey as an integer) of contracts on the call
+            %% stack
           }).
 

--- a/apps/aecontract/src/aect_call_tx.erl
+++ b/apps/aecontract/src/aect_call_tx.erl
@@ -277,6 +277,7 @@ run_contract(#contract_call_tx
     %% TODO: Handle different VMs and ABIs.
     %% TODO: Move init and execution to a separate moidule to be re used by
     %% both on chain and off chain calls.
+    ChainState    = aevm_chain:new_state(Trees, Height, ContractPubKey),
     try aevm_eeevm_state:init(
 	  #{ exec => #{ code     => Code,
 			address  => 0,        %% We start executing at address 0
@@ -291,7 +292,9 @@ run_contract(#contract_call_tx
                       currentDifficulty => 0,
                       currentGasLimit   => Gas,
                       currentNumber     => Height,
-                      currentTimestamp  => 0},
+                      currentTimestamp  => 0,
+                      chainState        => ChainState,
+                      chainAPI          => aevm_chain},
              pre => #{}},
           #{trace => false})
     of

--- a/apps/aecontract/src/aect_call_tx.erl
+++ b/apps/aecontract/src/aect_call_tx.erl
@@ -317,7 +317,7 @@ run_contract(#contract_call_tx
     %% TODO: Handle different VMs and ABIs.
     %% TODO: Move init and execution to a separate moidule to be re used by
     %% both on chain and off chain calls.
-    ChainState    = aevm_chain:new_state(Trees, Height, ContractPubKey),
+    ChainState = aec_vm_chain:new_state(Trees, Height, ContractPubKey),
     <<Address:?PUB_SIZE/unit:8>> = ContractPubKey,
     try aevm_eeevm_state:init(
 	  #{ exec => #{ code       => Code,
@@ -336,7 +336,7 @@ run_contract(#contract_call_tx
                       currentNumber     => Height,
                       currentTimestamp  => 0,
                       chainState        => ChainState,
-                      chainAPI          => aevm_chain},
+                      chainAPI          => aec_vm_chain},
              pre => #{}},
           #{trace => false})
     of

--- a/apps/aecontract/src/aect_call_tx.erl
+++ b/apps/aecontract/src/aect_call_tx.erl
@@ -17,8 +17,8 @@
          fee/1,
          nonce/1,
          origin/1,
-         check/3,
-         process/3,
+         check/4,
+         process/4,
          accounts/1,
          signers/1,
          serialization_template/1,
@@ -84,11 +84,11 @@ origin(#contract_call_tx{caller = CallerPubKey}) ->
 
 %% CallerAccount should exist, and have enough funds for the fee + gas cost
 %% Contract should exist and its vm_version should match the one in the call.
--spec check(tx(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()} | {error, term()}.
+-spec check(tx(), aetx:tx_context(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()} | {error, term()}.
 check(#contract_call_tx{caller = CallerPubKey, nonce = Nonce,
                         fee = Fee,
                         gas = GasLimit, gas_price = GasPrice
-                       } = CallTx, Trees, Height) ->
+                       } = CallTx, _Context, Trees, Height) ->
     RequiredAmount = Fee + GasLimit * GasPrice,
     Checks =
         [fun() -> aetx_utils:check_account(CallerPubKey, Trees, Height, Nonce, RequiredAmount) end,
@@ -108,10 +108,10 @@ accounts(Tx) ->
 signers(Tx) ->
     [caller(Tx)].
 
--spec process(tx(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()}.
+-spec process(tx(), aetx:tx_context(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()}.
 process(#contract_call_tx{caller = CallerPubKey, nonce = Nonce, fee = Fee,
                           gas_price = GasPrice
-                         } = CallTx, Trees0, Height) ->
+                         } = CallTx, Context, Trees0, Height) ->
     AccountsTree0  = aec_trees:accounts(Trees0),
     ContractsTree0 = aec_trees:contracts(Trees0),
 

--- a/apps/aecontract/src/aect_call_tx.erl
+++ b/apps/aecontract/src/aect_call_tx.erl
@@ -36,6 +36,7 @@
          gas_price/1,
          call_data/1]).
 
+-define(PUB_SIZE, 65).
 
 -define(CONTRACT_CALL_TX_VSN, 1).
 -define(CONTRACT_CALL_TX_TYPE, contract_call_tx).
@@ -305,9 +306,10 @@ run_contract(#contract_call_tx
     %% TODO: Move init and execution to a separate moidule to be re used by
     %% both on chain and off chain calls.
     ChainState    = aevm_chain:new_state(Trees, Height, ContractPubKey),
+    <<Address:?PUB_SIZE/unit:8>> = ContractPubKey,
     try aevm_eeevm_state:init(
 	  #{ exec => #{ code     => Code,
-			address  => 0,        %% We start executing at address 0
+			address  => Address,
 			caller   => Caller,
 			data     => CallData,
 			gas      => Gas,
@@ -340,7 +342,7 @@ run_contract(#contract_call_tx
 		{error,_Error, #{ gas :=_GasLeft}} ->
 		    aect_call:set_gas_used(Gas,
 					   aect_call:set_return_value(<<>>, Call))
-		    
+
 	    catch _:_ -> Call
 	    end
     catch _:_ ->

--- a/apps/aecontract/src/aect_contracts.erl
+++ b/apps/aecontract/src/aect_contracts.erl
@@ -19,6 +19,7 @@
         , pubkey/1
         , balance/1
         , height/1
+        , nonce/1
         , owner/1
         , vm_version/1
         , code/1
@@ -33,6 +34,7 @@
         , set_pubkey/2
         , set_balance/2
         , set_height/2
+        , set_nonce/2
         , set_owner/2
         , set_vm_version/2
         , set_code/2
@@ -54,6 +56,7 @@
         pubkey     :: pubkey(),
         balance    :: amount(),
         height     :: height(),
+        nonce      :: non_neg_integer(),
         %% Contract-specific fields
         owner      :: pubkey(),
         vm_version :: vm_version(),
@@ -97,6 +100,7 @@ new(ContractPubKey, RTx, BlockHeight) ->
     C = #contract{ pubkey     = ContractPubKey,
                    balance    = aect_create_tx:amount(RTx),
                    height     = BlockHeight,
+                   nonce      = 0,
                    %% Contract-specific fields
                    owner      = aect_create_tx:owner(RTx),
                    vm_version = aect_create_tx:vm_version(RTx),
@@ -120,6 +124,7 @@ serialize(#contract{} = C) ->
       [ {pubkey, pubkey(C)}
       , {balance, balance(C)}
       , {height, height(C)}
+      , {nonce, nonce(C)}
       , {owner, owner(C)}
       , {vm_version, vm_version(C)}
       , {code, code(C)}
@@ -135,6 +140,7 @@ deserialize(Bin) ->
     [ {pubkey, Pubkey}
     , {balance, Balance}
     , {height, Height}
+    , {nonce, Nonce}
     , {owner, Owner}
     , {vm_version, VmVersion}
     , {code, Code}
@@ -152,6 +158,7 @@ deserialize(Bin) ->
     #contract{ pubkey     = Pubkey
              , balance    = Balance
              , height     = Height
+             , nonce      = Nonce
              , owner      = Owner
              , vm_version = VmVersion
              , code       = Code
@@ -166,6 +173,7 @@ serialization_template(?CONTRACT_VSN) ->
     [ {pubkey, binary}
     , {balance, int}
     , {height, int}
+    , {nonce, int}
     , {owner, binary}
     , {vm_version, int}
     , {code, binary}
@@ -198,6 +206,10 @@ balance(C) -> C#contract.balance.
 %% The block height of the last transaction on the contract.
 -spec height(contract()) -> height().
 height(C) -> C#contract.height.
+
+%% The nonce of the contract account
+-spec nonce(contract()) -> non_neg_integer().
+nonce(C) -> C#contract.nonce.
 
 %% The owner of the contract is (initially) the account that created it.
 -spec owner(contract()) -> pubkey().
@@ -254,6 +266,10 @@ set_balance(X, C) ->
 set_height(X, C) ->
     C#contract{height = assert_field(height, X)}.
 
+-spec set_nonce(non_neg_integer(), contract()) -> contract().
+set_nonce(X, C) ->
+    C#contract{nonce = assert_field(nonce, X)}.
+
 -spec set_owner(pubkey(), contract()) -> contract().
 set_owner(X, C) ->
     C#contract{owner = assert_field(owner, X)}.
@@ -294,6 +310,7 @@ assert_fields(C) ->
     List = [ {pubkey,     C#contract.pubkey}
            , {balance,    C#contract.balance}
            , {height,     C#contract.height}
+           , {nonce,      C#contract.nonce}
            , {owner,      C#contract.owner}
            , {vm_version, C#contract.vm_version}
            , {code,       C#contract.code}
@@ -313,6 +330,7 @@ assert_fields(C) ->
 assert_field(pubkey, <<_:?PUB_SIZE/binary>> = X)         -> X;
 assert_field(balance, X)    when is_integer(X), X >= 0   -> X;
 assert_field(height, X)     when is_integer(X), X > 0    -> X;
+assert_field(nonce, X)      when is_integer(X), X >= 0   -> X;
 assert_field(owner,  <<_:?PUB_SIZE/binary>> = X)         -> X;
 assert_field(vm_version, X) when is_integer(X), X >= 0   -> X;
 assert_field(code, X)       when is_binary(X)            -> X;

--- a/apps/aecontract/src/aect_contracts.erl
+++ b/apps/aecontract/src/aect_contracts.erl
@@ -105,6 +105,8 @@ new(ContractPubKey, RTx, BlockHeight) ->
         aect_create_tx:code(RTx),
         aect_create_tx:deposit(RTx)).
 
+-spec new(pubkey(), height(), amount(), pubkey(), integer(), binary(), amount()) -> contract().
+%% NOTE: Should only be used for contract execution without transaction
 new(ContractPubKey, BlockHeight, Amount, Owner, VmVersion, Code, Deposit) ->
     C = #contract{ pubkey     = ContractPubKey,
                    balance    = Amount,

--- a/apps/aecontract/src/aect_contracts.erl
+++ b/apps/aecontract/src/aect_contracts.erl
@@ -13,6 +13,7 @@
 -export([ deserialize/1
         , id/1
         , new/3
+        , new/7 %% For use without transaction
         , serialize/1
         , compute_contract_pubkey/2
           %% Getters
@@ -97,19 +98,27 @@ id(C) ->
 
 -spec new(pubkey(), aect_create_tx:tx(), height()) -> contract().
 new(ContractPubKey, RTx, BlockHeight) ->
+    new(ContractPubKey, BlockHeight,
+        aect_create_tx:amount(RTx),
+        aect_create_tx:owner(RTx),
+        aect_create_tx:vm_version(RTx),
+        aect_create_tx:code(RTx),
+        aect_create_tx:deposit(RTx)).
+
+new(ContractPubKey, BlockHeight, Amount, Owner, VmVersion, Code, Deposit) ->
     C = #contract{ pubkey     = ContractPubKey,
-                   balance    = aect_create_tx:amount(RTx),
+                   balance    = Amount,
                    height     = BlockHeight,
                    nonce      = 0,
                    %% Contract-specific fields
-                   owner      = aect_create_tx:owner(RTx),
-                   vm_version = aect_create_tx:vm_version(RTx),
-                   code       = aect_create_tx:code(RTx),
+                   owner      = Owner,
+                   vm_version = VmVersion,
+                   code       = Code,
                    state      = <<>>,
                    log        = <<>>,
                    active     = true,
                    referers   = [],
-                   deposit    = aect_create_tx:deposit(RTx)
+                   deposit    = Deposit
                  },
     C = assert_fields(C),
     %% TODO: call the init function to initialise the state

--- a/apps/aecontract/src/aect_contracts.erl
+++ b/apps/aecontract/src/aect_contracts.erl
@@ -28,6 +28,8 @@
         , referers/1
         , deposit/1
           %% Setters
+        , spend/2
+        , earn/2
         , set_pubkey/2
         , set_balance/2
         , set_height/2
@@ -231,6 +233,14 @@ deposit(C) -> C#contract.deposit.
 
 %%%===================================================================
 %%% Setters
+
+-spec spend(amount(), contract()) -> contract().
+spend(Amount, C) ->
+    C#contract{balance = assert_field(balance, C#contract.balance - Amount)}.
+
+-spec earn(amount(), contract()) -> contract().
+earn(Amount, C) ->
+    C#contract{balance = assert_field(balance, C#contract.balance + Amount)}.
 
 -spec set_pubkey(pubkey(), contract()) -> contract().
 set_pubkey(X, C) ->

--- a/apps/aecontract/src/aect_create_tx.erl
+++ b/apps/aecontract/src/aect_create_tx.erl
@@ -17,8 +17,8 @@
          fee/1,
          nonce/1,
          origin/1,
-         check/3,
-         process/3,
+         check/4,
+         process/4,
          accounts/1,
          signers/1,
          serialization_template/1,
@@ -128,9 +128,9 @@ origin(#contract_create_tx{owner = OwnerPubKey}) ->
     OwnerPubKey.
 
 %% Owner should exist, and have enough funds for the fee
--spec check(tx(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()} | {error, term()}.
+-spec check(tx(), aetx:tx_context(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()} | {error, term()}.
 check(#contract_create_tx{owner = OwnerPubKey, nonce = Nonce,
-                          fee = Fee}, Trees, Height) ->
+                          fee = Fee}, _Context, Trees, Height) ->
     Checks =
         [fun() -> aetx_utils:check_account(OwnerPubKey, Trees, Height, Nonce, Fee) end],
 
@@ -147,10 +147,10 @@ accounts(#contract_create_tx{owner = OwnerPubKey}) ->
 signers(#contract_create_tx{owner = OwnerPubKey}) ->
     [OwnerPubKey].
 
--spec process(tx(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()}.
+-spec process(tx(), aetx:tx_context(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()}.
 process(#contract_create_tx{owner = OwnerPubKey,
                             nonce = Nonce,
-                            fee   = Fee} = CreateTx, Trees0, Height) ->
+                            fee   = Fee} = CreateTx, _Context, Trees0, Height) ->
     AccountsTree0  = aec_trees:accounts(Trees0),
     ContractsTree0 = aec_trees:contracts(Trees0),
 

--- a/apps/aecontract/src/aect_evm.erl
+++ b/apps/aecontract/src/aect_evm.erl
@@ -25,7 +25,7 @@ call(Code, CallData) ->
 
     %% TODO: proper setup of chain state!
     DummyPubKey = aect_contracts:compute_contract_pubkey(<<"TODO!!!">>, 1),
-    ChainState  = aevm_chain:new_state(aec_trees:new(), 1, DummyPubKey),
+    ChainState  = aec_vm_chain:new_state(aec_trees:new(), 1, DummyPubKey),
     Spec = #{ code => Code
             , address => 0
             , caller => 0
@@ -40,7 +40,7 @@ call(Code, CallData) ->
             , currentNumber => 1
             , currentTimestamp => 1
             , chainState => ChainState
-            , chainAPI => aevm_chain
+            , chainAPI => aec_vm_chain
             },
     try execute_call(Spec, true) of
         {ok, #{ out := Out }} -> {ok, aeu_hex:hexstring_encode(Out)};

--- a/apps/aecontract/src/aect_evm.erl
+++ b/apps/aecontract/src/aect_evm.erl
@@ -23,6 +23,9 @@ encode_call_data(_Contract, Function, Argument) ->
 call(Code, CallData) ->
     Data = aeu_hex:hexstring_decode(CallData),
 
+    %% TODO: proper setup of chain state!
+    DummyPubKey = aect_contracts:compute_contract_pubkey(<<"TODO!!!">>, 1),
+    ChainState  = aevm_chain:new_state(aec_trees:new(), 1, DummyPubKey),
     Spec = #{ code => Code
             , address => 0
             , caller => 0
@@ -36,6 +39,8 @@ call(Code, CallData) ->
             , currentGasLimit => 10000000000000000000000
             , currentNumber => 1
             , currentTimestamp => 1
+            , chainState => ChainState
+            , chainAPI => aevm_chain
             },
     try execute_call(Spec, true) of
         {ok, #{ out := Out }} -> {ok, aeu_hex:hexstring_encode(Out)};
@@ -59,6 +64,8 @@ execute_call(#{ code := CodeAsHexBinString
               , currentGasLimit := GasLimit
               , currentNumber := Number
               , currentTimestamp := TS
+              , chainState := ChainState
+              , chainAPI := ChainAPI
               }, Trace) ->
     %% TODO: Handle Contract In State.
     Code = aeu_hex:hexstring_decode(CodeAsHexBinString),
@@ -77,6 +84,8 @@ execute_call(#{ code := CodeAsHexBinString
                    , currentGasLimit => GasLimit
                    , currentNumber => Number
                    , currentTimestamp => TS
+                   , chainState => ChainState
+                   , chainAPI => ChainAPI
                    },
            pre => #{}},
     TraceSpec =

--- a/apps/aecontract/src/aect_ring.erl
+++ b/apps/aecontract/src/aect_ring.erl
@@ -53,8 +53,17 @@ simple_call(Code, Function, Argument) ->
         {error, E} -> {error, E};
         CallData ->
             %% TODO: proper setup of chain state!
-            DummyPubKey = aect_contracts:compute_contract_pubkey(<<"TODO!!!">>, 1),
-            ChainState  = aec_vm_chain:new_state(aec_trees:new(), 1, DummyPubKey),
+            Owner = <<123456:65/unit:8>>,
+            DummyPubKey = aect_contracts:compute_contract_pubkey(Owner, 1),
+            {Block, Trees} = aec_chain:top_block_with_state(),
+            BlockHeight = aec_blocks:height(Block) + 1,
+            Amount = 0,
+            VmVersion = 1,
+            Deposit = 0,
+            Contract = aect_contracts:new(DummyPubKey, BlockHeight, Amount,
+                                          Owner, VmVersion, Code, Deposit),
+            Trees1 = insert_contract(Contract, Trees),
+            ChainState  = aec_vm_chain:new_state(Trees1, BlockHeight, DummyPubKey),
             Spec = #{ code => Code
                     , address => 0
                     , caller => 0
@@ -62,7 +71,7 @@ simple_call(Code, Function, Argument) ->
                     , gas => 1000000
                     , gasPrice => 1
                     , origin => 0
-                    , value => 0
+                    , value => Amount
                     , currentCoinbase => 1
                     , currentDifficulty => 1
                     , currentGasLimit => 1000000
@@ -77,6 +86,11 @@ simple_call(Code, Function, Argument) ->
                 E -> {error, list_to_binary(io_lib:format("~p", [E]))}
             end
     end.
+
+insert_contract(Contract, Trees) ->
+    CTrees = aec_trees:contracts(Trees),
+    CTrees1 = aect_state_tree:insert_contract(Contract, CTrees),
+    aec_trees:set_contracts(Trees, CTrees1).
 
 -spec encode_call_data(binary(), binary(), binary()) -> {ok, binary()} | {error, binary()}.
 encode_call_data(Contract, Function, Argument) ->

--- a/apps/aecontract/src/aect_ring.erl
+++ b/apps/aecontract/src/aect_ring.erl
@@ -54,7 +54,7 @@ simple_call(Code, Function, Argument) ->
         CallData ->
             %% TODO: proper setup of chain state!
             DummyPubKey = aect_contracts:compute_contract_pubkey(<<"TODO!!!">>, 1),
-            ChainState  = aevm_chain:new_state(aec_trees:new(), 1, DummyPubKey),
+            ChainState  = aec_vm_chain:new_state(aec_trees:new(), 1, DummyPubKey),
             Spec = #{ code => Code
                     , address => 0
                     , caller => 0
@@ -68,7 +68,7 @@ simple_call(Code, Function, Argument) ->
                     , currentGasLimit => 1000000
                     , currentNumber => 1
                     , currentTimestamp => 1
-                    , chainAPI => aevm_chain
+                    , chainAPI => aec_vm_chain
                     , chainState => ChainState
                     },
             case aect_evm:execute_call(Spec, false) of

--- a/apps/aecontract/src/aect_ring.erl
+++ b/apps/aecontract/src/aect_ring.erl
@@ -52,6 +52,9 @@ simple_call(Code, Function, Argument) ->
     case create_call(Code, Function, Argument) of
         {error, E} -> {error, E};
         CallData ->
+            %% TODO: proper setup of chain state!
+            DummyPubKey = aect_contracts:compute_contract_pubkey(<<"TODO!!!">>, 1),
+            ChainState  = aevm_chain:new_state(aec_trees:new(), 1, DummyPubKey),
             Spec = #{ code => Code
                     , address => 0
                     , caller => 0
@@ -65,6 +68,8 @@ simple_call(Code, Function, Argument) ->
                     , currentGasLimit => 1000000
                     , currentNumber => 1
                     , currentTimestamp => 1
+                    , chainAPI => aevm_chain
+                    , chainState => ChainState
                     },
             case aect_evm:execute_call(Spec, false) of
                 {ok, #{ out := Out }} ->

--- a/apps/aecontract/src/aect_state_tree.erl
+++ b/apps/aecontract/src/aect_state_tree.erl
@@ -15,6 +15,7 @@
         , get_contract/2
         , insert_call/2
         , insert_contract/2
+        , enter_contract/2
         , lookup_contract/2
         , root_hash/1]).
 
@@ -52,7 +53,15 @@ insert_contract(Contract, Tree = #contract_tree{ contracts = CtTree }) ->
     Id         = aect_contracts:id(Contract),
     Serialized = aect_contracts:serialize(Contract),
     CtTree1    = aeu_mtrees:insert(Id, Serialized, CtTree),
-    Tree#contract_tree{ contracts = CtTree1}.
+    Tree#contract_tree{ contracts = CtTree1 }.
+
+%% @doc Update an existing contract.
+-spec enter_contract(aect_contracts:contract(), tree()) -> tree().
+enter_contract(Contract, Tree = #contract_tree{ contracts = CtTree }) ->
+    Id         = aect_contracts:id(Contract),
+    Serialized = aect_contracts:serialize(Contract),
+    CtTree1    = aeu_mtrees:enter(Id, Serialized, CtTree),
+    Tree#contract_tree{ contracts = CtTree1 }.
 
 -spec get_contract(aect_contracts:id(), tree()) -> aect_contracts:contract().
 get_contract(Id, #contract_tree{ contracts = CtTree }) ->

--- a/apps/aecontract/src/aect_utils.erl
+++ b/apps/aecontract/src/aect_utils.erl
@@ -7,7 +7,7 @@
 
 -module(aect_utils).
 
--export([hex_bytes/1, hex_byte/1, check_balance/3]).
+-export([hex_bytes/1, hex_byte/1, check_balance/3, check/2]).
 
 -include_lib("apps/aecore/include/common.hrl").
 
@@ -24,9 +24,10 @@ check_balance(ContractKey, Trees, Amount) ->
     ContractsTree = aec_trees:contracts(Trees),
     case aect_state_tree:lookup_contract(ContractKey, ContractsTree) of
         {value, Contract} ->
-            case aect_contracts:balance(Contract) >= Amount of
-                true  -> ok;
-                false -> {error, insufficient_funds}
-            end;
+            check(aect_contracts:balance(Contract) >= Amount, insufficient_funds);
         none -> {error, contract_not_found}
     end.
+
+check(true, _) -> ok;
+check(false, Err) -> {error, Err}.
+

--- a/apps/aecontract/src/aect_utils.erl
+++ b/apps/aecontract/src/aect_utils.erl
@@ -7,7 +7,7 @@
 
 -module(aect_utils).
 
--export([hex_bytes/1, hex_byte/1]).
+-export([hex_bytes/1, hex_byte/1, check_balance/3]).
 
 -include_lib("apps/aecore/include/common.hrl").
 
@@ -19,3 +19,14 @@ hex_byte(N) ->
 hex_bytes(Bin) ->
     lists:flatten("0x" ++ [io_lib:format("~2.16.0B", [B]) || <<B:8>> <= Bin]).
 
+-spec check_balance(pubkey(), aec_trees:trees(), non_neg_integer()) -> ok | {error, term()}.
+check_balance(ContractKey, Trees, Amount) ->
+    ContractsTree = aec_trees:contracts(Trees),
+    case aect_state_tree:lookup_contract(ContractKey, ContractsTree) of
+        {value, Contract} ->
+            case aect_contracts:balance(Contract) >= Amount of
+                true  -> ok;
+                false -> {error, insufficient_funds}
+            end;
+        none -> {error, contract_not_found}
+    end.

--- a/apps/aecontract/test/aecontract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_SUITE.erl
@@ -117,10 +117,14 @@ call_contract(_Cfg) ->
     %% Now call check that we can call it.
     Fee           = 107,
     GasPrice      = 2,
+    Value         = 52,
     Arg           = <<"42">>,
     CallData = aect_ring:create_call(IdContract, <<"main">>, Arg),
     CallTx = aect_test_utils:call_tx(Caller, ContractKey,
-                                     #{call_data => CallData, gas_price => GasPrice, fee => Fee}, S3),
+                                     #{call_data => CallData,
+                                       gas_price => GasPrice,
+                                       amount    => Value,
+                                       fee       => Fee}, S3),
     {SignedTx1, [SignedTx1], S4} = sign_and_apply_transaction(CallTx, CallerPrivKey, S3),
     CallId = aect_call:id(Caller, aetx:nonce(CallTx), ContractKey),
 
@@ -130,7 +134,7 @@ call_contract(_Cfg) ->
 
     %% ...and that we got charged the right amount for gas and fee.
     NewCallerBalance = aec_accounts:balance(aect_test_utils:get_account(Caller, S4)),
-    NewCallerBalance = CallerBalance - Fee - GasPrice * aect_call:gas_used(Call),
+    NewCallerBalance = CallerBalance - Fee - GasPrice * aect_call:gas_used(Call) - Value,
 
     {ok, S4}.
 

--- a/apps/aecore/include/blocks.hrl
+++ b/apps/aecore/include/blocks.hrl
@@ -1,8 +1,8 @@
 -include("pow.hrl").
 
--define(PROTOCOL_VERSION, 9).
+-define(PROTOCOL_VERSION, 10).
 
--define(GENESIS_VERSION, 9).
+-define(GENESIS_VERSION, 10).
 -define(GENESIS_HEIGHT, 0).
 
 -define(BLOCK_HEADER_HASH_BYTES, 32).

--- a/apps/aecore/src/aec_coinbase_tx.erl
+++ b/apps/aecore/src/aec_coinbase_tx.erl
@@ -10,8 +10,8 @@
          fee/1,
          nonce/1,
          origin/1,
-         check/3,
-         process/3,
+         check/4,
+         process/4,
          accounts/1,
          signers/1,
          serialize/1,
@@ -58,12 +58,12 @@ nonce(#coinbase_tx{}) ->
 origin(#coinbase_tx{}) ->
     undefined.
 
--spec check(tx(), aec_trees:trees(), height()) ->
+-spec check(tx(), aetx:tx_context(), aec_trees:trees(), height()) ->
                     {ok, aec_trees:trees()} | {error, term()}.
-check(#coinbase_tx{block_height = CBHeight}, _Trees, Height)
+check(#coinbase_tx{block_height = CBHeight}, _Context, _Trees, Height)
     when CBHeight =/= Height ->
     {error, wrong_height};
-check(#coinbase_tx{account = AccountPubkey, reward = Reward}, Trees, Height) ->
+check(#coinbase_tx{account = AccountPubkey, reward = Reward}, _Context, Trees, Height) ->
     ExpectedReward = aec_governance:block_mine_reward(),
     case Reward =:= ExpectedReward of
         true ->
@@ -75,8 +75,8 @@ check(#coinbase_tx{account = AccountPubkey, reward = Reward}, Trees, Height) ->
 %% Only aec_governance:block_mine_reward() is granted to miner's account here.
 %% Amount from all the fees of transactions included in the block
 %% is added to miner's account in aec_trees:apply_signed_txs/3.
--spec process(tx(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()}.
-process(#coinbase_tx{account = AccountPubkey, reward = Reward}, Trees0, Height) ->
+-spec process(tx(), aetx:tx_context(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()}.
+process(#coinbase_tx{account = AccountPubkey, reward = Reward}, _Context, Trees0, Height) ->
     AccountsTrees0 = aec_trees:accounts(Trees0),
     {value, Account0} = aec_accounts_trees:lookup(AccountPubkey, AccountsTrees0),
 

--- a/apps/aecore/src/aec_spend_tx.erl
+++ b/apps/aecore/src/aec_spend_tx.erl
@@ -11,8 +11,8 @@
          nonce/1,
          origin/1,
          recipient/1,
-         check/3,
-         process/3,
+         check/4,
+         process/4,
          accounts/1,
          signers/1,
          serialization_template/1,
@@ -76,8 +76,8 @@ origin(#spend_tx{sender = Sender}) ->
 recipient(#spend_tx{recipient = Recipient}) ->
     Recipient.
 
--spec check(tx(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()} | {error, term()}.
-check(#spend_tx{recipient = RecipientPubkey} = SpendTx, Trees0, Height) ->
+-spec check(tx(), aetx:tx_context(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()} | {error, term()}.
+check(#spend_tx{recipient = RecipientPubkey} = SpendTx, _Context, Trees0, Height) ->
     Checks = [fun check_tx_fee/3,
               fun check_sender_account/3],
     case aeu_validation:run(Checks, [SpendTx, Trees0, Height]) of
@@ -99,12 +99,12 @@ accounts(#spend_tx{sender = SenderPubKey, recipient = RecipientPubKey}) ->
 -spec signers(tx()) -> [pubkey()].
 signers(#spend_tx{sender = SenderPubKey}) -> [SenderPubKey].
 
--spec process(tx(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()}.
+-spec process(tx(), aetx:tx_context(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()}.
 process(#spend_tx{sender = SenderPubkey,
                   recipient = RecipientPubkey,
                   amount = Amount,
                   fee = Fee,
-                  nonce = Nonce}, Trees0, Height) ->
+                  nonce = Nonce}, _Context, Trees0, Height) ->
     AccountsTrees0 = aec_trees:accounts(Trees0),
 
     {value, SenderAccount0} = aec_accounts_trees:lookup(SenderPubkey, AccountsTrees0),

--- a/apps/aecore/src/aec_vm_chain.erl
+++ b/apps/aecore/src/aec_vm_chain.erl
@@ -1,18 +1,18 @@
 %%%=============================================================================
 %%% @copyright 2018, Aeternity Anstalt
 %%% @doc
-%%%    Implementation of the aevm_chain_api.
+%%%    Implementation of the aec_vm_chain_api.
 %%% @end
 %%%=============================================================================
--module(aevm_chain).
+-module(aec_vm_chain).
 
 -include_lib("apps/aecore/include/common.hrl").
 
--behaviour(aevm_chain_api).
+-behaviour(aec_vm_chain_api).
 
 -export([new_state/3, get_trees/1]).
 
-%% aevm_chain_api callbacks
+%% aec_vm_chain_api callbacks
 -export([get_balance/1,
          spend/3,
          call_contract/6]).
@@ -68,7 +68,7 @@ spend(Recipient, Amount, State = #state{ trees   = Trees,
 %% @doc Call another contract.
 -spec call_contract(pubkey(), non_neg_integer(), non_neg_integer(), binary(),
                     [non_neg_integer()], chain_state()) ->
-        {ok, aevm_chain_api:call_result(), chain_state()} | {error, term()}.
+        {ok, aec_vm_chain_api:call_result(), chain_state()} | {error, term()}.
 call_contract(Target, Gas, Value, CallData, CallStack,
               State = #state{ trees   = Trees,
                               height  = Height,
@@ -95,9 +95,9 @@ call_contract(Target, Gas, Value, CallData, CallStack,
             GasUsed = aect_call:gas_used(Call),
             Result  = case aect_call:return_value(Call) of
                           %% TODO: currently we don't set any sensible return value on exceptions
-                          <<>> -> aevm_chain_api:call_exception(out_of_gas, GasUsed);
+                          <<>> -> aec_vm_chain_api:call_exception(out_of_gas, GasUsed);
                           Bin when is_binary(Bin) ->
-                            aevm_chain_api:call_result(Bin, GasUsed)
+                            aec_vm_chain_api:call_result(Bin, GasUsed)
                       end,
             {ok, Result, State#state{ trees = Trees2, nonce = Nonce + 1 }}
     end.

--- a/apps/aecore/src/aec_vm_chain_api.erl
+++ b/apps/aecore/src/aec_vm_chain_api.erl
@@ -5,7 +5,7 @@
 %%%    chain.
 %%% @end
 %%%=============================================================================
--module(aevm_chain_api).
+-module(aec_vm_chain_api).
 
 -include_lib("apps/aecore/include/common.hrl").
 

--- a/apps/aecore/test/aec_mining_tests.erl
+++ b/apps/aecore/test/aec_mining_tests.erl
@@ -35,8 +35,8 @@ mine_block_test_() ->
                  % this will result in a change in the hash of the header
                  % and will invalidate the nonce value below
                  % in order to find a proper nonce for your
-                 %let_it_crash = generate_valid_test_data(TopBlock, 100000000000000),
-                 meck:expect(aec_pow, pick_nonce, 0, 17575765576845162115),
+                 % let_it_crash = generate_valid_test_data(TopBlock, 100000000000000),
+                 meck:expect(aec_pow, pick_nonce, 0, 11360486843977841823),
 
                  {ok, BlockCandidate, Nonce} = ?TEST_MODULE:create_block_candidate(TopBlock, aec_trees:new(), []),
                  HeaderBin = aec_headers:serialize_for_hash(aec_blocks:to_header(BlockCandidate)),

--- a/apps/aens/src/aens_claim_tx.erl
+++ b/apps/aens/src/aens_claim_tx.erl
@@ -18,8 +18,8 @@
          fee/1,
          nonce/1,
          origin/1,
-         check/3,
-         process/3,
+         check/4,
+         process/4,
          accounts/1,
          signers/1,
          serialization_template/1,
@@ -76,9 +76,9 @@ nonce(#ns_claim_tx{nonce = Nonce}) ->
 origin(#ns_claim_tx{account = AccountPubKey}) ->
     AccountPubKey.
 
--spec check(tx(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()} | {error, term()}.
+-spec check(tx(), aetx:tx_context(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()} | {error, term()}.
 check(#ns_claim_tx{account = AccountPubKey, nonce = Nonce,
-                   fee = Fee, name = Name, name_salt = NameSalt}, Trees, Height) ->
+                   fee = Fee, name = Name, name_salt = NameSalt}, _Context, Trees, Height) ->
     case aens_utils:to_ascii(Name) of
         {ok, NameAscii} ->
             %% TODO: Maybe include burned fee in tx fee. To do so, mechanism determining
@@ -99,9 +99,9 @@ check(#ns_claim_tx{account = AccountPubKey, nonce = Nonce,
             {error, Reason}
     end.
 
--spec process(tx(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()}.
+-spec process(tx(), aetx:tx_context(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()}.
 process(#ns_claim_tx{account = AccountPubKey, nonce = Nonce, fee = Fee,
-                     name = PlainName, name_salt = NameSalt} = ClaimTx, Trees0, Height) ->
+                     name = PlainName, name_salt = NameSalt} = ClaimTx, _Context, Trees0, Height) ->
     AccountsTree0 = aec_trees:accounts(Trees0),
     NSTree0 = aec_trees:ns(Trees0),
 

--- a/apps/aens/src/aens_preclaim_tx.erl
+++ b/apps/aens/src/aens_preclaim_tx.erl
@@ -18,8 +18,8 @@
          fee/1,
          nonce/1,
          origin/1,
-         check/3,
-         process/3,
+         check/4,
+         process/4,
          accounts/1,
          signers/1,
          serialization_template/1,
@@ -74,9 +74,9 @@ nonce(#ns_preclaim_tx{nonce = Nonce}) ->
 origin(#ns_preclaim_tx{account = AccountPubKey}) ->
     AccountPubKey.
 
--spec check(tx(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()} | {error, term()}.
+-spec check(tx(), aetx:tx_context(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()} | {error, term()}.
 check(#ns_preclaim_tx{account = AccountPubKey, nonce = Nonce,
-                      fee = Fee, commitment = Commitment}, Trees, Height) ->
+                      fee = Fee, commitment = Commitment}, _Context, Trees, Height) ->
     Checks =
         [fun() -> aetx_utils:check_account(AccountPubKey, Trees, Height, Nonce, Fee) end,
          fun() -> check_not_commitment(Commitment, Trees) end],
@@ -86,9 +86,9 @@ check(#ns_preclaim_tx{account = AccountPubKey, nonce = Nonce,
         {error, Reason} -> {error, Reason}
     end.
 
--spec process(tx(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()}.
+-spec process(tx(), aetx:tx_context(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()}.
 process(#ns_preclaim_tx{account = AccountPubKey, fee = Fee,
-                        nonce = Nonce} = PreclaimTx, Trees0, Height) ->
+                        nonce = Nonce} = PreclaimTx, _Context, Trees0, Height) ->
     AccountsTree0 = aec_trees:accounts(Trees0),
     NSTree0 = aec_trees:ns(Trees0),
 

--- a/apps/aens/src/aens_revoke_tx.erl
+++ b/apps/aens/src/aens_revoke_tx.erl
@@ -17,8 +17,8 @@
          fee/1,
          nonce/1,
          origin/1,
-         check/3,
-         process/3,
+         check/4,
+         process/4,
          accounts/1,
          signers/1,
          serialization_template/1,
@@ -69,9 +69,9 @@ nonce(#ns_revoke_tx{nonce = Nonce}) ->
 origin(#ns_revoke_tx{account = AccountPubKey}) ->
     AccountPubKey.
 
--spec check(tx(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()} | {error, term()}.
+-spec check(tx(), aetx:tx_context(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()} | {error, term()}.
 check(#ns_revoke_tx{account = AccountPubKey, nonce = Nonce,
-                    fee = Fee, name_hash = NameHash}, Trees, Height) ->
+                    fee = Fee, name_hash = NameHash}, _Context, Trees, Height) ->
     Checks =
         [fun() -> aetx_utils:check_account(AccountPubKey, Trees, Height, Nonce, Fee) end,
          fun() -> aens_utils:check_name_claimed_and_owned(NameHash, AccountPubKey, Trees) end],
@@ -81,9 +81,9 @@ check(#ns_revoke_tx{account = AccountPubKey, nonce = Nonce,
         {error, Reason} -> {error, Reason}
     end.
 
--spec process(tx(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()}.
+-spec process(tx(), aetx:tx_context(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()}.
 process(#ns_revoke_tx{account = AccountPubKey, fee = Fee,
-                      name_hash = NameHash, nonce = Nonce}, Trees0, Height) ->
+                      name_hash = NameHash, nonce = Nonce}, _Context, Trees0, Height) ->
     AccountsTree0 = aec_trees:accounts(Trees0),
     NamesTree0 = aec_trees:ns(Trees0),
 

--- a/apps/aens/src/aens_transfer_tx.erl
+++ b/apps/aens/src/aens_transfer_tx.erl
@@ -18,8 +18,8 @@
          fee/1,
          nonce/1,
          origin/1,
-         check/3,
-         process/3,
+         check/4,
+         process/4,
          accounts/1,
          signers/1,
          serialization_template/1,
@@ -75,9 +75,9 @@ nonce(#ns_transfer_tx{nonce = Nonce}) ->
 origin(#ns_transfer_tx{account = AccountPubKey}) ->
     AccountPubKey.
 
--spec check(tx(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()} | {error, term()}.
+-spec check(tx(), aetx:tx_context(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()} | {error, term()}.
 check(#ns_transfer_tx{account = AccountPubKey, nonce = Nonce,
-                      fee = Fee, name_hash = NameHash}, Trees, Height) ->
+                      fee = Fee, name_hash = NameHash}, _Context, Trees, Height) ->
     Checks =
         [fun() -> aetx_utils:check_account(AccountPubKey, Trees, Height, Nonce, Fee) end,
          fun() -> aens_utils:check_name_claimed_and_owned(NameHash, AccountPubKey, Trees) end],
@@ -87,9 +87,9 @@ check(#ns_transfer_tx{account = AccountPubKey, nonce = Nonce,
         {error, Reason} -> {error, Reason}
     end.
 
--spec process(tx(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()}.
+-spec process(tx(), aetx:tx_context(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()}.
 process(#ns_transfer_tx{account = AccountPubKey, fee = Fee,
-                        name_hash = NameHash, nonce = Nonce} = TransferTx, Trees0, Height) ->
+                        name_hash = NameHash, nonce = Nonce} = TransferTx, _Context, Trees0, Height) ->
     AccountsTree0 = aec_trees:accounts(Trees0),
     NamesTree0 = aec_trees:ns(Trees0),
 

--- a/apps/aens/src/aens_update_tx.erl
+++ b/apps/aens/src/aens_update_tx.erl
@@ -18,8 +18,8 @@
          fee/1,
          nonce/1,
          origin/1,
-         check/3,
-         process/3,
+         check/4,
+         process/4,
          accounts/1,
          signers/1,
          serialization_template/1,
@@ -81,9 +81,9 @@ nonce(#ns_update_tx{nonce = Nonce}) ->
 origin(#ns_update_tx{account = AccountPubKey}) ->
     AccountPubKey.
 
--spec check(tx(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()} | {error, term()}.
+-spec check(tx(), aetx:tx_context(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()} | {error, term()}.
 check(#ns_update_tx{account = AccountPubKey, nonce = Nonce,
-                    fee = Fee, name_hash = NameHash, ttl = TTL}, Trees, Height) ->
+                    fee = Fee, name_hash = NameHash, ttl = TTL}, _Context, Trees, Height) ->
     Checks =
         [fun() -> check_ttl(TTL) end,
          fun() -> aetx_utils:check_account(AccountPubKey, Trees, Height, Nonce, Fee) end,
@@ -94,9 +94,9 @@ check(#ns_update_tx{account = AccountPubKey, nonce = Nonce,
         {error, Reason} -> {error, Reason}
     end.
 
--spec process(tx(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()}.
+-spec process(tx(), aetx:tx_context(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()}.
 process(#ns_update_tx{account = AccountPubKey, nonce = Nonce, fee = Fee,
-                      name_hash = NameHash} = UpdateTx, Trees0, Height) ->
+                      name_hash = NameHash} = UpdateTx, _Context, Trees0, Height) ->
     AccountsTree0 = aec_trees:accounts(Trees0),
     NSTree0 = aec_trees:ns(Trees0),
 

--- a/apps/aeoracle/src/aeo_extend_tx.erl
+++ b/apps/aeoracle/src/aeo_extend_tx.erl
@@ -16,8 +16,8 @@
          fee/1,
          nonce/1,
          origin/1,
-         check/3,
-         process/3,
+         check/4,
+         process/4,
          accounts/1,
          signers/1,
          serialize/1,
@@ -75,9 +75,9 @@ origin(#oracle_extend_tx{oracle = OraclePK}) ->
 
 %% Account should exist, and have enough funds for the fee
 %% Oracle should exist.
--spec check(tx(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()} | {error, term()}.
+-spec check(tx(), aetx:tx_context(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()} | {error, term()}.
 check(#oracle_extend_tx{oracle = OraclePK, nonce = Nonce,
-                        ttl = TTL, fee = Fee}, Trees, Height) ->
+                        ttl = TTL, fee = Fee}, _Context, Trees, Height) ->
     Checks =
         [fun() -> aetx_utils:check_account(OraclePK, Trees, Height, Nonce, Fee) end,
          fun() -> ensure_oracle(OraclePK, Trees) end,
@@ -96,9 +96,9 @@ accounts(#oracle_extend_tx{oracle = OraclePK}) ->
 signers(#oracle_extend_tx{oracle = OraclePK}) ->
     [OraclePK].
 
--spec process(tx(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()}.
+-spec process(tx(), aetx:tx_context(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()}.
 process(#oracle_extend_tx{oracle = OraclePK, nonce = Nonce, fee = Fee, ttl = TTL},
-        Trees0, Height) ->
+        _Context, Trees0, Height) ->
     AccountsTree0 = aec_trees:accounts(Trees0),
     OraclesTree0  = aec_trees:oracles(Trees0),
 

--- a/apps/aeoracle/src/aeo_query_tx.erl
+++ b/apps/aeoracle/src/aeo_query_tx.erl
@@ -16,8 +16,8 @@
          fee/1,
          nonce/1,
          origin/1,
-         check/3,
-         process/3,
+         check/4,
+         process/4,
          accounts/1,
          signers/1,
          serialization_template/1,
@@ -105,10 +105,10 @@ origin(#oracle_query_tx{sender = SenderPubKey}) ->
 %% SenderAccount should exist, and have enough funds for the fee + the query_fee.
 %% Oracle should exist, and query_fee should be enough
 %% Fee should cover TTL
--spec check(tx(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()} | {error, term()}.
+-spec check(tx(), aetx:tx_context(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()} | {error, term()}.
 check(#oracle_query_tx{sender = SenderPubKey, nonce = Nonce,
                        oracle = OraclePubKey, query_fee = QFee,
-                       query_ttl = TTL, response_ttl = RTTL, fee = Fee} = Q, Trees, Height) ->
+                       query_ttl = TTL, response_ttl = RTTL, fee = Fee} = Q, _Context, Trees, Height) ->
     Checks =
         [fun() -> aetx_utils:check_account(SenderPubKey, Trees, Height, Nonce, Fee + QFee) end,
          fun() -> aeo_utils:check_ttl_fee(Height, TTL, Fee - ?ORACLE_QUERY_TX_FEE) end,
@@ -130,9 +130,9 @@ accounts(#oracle_query_tx{sender = SenderPubKey,
 signers(#oracle_query_tx{sender = SenderPubKey}) ->
     [SenderPubKey].
 
--spec process(tx(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()}.
+-spec process(tx(), aetx:tx_context(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()}.
 process(#oracle_query_tx{sender = SenderPubKey, nonce = Nonce, fee = Fee,
-                         query_fee = QueryFee} = QueryTx, Trees0, Height) ->
+                         query_fee = QueryFee} = QueryTx, _Context, Trees0, Height) ->
     AccountsTree0 = aec_trees:accounts(Trees0),
     OraclesTree0  = aec_trees:oracles(Trees0),
 

--- a/apps/aeoracle/src/aeo_register_tx.erl
+++ b/apps/aeoracle/src/aeo_register_tx.erl
@@ -16,8 +16,8 @@
          fee/1,
          nonce/1,
          origin/1,
-         check/3,
-         process/3,
+         check/4,
+         process/4,
          accounts/1,
          signers/1,
          serialization_template/1,
@@ -95,9 +95,9 @@ origin(#oracle_register_tx{account = AccountPubKey}) ->
     AccountPubKey.
 
 %% Account should exist, and have enough funds for the fee.
--spec check(tx(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()} | {error, term()}.
+-spec check(tx(), aetx:tx_context(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()} | {error, term()}.
 check(#oracle_register_tx{account = AccountPubKey, nonce = Nonce,
-                          ttl = TTL, fee = Fee}, Trees, Height) ->
+                          ttl = TTL, fee = Fee}, _Context, Trees, Height) ->
     Checks =
         [fun() -> aetx_utils:check_account(AccountPubKey, Trees, Height, Nonce, Fee) end,
          fun() -> ensure_not_oracle(AccountPubKey, Trees) end,
@@ -116,10 +116,10 @@ accounts(#oracle_register_tx{account = AccountPubKey}) ->
 signers(#oracle_register_tx{account = AccountPubKey}) ->
     [AccountPubKey].
 
--spec process(tx(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()}.
+-spec process(tx(), aetx:tx_context(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()}.
 process(#oracle_register_tx{account       = AccountPubKey,
                             nonce         = Nonce,
-                            fee           = Fee} = RegisterTx, Trees0, Height) ->
+                            fee           = Fee} = RegisterTx, _Context, Trees0, Height) ->
     AccountsTree0 = aec_trees:accounts(Trees0),
     OraclesTree0  = aec_trees:oracles(Trees0),
 

--- a/apps/aeoracle/src/aeo_response_tx.erl
+++ b/apps/aeoracle/src/aeo_response_tx.erl
@@ -16,8 +16,8 @@
          fee/1,
          nonce/1,
          origin/1,
-         check/3,
-         process/3,
+         check/4,
+         process/4,
          accounts/1,
          signers/1,
          serialization_template/1,
@@ -83,9 +83,9 @@ origin(#oracle_response_tx{oracle = OraclePubKey}) ->
 
 %% Oracle should exist, and have enough funds for the fee.
 %% QueryId id should match oracle.
--spec check(tx(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()} | {error, term()}.
+-spec check(tx(), aetx:tx_context(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()} | {error, term()}.
 check(#oracle_response_tx{oracle = OraclePubKey, nonce = Nonce,
-                          query_id = QId, fee = Fee}, Trees, Height) ->
+                          query_id = QId, fee = Fee}, _Context, Trees, Height) ->
     case fetch_query(OraclePubKey, QId, Trees) of
         {value, I} ->
             ResponseTTL = aeo_query:response_ttl(I),
@@ -113,10 +113,10 @@ accounts(#oracle_response_tx{oracle = OraclePubKey}) ->
 signers(#oracle_response_tx{oracle = OraclePubKey}) ->
     [OraclePubKey].
 
--spec process(tx(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()}.
+-spec process(tx(), aetx:tx_context(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()}.
 process(#oracle_response_tx{oracle = OraclePubKey, nonce = Nonce,
                             query_id = QId, response = Response,
-                            fee = Fee}, Trees0, Height) ->
+                            fee = Fee}, _Context, Trees0, Height) ->
     AccountsTree0 = aec_trees:accounts(Trees0),
     OraclesTree0  = aec_trees:oracles(Trees0),
 

--- a/apps/aetx/src/aetx.erl
+++ b/apps/aetx/src/aetx.erl
@@ -8,6 +8,7 @@
 
 -export([ accounts/1
         , check/3
+        , check_from_contract/3
         , deserialize_from_binary/1
         , fee/1
         , hash/1
@@ -17,6 +18,7 @@
         , nonce/1
         , origin/1
         , process/3
+        , process_from_contract/3
         , serialize_for_client/1
         , serialize_to_binary/1
         , signers/1
@@ -59,9 +61,14 @@
                      | aect_create_tx:tx()
                      | aect_call_tx:tx().
 
+%% @doc Where does this transaction come from? Is it a top level transaction or was it created by
+%%      smart contract. In the latter case the fee logic is different.
+-type tx_context() :: aetx_transaction | aetx_contract.
+
 -export_type([ tx/0
              , tx_instance/0
-             , tx_type/0 ]).
+             , tx_type/0
+             , tx_context/0 ]).
 
 %% -- Behaviour definition ---------------------------------------------------
 
@@ -85,10 +92,12 @@
 -callback signers(Tx :: tx_instance()) ->
     [pubkey()].
 
--callback check(Tx :: tx_instance(), Trees :: aec_trees:trees(), Height :: non_neg_integer()) ->
+-callback check(Tx :: tx_instance(), Context :: tx_context(),
+                Trees :: aec_trees:trees(), Height :: non_neg_integer()) ->
     {ok, NewTrees :: aec_trees:trees()} | {error, Reason :: term()}.
 
--callback process(Tx :: tx_instance(), Trees :: aec_trees:trees(), Height :: non_neg_integer()) ->
+-callback process(Tx :: tx_instance(), Context :: tx_context(),
+                  Trees :: aec_trees:trees(), Height :: non_neg_integer()) ->
     {ok, NewTrees :: aec_trees:trees()}.
 
 -callback serialize(Tx :: tx_instance()) ->
@@ -144,12 +153,22 @@ signers(#aetx{ cb = CB, tx = Tx }) ->
 -spec check(Tx :: tx(), Trees :: aec_trees:trees(), Height :: non_neg_integer()) ->
     {ok, NewTrees :: aec_trees:trees()} | {error, Reason :: term()}.
 check(#aetx{ cb = CB, tx = Tx }, Trees, Height) ->
-    CB:check(Tx, Trees, Height).
+    CB:check(Tx, aetx_transaction, Trees, Height).
+
+-spec check_from_contract(Tx :: tx(), Trees :: aec_trees:trees(), Height :: non_neg_integer()) ->
+    {ok, NewTrees :: aec_trees:trees()} | {error, Reason :: term()}.
+check_from_contract(#aetx{ cb = CB, tx = Tx }, Trees, Height) ->
+    CB:check(Tx, aetx_contract, Trees, Height).
 
 -spec process(Tx :: tx(), Trees :: aec_trees:trees(), Height :: non_neg_integer()) ->
     {ok, NewTrees :: aec_trees:trees()}.
 process(#aetx{ cb = CB, tx = Tx }, Trees, Height) ->
-    CB:process(Tx, Trees, Height).
+    CB:process(Tx, aetx_transaction, Trees, Height).
+
+-spec process_from_contract(Tx :: tx(), Trees :: aec_trees:trees(), Height :: non_neg_integer()) ->
+    {ok, NewTrees :: aec_trees:trees()}.
+process_from_contract(#aetx{ cb = CB, tx = Tx }, Trees, Height) ->
+    CB:process(Tx, aetx_contract, Trees, Height).
 
 -spec serialize_for_client(Tx :: tx()) -> map().
 serialize_for_client(#aetx{ cb = CB, type = Type, tx = Tx }) ->

--- a/apps/aevm/src/aevm_chain.erl
+++ b/apps/aevm/src/aevm_chain.erl
@@ -1,0 +1,84 @@
+%%%=============================================================================
+%%% @copyright 2018, Aeternity Anstalt
+%%% @doc
+%%%    Implementation of the aevm_chain_api.
+%%% @end
+%%%=============================================================================
+-module(aevm_chain).
+
+-include_lib("apps/aecore/include/common.hrl").
+
+-behaviour(aevm_chain_api).
+
+-export([new_state/3]).
+
+%% aevm_chain_api callbacks
+-export([get_balance/1, spend/3]).
+
+-record(state, {trees   :: aec_trees:trees(),
+                height  :: height(),
+                account :: pubkey()     %% the contract account
+               }).
+
+-type chain_state() :: #state{}.
+
+%% -- API --------------------------------------------------------------------
+
+%% @doc Create a chain state.
+-spec new_state(aec_trees:trees(), height(), pubkey()) -> chain_state().
+new_state(Trees, Height, ContractAccount) ->
+    #state{ trees   = Trees,
+            height  = Height,
+            account = ContractAccount }.
+
+%% @doc Get the balance of the contract account.
+-spec get_balance(chain_state()) -> non_neg_integer().
+get_balance(#state{ trees = Trees, account = PubKey }) ->
+    do_get_balance(PubKey, Trees).
+
+%% @doc Spend money from the contract account.
+-spec spend(pubkey(), non_neg_integer(), chain_state()) ->
+          {ok, chain_state()} | {error, term()}.
+spend(Recipient, Amount, State = #state{ trees   = Trees,
+                                         height  = Height,
+                                         account = ContractKey }) ->
+    case do_spend(Recipient, ContractKey, Amount, Trees, Height) of
+        {ok, Trees1}     -> {ok, State#state{ trees = Trees1 }};
+        Err = {error, _} -> Err
+    end.
+
+%% -- Internal functions -----------------------------------------------------
+
+do_get_balance(ContractKey, Trees) ->
+    ContractsTree = aec_trees:contracts(Trees),
+    Contract      = aect_state_tree:get_contract(ContractKey, ContractsTree),
+    aect_contracts:balance(Contract).
+
+%% TODO: can only spend to proper accounts. Not other contracts.
+%% Note that we cannot use an aec_spend_tx here, since we are spending from a
+%% contract account and not a proper account.
+do_spend(Recipient, ContractKey, Amount, Trees, Height) ->
+    try
+        ContractsTree = aec_trees:contracts(Trees),
+        AccountsTree  = aec_trees:accounts(Trees),
+        Contract      = aect_state_tree:get_contract(ContractKey, ContractsTree),
+        Balance       = aect_contracts:balance(Contract),
+        [ throw(no_funds) || Balance < Amount ],
+        RecipAccount  =
+            case aec_accounts_trees:lookup(Recipient, AccountsTree) of
+                none          ->
+                    io:format("~p\n", [AccountsTree]),
+                    throw(bad_recip);
+                {value, Acct} -> Acct
+            end,
+        {ok, RecipAccount1} = aec_accounts:earn(RecipAccount, Amount, Height),
+        AccountsTree1       = aec_accounts_trees:enter(RecipAccount1, AccountsTree),
+        Contract1           = aect_contracts:set_balance(Balance - Amount, Contract),
+        ContractsTree1      = aect_state_tree:enter_contract(Contract1, ContractsTree),
+        Trees1              = aec_trees:set_contracts(aec_trees:set_accounts(Trees, AccountsTree1),
+                                                      ContractsTree1),
+        {ok, Trees1}
+    catch _:bad_recip -> {error, {bad_recipient_account, Recipient}};
+          _:no_funds  -> {error, insufficient_funds}
+    end.
+

--- a/apps/aevm/src/aevm_chain.erl
+++ b/apps/aevm/src/aevm_chain.erl
@@ -15,7 +15,7 @@
 %% aevm_chain_api callbacks
 -export([get_balance/1,
          spend/3,
-         call_contract/5]).
+         call_contract/6]).
 
 -record(state, {trees   :: aec_trees:trees(),
                 height  :: height(),
@@ -66,9 +66,10 @@ spend(Recipient, Amount, State = #state{ trees   = Trees,
     end.
 
 %% @doc Call another contract.
--spec call_contract(pubkey(), non_neg_integer(), non_neg_integer(), binary(), chain_state()) ->
+-spec call_contract(pubkey(), non_neg_integer(), non_neg_integer(), binary(),
+                    [non_neg_integer()], chain_state()) ->
         {ok, aevm_chain_api:call_result(), chain_state()} | {error, term()}.
-call_contract(Target, Gas, Value, CallData,
+call_contract(Target, Gas, Value, CallData, CallStack,
               State = #state{ trees   = Trees,
                               height  = Height,
                               account = ContractKey,
@@ -83,7 +84,8 @@ call_contract(Target, Gas, Value, CallData,
                             amount     => Value,
                             gas        => Gas,
                             gas_price  => 0,
-                            call_data  => CallData }),
+                            call_data  => CallData,
+                            call_stack => CallStack }),
     case aetx:check_from_contract(CallTx, Trees, Height) of
         Err = {error, _} -> Err;
         {ok, Trees1} ->

--- a/apps/aevm/src/aevm_chain_api.erl
+++ b/apps/aevm/src/aevm_chain_api.erl
@@ -9,14 +9,55 @@
 
 -include_lib("apps/aecore/include/common.hrl").
 
+-export_type([call_result/0, exception/0]).
+
+-export([call_result/2, call_exception/2,
+         return_value/1, gas_spent/1]).
+
 %% @doc The state of the chain. Specific to the API implementation.
 -type chain_state() :: any().
 
-%% @doc Execute a spend transaction from the contract account.
+-type exception() :: out_of_gas.
+
+-record(call_result, { result    :: binary() | exception()
+                     , gas_spent :: non_neg_integer() }).
+
+-opaque call_result() :: #call_result{}.
+
+%% -- Callback API -----------------------------------------------------------
+
+%% Execute a spend transaction from the contract account.
 -callback spend(Recipient :: pubkey(),
                 Amount    :: non_neg_integer(),
                 State     :: chain_state()) -> {ok, chain_state()} | {error, term()}.
 
-%% @doc Get the current balance of the contract account.
+%% Get the current balance of the contract account.
 -callback get_balance(State :: chain_state()) -> non_neg_integer().
+
+%% Make a call to another contract.
+-callback call_contract(Contract :: pubkey(),
+                        Gas      :: non_neg_integer(),
+                        Value    :: non_neg_integer(),
+                        CallData :: binary(),
+                        State    :: chain_state()) ->
+                    {ok, call_result(), chain_state()} | {error, term()}.
+
+%% -- Call results -----------------------------------------------------------
+
+-spec call_result(binary(), non_neg_integer()) -> call_result().
+call_result(Result, GasSpent) ->
+    #call_result{ result = Result, gas_spent = GasSpent }.
+
+-spec call_exception(exception(), non_neg_integer()) -> call_result().
+call_exception(Exception, GasSpent) ->
+    #call_result{ result = Exception, gas_spent = GasSpent }.
+
+-spec return_value(call_result()) -> {ok, binary()} | {error, exception()}.
+return_value(#call_result{ result = Res }) when is_binary(Res) ->
+    {ok, Res};
+return_value(#call_result{ result = Err }) ->
+    {error, Err}.
+
+-spec gas_spent(call_result()) -> non_neg_integer().
+gas_spent(#call_result{ gas_spent = Gas }) -> Gas.
 

--- a/apps/aevm/src/aevm_chain_api.erl
+++ b/apps/aevm/src/aevm_chain_api.erl
@@ -1,0 +1,22 @@
+%%%=============================================================================
+%%% @copyright 2018, Aeternity Anstalt
+%%% @doc
+%%%    This module defines the callbacks required by a VM to interact with the
+%%%    chain.
+%%% @end
+%%%=============================================================================
+-module(aevm_chain_api).
+
+-include_lib("apps/aecore/include/common.hrl").
+
+%% @doc The state of the chain. Specific to the API implementation.
+-type chain_state() :: any().
+
+%% @doc Execute a spend transaction from the contract account.
+-callback spend(Recipient :: pubkey(),
+                Amount    :: non_neg_integer(),
+                State     :: chain_state()) -> {ok, chain_state()} | {error, term()}.
+
+%% @doc Get the current balance of the contract account.
+-callback get_balance(State :: chain_state()) -> non_neg_integer().
+

--- a/apps/aevm/src/aevm_chain_api.erl
+++ b/apps/aevm/src/aevm_chain_api.erl
@@ -35,11 +35,12 @@
 -callback get_balance(State :: chain_state()) -> non_neg_integer().
 
 %% Make a call to another contract.
--callback call_contract(Contract :: pubkey(),
-                        Gas      :: non_neg_integer(),
-                        Value    :: non_neg_integer(),
-                        CallData :: binary(),
-                        State    :: chain_state()) ->
+-callback call_contract(Contract  :: pubkey(),
+                        Gas       :: non_neg_integer(),
+                        Value     :: non_neg_integer(),
+                        CallData  :: binary(),
+                        CallStack :: [non_neg_integer()],
+                        State     :: chain_state()) ->
                     {ok, call_result(), chain_state()} | {error, term()}.
 
 %% -- Call results -----------------------------------------------------------

--- a/apps/aevm/src/aevm_eeevm.erl
+++ b/apps/aevm/src/aevm_eeevm.erl
@@ -41,7 +41,7 @@ valid_jumpdests(State) ->
     JumpDests = jumpdests(0,Code, #{}),
     aevm_eeevm_state:set_jumpdests(JumpDests, State).
 
-%% Jump Destination Validity. 
+%% Jump Destination Validity.
 %% DJ (c, i) ≡ {} if i > |c|
 %%             {i} ∪ DJ (c, N(i, c[i])) if c[i] = JUMPDEST
 %%             DJ (c, N(i, c[i])) otherwise
@@ -470,7 +470,7 @@ loop(StateIn) ->
 		    %% Get price of gas in current environment.
 		    %% µ's[0] ≡ Ip
 		    %%  This is gas price specified by the
-		    %% originating transaction.   
+		    %% originating transaction.
 		    Arg = aevm_eeevm_state:gasprice(State0),
 		    State1 = push(Arg, State0),
 		    next_instruction(OP, State, State1);
@@ -643,7 +643,7 @@ loop(StateIn) ->
 		    %%                   Gsset if µs[1] =/= 0
 		    %% CSSTORE(σ, µ)) ≡           ∧ σ[Ia]s[µs[0]] = 0
 		    %%                   Gsreset otherwise
-		    %% A'r ≡ Ar + Rsclear if µs[1] = 0 
+		    %% A'r ≡ Ar + Rsclear if µs[1] = 0
 		    %%                      ∧ σ[Ia]s[µs[0]] =/= 0
 		    %%       0 otherwise
 		    {Address, State1} = pop(State0),
@@ -675,9 +675,9 @@ loop(StateIn) ->
 			if Us1 =/= 0 ->
 				JumpDests =  aevm_eeevm_state:jumpdests(State1),
 				case maps:get(Us0, JumpDests, false) of
-				    true -> 
+				    true ->
 					set_cp(Us0-1, State2);
-				    false -> 
+				    false ->
 					eval_error({{invalid_jumpdest, Us0}}, State1)
 				end;
 			   true      -> State2
@@ -950,7 +950,7 @@ loop(StateIn) ->
 		    State4 = log({Us2}, Us0, Us1, State3),
 		    next_instruction(OP, State, State4);
 		?LOG2 ->
-		    %% 0xa2 LOG2 δ=4 α=0 
+		    %% 0xa2 LOG2 δ=4 α=0
 		    %% Append log record with one topic.
 		    %% t ≡ (µs[2],(µs[3])
 		    {Us0, State1} = pop(State0),
@@ -987,7 +987,7 @@ loop(StateIn) ->
 		    eval_error({illegal_instruction, OP}, State0);
 		%% F0s: System operations
 		?CREATE->
-		    %% 0xf0 CREATE δ=3 α=1 
+		    %% 0xf0 CREATE δ=3 α=1
 		    %% Create a new account with associated code.
 		    %% i ≡ µm[µs[1] . . .(µs[1] + µs[2] − 1)]
 		    %% (σ', µ'g, A+) ≡ (Λ(σ∗, Ia, Io, L(µg), Ip, µs[0], i, Ie + 1)
@@ -1126,8 +1126,8 @@ loop(StateIn) ->
 		16#fb -> eval_error({illegal_instruction, OP}, State0);
 		16#fc -> eval_error({illegal_instruction, OP}, State0);
 		16#fd -> eval_error({illegal_instruction, OP}, State0);
-		?INVALID -> 
-		    %% 0xfe INVALID δ=∅ α=∅ 
+		?INVALID ->
+		    %% 0xfe INVALID δ=∅ α=∅
 		    %% Designated invalid instruction.
 		    eval_error({the_invalid_instruction, OP}, State0);
 		?SUICIDE ->
@@ -1418,10 +1418,10 @@ recursive_call(State, Op) ->
     CallDepth = aevm_eeevm_state:calldepth(State),
     case CallDepth < 1024 of
         false -> {0, State}; %% TODO: Should this consume gas?
-        true  -> recursive_call(CallDepth, State, Op)
+        true  -> recursive_call1(State, Op)
     end.
 
-recursive_call(CallDepth, StateIn, Op) ->
+recursive_call1(StateIn, Op) ->
     %% Message-call into an account.
     %% i ≡ µm[µs[3] . . .(µs[3] + µs[4] − 1)]
     State0            = spend_call_gas(StateIn, Op),
@@ -1469,8 +1469,7 @@ recursive_call(CallDepth, StateIn, Op) ->
                  ?DELEGATECALL -> aevm_eeevm_state:caller(State8)
              end,
     CallState = aevm_eeevm_state:prepare_for_call(Caller, Dest, CallGas, Value,
-                                                  Code, CallDepth,
-                                                  State8),
+                                                  Code, State8),
     case aevm_eeevm_state:no_recursion(State8) of
         true  -> %% Just set up a call for testing without actually calling.
             GasOut = GasAfterSpend + CallGas,

--- a/apps/aevm/src/aevm_eeevm_state.erl
+++ b/apps/aevm/src/aevm_eeevm_state.erl
@@ -81,7 +81,7 @@ init(#{ env  := Env
          , gas_price   => maps:get(gasPrice, Exec)
          , origin      => maps:get(origin, Exec)
          , value       => maps:get(value, Exec)
-         , call_stack  => maps:get(call_stack, Exec, 0)
+         , call_stack  => maps:get(call_stack, Exec, [])
 
          , coinbase   => maps:get(currentCoinbase, Env)
          , difficulty => maps:get(currentDifficulty, Env)

--- a/apps/aevm/src/aevm_eeevm_state.erl
+++ b/apps/aevm/src/aevm_eeevm_state.erl
@@ -9,56 +9,56 @@
 
 -module(aevm_eeevm_state).
 -export([ accountbalance/2
-	, add_trace/2
-	, add_callcreates/2
-	, address/1
-	, blockhash/3
-	, calldepth/1
+        , add_trace/2
+        , add_callcreates/2
+        , address/1
+        , blockhash/3
+        , calldepth/1
         , caller/1
         , callcreates/1
-	, code/1
-	, coinbase/1
-	, cp/1
-	, data/1
-	, difficulty/1
-	, extbalance/2
-	, extcode/2
-	, extcode/4
-	, extcodesize/2
-	, gas/1
-	, gaslimit/1
-	, gasprice/1
-	, init/1
-	, init/2
-	, jumpdests/1
-	, logs/1
-	, origin/1
+        , code/1
+        , coinbase/1
+        , cp/1
+        , data/1
+        , difficulty/1
+        , extbalance/2
+        , extcode/2
+        , extcode/4
+        , extcodesize/2
+        , gas/1
+        , gaslimit/1
+        , gasprice/1
+        , init/1
+        , init/2
+        , jumpdests/1
+        , logs/1
+        , origin/1
         , out/1
         , prepare_for_call/7
-	, mem/1
+        , mem/1
         , no_recursion/1
-	, number/1
-	, return_data/1
+        , number/1
+        , return_data/1
         , chain_state/1
         , chain_api/1
-	, set_code/2
-	, set_cp/2
-	, set_gas/2
-	, set_jumpdests/2
-	, set_logs/2
-	, set_mem/2
-	, set_out/2
-	, set_selfdestruct/2
-	, set_stack/2
-	, set_storage/2
+        , set_code/2
+        , set_cp/2
+        , set_gas/2
+        , set_jumpdests/2
+        , set_logs/2
+        , set_mem/2
+        , set_out/2
+        , set_selfdestruct/2
+        , set_stack/2
+        , set_storage/2
         , set_chain_state/2
-	, stack/1
-	, storage/1
-	, timestamp/1
-	, trace/1
-	, trace_format/3
-	, value/1
-	]).
+        , stack/1
+        , storage/1
+        , timestamp/1
+        , trace/1
+        , trace_format/3
+        , value/1
+        ]).
 
 -include("aevm_eeevm.hrl").
 
@@ -72,68 +72,68 @@ init(#{ env  := Env
     NoRecursion = maps:get(no_recursion, Opts, false),
 
     State =
-	#{ address     => Address
-	 , caller      => maps:get(caller, Exec)
-	 , return_data => maps:get(return_data, Exec, <<>>)
-	 , data        => maps:get(data, Exec)
-	 , gas         => maps:get(gas, Exec)
-	 , gas_price   => maps:get(gasPrice, Exec)
-	 , origin      => maps:get(origin, Exec)
-	 , value       => maps:get(value, Exec)
-	 , calldepth   => 0
+        #{ address     => Address
+         , caller      => maps:get(caller, Exec)
+         , return_data => maps:get(return_data, Exec, <<>>)
+         , data        => maps:get(data, Exec)
+         , gas         => maps:get(gas, Exec)
+         , gas_price   => maps:get(gasPrice, Exec)
+         , origin      => maps:get(origin, Exec)
+         , value       => maps:get(value, Exec)
+         , calldepth   => 0
 
-	 , coinbase   => maps:get(currentCoinbase, Env)
-	 , difficulty => maps:get(currentDifficulty, Env)
-	 , gas_limit  => maps:get(currentGasLimit, Env)
-	 , number     => maps:get(currentNumber, Env)
-	 , timestamp  => maps:get(currentTimestamp, Env)
+         , coinbase   => maps:get(currentCoinbase, Env)
+         , difficulty => maps:get(currentDifficulty, Env)
+         , gas_limit  => maps:get(currentGasLimit, Env)
+         , number     => maps:get(currentNumber, Env)
+         , timestamp  => maps:get(currentTimestamp, Env)
 
-	 , balances        => get_balances(Pre)
-	 , ext_code_blocks => get_ext_code_blocks(Pre)
-	 , ext_code_sizes  => get_ext_code_sizes(Pre)
-	 , block_hash_fun  => BlockHashFun
-	 , no_recursion => NoRecursion
+         , balances        => get_balances(Pre)
+         , ext_code_blocks => get_ext_code_blocks(Pre)
+         , ext_code_sizes  => get_ext_code_sizes(Pre)
+         , block_hash_fun  => BlockHashFun
+         , no_recursion => NoRecursion
 
-	 , do_trace  => maps:get(trace, Opts, false)
-	 , trace => []
-	 , trace_fun => init_trace_fun(Opts)
+         , do_trace  => maps:get(trace, Opts, false)
+         , trace => []
+         , trace_fun => init_trace_fun(Opts)
 
          , chain_state => maps:get(chainState, Env)
          , chain_api   => maps:get(chainAPI, Env)
 
-	 , environment =>
-	       #{ spec => Spec
-		, options => Opts }
+         , environment =>
+               #{ spec => Spec
+                , options => Opts }
 
-	 },
+         },
 
     init_vm(State,
-	    maps:get(code, Exec),
-	    init_storage(Address, Pre)).
+            maps:get(code, Exec),
+            init_storage(Address, Pre)).
 
 init_vm(State, Code, Store) ->
     State#{ out       => <<>>
-	  , call      => #{}
-	  , callcreates => []
-	  , code      => Code
-	  , cp        => 0
-	  , logs      => []
-	  , memory    => #{}
-	  , return_data => <<>>
-	  , stack     => []
-	  , storage   => Store
-	  }.
+          , call      => #{}
+          , callcreates => []
+          , code      => Code
+          , cp        => 0
+          , logs      => []
+          , memory    => #{}
+          , return_data => <<>>
+          , stack     => []
+          , storage   => Store
+          }.
 
 prepare_for_call(Caller, Dest, CallGas, Value, Code, CallDepth, State) ->
     #{ environment := #{ spec := #{ pre := Pre}}} = State,
     Store = init_storage(Dest, Pre),
     State1 = init_vm(State, Code, Store),
     State1#{ address => Dest
-	   , gas => CallGas
-	   , value => Value
-	   , caller    => Caller
-	   , calldepth => CallDepth + 1
-	   }.
+           , gas => CallGas
+           , value => Value
+           , caller    => Caller
+           , calldepth => CallDepth + 1
+           }.
 
 init_storage(Address, #{} = Pre) ->
     case maps:get(Address, Pre, undefined) of
@@ -159,28 +159,28 @@ get_ext_code_blocks(#{} = Pre) ->
 get_balances(#{} = Pre) ->
     maps:from_list(
       [{Address, B} || {Address, #{balance := B}}
-			   <- maps:to_list(Pre)]).
+                           <- maps:to_list(Pre)]).
 
 get_blockhash_fun(Opts, Env, H) ->
     case maps:get(blockhash, Opts, default) of
-	%% default -> fun(N,A) -> aevm_eeevm_env:get_block_hash(H,N,A) end;
-	%% sha3 ->
-	_ -> fun(N,_A) ->
-			%% Because the data of the blockchain is not
-			%% given, the opcode BLOCKHASH could not
-			%% return the hashes of the corresponding
-			%% blocks. Therefore we define the hash of
-			%% block number n to be SHA3-256("n").
-			CurrentNumber = maps:get(currentNumber, Env),
-			if (N >= CurrentNumber) or (_A == 256) or (H==0) -> 0;
-			   CurrentNumber - 256 > N -> 0;
-			   true ->
-				BinN = integer_to_binary(N),
-				Hash = aec_hash:hash(evm, BinN),
-				<<Val:256/integer-unsigned>> = Hash,
-				Val
-			end
-		end
+        %% default -> fun(N,A) -> aevm_eeevm_env:get_block_hash(H,N,A) end;
+        %% sha3 ->
+        _ -> fun(N,_A) ->
+                        %% Because the data of the blockchain is not
+                        %% given, the opcode BLOCKHASH could not
+                        %% return the hashes of the corresponding
+                        %% blocks. Therefore we define the hash of
+                        %% block number n to be SHA3-256("n").
+                        CurrentNumber = maps:get(currentNumber, Env),
+                        if (N >= CurrentNumber) or (_A == 256) or (H==0) -> 0;
+                           CurrentNumber - 256 > N -> 0;
+                           true ->
+                                BinN = integer_to_binary(N),
+                                Hash = aec_hash:hash(evm, BinN),
+                                <<Val:256/integer-unsigned>> = Hash,
+                                Val
+                        end
+                end
     end.
 
 
@@ -205,14 +205,14 @@ extcodesize(Adr, State) ->
     maps:get(Adr band ?MASK160, maps:get(ext_code_sizes, State), 0).
 extcode(Account, Start, Length, State) ->
     CodeBlock = maps:get(Account band ?MASK160,
-			 maps:get(ext_code_blocks, State), <<>>),
+                         maps:get(ext_code_blocks, State), <<>>),
     aevm_eeevm_utils:bin_copy(Start, Length, CodeBlock).
 extcode(Account, State) ->
     maps:get(Account band ?MASK160,
-	     maps:get(ext_code_blocks, State), <<>>).
+             maps:get(ext_code_blocks, State), <<>>).
 extbalance(Account, State) ->
     maps:get(Account band ?MASK160,
-	     maps:get(balances, State), <<>>).
+             maps:get(balances, State), <<>>).
 no_recursion(State) ->
     maps:get(no_recursion, State).
 
@@ -267,17 +267,17 @@ trace_format(String, Argument, State) ->
     Code = aevm_eeevm_state:code(State),
     OP   = aevm_eeevm:code_get_op(CP, Code),
     case do_trace(State) of
-	true ->
-	    F = trace_fun(State),
-	    F("[~4.16.0B] ~8.16.0B : ~w",
-	      [Account, CP, aevm_opcodes:op_name(OP)]),
-	    F(" ~w", [stack(State)]),
-	    F(" ~s", [format_mem(mem(State))]),
-	    F(" ~p", [gas(State)]),
-	    F(String, Argument),
-	    add_trace([{CP, OP, aevm_opcodes:op_name(OP)}], State);
-	false ->
-	    State
+        true ->
+            F = trace_fun(State),
+            F("[~4.16.0B] ~8.16.0B : ~w",
+              [Account, CP, aevm_opcodes:op_name(OP)]),
+            F(" ~w", [stack(State)]),
+            F(" ~s", [format_mem(mem(State))]),
+            F(" ~p", [gas(State)]),
+            F(String, Argument),
+            add_trace([{CP, OP, aevm_opcodes:op_name(OP)}], State);
+        false ->
+            State
     end.
 
 -define(MAXMEMPOS,5).
@@ -285,7 +285,7 @@ trace_format(String, Argument, State) ->
 format_mem(Mem) ->
    lists:flatten(
      "[" ++
-	 format_mem(lists:sort(maps:to_list(Mem)), ?MAXMEMPOS)
+         format_mem(lists:sort(maps:to_list(Mem)), ?MAXMEMPOS)
      ++ "]").
 format_mem([],_) -> [];
 format_mem( _,0) -> " ...";

--- a/apps/aevm/src/aevm_eeevm_state.erl
+++ b/apps/aevm/src/aevm_eeevm_state.erl
@@ -39,6 +39,8 @@
         , no_recursion/1
 	, number/1
 	, return_data/1
+        , chain_state/1
+        , chain_api/1
 	, set_code/2
 	, set_cp/2
 	, set_gas/2
@@ -49,6 +51,7 @@
 	, set_selfdestruct/2
 	, set_stack/2
 	, set_storage/2
+        , set_chain_state/2
 	, stack/1
 	, storage/1
 	, timestamp/1
@@ -68,7 +71,7 @@ init(#{ env  := Env
     BlockHashFun = get_blockhash_fun(Opts, Env, Address),
     NoRecursion = maps:get(no_recursion, Opts, false),
 
-    State = 
+    State =
 	#{ address     => Address
 	 , caller      => maps:get(caller, Exec)
 	 , return_data => maps:get(return_data, Exec, <<>>)
@@ -95,7 +98,10 @@ init(#{ env  := Env
 	 , trace => []
 	 , trace_fun => init_trace_fun(Opts)
 
-	 , environment => 
+         , chain_state => maps:get(chainState, Env)
+         , chain_api   => maps:get(chainAPI, Env)
+
+	 , environment =>
 	       #{ spec => Spec
 		, options => Opts }
 
@@ -201,10 +207,10 @@ extcode(Account, Start, Length, State) ->
     CodeBlock = maps:get(Account band ?MASK160,
 			 maps:get(ext_code_blocks, State), <<>>),
     aevm_eeevm_utils:bin_copy(Start, Length, CodeBlock).
-extcode(Account, State) ->    
+extcode(Account, State) ->
     maps:get(Account band ?MASK160,
 	     maps:get(ext_code_blocks, State), <<>>).
-extbalance(Account, State) ->    
+extbalance(Account, State) ->
     maps:get(Account band ?MASK160,
 	     maps:get(balances, State), <<>>).
 no_recursion(State) ->
@@ -230,6 +236,9 @@ do_trace(State)    -> maps:get(do_trace, State).
 trace(State)       -> maps:get(trace, State).
 trace_fun(State)   -> maps:get(trace_fun, State).
 
+chain_state(State) -> maps:get(chain_state, State).
+chain_api(State)   -> maps:get(chain_api, State).
+
 set_cp(Value, State)      -> maps:put(cp, Value, State).
 set_code(Value, State)    -> maps:put(code, Value, State).
 set_stack(Value, State)   -> maps:put(stack, Value, State).
@@ -240,6 +249,7 @@ set_logs(Value, State)    -> maps:put(logs, Value, State).
 set_storage(Value, State) -> maps:put(storage, Value, State).
 set_jumpdests(Value, State)    -> maps:put(jumpdests, Value, State).
 set_selfdestruct(Value, State) -> maps:put(selfdestruct, Value, State).
+set_chain_state(Value, State) -> maps:put(chain_state, Value, State).
 
 add_callcreates(#{ data := _
                  , destination := _
@@ -274,13 +284,13 @@ trace_format(String, Argument, State) ->
 
 format_mem(Mem) ->
    lists:flatten(
-     "[" ++ 
+     "[" ++
 	 format_mem(lists:sort(maps:to_list(Mem)), ?MAXMEMPOS)
      ++ "]").
 format_mem([],_) -> [];
 format_mem( _,0) -> " ...";
-format_mem([{N,V}|Rest], ?MAXMEMPOS) when is_integer(N) -> 
+format_mem([{N,V}|Rest], ?MAXMEMPOS) when is_integer(N) ->
     io_lib:format("~w:~w",[N,V]) ++ format_mem(Rest, ?MAXMEMPOS-1);
-format_mem([{N,V}|Rest],          P) when is_integer(N) -> 
+format_mem([{N,V}|Rest],          P) when is_integer(N) ->
     io_lib:format(", ~w:~w",[N,V]) ++ format_mem(Rest, P-1);
 format_mem([_|Rest], P) -> format_mem(Rest, P).

--- a/apps/aevm/test/aevm_dummy_chain.erl
+++ b/apps/aevm/test/aevm_dummy_chain.erl
@@ -15,11 +15,11 @@
 %% aevm_chain_api callbacks
 -export([get_balance/1,
          spend/3,
-         call_contract/5]).
+         call_contract/6]).
 
 new_state() -> no_state.
 
-get_balance(_S)                -> 0.
-spend(_Recipient, _Amount, _S) -> {error, cant_spend_with_dummy_chain}.
-call_contract(_, _, _, _, _)   -> {error, cant_call_contracts_with_dummy_chain}.
+get_balance(_S)                 -> 0.
+spend(_Recipient, _Amount, _S)  -> {error, cant_spend_with_dummy_chain}.
+call_contract(_, _, _, _, _, _) -> {error, cant_call_contracts_with_dummy_chain}.
 

--- a/apps/aevm/test/aevm_dummy_chain.erl
+++ b/apps/aevm/test/aevm_dummy_chain.erl
@@ -1,18 +1,18 @@
 %%%=============================================================================
 %%% @copyright 2018, Aeternity Anstalt
 %%% @doc
-%%%    Dummy implementation of the aevm_chain_api. Doesn't keep any state. To
+%%%    Dummy implementation of the aec_vm_chain_api. Doesn't keep any state. To
 %%%    use when testing contracts that don't interact with the chain.
 %%% @end
 %%%=============================================================================
 
 -module(aevm_dummy_chain).
 
--behaviour(aevm_chain_api).
+-behaviour(aec_vm_chain_api).
 
 -export([new_state/0]).
 
-%% aevm_chain_api callbacks
+%% aec_vm_chain_api callbacks
 -export([get_balance/1,
          spend/3,
          call_contract/6]).

--- a/apps/aevm/test/aevm_dummy_chain.erl
+++ b/apps/aevm/test/aevm_dummy_chain.erl
@@ -1,0 +1,25 @@
+%%%=============================================================================
+%%% @copyright 2018, Aeternity Anstalt
+%%% @doc
+%%%    Dummy implementation of the aevm_chain_api. Doesn't keep any state. To
+%%%    use when testing contracts that don't interact with the chain.
+%%% @end
+%%%=============================================================================
+
+-module(aevm_dummy_chain).
+
+-behaviour(aevm_chain_api).
+
+-export([new_state/0]).
+
+%% aevm_chain_api callbacks
+-export([get_balance/1,
+         spend/3,
+         call_contract/5]).
+
+new_state() -> no_state.
+
+get_balance(_S)                -> 0.
+spend(_Recipient, _Amount, _S) -> {error, cant_spend_with_dummy_chain}.
+call_contract(_, _, _, _, _)   -> {error, cant_call_contracts_with_dummy_chain}.
+

--- a/apps/aevm/test/aevm_test_utils.erl
+++ b/apps/aevm/test/aevm_test_utils.erl
@@ -170,7 +170,12 @@ get_config({DirPath, TestName,_Opts}) ->
     Bin    = get_config_file(DirPath, TestName),
     Json   = jsx:decode(Bin, [return_maps, {labels, attempt_atom}]),
     Config = build_config(Json),
-    maps:get(TestName, Config).
+    TestConfig = maps:get(TestName, Config),
+    DefaultEnv = #{ chainState => aevm_dummy_chain:new_state()
+                  , chainAPI => aevm_dummy_chain
+                  },
+    maps:update_with(env, fun(Env) -> maps:merge(DefaultEnv, Env) end,
+                     TestConfig).
 
 get_config_file(DirPath, TestName) ->
     FileName = config_filename(DirPath, TestName),

--- a/deployment/ansible/deploy.yml
+++ b/deployment/ansible/deploy.yml
@@ -64,7 +64,7 @@
           port: 3114
       chain:
         persist: true
-        db_path: "./db41"
+        db_path: "./db42"
       keypair:
         dir: "keys"
         password: "{{ vault_keys_password|default('secret') }}"

--- a/py/tests/integration/test_unsigned_tx.py
+++ b/py/tests/integration/test_unsigned_tx.py
@@ -138,7 +138,8 @@ def test_contract_call():
     # The call runs out of gas and all gas is consumed
     # assert contract called:
     assert_equals(alice_balance0, alice_balance + test_settings["contract_call"]["fee"]
-                  + test_settings["contract_call"]["gas"])
+                  + test_settings["contract_call"]["gas"]
+                  + test_settings["contract_call"]["amount"])
     print("Fee and gas was consumed, transaction is part of the chain")
 
     cleanup(node, root_dir)

--- a/test/aebytecode_aevm_SUITE.erl
+++ b/test/aebytecode_aevm_SUITE.erl
@@ -20,7 +20,8 @@ execute_identy_fun_from_file(_Cfg) ->
     CodeDir = code:lib_dir(aebytecode, test),
     FileName = filename:join(CodeDir, "asm_code/identity.aesm"),
     Code = aeb_asm:file(FileName, []),
-    {ok, Res} = 
+    ChainState = aevm_dummy_chain:new_state(),
+    {ok, Res} =
         aevm_eeevm:eval(
           aevm_eeevm_state:init(
             #{ exec => #{ code => Code,
@@ -35,7 +36,9 @@ execute_identy_fun_from_file(_Cfg) ->
                         currentDifficulty => 0,
                         currentGasLimit => 10000,
                         currentNumber => 0,
-                        currentTimestamp => 0},
+                        currentTimestamp => 0,
+                        chainState => ChainState,
+                        chainAPI => aevm_dummy_chain},
                pre => #{}},
             #{trace => false})
          ),

--- a/test/aevm_chain_SUITE.erl
+++ b/test/aevm_chain_SUITE.erl
@@ -1,0 +1,135 @@
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2018, Aeternity Anstalt
+%%% @doc CT test suite for AEVM/chain interface
+%%% @end
+%%%-------------------------------------------------------------------
+-module(aevm_chain_SUITE).
+
+%% common_test exports
+-export([ all/0
+        , groups/0
+        ]).
+
+%% test case exports
+-export([ contracts/1
+        , spend/1
+        ]).
+
+-include_lib("common_test/include/ct.hrl").
+
+%%%===================================================================
+%%% Common test framework
+%%%===================================================================
+
+all() ->
+    [{group, all_tests}
+    ].
+
+groups() ->
+    [ {all_tests, [sequence],
+        [ {group, spend}
+        , {group, contracts}
+        ]}
+    , {spend, [sequence],
+        [ spend ]}
+    , {contracts, [sequence],
+        [ contracts ]}
+    ].
+
+%%%===================================================================
+%%% Setup
+%%%===================================================================
+
+%% Uses aect_test_utils to set up the chain, but after the setup everything is
+%% done through the aevm_chain_api.
+setup_chain() ->
+    S0              = aect_test_utils:new_state(),
+    {Account1, S1}  = aect_test_utils:setup_new_account(S0),
+    {Account2, S2}  = aect_test_utils:setup_new_account(S1),
+    {Contract1, S3} = create_contract(Account1, S2),
+    {Contract2, S4} = create_contract(Account2, S3),
+    Trees = aect_test_utils:trees(S4),
+    InitS = aevm_chain:new_state(Trees, 1, Contract1),
+    {[Account1, Account2, Contract1, Contract2], InitS}.
+
+create_contract(Owner, S) ->
+    OwnerPrivKey = aect_test_utils:priv_key(Owner, S),
+    IdContract   = aect_test_utils:compile_contract("contracts/identity.aer"),
+    CreateTx     = aect_test_utils:create_tx(Owner, #{code => IdContract, amount => 2000}, S),
+    {SignedTx, [SignedTx], S1} = sign_and_apply_transaction(CreateTx, OwnerPrivKey, S),
+    {aect_contracts:compute_contract_pubkey(Owner, aetx:nonce(CreateTx)), S1}.
+
+sign_and_apply_transaction(Tx, PrivKey, S1) ->
+    SignedTx = aetx_sign:sign(Tx, PrivKey),
+    Trees    = aect_test_utils:trees(S1),
+    Height   = 1,
+    {ok, AcceptedTxs, Trees1} = aec_trees:apply_signed_txs([SignedTx], Trees, Height),
+    S2       = aect_test_utils:set_trees(Trees1, S1),
+    {SignedTx, AcceptedTxs, S2}.
+
+get_account_balance(Acc, S) ->
+    Trees    = aevm_chain:get_trees(S),
+    Accounts = aec_trees:accounts(Trees),
+    aec_accounts:balance(aec_accounts_trees:get(Acc, Accounts)).
+
+get_contract_balance(Contract, S) ->
+    Trees     = aevm_chain:get_trees(S),
+    Contracts = aec_trees:contracts(Trees),
+    aect_contracts:balance(aect_state_tree:get_contract(Contract, Contracts)).
+
+call_data(Arg) ->
+    Code = aect_test_utils:compile_contract("contracts/identity.aer"),
+    aect_ring:create_call(Code, <<"main">>, Arg).
+
+%%%===================================================================
+%%% Spend tests
+%%%===================================================================
+
+spend(_Cfg) ->
+    {[Acc, _Acc2, _Contract1, _Contract2], S} = setup_chain(),
+    AccBal1  = get_account_balance(Acc, S),
+    Bal1     = aevm_chain:get_balance(S),
+    Amount   = 50,
+    {ok, S1} = aevm_chain:spend(Acc, Amount, S),
+    Bal2     = aevm_chain:get_balance(S1),
+    Bal2     = Bal1 - Amount,
+    AccBal2  = get_account_balance(Acc, S1),
+    AccBal2  = AccBal1 + Amount,
+    {error, insufficient_funds}
+             = aevm_chain:spend(Acc, 1000000, S1),
+    ok.
+
+%%%===================================================================
+%%% Contract tests
+%%%===================================================================
+
+contracts(_Cfg) ->
+    {[_Acc, _Acc2, _Contract1, Contract2], S} = setup_chain(),
+    _S1 = lists:foldl(fun({Value, Arg}, S0) -> make_call(Contract2, Value, Arg, S0) end,
+                      S, [{I * 100, I + 100} || I <- lists:seq(1, 10)]),
+    ok.
+
+make_call(To, Value, Arg, S) ->
+    C1Bal1   = aevm_chain:get_balance(S),
+    C2Bal1   = get_contract_balance(To, S),
+    CallData = call_data(integer_to_binary(Arg)),
+    Gas      = 10000,
+    CallRes  = aevm_chain:call_contract(To, Gas, Value, CallData, S),
+    case C1Bal1 >= Value of
+        true ->
+            {ok, Res, S1} = CallRes,
+            GasUsed  = aevm_chain_api:gas_spent(Res),
+            {ok, <<Arg:256>>} = aevm_chain_api:return_value(Res),
+            true     = GasUsed > 0,
+            true     = GasUsed =< Gas,
+            C1Bal2   = aevm_chain:get_balance(S1),
+            C1Bal2   = C1Bal1 - Value,
+            C2Bal2   = get_contract_balance(To, S1),
+            C2Bal2   = C2Bal1 + Value,
+            S1;
+        false ->
+            {error, insufficient_funds} = CallRes,
+            S
+    end.
+
+

--- a/test/aevm_chain_SUITE.erl
+++ b/test/aevm_chain_SUITE.erl
@@ -110,11 +110,12 @@ contracts(_Cfg) ->
     ok.
 
 make_call(To, Value, Arg, S) ->
-    C1Bal1   = aevm_chain:get_balance(S),
-    C2Bal1   = get_contract_balance(To, S),
-    CallData = call_data(integer_to_binary(Arg)),
-    Gas      = 10000,
-    CallRes  = aevm_chain:call_contract(To, Gas, Value, CallData, S),
+    C1Bal1    = aevm_chain:get_balance(S),
+    C2Bal1    = get_contract_balance(To, S),
+    CallData  = call_data(integer_to_binary(Arg)),
+    Gas       = 10000,
+    CallStack = [],
+    CallRes   = aevm_chain:call_contract(To, Gas, Value, CallData, CallStack, S),
     case C1Bal1 >= Value of
         _ when Value < 0 ->
             {error, negative_amount} = CallRes,

--- a/test/aevm_chain_SUITE.erl
+++ b/test/aevm_chain_SUITE.erl
@@ -106,7 +106,7 @@ spend(_Cfg) ->
 contracts(_Cfg) ->
     {[_Acc, _Acc2, _Contract1, Contract2], S} = setup_chain(),
     _S1 = lists:foldl(fun({Value, Arg}, S0) -> make_call(Contract2, Value, Arg, S0) end,
-                      S, [{I * 100, I + 100} || I <- lists:seq(1, 10)]),
+                      S, [{(I - 3) * 100, I + 100} || I <- lists:seq(1, 10)]),
     ok.
 
 make_call(To, Value, Arg, S) ->
@@ -116,6 +116,9 @@ make_call(To, Value, Arg, S) ->
     Gas      = 10000,
     CallRes  = aevm_chain:call_contract(To, Gas, Value, CallData, S),
     case C1Bal1 >= Value of
+        _ when Value < 0 ->
+            {error, negative_amount} = CallRes,
+            S;
         true ->
             {ok, Res, S1} = CallRes,
             GasUsed  = aevm_chain_api:gas_spent(Res),

--- a/test/contract_ring_bytecode_aevm_SUITE.erl
+++ b/test/contract_ring_bytecode_aevm_SUITE.erl
@@ -8,7 +8,7 @@
 
 %% test case exports
 -export(
-   [ 
+   [
      execute_identity_fun_from_ring_file/1
    ]).
 
@@ -36,7 +36,9 @@ execute_identity_fun_from_ring_file(_Cfg) ->
              currentDifficulty => 0,
              currentGasLimit => 10000,
              currentNumber => 0,
-             currentTimestamp => 0},
+             currentTimestamp => 0,
+             chainState => aevm_dummy_chain:new_state(),
+             chainAPI => aevm_dummy_chain},
           true),
     <<42:256>> = RetVal,
     ok.

--- a/test/ring_bytecode_aevm_SUITE.erl
+++ b/test/ring_bytecode_aevm_SUITE.erl
@@ -8,7 +8,7 @@
 
 %% test case exports
 -export(
-   [ 
+   [
      execute_identity_fun_from_bytecode/1
      , execute_identity_fun_from_ring_file/1
    ]).
@@ -16,7 +16,7 @@
 -include_lib("common_test/include/ct.hrl").
 
 all() ->
-    [ 
+    [
       execute_identity_fun_from_bytecode,
       execute_identity_fun_from_ring_file ].
 
@@ -30,7 +30,7 @@ execute_identity_fun_from_ring_file(_Cfg) ->
     %% Create the call data
     CallData = aer_abi:create_calldata(Code, "main", "42"),
 
-    {ok, Res} = 
+    {ok, Res} =
         aevm_eeevm:eval(
           aevm_eeevm_state:init(
             #{ exec => #{ code => Code,
@@ -45,7 +45,9 @@ execute_identity_fun_from_ring_file(_Cfg) ->
                         currentDifficulty => 0,
                         currentGasLimit => 10000,
                         currentNumber => 0,
-                        currentTimestamp => 0},
+                        currentTimestamp => 0,
+                        chainState => aevm_dummy_chain:new_state(),
+                        chainAPI => aevm_dummy_chain},
                pre => #{}},
             #{trace => true})
          ),
@@ -54,11 +56,11 @@ execute_identity_fun_from_ring_file(_Cfg) ->
     ok.
 
 execute_identity_fun_from_bytecode(_Cfg) ->
-    Code = 
+    Code =
         <<96,0,53,128,127,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
           0,0,0,0,0,20,98,0,0,44,87,0,91,96,32,53,98,0,0,58,144,98,0,0,67,86,91,
           96,0,82,96,32,96,0,243,91,128,144,80,144,86>>,
-    {ok, Res} = 
+    {ok, Res} =
         aevm_eeevm:eval(
           aevm_eeevm_state:init(
             #{ exec => #{ code => Code,
@@ -73,7 +75,9 @@ execute_identity_fun_from_bytecode(_Cfg) ->
                         currentDifficulty => 0,
                         currentGasLimit => 10000,
                         currentNumber => 0,
-                        currentTimestamp => 0},
+                        currentTimestamp => 0,
+                        chainState => aevm_dummy_chain:new_state(),
+                        chainAPI => aevm_dummy_chain},
                pre => #{}},
             #{trace => true})
          ),


### PR DESCRIPTION
This PR implements a bare-bones interface between the chain and a VM. It currently contains `spend` and `call_contract` functions. All the required information about the chain is kept in a state that's abstract to the VM.

https://www.pivotaltracker.com/n/projects/2159793/stories/154173362