### PR TITLE
Separate business logic from http layer

### DIFF
--- a/apps/aecore/src/aec_headers.erl
+++ b/apps/aecore/src/aec_headers.erl
@@ -60,47 +60,39 @@ time_in_msecs(Header) ->
 serialize_to_map(H = #header{}) ->
     Serialized =
       #{<<"height">> =>  height(H),
-        <<"prev_hash">> => aec_base58c:encode(block_hash, prev_hash(H)),
-        <<"state_hash">> => aec_base58c:encode(block_state_hash, H#header.root_hash),
+        <<"prev_hash">> => prev_hash(H),
+        <<"state_hash">> => H#header.root_hash,
         <<"target">> => H#header.target,
         <<"nonce">> => H#header.nonce,
         <<"time">> => H#header.time,
-        <<"pow">> => serialize_pow_evidence(H#header.pow_evidence),
+        <<"pow">> => H#header.pow_evidence,
         <<"version">> => H#header.version,
-        <<"txs_hash">> => aec_base58c:encode(block_tx_hash, H#header.txs_hash)
+        <<"txs_hash">> => H#header.txs_hash
       },
     {ok, Serialized}.
 
 
--spec deserialize_from_map(map()) -> {ok, header()} | {error, deserialize}.
+-spec deserialize_from_map(map()) -> header().
 deserialize_from_map(H = #{}) ->
-      #{<<"height">> := Height,
-        <<"prev_hash">> := PrevHash,
-        <<"state_hash">> := RootHash,
-        <<"target">> := Target,
-        <<"nonce">> := Nonce,
-        <<"time">> := Time,
-        <<"version">> := Version,
-        <<"pow">> := PowEvidence,
-        <<"txs_hash">> := TxsHash
-      } = H,
-    try
-        {block_hash, DecPrevHash} = aec_base58c:decode(PrevHash),
-        {block_state_hash, DecRootHash} = aec_base58c:decode(RootHash),
-        {block_tx_hash, DecTxsHash} = aec_base58c:decode(TxsHash),
-        {ok, #header{height = Height,
-                     prev_hash = DecPrevHash,
-                     root_hash = DecRootHash,
-                     target = Target,
-                     nonce = Nonce,
-                     time = Time,
-                     version = Version,
-                     pow_evidence = deserialize_pow_evidence(PowEvidence),
-                     txs_hash = DecTxsHash}}
-    catch
-        error:_ ->
-            {error, deserialize}
-    end.
+    #{<<"height">> := Height,
+      <<"prev_hash">> := PrevHash,
+      <<"state_hash">> := RootHash,
+      <<"target">> := Target,
+      <<"nonce">> := Nonce,
+      <<"time">> := Time,
+      <<"version">> := Version,
+      <<"pow">> := PowEvidence,
+      <<"txs_hash">> := TxsHash
+    } = H,
+    #header{height = Height,
+                 prev_hash = PrevHash,
+                 root_hash = RootHash,
+                 target = Target,
+                 nonce = Nonce,
+                 time = Time,
+                 version = Version,
+                 pow_evidence = PowEvidence,
+                 txs_hash = TxsHash}.
 
 -spec serialize_for_hash(header()) -> deterministic_header_binary().
 serialize_for_hash(H) ->

--- a/apps/aecore/test/aec_headers_tests.erl
+++ b/apps/aecore/test/aec_headers_tests.erl
@@ -17,7 +17,7 @@ getters_test() ->
 network_serialization_test() ->
     Header = #header{},
     {ok, SerializedHeader} = ?TEST_MODULE:serialize_to_map(Header),
-    {ok, DeserializedHeader} =
+    DeserializedHeader =
         ?TEST_MODULE:deserialize_from_map(SerializedHeader),
     ?assertEqual(Header, DeserializedHeader),
     ?assertEqual({ok, SerializedHeader},

--- a/apps/aehttp/priv/swagger.json
+++ b/apps/aehttp/priv/swagger.json
@@ -946,8 +946,8 @@
               "$ref" : "#/definitions/OracleQuestions"
             }
           },
