### PR TITLE
Stop docker container using epoch stop command - Feedback

### DIFF
--- a/system_test/helpers/aest_docker.erl
+++ b/system_test/helpers/aest_docker.erl
@@ -189,12 +189,17 @@ stop_node(NodeState) -> stop_node(NodeState, #{}).
 -spec stop_node(node_state(), stop_node_options()) -> node_state().
 stop_node(#{container_id := ID, hostname := Name} = NodeState, Opts) ->
     Timeout = maps:get(soft_timeout, Opts, ?EPOCH_STOP_TIMEOUT),
-    aest_docker_api:exec(ID, ["/home/epoch/node/bin/epoch", "stop"]),
-    case wait_stopped(ID, Timeout) of
-        timeout -> aest_docker_api:stop_container(ID, Opts);
-        ok -> ok
+    case is_running(ID) of
+        false ->
+            log(NodeState, "Container ~p [~s] already not running", [Name, ID]);
+        true ->
+            aest_docker_api:exec(ID, ["/home/epoch/node/bin/epoch", "stop"]),
+            case wait_stopped(ID, Timeout) of
+                timeout -> aest_docker_api:stop_container(ID, Opts);
+                ok -> ok
+            end,
+            log(NodeState, "Container ~p [~s] stopped", [Name, ID])
     end,
-    log(NodeState, "Container ~p [~s] stopped", [Name, ID]),
     NodeState.
 
 -spec kill_node(node_state()) -> node_state().
@@ -243,16 +248,14 @@ write_template(TemplateFile, OutputFile, Context) ->
 
 wait_stopped(Id, Timeout) -> wait_stopped(Id, Timeout, os:timestamp()).
 
-
 wait_stopped(Id, Timeout, StartTime) ->
-    case aest_docker_api:inspect(Id) of
-        undefined -> maybe_continue_waiting(Id, Timeout, StartTime);
-        #{'State' := State} ->
-            case maps:get('Running', State) of
-                false -> ok;
-                _ -> maybe_continue_waiting(Id, Timeout, StartTime)
-            end
+    case is_running(Id) of
+        false -> ok;
+        true -> maybe_continue_waiting(Id, Timeout, StartTime)
     end.
+
+is_running(Id) ->
+    maps:get('Running', maps:get('State', aest_docker_api:inspect(Id))).
 
 maybe_continue_waiting(Id, infinity, StartTime) ->
     timer:sleep(100),

--- a/system_test/helpers/aest_docker_api.erl
+++ b/system_test/helpers/aest_docker_api.erl
@@ -113,7 +113,9 @@ kill_container(ID) ->
 inspect(ID) ->
     case docker_get([containers, ID, json]) of
         {ok, 200, Info} -> Info;
-        _ -> undefined
+        {ok, 404, _} -> throw({container_not_found, ID});
+        {ok, 500, Response} ->
+            throw({docker_error, maps:get(message, Response)})
     end.
 
 %% Returning stdout is not working because hackney doesn't support results

--- a/system_test/helpers/aest_docker_api.erl
+++ b/system_test/helpers/aest_docker_api.erl
@@ -262,7 +262,7 @@ docker_fetch_json_body(ClientRef, Type) ->
     end.
 
 decode(<<>>, _) -> {ok, undefined};
-decode(Data, raw) -> Data;
+decode(Data, raw) -> {ok, Data};
 decode(Data, json) ->
     try jsx:decode(Data, [{labels, attempt_atom}, return_maps]) of
         JsonObj -> {ok, JsonObj}

--- a/system_test/helpers/aest_docker_api.erl
+++ b/system_test/helpers/aest_docker_api.erl
@@ -91,7 +91,8 @@ stop_container(ID, Opts) ->
         infinity -> infinity;
         HTSecs -> HTSecs * 1000
     end,
-    case docker_post([containers, ID, stop], Query, undefined, ReqTimeout) of
+    PostOpts = #{timeout => ReqTimeout},
+    case docker_post([containers, ID, stop], Query, undefined, PostOpts) of
         {ok, 204, _} -> ok;
         {ok, 304, _} -> throw({container_not_started, ID});
         {ok, 404, _} -> throw({container_not_found, ID});

--- a/system_test/helpers/aest_nodes.erl
+++ b/system_test/helpers/aest_nodes.erl
@@ -395,7 +395,8 @@ mgr_safe_stop_backends(#{backends := Backends} = State) ->
             Mod:stop(BackendState)
         catch
             _:E ->
-                log(State, "Error while stopping backend ~p: ~p", [Mod, E])
+                ST = erlang:get_stacktrace(),
+                log(State, "Error while stopping backend ~p: ~p~n~p", [Mod, E, ST])
         end
     end, Backends),
     State#{backends := #{}}.
@@ -408,7 +409,8 @@ mgr_safe_stop_all(Timeout, #{nodes := Nodes1} = State) ->
             {Backend, Backend:stop_node(NodeState, Opts)}
         catch
             _:E ->
-                log(State, "Error while stopping node ~p: ~p", [Name, E]),
+                ST = erlang:get_stacktrace(),
+                log(State, "Error while stopping node ~p: ~p~n~p", [Name, E, ST]),
                 {Backend, NodeState}
         end
     end, Nodes1),
@@ -420,7 +422,8 @@ mgr_safe_delete_all(#{nodes := Nodes1} = State) ->
             {Backend, Backend:delete_node(NodeState)}
         catch
             _:E ->
-                log(State, "Error while stopping node ~p: ~p", [Name, E]),
+                ST = erlang:get_stacktrace(),
+                log(State, "Error while stopping node ~p: ~p~n~p", [Name, E, ST]),
                 {Backend, NodeState}
         end
     end, Nodes1),


### PR DESCRIPTION
While reviewing PR #912 I experienced some intermittent failures in the system tests hence probably triggered some unexplored test code paths - hence this PR.

```
=== Location: [{aest_nodes,assert_expiration,290},
              {aest_nodes,wait_for_height,296},
              {aest_sync_SUITE,new_node_joins_network,95},
              {test_server,ts_tc,1546},
              {test_server,run_test_case_eval1,1062},
              {test_server,run_test_case_eval,994}]
=== Reason: timeout
  in function  aest_nodes:assert_expiration/1 (/Users/luca/dev/aeternity/epoch/_build/system_test+test/extras/system_test/helpers/aest_nodes.erl, line 290)
  in call from aest_nodes:wait_for_height/5 (/Users/luca/dev/aeternity/epoch/_build/system_test+test/extras/system_test/helpers/aest_nodes.erl, line 296)
  in call from aest_sync_SUITE:new_node_joins_network/1 (/Users/luca/dev/aeternity/epoch/_build/system_test+test/extras/system_test/aest_sync_SUITE.erl, line 95)
  in call from test_server:ts_tc/3 (test_server.erl, line 1546)
  in call from test_server:run_test_case_eval1/6 (test_server.erl, line 1062)
  in call from test_server:run_test_case_eval/9 (test_server.erl, line 994)
```