### PR TITLE
Empty accounts.json processing

### DIFF
--- a/apps/aecore/src/aec_genesis_block_settings.erl
+++ b/apps/aecore/src/aec_genesis_block_settings.erl
@@ -1,26 +1,44 @@
 -module(aec_genesis_block_settings).
 
 -export([dir/0,
-         preset_accounts/0]).
+         preset_accounts/0,
+         read_presets/0]).
 
 dir() ->
     filename:join(aeu_env:data_dir(aecore), ".genesis").
 
+-spec preset_accounts() -> list().
 preset_accounts() ->
-    PresetAccountsFile = filename:join([dir(), "accounts.json"]),
-    case file:read_file(PresetAccountsFile) of
-        {error, _Err} ->
+    case read_presets() of
+        {error, {_Err, PresetAccountsFile}} ->
             % no setup, no preset accounts
             erlang:error({genesis_accounts_file_missing, PresetAccountsFile});
         {ok, JSONData} ->
+            DecodedData =
+                try jsx:decode(JSONData) of
+                    %% JSX decodes an empty json object as [{}]:
+                    %% [{}] = jsx:decode(<<"{}">>).
+                    [{}] -> [];
+                    L when is_list(L) -> L
+                catch
+                  error:_ ->
+                    erlang:error(invalid_accounts_json)
+                end,
             Accounts =
                 lists:map(
                     fun({EncodedPubKey, Amt}) ->
                         {ok, PubKey} = aec_base58c:safe_decode(account_pubkey, EncodedPubKey),
-                        %% PubKey = base64:decode(EncodedPubKey),
                         {PubKey, Amt}
                     end,
-                    jsx:decode(JSONData)),
+                    DecodedData),
             % ensure deterministic ordering of accounts
             lists:keysort(1, Accounts)
+    end.
+
+-spec read_presets() -> {ok, binary()}| {error, atom(), string()}.
+read_presets() ->
+    PresetAccountsFile = filename:join([dir(), "accounts.json"]),
+    case file:read_file(PresetAccountsFile) of
+        {ok, _} = OK -> OK;
+        {error, Err} -> {error, {Err, PresetAccountsFile}}
     end.

--- a/apps/aecore/test/aec_genesis_block_settings_tests.erl
+++ b/apps/aecore/test/aec_genesis_block_settings_tests.erl
@@ -1,0 +1,100 @@
+-module(aec_genesis_block_settings_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("common.hrl").
+-include("blocks.hrl").
+
+-define(TEST_MODULE, aec_genesis_block_settings).
+-define(ROOT_DIR, "/tmp").
+-define(DIR, ?ROOT_DIR ++ "/.genesis").
+-define(FILENAME, ?DIR ++ "/accounts.json").
+
+%%%===================================================================
+%%% Test cases
+%%%===================================================================
+
+preset_accounts_test_() ->
+    {foreach,
+     fun() ->
+         file:make_dir(?DIR),
+         meck:new(aeu_env, [passthrough]),
+         meck:expect(aeu_env, data_dir, fun(aecore) -> ?ROOT_DIR end),
+         ok
+     end,
+     fun(ok) ->
+         delete_dir(),
+         meck:unload(aeu_env),
+         ok
+     end,
+     [ {"Preset accounts parsing: broken file",
+        fun() ->
+            %% empty file
+            expect_accounts(<<"">>),
+            ?assertError(invalid_accounts_json, ?TEST_MODULE:preset_accounts()),
+            %% broken json
+            expect_accounts(<<"{">>),
+            ?assertError(invalid_accounts_json, ?TEST_MODULE:preset_accounts()),
+            %% broken json
+            expect_accounts(<<"{\"Alice\":1,\"Bob\":2">>),
+            ?assertError(invalid_accounts_json, ?TEST_MODULE:preset_accounts()),
+            %% not json at all 
+            expect_accounts(<<"Hejsan svejsan">>),
+            ?assertError(invalid_accounts_json, ?TEST_MODULE:preset_accounts()),
+            ok
+        end},
+       {"Preset accounts parsing: empty object",
+        fun() ->
+            expect_accounts(<<"{}">>),
+            ?assertEqual([], ?TEST_MODULE:preset_accounts()),
+            expect_accounts(<<"{ }">>),
+            ?assertEqual([], ?TEST_MODULE:preset_accounts()),
+            ok
+        end},
+
+       {"Preset accounts parsing: a preset account",
+        fun() ->
+            expect_accounts([{<<"some pubkey">>, 10}]),
+            ?assertEqual([{<<"some pubkey">>, 10}], ?TEST_MODULE:preset_accounts()),
+            ok
+        end},
+       {"Preset accounts parsing: deterministic ordering",
+        fun() ->
+            Accounts =
+                [{<<"Alice">>, 10},
+                 {<<"Carol">>, 20},
+                 {<<"Bob">>, 42}],
+            AccountsOrdered = lists:keysort(1, Accounts),
+            expect_accounts(Accounts),
+            ?assertEqual(AccountsOrdered, ?TEST_MODULE:preset_accounts()),
+            ok
+        end},
+       {"Preset accounts parsing: preset accounts file missing",
+        fun() ->
+            delete_file(),
+            ?assertError({genesis_accounts_file_missing, ?FILENAME}, ?TEST_MODULE:preset_accounts()),
+            ok
+        end}
+
+     ]}.
+
+expect_accounts(B) when is_binary(B) ->
+    file:write_file(?FILENAME, B, [binary]);
+expect_accounts(L0) when is_list(L0) ->
+    L =
+        lists:map(
+            fun({PK, Amt}) ->
+                {aec_base58c:encode(account_pubkey, PK), Amt}
+            end,
+            L0),
+    expect_accounts(jsx:encode(L)).
+
+delete_file() ->
+    case file:delete(?FILENAME) of
+        ok -> ok;
+        {error, enoent} -> ok
+    end.
+
+delete_dir() ->
+    ok = delete_file(),
+    ok = file:del_dir(?DIR).
+


### PR DESCRIPTION
Addressing some corner cases:

* Empty `accounts.json`

* `accounts.json` containing an empty js object: JSX has some curious behaviour with it ( `[{}] = jsx:decode(<<"{}">>).`) and it was causing crashes

Added EUnit tests to cover the functionality of the module

Reopened the PR. Test change is testing with actual file without meck-ing reading it.