-          "404" : {
-            "description" : "Oracle not found",
+          "400" : {
+            "description" : "Invalid parameters",
             "schema" : {
               "$ref" : "#/definitions/Error"
             }

--- a/apps/aehttp/src/aehttp_api_parser.erl
+++ b/apps/aehttp/src/aehttp_api_parser.erl
@@ -1,0 +1,206 @@
+-module(aehttp_api_parser).
+
+-export([encode/2,
+         encode/3,
+         encode_client_readable_block/2,
+         decode/2]).
+
+-define(HEADER_OBJ, [{<<"prev_hash">>, block_hash},
+                     {<<"state_hash">>, block_state_hash},
+                     {<<"pow">>, {fun aec_headers:serialize_pow_evidence/1,
+                                    fun(Pow) ->
+                                        {ok, aec_headers:deserialize_pow_evidence(Pow)}
+                                    end}},
+                     {<<"txs_hash">>, block_tx_hash}]).
+-define(OBJECTS, #{ping => [{<<"genesis_hash">>, block_hash},
+                            {<<"best_hash">>, block_hash}],
+                   header_map => ?HEADER_OBJ,
+                   block_map => [ {<<"transactions">>, {list, tx}} | ?HEADER_OBJ],
+                   block => {fun(Block) ->
+                                BMap = aehttp_logic:cleanup_genesis(
+                                            aec_blocks:serialize_to_map(Block)),
+                                encode(block_map, BMap)
+                            end,
+                            fun(BMap) ->
+                                FullBMap = aehttp_logic:add_missing_to_genesis_block(BMap),
+                                case decode(block_map, FullBMap) of
+                                    {ok, Decoded} ->
+                                        {ok, _Block} = aec_blocks:deserialize_from_map(Decoded);
+                                    Err -> Err
+                                end
+                            end},
+                   header => {fun(Header) ->
+                                {ok, HMap0} = aec_headers:serialize_to_map(Header),
+                                HMap = aehttp_logic:cleanup_genesis(HMap0),
+                                encode(header_map, HMap)
+                            end,
+                            fun(HMap) ->
+                                FullHMap = aehttp_logic:add_missing_to_genesis_block(HMap),
+                                case decode(header_map, FullHMap) of
+                                    {ok, Decoded} ->
+                                        {ok, aec_headers:deserialize_from_map(Decoded)};
+                                    Err -> Err
+                                end
+                            end},
+                   client_block => {fun encode_block_for_client/2,
+                                    fun(_) -> {error, not_implemented} end},
+                   tx => {fun(Tx) ->
+                              #{<<"tx">> => aec_base58c:encode(transaction,
+                                  aetx_sign:serialize_to_binary(Tx))}
+                          end,
+                          fun Decode(#{<<"tx">> := EncodedTx}) ->
+                              Decode(EncodedTx);
+                              Decode(EncodedTx) when is_binary(EncodedTx) ->
+                              case aec_base58c:safe_decode(transaction, EncodedTx) of
+                                  {error, _} = Err ->  Err;
+                                  {ok, DecodedTx} ->
+                                      try {ok, aetx_sign:deserialize_from_binary(DecodedTx)}
+                                      catch _:_ -> {error, broken_tx}
+                                      end
+                              end
+                          end},
+                   tx_list => {list, tx},
+                   account_balance => [{<<"pub_key">>, account_pubkey}],
+                   account_balances => {list, account_balance},
+                   node_version => [{<<"genesis_hash">>, block_hash}],
+
+                   oracle => [{<<"address">>, oracle_pubkey}],
+                   oracle_list => {list, oracle},
+
+                   oracle_query => [{<<"query_id">>, oracle_query_id}],
+                   oracle_queries_list => {list, oracle_query}
+
+                  }).
+
+-spec encode(atom(), term() | list()) -> map() | list().
+encode(ObjectType, Data) ->
+    encode(ObjectType, Data, []).
+
+encode_client_readable_block(Block, TxEncoding) ->
+    encode(client_block, Block, TxEncoding).
+
+encode(ObjectType, Data, Params) ->
+    Rule = parsing_rules(ObjectType),
+    EncodeFun = encode_fun(Rule),
+    EncodeFun(Rule, Data, Params).
+
+-spec decode(atom(), map() | list()) -> {ok, term()} | {error, map()}.
+decode(ObjectType, Data) ->
+    Rule = parsing_rules(ObjectType),
+    DecodeFun = decode_fun(Rule),
+    DecodeFun(Rule, Data).
+
+encode_object(Rules, Object, Params) when is_list(Rules) ->
+    lists:foldl(
+        fun({Key, _} = Rule, Accum) ->
+            case maps:find(Key, Accum) of
+                {ok, Val} ->
+                    EncodeFun = encode_fun(Rule),
+                    EncodedVal = EncodeFun(Rule, Val, Params),
+                    maps:put(Key, EncodedVal, Accum);
+                error ->
+                    Accum
+            end
+        end,
+        Object,
+        Rules).
+
+decode_object(Rules, Object) ->
+    decode_object(Rules, Object, []).
+
+decode_object([], Object, []) ->
+    {ok, Object};
+decode_object([], _Object, Errors) ->
+    {error, maps:from_list(Errors)};
+decode_object([{Key, _} = Rule | T], Object, Errors) ->
+    case maps:find(Key, Object) of
+        error -> decode_object(T, Object, Errors);
+        {ok, EncodedVal} ->
+            DecodeFun = decode_fun(Rule),
+            case DecodeFun(Rule, EncodedVal) of
+                {ok, Val} ->
+                    decode_object(T, maps:put(Key, Val, Object), Errors);
+                {error, Reason} ->
+                    decode_object(T, Object, [{Key, Reason} | Errors])
+            end
+    end.
+
+encode_value({EncodeFun, _}, Val, _) when is_function(EncodeFun, 1) ->
+    EncodeFun(Val);
+encode_value({_, {EncodeFun, _}}, Val, _) when is_function(EncodeFun, 1) ->
+    EncodeFun(Val);
+encode_value({EncodeFun, _}, Val, Params) when is_function(EncodeFun, 2) ->
+    EncodeFun(Val, Params);
+encode_value({_, {EncodeFun, _}}, Val, Params) when is_function(EncodeFun, 2) ->
+    EncodeFun(Val, Params);
+encode_value({_, HashType}, Val, _) when is_atom(HashType) ->
+    aec_base58c:encode(HashType, Val).
+
+decode_value({_, DecodeFun}, EncodedVal) when is_function(DecodeFun, 1) ->
+    DecodeFun(EncodedVal);
+decode_value({_, {_, DecodeFun}}, EncodedVal) when is_function(DecodeFun, 1) ->
+    DecodeFun(EncodedVal);
+decode_value({_, HashType}, Val) when is_atom(HashType) ->
+    aec_base58c:safe_decode(HashType, Val).
+
+encode_list({_, {list, Type}}, Elems, Params) when is_list(Elems) ->
+    encode_list({list, Type}, Elems, Params);
+encode_list({list, Type}, Elems, Params) when is_list(Elems) ->
+    lists:map(
+        fun(Element) ->
+            encode(Type, Element, Params)
+        end,
+        Elems).
+
+decode_list({_, {list, Type}}, Elems) when is_list(Elems) ->
+    decode_list({list, Type}, Elems);
+decode_list({list, Type}, Elems) when is_list(Elems) ->
+    {Succeeded, Failed} =
+        %% preserve order!
+        lists:foldr(
+            fun(El, {Oks, Errs}) ->
+                case decode(Type, El) of
+                    {ok, Decoded} -> {[Decoded | Oks], Errs};
+                    {error, ErrMsg} -> {Oks, [{El, ErrMsg} | Errs]}
+                end
+            end,
+            {[], []},
+            Elems),
+    case Failed =/= [] of
+        true -> {error, Failed};
+        false -> {ok, Succeeded}
+    end.
+
+parsing_rules(ObjectType) ->
+    maps:get(ObjectType, ?OBJECTS).
+
+encode_fun(Rule) ->
+    case rule_type(Rule) of
+        list -> fun encode_list/3;
+        value -> fun encode_value/3;
+        object -> fun encode_object/3
+    end.
+
+decode_fun(Rule) ->
+    case rule_type(Rule) of
+        list -> fun decode_list/2;
+        value -> fun decode_value/2;
+        object -> fun decode_object/2
+    end.
+
+rule_type({_, {list, _Type}}) -> list;
+rule_type({list, _Type}) -> list;
+rule_type({_, _}) -> value;
+rule_type(L) when is_list(L) -> object.
+
+encode_block_for_client(Block, Encoding) ->
+    Header = aec_blocks:to_header(Block),
+    EncodedHeader = encode(header, Header),
+    Txs =
+        lists:map(
+            fun(Tx) ->
+                aetx_sign:serialize_for_client(Encoding, Header, Tx)
+            end,
+            aec_blocks:txs(Block)),
+    maps:put(<<"transactions">>, Txs, EncodedHeader).
+

