### PR TITLE
Log container logs on system test cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -228,7 +228,7 @@ clean:
 	( cd apps/aering/test/contracts && $(MAKE) clean; )
 	( cd $(HTTP_APP) && $(MAKE) clean; )
 	@$(MAKE) multi-distclean
-	@rm -rf _build/system_test+test _build/system_test _build/test _build/prod _build/local
+	@rm -rf _build/system_test+test _build/system_test system_test/logs _build/test _build/prod _build/local
 	@rm -rf _build/default/plugins
 	@rm -rf $$(ls -d _build/default/lib/* | grep -v '[^_]rocksdb') ## Dependency `rocksdb` takes long to build.
 

--- a/system_test/helpers/aest_docker.erl
+++ b/system_test/helpers/aest_docker.erl
@@ -70,7 +70,7 @@
 }.
 
 -type stop_node_options() :: #{
-    soft_timeout => pos_integer(),
+    soft_timeout => pos_integer() | infinity,
     hard_timeout => pos_integer()
 }.
 

--- a/system_test/helpers/aest_docker.erl
+++ b/system_test/helpers/aest_docker.erl
@@ -201,11 +201,12 @@ start_node(#{container_id := ID, hostname := Name} = NodeState) ->
 -spec stop_node(node_state(), stop_node_options()) -> node_state().
 stop_node(#{container_id := ID, hostname := Name} = NodeState, Opts) ->
     Timeout = maps:get(soft_timeout, Opts, ?EPOCH_STOP_TIMEOUT),
+    TimeoutMs = case Timeout of infinity -> infinity; _ -> Timeout * 1000 end,
     case is_running(ID) of
         false ->
             log(NodeState, "Container ~p [~s] already not running", [Name, ID]);
         true ->
-            attempt_epoch_stop(NodeState, Timeout),
+            attempt_epoch_stop(NodeState, TimeoutMs),
             case wait_stopped(ID, Timeout) of %% TODO Fix this call that has timeout actual parameter as seconds but handled inside function definition as milliseconds.
                 timeout ->
                     aest_docker_api:stop_container(ID, Opts);

--- a/system_test/helpers/aest_docker.erl
+++ b/system_test/helpers/aest_docker.erl
@@ -9,7 +9,7 @@
 -export([setup_node/2]).
 -export([delete_node/1]).
 -export([start_node/1]).
--export([stop_node/1, stop_node/2]).
+-export([stop_node/2]).
 -export([kill_node/1]).
 -export([get_peer_address/1]).
 -export([get_service_address/2]).
@@ -196,9 +196,6 @@ start_node(#{container_id := ID, hostname := Name} = NodeState) ->
     aest_docker_api:start_container(ID),
     log(NodeState, "Container ~p [~s] started", [Name, ID]),
     NodeState.
-
--spec stop_node(node_state()) -> node_state().
-stop_node(NodeState) -> stop_node(NodeState, #{}).
 
 -spec stop_node(node_state(), stop_node_options()) -> node_state().
 stop_node(#{container_id := ID, hostname := Name} = NodeState, Opts) ->

--- a/system_test/helpers/aest_docker.erl
+++ b/system_test/helpers/aest_docker.erl
@@ -212,11 +212,9 @@ stop_node(#{container_id := ID, hostname := Name} = NodeState, Opts) ->
                 "attempting to stop node by executing command ~s",
                 [Name, ID, CmdStr]),
             try
-                aest_docker_api:exec(ID, Cmd, #{timeout => Timeout})
-            of
-                {ok, _} ->
-                    log(NodeState, "Command executed on container ~p [~s]: ~s",
-                        [Name, ID, CmdStr])
+                {ok, _} = aest_docker_api:exec(ID, Cmd, #{timeout => Timeout}),
+                log(NodeState, "Command executed on container ~p [~s]: ~s",
+                    [Name, ID, CmdStr])
             catch
                 throw:{exec_start_timeout, TimeoutInfo} ->
                     log(NodeState,

--- a/system_test/helpers/aest_docker.erl
+++ b/system_test/helpers/aest_docker.erl
@@ -210,7 +210,7 @@ stop_node(#{container_id := ID, hostname := Name} = NodeState, Opts) ->
                 "Container ~p [~s] still running: "
                 "attempting to stop node by executing command ~s",
                 [Name, ID, CmdStr]),
-            aest_docker_api:exec(ID, Cmd, #{timeout => 5}),
+            aest_docker_api:exec(ID, Cmd, #{timeout => Timeout}),
             log(NodeState, "Command executed on container ~p [~s]: ~s",
                 [Name, ID, CmdStr]),
             case wait_stopped(ID, Timeout) of %% TODO Fix this call that has timeout actual parameter as seconds but handled inside function definition as milliseconds.

--- a/system_test/helpers/aest_docker.erl
+++ b/system_test/helpers/aest_docker.erl
@@ -204,7 +204,15 @@ stop_node(#{container_id := ID, hostname := Name} = NodeState, Opts) ->
         false ->
             log(NodeState, "Container ~p [~s] already not running", [Name, ID]);
         true ->
-            aest_docker_api:exec(ID, ["/home/epoch/node/bin/epoch", "stop"]),
+            Cmd = ["/home/epoch/node/bin/epoch", "stop"],
+            CmdStr = lists:join($ , Cmd),
+            log(NodeState,
+                "Container ~p [~s] still running: "
+                "attempting to stop node by executing command ~s",
+                [Name, ID, CmdStr]),
+            aest_docker_api:exec(ID, Cmd),
+            log(NodeState, "Command executed on container ~p [~s]: ~s",
+                [Name, ID, CmdStr]),
             case wait_stopped(ID, Timeout) of
                 timeout -> aest_docker_api:stop_container(ID, Opts);
                 ok -> ok

--- a/system_test/helpers/aest_docker.erl
+++ b/system_test/helpers/aest_docker.erl
@@ -210,7 +210,7 @@ stop_node(#{container_id := ID, hostname := Name} = NodeState, Opts) ->
                 "Container ~p [~s] still running: "
                 "attempting to stop node by executing command ~s",
                 [Name, ID, CmdStr]),
-            aest_docker_api:exec(ID, Cmd),
+            aest_docker_api:exec(ID, Cmd, #{timeout => 5}),
             log(NodeState, "Command executed on container ~p [~s]: ~s",
                 [Name, ID, CmdStr]),
             case wait_stopped(ID, Timeout) of %% TODO Fix this call that has timeout actual parameter as seconds but handled inside function definition as milliseconds.

--- a/system_test/helpers/aest_docker.erl
+++ b/system_test/helpers/aest_docker.erl
@@ -11,6 +11,7 @@
 -export([start_node/1]).
 -export([stop_node/2]).
 -export([kill_node/1]).
+-export([node_logs/1]).
 -export([get_peer_address/1]).
 -export([get_service_address/2]).
 
@@ -226,6 +227,10 @@ kill_node(#{container_id := ID, hostname := Name} = NodeState) ->
     aest_docker_api:kill_container(ID),
     log(NodeState, "Container ~p [~s] killed", [Name, ID]),
     NodeState.
+
+-spec node_logs(node_state()) -> iodata().
+node_logs(#{container_id := ID} = _NodeState) ->
+    aest_docker_api:container_logs(ID).
 
 -spec get_peer_address(node_state()) -> binary().
 get_peer_address(NodeState) ->

--- a/system_test/helpers/aest_docker.erl
+++ b/system_test/helpers/aest_docker.erl
@@ -213,7 +213,7 @@ stop_node(#{container_id := ID, hostname := Name} = NodeState, Opts) ->
             aest_docker_api:exec(ID, Cmd),
             log(NodeState, "Command executed on container ~p [~s]: ~s",
                 [Name, ID, CmdStr]),
-            case wait_stopped(ID, Timeout) of
+            case wait_stopped(ID, Timeout) of %% TODO Fix this call that has timeout actual parameter as seconds but handled inside function definition as milliseconds.
                 timeout -> aest_docker_api:stop_container(ID, Opts);
                 ok -> ok
             end,

--- a/system_test/helpers/aest_docker_api.erl
+++ b/system_test/helpers/aest_docker_api.erl
@@ -136,12 +136,7 @@ exec(ID, Cmd, Opts) ->
                 'Detach' => false,
                 'Tty' => true
             },
-            TimeoutOpts =
-                case Opts of
-                    #{timeout := infinity} -> #{timeout => infinity};
-                    #{timeout := Seconds} -> #{timeout => Seconds * 1000};
-                    #{} -> #{}
-                end,
+            TimeoutOpts = maps:with([timeout], Opts),
             PostOpts = maps:merge(#{result_type => raw}, TimeoutOpts),
             case
                 docker_post([exec, ExecId, start], #{}, ExecStartBody, PostOpts)

--- a/system_test/helpers/aest_docker_api.erl
+++ b/system_test/helpers/aest_docker_api.erl
@@ -149,7 +149,9 @@ exec(ID, Cmd, Opts) ->
                 {ok, 200, Result} -> {ok, Result};
                 {ok, 404, _} -> throw({exec_not_found, ExecId});
                 {ok, 500, Response} ->
-                    throw({docker_error, maps:get(message, Response)})
+                    throw({docker_error, maps:get(message, Response)});
+                {error, timeout} ->
+                    throw({exec_start_timeout, {ID, ExecId}})
             end
     end.
 

--- a/system_test/helpers/aest_nodes.erl
+++ b/system_test/helpers/aest_nodes.erl
@@ -15,7 +15,7 @@
 %% Generic API exports
 -export([setup_nodes/2]).
 -export([start_node/2]).
--export([stop_node/2, stop_node/3]).
+-export([stop_node/3]).
 -export([kill_node/2]).
 -export([get_service_address/3]).
 -export([http_get/5]).
@@ -42,7 +42,6 @@
 -define(CALL_TIMEOUT, 60000).
 -define(NODE_TEARDOWN_TIMEOUT, 0).
 -define(DEFAULT_HTTP_TIMEOUT, 3000).
--define(DEFAULT_STOP_TIMEOUT, 30).
 
 %=== TYPES ====================================================================
 
@@ -131,12 +130,6 @@ setup_nodes(NodeSpecs, Ctx) ->
 -spec start_node(atom(), test_ctx()) -> ok.
 start_node(NodeName, Ctx) ->
     call(ctx2pid(Ctx), {start_node, NodeName}).
-
-%% @doc Stops a node previously started.
-%% The node will get killed after 30 seconds if it does not stop.
--spec stop_node(atom(), test_ctx()) -> ok.
-stop_node(NodeName, Ctx) ->
-    call(ctx2pid(Ctx), {stop_node, NodeName, ?DEFAULT_STOP_TIMEOUT}).
 
 %% @doc Stops a node previously started with explicit timeout (in seconds)
 %% after which the node will be killed.

--- a/system_test/helpers/aest_nodes.erl
+++ b/system_test/helpers/aest_nodes.erl
@@ -44,7 +44,7 @@
 -define(DEFAULT_HTTP_TIMEOUT, 3000).
 -define(DEFAULT_STOP_TIMEOUT, 30).
 
-%=== TYPRES ====================================================================
+%=== TYPES ====================================================================
 
 -type test_ctx() :: pid() | proplists:proplist().
 -type node_service() :: ext_http | int_http | int_ws.


### PR DESCRIPTION
Extracted from https://github.com/aeternity/epoch/pull/902

Auxiliary needed system test improvements for development of https://www.pivotaltracker.com/story/show/153778514
* Fixes intermittent timeout (see commit "Fix intermittent test failure in system test")
* Dump logs of containers for better understand of what happened in test (see commit "Dump container logs on system test cleanup")
* Other commits are preparatory/auxiliary/minor