--- a/apps/aehttp/src/aehttp_int_tx_logic.erl
+++ b/apps/aehttp/src/aehttp_int_tx_logic.erl
@@ -1,0 +1,232 @@
+-module(aehttp_int_tx_logic).
+
+-import(aeu_debug, [pp/1]).
+
+-export([sender_and_hash/1]).
+
+-export([ spend/3
+       ]).
+
+-export([ oracle_register/6
+        , oracle_extend/3
+        , oracle_query/7
+        , oracle_response/3
+        , get_oracles/2
+        , get_oracle_questions/3
+       ]).
+
+-export([ name_preclaim/2
+        , name_claim/3
+        , name_update/5
+        , name_transfer/3
+        , name_revoke/2
+       ]).
+
+sender_and_hash(Tx) ->
+    Sender = aetx:origin(Tx), 
+    TxHash = aetx:hash(Tx),
+    {Sender, TxHash}.
+
+spend(EncodedRecipient, Amount, Fee) ->
+    create_tx(
+        fun(SenderPubkey, Nonce) ->
+            case aec_chain:resolve_name(account_pubkey, EncodedRecipient) of
+                {ok, DecodedRecipientPubkey} ->
+                    aec_spend_tx:new(
+                      #{sender    => SenderPubkey,
+                        recipient => DecodedRecipientPubkey,
+                        amount    => Amount,
+                        fee       => Fee,
+                        nonce     => Nonce});
+                {error, _} ->
+                    {error, invalid_key}
+            end
+        end).
+
+oracle_register(QueryFormat, ResponseFormat, QueryFee, Fee, TTLType, TTLValue) ->
+    create_tx(
+        fun(Pubkey, Nonce) ->
+            aeo_register_tx:new(
+              #{account       => Pubkey,
+                nonce         => Nonce,
+                query_spec    => QueryFormat,
+                response_spec => ResponseFormat,
+                query_fee     => QueryFee,
+                ttl           => {TTLType, TTLValue},
+                fee           => Fee})
+          end).
+
+oracle_extend(Fee, TTLType, TTLValue) ->
+    create_tx(
+        fun(Pubkey, Nonce) ->
+            aeo_extend_tx:new(
+              #{oracle => Pubkey,
+                nonce  => Nonce,
+                ttl    => {TTLType, TTLValue},
+                fee    => Fee})
+          end).
+
+oracle_query(EncodedOraclePubkey, Query, QueryFee, QueryTTLType,
+             QueryTTLValue, ResponseTTLValue, Fee) ->
+    create_tx(
+        fun(Pubkey, Nonce) ->
+            case aec_chain:resolve_name(oracle_pubkey, EncodedOraclePubkey) of
+                {ok, DecodedOraclePubkey} ->
+                    {ok, Tx} =
+                        aeo_query_tx:new(
+                          #{sender       => Pubkey,
+                            nonce        => Nonce,
+                            oracle       => DecodedOraclePubkey,
+                            query        => Query,
+                            query_fee    => QueryFee,
+                            query_ttl    => {QueryTTLType, QueryTTLValue},
+                            response_ttl => {delta, ResponseTTLValue},
+                            fee          => Fee}),
+                    QId = aeo_query:id(Pubkey, Nonce, DecodedOraclePubkey),
+                    {ok, Tx, QId};
+                {error, _} -> {error, invalid_key}
+              end
+          end).
+
+oracle_response(DecodedQueryId, Response, Fee) ->
+    create_tx(
+        fun(Pubkey, Nonce) ->
+            aeo_response_tx:new(
+              #{oracle   => Pubkey,
+                nonce    => Nonce,
+                query_id => DecodedQueryId,
+                response => Response,
+                fee      => Fee})
+          end).
+
+get_oracles(From, Max) ->
+    {ok, Oracles} = aec_chain:get_oracles(From, Max),
+    FmtOracles =
+        lists:map(
+            fun(O) -> #{<<"address">> => aeo_oracles:id(O),
+                        query_format => aeo_oracles:query_format(O),
+                        response_format => aeo_oracles:response_format(O),
+                        query_fee => aeo_oracles:query_fee(O),
+                        expires_at => aeo_oracles:expires(O)}
+            end,
+            Oracles),
+    {ok, FmtOracles}.
+
+get_oracle_questions(OracleId, From, Max) ->
+    {ok, Queries} = aec_chain:get_open_oracle_queries(OracleId, From, Max),
+    FmtQueries =
+        lists:map(
+            fun(Q) -> #{<<"query_id">> => aeo_query:id(Q),
+                        query => aeo_query:query(Q),
+                        query_fee => aeo_query:fee(Q),
+                        expires_at => aeo_query:expires(Q)}
+            end,
+            Queries),
+    {ok, FmtQueries}.
+
+name_preclaim(DecodedCommitment, Fee) ->
+    create_tx(
+        fun(Pubkey, Nonce) ->
+            aens_preclaim_tx:new(
+              #{account    => Pubkey,
+                nonce      => Nonce,
+                commitment => DecodedCommitment,
+                fee        => Fee})
+          end).
+
+name_claim(Name, NameSalt, Fee) ->
+    create_tx(
+        fun(Pubkey, Nonce) ->
+            case aens:get_name_hash(Name) of
+                {ok, NameHash} ->
+                    {ok, Tx} =
+                        aens_claim_tx:new(
+                          #{account   => Pubkey,
+                            nonce     => Nonce,
+                            name      => Name,
+                            name_salt => NameSalt,
+                            fee       => Fee}),
+                    {ok, Tx, NameHash};
+                {error, _Reason} = Err -> Err
+            end
+          end).
+
+name_update(DecodedNameHash, NameTTL, Pointers, TTL, Fee) ->
+    create_tx(
+        fun(Pubkey, Nonce) ->
+            aens_update_tx:new(
+              #{account   => Pubkey,
+                nonce     => Nonce,
+                name_hash => DecodedNameHash,
+                name_ttl  => NameTTL,
+                pointers  => jsx:decode(Pointers),
+                ttl       => TTL,
+                fee       => Fee})
+          end).
+
+name_transfer(DecodedNameHash, DecodedRecipientPubKey, Fee) ->
+    create_tx(
+        fun(Pubkey, Nonce) ->
+            aens_transfer_tx:new(
+              #{account           => Pubkey,
+                nonce             => Nonce,
+                name_hash         => DecodedNameHash,
+                recipient_account => DecodedRecipientPubKey,
+                fee               => Fee})
+          end).
+
+name_revoke(DecodedNameHash, Fee) ->
+    create_tx(
+        fun(Pubkey, Nonce) ->
+            aens_revoke_tx:new(
+              #{account   => Pubkey,
+                nonce     => Nonce,
+                name_hash => DecodedNameHash,
+                fee       => Fee})
+          end).
+
+%% Internals
+%%
+create_tx(TxFun) ->
+    case get_local_pubkey_with_next_nonce() of
+        {ok, Pubkey, Nonce} ->
+            case TxFun(Pubkey, Nonce) of
+                {error, _} = Err -> Err;
+                {ok, Tx} ->
+                    sign_and_push_to_mempool(Tx),
+                    {ok, Tx};
+                {ok, Tx, Result} ->
+                    sign_and_push_to_mempool(Tx),
+                    {ok, Tx, Result}
+            end;
+        {error, _} = Err -> Err
+    end.
+
+-spec get_local_pubkey_with_next_nonce() -> {ok, binary(), integer()} |
+                              {error, account_not_found | key_not_found}.
+get_local_pubkey_with_next_nonce() ->
+    case aec_keys:pubkey() of
+        {ok, Pubkey} ->
+            lager:debug("SenderPubKey matches ours"),
+            case aec_next_nonce:pick_for_account(Pubkey) of
+                {ok, Nonce} ->
+                    lager:debug("Nonce = ~p", [Nonce]),
+                    {ok, Pubkey, Nonce};
+                {error, account_not_found} = Error ->
+                    lager:debug("Account not found"),
+                    %% Account was not found in state trees
+                    %% so effectively there have been no funds
+                    %% ever granted to it.
+                    Error
+            end;
+        {error, key_not_found} = Error ->
+            Error
+    end.
+
+sign_and_push_to_mempool(Tx) ->
+    lager:debug("Tx = ~p", [pp(Tx)]),
+    {ok, SignedTx} = aec_keys:sign(Tx),
+    ok = aec_tx_pool:push(SignedTx),
+    lager:debug("pushed; peek() -> ~p",
+                [pp(aec_tx_pool:peek(10))]).
+

--- a/apps/aehttp/src/aehttp_logic.erl
+++ b/apps/aehttp/src/aehttp_logic.erl
@@ -1,0 +1,235 @@
+-module(aehttp_logic).
+
+-export([ get_top/0
+        , get_top_height/0
+        , get_top_hash/0
+        , get_header_by_hash/1
+        , get_header_by_height/1
+        , get_headers_list/3
+        , get_block_by_height/1
+        , get_block_by_hash/1
+        , get_block_latest/0
+        , get_block_pending/0
+        , get_block_genesis/0
+        , get_block_range_by_hash/2
+        , get_block_range_by_height/2
+        , get_genesis_hash/0
+        , get_top_blocks_time_summary/1
+        ]).
+
+-export([ get_account_balance/1
+        , get_account_balance_at_hash/2
+        , get_all_accounts_balances/0
+        ]).
+
+-export([ version/0
+        , revision/0
+        ]).
+
+-export([ contract_compile/2
+        , contract_call/4
+        , contract_encode_call_data/4
+        ]).
+
+-export([miner_key/0]).
+
+-export([ all_peers/0
+        , blocked_peers/0
+        ]).
+
+-export([cleanup_genesis/1,
+         add_missing_to_genesis_block/1]).
+
+-spec get_top() -> {ok, aec_headers:header()}.
+get_top() ->
+    Header = aec_chain:top_header(),
+    {ok, Header}.
+
+-spec get_top_height() -> {ok, integer()}.
+get_top_height() ->
+    TopHeader = aec_chain:top_header(),
+    Height = aec_headers:height(TopHeader),
+    {ok, Height}.
+
+-spec get_top_hash() -> {ok, binary()}.
+get_top_hash() ->
+    TopHeader = aec_chain:top_header(),
+    {ok, _Hash} = aec_headers:hash_header(TopHeader).
+
+-spec get_header_by_hash(binary()) -> {ok, aec_headers:header()} | {error, header_not_found}.
+get_header_by_hash(Hash) ->
+    case aec_chain:get_header(Hash) of
+        {ok, _Header} = OK -> OK;
+        error ->
+            {error, header_not_found}
+    end.
+
+-spec get_header_by_height(integer()) -> {ok, aec_headers:header()} | {error, chain_too_short}.
+get_header_by_height(Height) ->
+    case aec_chain:get_header_by_height(Height) of
+        {ok, _Header} = OK -> OK;
+        {error, chain_too_short} = Err ->
+            Err
+    end.
+
+-spec get_block_by_height(integer()) -> {ok, aec_blocks:block()} |
+                                        {error, block_not_found | chain_too_short}.
+get_block_by_height(Height) ->
+    case aec_chain:get_block_by_height(Height) of
+        {ok, Block} ->
+            {ok, Block};
+        {error, Msg} = Err when Msg =:= block_not_found orelse
+                                Msg =:= chain_too_short ->
+            Err
+    end.
+
+get_block_genesis() ->
+    GenBlock = aec_chain:genesis_block(),
+    {ok, GenBlock}.
+
+get_block_latest() ->
+    TopBlock = aec_chain:top_block(),
+    {ok, TopBlock}.
+
+get_block_pending() ->
+    aec_conductor:get_block_candidate().
+
+-spec get_block_by_hash(binary()) -> {ok, aec_blocks:block()} |
+                                     {error, block_not_found}.
+get_block_by_hash(Hash) ->
+    case aec_chain:get_block(Hash) of
+        {ok, Block} ->
+            {ok, Block};
+        error ->
+            {error, block_not_found}
+    end.
+
+get_block_range_by_hash(HashFrom, HashTo) ->
+    aec_chain:get_block_range_by_hash(HashFrom, HashTo).
+
+get_block_range_by_height(HeightFrom, HeightTo) ->
+    aec_chain:get_block_range_by_height(HeightFrom, HeightTo).
+
+-spec get_headers_list(binary(), integer(), backward | forward) ->
+    {ok, list()} | {error, atom}.
+get_headers_list(Hash, N, Direction) ->
+    Fun =
+        case Direction of
+            forward  -> fun aec_chain:get_at_most_n_headers_forward_from_hash/2;
+            backward -> fun aec_chain:get_n_headers_backwards_from_hash/2
+        end,
+    case Fun(Hash, N) of
+        {ok, _Headers} = OK -> OK;
+        error ->
+            {error, header_not_found}
+    end.
+
+-spec get_account_balance(binary()) -> {ok, integer()}
+                                     | {error, account_not_found}.
+get_account_balance(Pubkey) when is_binary(Pubkey) ->
+    case aec_chain:get_account(Pubkey) of
+        {value, A} ->
+            {ok, aec_accounts:balance(A)};
+        none ->
+            {error, account_not_found}
+    end.
+
+get_account_balance_at_hash(AccountPubkey, Hash) ->
+    case aec_chain:get_account_at_hash(AccountPubkey, Hash) of
+        {error, no_state_trees} -> {error, not_on_main_chain};
+        none                    -> {error, account_not_found};
+        {value, Account}        -> {ok, aec_accounts:balance(Account)}
+    end.
+
+-spec get_all_accounts_balances() -> {ok, [map()]}.
+get_all_accounts_balances() ->
+    {ok, AccountsBalances} =
+        aec_chain:all_accounts_balances_at_hash(aec_chain:top_block_hash()),
+    FormattedBalances =
+        lists:foldl(
+          fun({Pubkey, Balance}, Acc) ->
+              [#{<<"pub_key">> => Pubkey,
+                 <<"balance">> => Balance} | Acc]
+          end, [], AccountsBalances),
+    {ok, FormattedBalances}.
+
+version() -> {ok, aeu_info:get_version()}.
+
+revision() -> {ok, aeu_info:get_revision()}.
+
+get_genesis_hash() -> {ok, aec_chain:genesis_hash()}.
+
+get_top_blocks_time_summary(Count) ->
+    TimeSummary0 = aec_chain:get_top_N_blocks_time_summary(Count),
+    TimeSummary =
+        lists:foldl(
+          fun({Height, Ts, Delta, Difficulty}, Acc) ->
+                  [#{height => Height,
+                    time => Ts,
+                    difficulty => Difficulty,
+                    time_delta_to_parent => Delta} | Acc];
+            ({Height, Ts, Difficulty}, Acc) ->
+                  [#{height => Height,
+                    time => Ts,
+                    difficulty => Difficulty} | Acc]
+          end, [], TimeSummary0),
+    {ok, lists:reverse(TimeSummary)}.
+
+contract_compile(Code, Options) ->
+    case aect_ring:compile(Code, Options) of
+          {ok, _ByteCode} = OK -> OK;
+          {error, _ErrorMsg} = Err -> Err
+    end.
+
+contract_call(ABI, Code, Function, Argument) ->
+    case aect_dispatch:call(ABI, Code, Function, Argument) of
+        {ok, _Result} = OK -> OK;
+        {error, _ErrorMsg} = Err -> Err
+    end.
+
+contract_encode_call_data(ABI, Code, Function, Argument) ->
+    case aect_dispatch:encode_call_data(ABI, Code, Function, Argument) of
+        {ok, _Result} = OK -> OK;
+        {error, _ErrorMsg} = Err -> Err
+    end.
+
+miner_key() ->
+    case aec_keys:pubkey() of
+        {ok, _Pubkey} = OK -> OK;
+        {error, key_not_found} = Err -> Err
+    end.
+
+all_peers() -> aec_peers:all().
+
+blocked_peers() -> aec_peers:blocked().
+
+%% Private
+empty_fields_in_genesis() ->
+    [ <<"prev_hash">>,
+      <<"pow">>,
+      <<"txs_hash">>,
+      <<"transactions">>].
+
+% assuming no transactions in genesis block
+% if this changes - both functions should be changes:
+% empty_fields_in_genesis/0 and values_for_empty_fields_in_genesis/0
+values_for_empty_fields_in_genesis() ->
+    true = lists:member(<<"transactions">>, empty_fields_in_genesis()),
+    #{<<"prev_hash">> => aec_base58c:encode(
+                           block_hash, aec_block_genesis:prev_hash()),
+      <<"pow">> => aec_headers:serialize_pow_evidence(aec_block_genesis:pow()),
+      <<"txs_hash">> => aec_base58c:encode(
+                          block_tx_hash, aec_block_genesis:txs_hash()),
+      <<"transactions">> => aec_block_genesis:transactions()}.
+
+%% to be used for both headers and blocks
+cleanup_genesis(#{<<"height">> := 0} = Genesis) ->
+    maps:without(empty_fields_in_genesis(), Genesis);
+cleanup_genesis(Val) ->
+    Val.
+
+add_missing_to_genesis_block(#{<<"height">> := 0} = Block) ->
+    maps:merge(Block, values_for_empty_fields_in_genesis());
+add_missing_to_genesis_block(Val) ->
+    Val.
+

--- a/apps/aehttp/src/ws_int_dispatch.erl
+++ b/apps/aehttp/src/ws_int_dispatch.erl
@@ -42,16 +42,13 @@ do_execute(chain, get, QueryPayload) ->
         {error, ErrMsg} ->
             {error, ErrMsg};
         {ok, Block} ->
-            Val0 =
+            Val =
                   case Type of
                       <<"header">> ->
-                          {ok, HH} = aec_headers:serialize_to_map(
-                              aec_blocks:to_header(Block)),
-                          HH;
+                          aehttp_api_parser:encode(header, aec_blocks:to_header(Block));
                       <<"block">> ->
-                          aec_blocks:serialize_to_map(Block)
+                          aehttp_api_parser:encode(block, Block)
                   end,
-            Val = aehttp_dispatch_ext:cleanup_genesis(Val0),
             {ok, chain, requested_data, [{type, Type}, Query, {Type, Val}]}
     end;
 do_execute(chain, unsubscribe_all, Data) ->

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -429,8 +429,7 @@ get_top_empty_chain(_Config) ->
     {ok, 200, HeaderMap} = get_top(),
     ct:log("~p returned header = ~p", [?NODE, HeaderMap]),
     {ok, 200, GenBlockMap} = get_block_by_height(0),
-    {ok, GenBlock} = aec_blocks:deserialize_from_map(
-                      aehttp_dispatch_ext:add_missing_to_genesis_block(GenBlockMap)),
+    {ok, GenBlock} = aehttp_api_parser:decode(block, GenBlockMap),
     ExpectedMap = header_to_endpoint_top(aec_blocks:to_header(GenBlock)),
     ct:log("Cleaned top header = ~p", [ExpectedMap]),
     HeaderMap = ExpectedMap,
@@ -1194,7 +1193,8 @@ post_broken_blocks(Config) ->
     aecore_suite_utils:connect(aecore_suite_utils:node_name(?NODE)),
     GH = rpc(aec_chain, top_header, []),
     0 = aec_headers:height(GH), %chain is empty
-    CorrectBlockMap = aec_blocks:serialize_to_map(CorrectBlock),
+    CorrectBlockMap =
+        aehttp_api_parser:encode(block, CorrectBlock),
     BrokenBlocks =
         lists:map(
             fun({Key, Value}) ->
@@ -1215,7 +1215,7 @@ post_broken_blocks(Config) ->
     lists:foreach(
         fun({BrokenField, BlockMap}) ->
             ct:log("Testing with a broken ~p", [BrokenField]),
-            {ok, Block} = aec_blocks:deserialize_from_map(BlockMap),
+            {ok, Block} = aehttp_api_parser:decode(block, BlockMap),
             {ok, 400, #{<<"reason">> := <<"Block rejected">>}} = post_block(Block),
             H = rpc(aec_chain, top_header, []),
             0 = aec_headers:height(H) %chain is still empty
@@ -1260,7 +1260,7 @@ post_broken_tx(_Config) ->
                   end,
     EncodedBrokenTx = aec_base58c:encode(transaction, BrokenTxBin),
     EncodedSignedTx = aec_base58c:encode(transaction, SignedTxBin),
-    {ok, 400, #{<<"reason">> := <<"Invalid tx">>}} = post_tx(EncodedBrokenTx),
+    {ok, 400, #{<<"reason">> := <<"Invalid base58Check encoding">>}} = post_tx(EncodedBrokenTx),
     {ok, 200, _} = post_tx(EncodedSignedTx),
     ok.
 
@@ -2943,7 +2943,8 @@ get_account_transactions(EncodedPubKey, Params) ->
 
 post_block(Block) ->
     Host = external_address(),
-    BlockMap = aec_blocks:serialize_to_map(Block),
+    BlockMap =
+        aehttp_api_parser:encode(block, Block),
     http_request(Host, post, "block", BlockMap).
 
 post_tx(TxSerialized) ->
@@ -3489,21 +3490,19 @@ process_http_return(R) ->
 
 header_to_endpoint_top(Header) ->
     {ok, Hash} = aec_headers:hash_header(Header),
-    {ok, HMap} = aec_headers:serialize_to_map(Header),
-    CleanedH = aehttp_dispatch_ext:cleanup_genesis(HMap),
-    maps:put(<<"hash">>, aec_base58c:encode(block_hash, Hash), CleanedH).
+    maps:put(<<"hash">>, aec_base58c:encode(block_hash, Hash),
+             aehttp_api_parser:encode(header, Header)).
 
 block_to_endpoint_gossip_map(Block) ->
-    BMap = aec_blocks:serialize_to_map(Block),
-    aehttp_dispatch_ext:cleanup_genesis(BMap).
+    aehttp_api_parser:encode(block, Block).
 
 block_to_endpoint_map(Block) ->
     block_to_endpoint_map(Block, #{tx_encoding => message_pack}).
 
 block_to_endpoint_map(Block, Options) ->
     Encoding = maps:get(tx_encoding, Options, message_pack),
-    BMap = aec_blocks:serialize_client_readable(Encoding, Block),
-    Expected = aehttp_dispatch_ext:cleanup_genesis(BMap),
+    BMap = aehttp_api_parser:encode_client_readable_block(Block, Encoding),
+    Expected = aehttp_logic:cleanup_genesis(BMap),
 
     %% Validate that all transactions have the correct block height and hash
     ExpectedTxs = maps:get(<<"transactions">>, Expected, []),

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -794,8 +794,8 @@ paths:
           description: Active oracle questions
           schema:
             $ref: '#/definitions/OracleQuestions'
-        '404':
-          description: Oracle not found
+        '400':
+          description: Invalid parameters
           schema:
             $ref: '#/definitions/Error'
       security:


### PR DESCRIPTION
* Refactored the serialization to be separated from the node internals

* Moved business logic to a separate module `aehttp_logic`

* Moved signed transaction-specific logic (that is going to be deprecated) to a `aehttp_int_tx_logic module`

Still TODO: rebase on top of noise protocol changes and apply them accordingly