### PR TITLE
Test for detecting consensus break of master from testnet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ swagger/swagger-codegen-cli-*.jar
 .virtualenv/
 *.retry
 system_test/logs
+system_test/aest_fork_SUITE_data/mnesia_ae-uat-epoch_backup*

--- a/Makefile
+++ b/Makefile
@@ -151,8 +151,17 @@ eunit:
 
 all-tests: eunit test
 
-system-test:
+system-test: | system_test/aest_fork_SUITE_data/mnesia_ae-uat-epoch_backup.tar
 	@./rebar3 as system_test do ct --dir system_test --logdir system_test/logs $(CT_TEST_FLAGS)
+
+system_test/aest_fork_SUITE_data/mnesia_ae-uat-epoch_backup.tar: system_test/aest_fork_SUITE_data/mnesia_ae-uat-epoch_backup
+	tar -c -C $(<D) -f $@ $(<F)
+
+system_test/aest_fork_SUITE_data/mnesia_ae-uat-epoch_backup: system_test/aest_fork_SUITE_data/mnesia_ae-uat-epoch_backup.gz
+	zcat <$< >$@
+
+system_test/aest_fork_SUITE_data/mnesia_ae-uat-epoch_backup.gz:
+	curl -fsS --create-dirs -o $@ https://5196-99802036-gh.circle-artifacts.com/0/tmp/chain_snapshots/ae-uat-epoch-n2/tmp/mnesia_ae-uat-epoch-n2_db_backup_1521936102.gz
 
 aevm-test: aevm-test-deps
 	@./rebar3 eunit --application=aevm

--- a/system_test/aest_fork_SUITE.erl
+++ b/system_test/aest_fork_SUITE.erl
@@ -1,0 +1,166 @@
+-module(aest_fork_SUITE).
+
+%=== EXPORTS ===================================================================
+
+% Common Test exports
+-export([all/0]).
+-export([init_per_testcase/2]).
+-export([end_per_testcase/2]).
+
+% Test cases
+-export([
+         node_persisting_chain_and_not_mining_has_genesis/1,
+         restore_db_backup_on_same_release/1,
+         new_node_can_receive_short_chain_from_old_node/1
+        ]).
+
+%=== INCLUDES ==================================================================
+
+-include_lib("stdlib/include/assert.hrl").
+
+%=== MACROS ====================================================================
+
+-define(DB_BACKUP_TAR, "mnesia_ae-uat-epoch_backup.tar").
+-define(DB_BACKUP_CONTENT, "mnesia_ae-uat-epoch_backup").
+-define(DB_BACKUP_DEST_DIR, "/tmp/mnesia_backup").
+
+-define(OLD_NODE1, #{
+          name    => old_node1,
+          peers   => [<<"http://unexistent_node:42/">>],
+          backend => aest_docker,
+          source  => {pull, "aeternity/epoch:v0.9.0"}
+         }).
+
+-define(NEW_NODE1, #{
+          name    => new_node1,
+          peers   => [old_node1],
+          backend => aest_docker,
+          source  => {pull, "aeternity/epoch:v0.9.0"}
+         }).
+
+%=== COMMON TEST FUNCTIONS =====================================================
+
+all() ->
+    [
+     %% Validation of test assumptions.
+     node_persisting_chain_and_not_mining_has_genesis,
+     %% ----
+     %% Sanity checks on software version supporting only old
+     %% protocol:
+     %%
+     %% * Old node can restore DB backup of testnet.
+     restore_db_backup_on_same_release,
+     %%
+     %% * (Slow test execution time.) Old node can mine after having restored DB backup.
+                                                % TODO (Low priority.)
+     %% ----
+     %% Checks on capability of software version supporting both old
+     %% and new version of the protocol to receive chain from software
+     %% version supporting only old protocol:
+     %%
+     %% * New node can receive short chain from old node.
+     new_node_can_receive_short_chain_from_old_node
+     %%
+     %% * New node accepts long chain from old node only up to configured height for new protocol.
+                                                % TODO (Medium priority.)
+     %% ----
+     %% Checks on capability of software version supporting both old
+     %% and new version of the protocol to mine using old protocol:
+     %%
+     %% * (Slow test execution time.) New node can mine using old protocol (strictly only coinbase tx) on short chain received from old node.
+                                                % TODO (High priority.)
+     %%
+     %% * (Slow test execution time.) New node can mine using old protocol (smoke test with spend tx) on short chain received from old node.
+                                                % TODO (Low priority.)
+     %% * (Slow test execution time.) New node resolve forks on portion of chain using old protocol in favour of fork with highest total difficulty mined by old nodes.
+                                                % TODO (Low priority.)
+     %% ----
+     %% Checks on capability of software version supporting both old
+     %% and new version of the protocol to mine using new protocol:
+     %%
+     %% * (Slow test execution time.) New node can mine using old protocol (strictly only coinbase tx) on short chain received from old node then using new protocol (strictly only coinbase tx).
+                                                % TODO (High priority.)
+     %%
+     %% * (Slow test execution time.) New node can mine using old protocol (strictly only coinbase tx) on short chain received from old node then using new protocol (smoke test with spend tx).
+                                                % TODO (Medium priority.)
+    ].
+
+init_per_testcase(_TC, Config) ->
+    aest_nodes:ct_setup(Config).
+
+end_per_testcase(_TC, Config) ->
+    aest_nodes:ct_cleanup(Config).
+
+%=== TEST CASES ================================================================
+
+node_persisting_chain_and_not_mining_has_genesis(Cfg) ->
+    aest_nodes:setup_nodes([?OLD_NODE1], Cfg),
+    start_node(old_node1, Cfg),
+    _ = get_block_by_height(old_node1, 0, Cfg),
+    ok.
+
+restore_db_backup_on_same_release(Cfg) ->
+    aest_nodes:setup_nodes([?OLD_NODE1], Cfg),
+    start_node(old_node1, Cfg),
+    {ok, {TopHash, TopHeight}} = restore_db_backup_on_node(old_node1, Cfg),
+    ?assertMatch(X when is_integer(X) andalso X > 0, TopHeight),
+    B = get_block_by_height(old_node1, TopHeight, Cfg),
+    ?assertEqual(TopHash, maps:get(hash, B)),
+    ok.
+
+new_node_can_receive_short_chain_from_old_node(Cfg) ->
+    aest_nodes:setup_nodes([?OLD_NODE1, ?NEW_NODE1], Cfg),
+    start_node(old_node1, Cfg),
+    {ok, {TopHash, TopHeight}} = restore_db_backup_on_node(old_node1, Cfg),
+    start_node(new_node1, Cfg),
+    aest_nodes:wait_for_height(TopHeight, [old_node1], 5000, Cfg),
+    wait_for_height_syncing(TopHeight, [new_node1], {{45000, ms}, {100, blocks}}, Cfg),
+    B = get_block_by_height(old_node1, TopHeight, Cfg),
+    ?assertEqual(TopHash, maps:get(hash, B)),
+    ok.
+
+%=== INTERNAL FUNCTIONS ========================================================
+
+get_block_by_height(NodeName, Height, Cfg) ->
+    {ok, 200, B} = aest_nodes:http_get(NodeName, int_http, [v2, block, height, Height], #{}, Cfg),
+    B.
+
+wait_for_height_syncing(MinHeight, NodeNames, {{Timeout, ms}, {Blocks, blocks}}, Cfg) ->
+    %% TODO Expecting syncing to happen at `Blocks` blocks per `Timeout` ms logging progress update - rather than a single wait without progress log.
+    aest_nodes:wait_for_height(MinHeight, NodeNames, Timeout, Cfg).
+
+start_node(NodeName, Cfg) ->
+    aest_nodes:start_node(NodeName, Cfg),
+    F = fun() -> try get_block_by_height(NodeName, 0, Cfg), true catch _:_ -> false end end,
+    aec_test_utils:wait_for_it(F, true).
+
+restore_db_backup_on_node(NodeName, Cfg) ->
+    restore_db_backup_on_node(
+      NodeName,
+      db_backup_tar(Cfg), ?DB_BACKUP_CONTENT,
+      ?DB_BACKUP_DEST_DIR,
+      Cfg).
+
+restore_db_backup_on_node(NodeName, Tar, Content, DestDir, Cfg) ->
+    ct:log("Restoring DB backup ~s on node ~s", [Tar, NodeName]),
+    {ok, TarBin} = file:read_file(Tar),
+    _ = aest_nodes:run_cmd_in_node_dir(NodeName, ["mkdir", DestDir], Cfg),
+    "" = aest_nodes:run_cmd_in_node_dir(NodeName, ["ls", DestDir], Cfg),
+    ok = aest_nodes:extract_archive(NodeName, DestDir, TarBin, Cfg),
+    Content = aest_nodes:run_cmd_in_node_dir(NodeName, ["ls", DestDir], Cfg),
+    Dest = DestDir ++ "/" ++ Content,
+    RestoreCmd =
+        ["bin/epoch",
+         "eval",
+         "'{atomic, [_|_] = Tabs} = mnesia:restore(\"" ++ Dest ++ "\", []), "
+         "ok.'"],
+    "ok" = aest_nodes:run_cmd_in_node_dir(NodeName, RestoreCmd, Cfg),
+    Top = #{height := TopHeight,
+            hash := TopHash} = aest_nodes:get_top(NodeName, Cfg),
+    ct:log("Restored DB backup ~s on node ~s, whose top is now~n~p",
+           [Tar, NodeName, Top]),
+    {ok, {TopHash, TopHeight}}.
+
+db_backup_tar(Cfg) ->
+    {_, DataDir} = proplists:lookup(data_dir, Cfg),
+    filename:join(DataDir, ?DB_BACKUP_TAR).

--- a/system_test/aest_fork_SUITE_data/epoch.yaml.mustache
+++ b/system_test/aest_fork_SUITE_data/epoch.yaml.mustache
@@ -1,0 +1,25 @@
+{{#epoch_config}}
+---
+peers:
+{{#peers}}
+    - {{ext_addr}}
+{{/peers}}
+
+http:
+    external:
+        peer_address: {{ext_addr}}
+    internal:
+        listen_address: 0.0.0.0
+        port: {{services.int_http.port}}
+
+websocket:
+    internal:
+        listen_address: 0.0.0.0
+        port: {{services.int_ws.port}}
+
+chain:
+    persist: true
+
+mining:
+    autostart: false
+{{/epoch_config}}

--- a/system_test/helpers/aest_docker.erl
+++ b/system_test/helpers/aest_docker.erl
@@ -10,6 +10,7 @@
 -export([start_node/1]).
 -export([stop_node/1, stop_node/2]).
 -export([kill_node/1]).
+-export([node_logs/1]).
 -export([get_service_address/2]).
 
 %=== MACROS ====================================================================
@@ -207,6 +208,9 @@ kill_node(#{container_id := ID, hostname := Name} = NodeState) ->
     aest_docker_api:kill_container(ID),
     log(NodeState, "Container ~p [~s] killed", [Name, ID]),
     NodeState.
+
+node_logs(#{container_id := ID} = _NodeState) ->
+    aest_docker_api:container_logs(ID).
 
 -spec get_service_address(node_state(), service_label()) -> binary().
 get_service_address(Service, NodeState) ->

--- a/system_test/helpers/aest_docker.erl
+++ b/system_test/helpers/aest_docker.erl
@@ -189,12 +189,17 @@ stop_node(NodeState) -> stop_node(NodeState, #{}).
 -spec stop_node(node_state(), stop_node_options()) -> node_state().
 stop_node(#{container_id := ID, hostname := Name} = NodeState, Opts) ->
     Timeout = maps:get(soft_timeout, Opts, ?EPOCH_STOP_TIMEOUT),
-    aest_docker_api:exec(ID, ["/home/epoch/node/bin/epoch", "stop"]),
-    case wait_stopped(ID, Timeout) of
-        timeout -> aest_docker_api:stop_container(ID, Opts);
-        ok -> ok
+    case is_running(ID) of
+        false ->
+            log(NodeState, "Container ~p [~s] already not running", [Name, ID]);
+        true ->
+            aest_docker_api:exec(ID, ["/home/epoch/node/bin/epoch", "stop"]),
+            case wait_stopped(ID, Timeout) of
+                timeout -> aest_docker_api:stop_container(ID, Opts);
+                ok -> ok
+            end,
+            log(NodeState, "Container ~p [~s] stopped", [Name, ID])
     end,
-    log(NodeState, "Container ~p [~s] stopped", [Name, ID]),
     NodeState.
 
 -spec kill_node(node_state()) -> node_state().
@@ -243,16 +248,14 @@ write_template(TemplateFile, OutputFile, Context) ->
 
 wait_stopped(Id, Timeout) -> wait_stopped(Id, Timeout, os:timestamp()).
 
-
 wait_stopped(Id, Timeout, StartTime) ->
-    case aest_docker_api:inspect(Id) of
-        undefined -> maybe_continue_waiting(Id, Timeout, StartTime);
-        #{'State' := State} ->
-            case maps:get('Running', State) of
-                false -> ok;
-                _ -> maybe_continue_waiting(Id, Timeout, StartTime)
-            end
+    case is_running(Id) of
+        false -> ok;
+        true -> maybe_continue_waiting(Id, Timeout, StartTime)
     end.
+
+is_running(Id) ->
+    maps:get('Running', maps:get('State', aest_docker_api:inspect(Id))).
 
 maybe_continue_waiting(Id, infinity, StartTime) ->
     timer:sleep(100),

--- a/system_test/helpers/aest_docker.erl
+++ b/system_test/helpers/aest_docker.erl
@@ -11,6 +11,8 @@
 -export([stop_node/1, stop_node/2]).
 -export([kill_node/1]).
 -export([node_logs/1]).
+-export([extract_archive/3]).
+-export([run_cmd_in_node_dir/2]).
 -export([get_service_address/2]).
 
 %=== MACROS ====================================================================
@@ -211,6 +213,18 @@ kill_node(#{container_id := ID, hostname := Name} = NodeState) ->
 
 node_logs(#{container_id := ID} = _NodeState) ->
     aest_docker_api:container_logs(ID).
+
+extract_archive(#{container_id := ID, hostname := Name} = NodeState, Path, Archive) ->
+    ok = aest_docker_api:extract_archive(ID, Path, Archive),
+    log(NodeState, "Extracted archive of size ~p in container ~p [~s] at path ~p", [byte_size(Archive), Name, ID, Path]),
+    NodeState.
+
+run_cmd_in_node_dir(#{container_id := ID, hostname := Name} = NodeState, Cmd) ->
+    log(NodeState, "Running command ~p on container ~p [~s]", [Cmd, Name, ID]),
+    Cmd1 = lists:flatten(io_lib:format("docker exec ~s ~s", [ID, lists:join($ , Cmd)])),
+    Result = lib:nonl(os:cmd(Cmd1)),
+    log(NodeState, "Run command ~p on container ~p [~s] with result ~p", [Cmd, Name, ID, Result]),
+    {ok, Result, NodeState}.
 
 -spec get_service_address(node_state(), service_label()) -> binary().
 get_service_address(Service, NodeState) ->

--- a/system_test/helpers/aest_docker_api.erl
+++ b/system_test/helpers/aest_docker_api.erl
@@ -18,6 +18,7 @@
 -export([kill_container/1]).
 -export([inspect/1]).
 -export([exec/2]).
+-export([extract_archive/3]).
 -export([container_logs/1]).
 
 %=== MACROS ====================================================================
@@ -147,6 +148,17 @@ exec(ID, Cmd) ->
             end
     end.
 
+extract_archive(ID, Path, Archive) ->
+    Query = #{<<"path">> => list_to_binary(Path)},
+    case docker_put([containers, ID, archive], Query, Archive) of
+        {ok, 200, _} -> ok;
+        {ok, Status, Response} when is_integer(Status),
+                                    400 =< Status, Status < 500 ->
+            throw({client_error, Status, maps:get(message, Response)});
+        {ok, 500, Response} ->
+            throw({docker_error, maps:get(message, Response)})
+    end.
+
 container_logs(ID) ->
     Query = #{<<"stderr">> => <<"true">>, <<"stdout">> => <<"true">>},
     case docker_get([containers, ID, logs], Query, #{result_type => raw}) of
@@ -260,6 +272,20 @@ docker_post(Path, Query, BodyObj, Opts) ->
     ReqRes = hackney:request(post, url(Path, Query), Headers, BodyJSON,
                              [{recv_timeout, Timeout}]),
     case ReqRes of
+        {error, _Reason} = Error -> Error;
+        {ok, Status, _RespHeaders, ClientRef} ->
+            case docker_fetch_json_body(ClientRef, ResultType) of
+                {error, _Reason} = Error -> Error;
+                {ok, Response} -> {ok, Status, Response}
+            end
+    end.
+
+docker_put(Path, Query, Body) -> docker_put(Path, Query, Body, #{}).
+
+docker_put(Path, Query, Body, Opts) ->
+    ResultType = maps:get(result_type, Opts, json),
+    %% TODO Content type?
+    case hackney:request(put, url(Path, Query), [], Body, []) of
         {error, _Reason} = Error -> Error;
         {ok, Status, _RespHeaders, ClientRef} ->
             case docker_fetch_json_body(ClientRef, ResultType) of

--- a/system_test/helpers/aest_docker_api.erl
+++ b/system_test/helpers/aest_docker_api.erl
@@ -18,6 +18,7 @@
 -export([kill_container/1]).
 -export([inspect/1]).
 -export([exec/2]).
+-export([container_logs/1]).
 
 %=== MACROS ====================================================================
 
@@ -146,6 +147,15 @@ exec(ID, Cmd) ->
             end
     end.
 
+container_logs(ID) ->
+    Query = #{<<"stderr">> => <<"true">>, <<"stdout">> => <<"true">>},
+    case docker_get([containers, ID, logs], Query, #{result_type => raw}) of
+        {ok, 200, Response} -> Response;
+        {ok, 404, _} -> throw({container_not_found, ID});
+        {ok, 500, Response} ->
+            throw({docker_error, maps:get(message, decode_json(Response))})
+    end.
+
 %=== INTERNAL FUNCTIONS ========================================================
 
 create_network_object(name, Name, Body) ->
@@ -266,7 +276,9 @@ docker_fetch_json_body(ClientRef, Type) ->
 
 decode(<<>>, _) -> {ok, undefined};
 decode(Data, raw) -> {ok, Data};
-decode(Data, json) ->
+decode(Data, json) -> decode_json(Data).
+
+decode_json(Data) ->
     try jsx:decode(Data, [{labels, attempt_atom}, return_maps]) of
         JsonObj -> {ok, JsonObj}
     catch

--- a/system_test/helpers/aest_docker_api.erl
+++ b/system_test/helpers/aest_docker_api.erl
@@ -113,7 +113,9 @@ kill_container(ID) ->
 inspect(ID) ->
     case docker_get([containers, ID, json]) of
         {ok, 200, Info} -> Info;
-        _ -> undefined
+        {ok, 404, _} -> throw({container_not_found, ID});
+        {ok, 500, Response} ->
+            throw({docker_error, maps:get(message, Response)})
     end.
 
 %% Returning stdout is not working because hackney doesn't support results

--- a/system_test/helpers/aest_docker_api.erl
+++ b/system_test/helpers/aest_docker_api.erl
@@ -262,7 +262,7 @@ docker_fetch_json_body(ClientRef, Type) ->
     end.
 
 decode(<<>>, _) -> {ok, undefined};
-decode(Data, raw) -> Data;
+decode(Data, raw) -> {ok, Data};
 decode(Data, json) ->
     try jsx:decode(Data, [{labels, attempt_atom}, return_maps]) of
         JsonObj -> {ok, JsonObj}

--- a/system_test/helpers/aest_docker_api.erl
+++ b/system_test/helpers/aest_docker_api.erl
@@ -91,7 +91,8 @@ stop_container(ID, Opts) ->
         infinity -> infinity;
         HTSecs -> HTSecs * 1000
     end,
-    case docker_post([containers, ID, stop], Query, undefined, ReqTimeout) of
+    PostOpts = #{timeout => ReqTimeout},
+    case docker_post([containers, ID, stop], Query, undefined, PostOpts) of
         {ok, 204, _} -> ok;
         {ok, 304, _} -> throw({container_not_started, ID});
         {ok, 404, _} -> throw({container_not_found, ID});

--- a/system_test/helpers/aest_docker_api.erl
+++ b/system_test/helpers/aest_docker_api.erl
@@ -282,7 +282,7 @@ decode_json(Data) ->
     try jsx:decode(Data, [{labels, attempt_atom}, return_maps]) of
         JsonObj -> {ok, JsonObj}
     catch
-        error:badarg -> {error, bad_json}
+        error:badarg -> {error, {bad_json, Data}}
     end.
 
 encode(undefined) -> <<>>;

--- a/system_test/helpers/aest_nodes.erl
+++ b/system_test/helpers/aest_nodes.erl
@@ -44,7 +44,7 @@
 -define(DEFAULT_HTTP_TIMEOUT, 3000).
 -define(DEFAULT_STOP_TIMEOUT, 30).
 
-%=== TYPRES ====================================================================
+%=== TYPES ====================================================================
 
 -type test_ctx() :: pid() | proplists:proplist().
 -type node_service() :: ext_http | int_http | int_ws.

--- a/system_test/helpers/aest_nodes.erl
+++ b/system_test/helpers/aest_nodes.erl
@@ -17,6 +17,8 @@
 -export([start_node/2]).
 -export([stop_node/2, stop_node/3]).
 -export([kill_node/2]).
+-export([extract_archive/4]).
+-export([run_cmd_in_node_dir/3]).
 -export([get_service_address/3]).
 -export([http_get/5]).
 
@@ -149,6 +151,12 @@ stop_node(NodeName, Timeout, Ctx) ->
 kill_node(NodeName, Ctx) ->
     call(ctx2pid(Ctx), {kill_node, NodeName}).
 
+extract_archive(NodeName, Path, Archive, Ctx) ->
+    call(ctx2pid(Ctx), {extract_archive, NodeName, Path, Archive}).
+
+run_cmd_in_node_dir(NodeName, Cmd, Ctx) ->
+    call(ctx2pid(Ctx), {run_cmd_in_node_dir, NodeName, Cmd}).
+
 %% @doc Retrieves the address of a given node's service.
 -spec get_service_address(atom(), node_service(), test_ctx()) -> binary().
 get_service_address(NodeName, Service, Ctx) ->
@@ -229,6 +237,11 @@ handlex({stop_node, NodeName, Timeout}, _From, State) ->
     {reply, ok, mgr_stop_node(NodeName, Timeout, State)};
 handlex({kill_node, NodeName}, _From, State) ->
     {reply, ok, mgr_kill_node(NodeName, State)};
+handlex({extract_archive, NodeName, Path, Archive}, _From, State) ->
+    {reply, ok, mgr_extract_archive(NodeName, Path, Archive, State)};
+handlex({run_cmd_in_node_dir, NodeName, Cmd}, _From, State) ->
+    {ok, Reply, NewState} = mgr_run_cmd_in_node_dir(NodeName, Cmd, State),
+    {reply, Reply, NewState};
 handlex(dump_logs, _From, State) ->
     ok = mgr_dump_logs(State),
     {reply, ok, State};
@@ -329,6 +342,7 @@ url(Base, Item, QS) ->
     url(Base, [Item], QS).
 
 to_binary(Term) when is_atom(Term) -> atom_to_binary(Term, utf8);
+to_binary(Term) when is_integer(Term) -> integer_to_binary(Term);
 to_binary(Term)                    -> Term.
 
 hackney_json_body(ClientRef) ->
@@ -416,6 +430,16 @@ mgr_kill_node(NodeName, #{nodes := Nodes} = State) ->
     #{NodeName := {Mod, NodeState}} = Nodes,
     NodeState2 = Mod:kill_node(NodeState),
     State#{nodes := Nodes#{NodeName := {Mod, NodeState2}}}.
+
+mgr_extract_archive(NodeName, Path, Archive, #{nodes := Nodes} = State) ->
+    #{NodeName := {Mod, NodeState}} = Nodes,
+    NodeState2 = Mod:extract_archive(NodeState, Path, Archive),
+    State#{nodes := Nodes#{NodeName := {Mod, NodeState2}}}.
+
+mgr_run_cmd_in_node_dir(NodeName, Cmd, #{nodes := Nodes} = State) ->
+    #{NodeName := {Mod, NodeState}} = Nodes,
+    {ok, Result, NodeState2} = Mod:run_cmd_in_node_dir(NodeState, Cmd),
+    {ok, Result, State#{nodes := Nodes#{NodeName := {Mod, NodeState2}}}}.
 
 mgr_safe_stop_backends(#{backends := Backends} = State) ->
     maps:map(fun(Mod, BackendState) ->

--- a/system_test/helpers/aest_nodes.erl
+++ b/system_test/helpers/aest_nodes.erl
@@ -395,7 +395,8 @@ mgr_safe_stop_backends(#{backends := Backends} = State) ->
             Mod:stop(BackendState)
         catch
             _:E ->
-                log(State, "Error while stopping backend ~p: ~p", [Mod, E])
+                ST = erlang:get_stacktrace(),
+                log(State, "Error while stopping backend ~p: ~p~n~p", [Mod, E, ST])
         end
     end, Backends),
     State#{backends := #{}}.
@@ -408,7 +409,8 @@ mgr_safe_stop_all(Timeout, #{nodes := Nodes1} = State) ->
             {Backend, Backend:stop_node(NodeState, Opts)}
         catch
             _:E ->
-                log(State, "Error while stopping node ~p: ~p", [Name, E]),
+                ST = erlang:get_stacktrace(),
+                log(State, "Error while stopping node ~p: ~p~n~p", [Name, E, ST]),
                 {Backend, NodeState}
         end
     end, Nodes1),
@@ -420,7 +422,8 @@ mgr_safe_delete_all(#{nodes := Nodes1} = State) ->
             {Backend, Backend:delete_node(NodeState)}
         catch
             _:E ->
-                log(State, "Error while stopping node ~p: ~p", [Name, E]),
+                ST = erlang:get_stacktrace(),
+                log(State, "Error while stopping node ~p: ~p~n~p", [Name, E, ST]),
                 {Backend, NodeState}
         end
     end, Nodes1),

--- a/system_test/helpers/aest_nodes.erl
+++ b/system_test/helpers/aest_nodes.erl
@@ -93,6 +93,7 @@ ct_setup(Config) ->
 -spec ct_cleanup(test_ctx()) -> ok.
 ct_cleanup(Ctx) ->
     Pid = ctx2pid(Ctx),
+    call(Pid, dump_logs),
     call(Pid, cleanup),
     call(Pid, stop),
     wait_for_exit(Pid, 120000),
@@ -228,6 +229,9 @@ handlex({stop_node, NodeName, Timeout}, _From, State) ->
     {reply, ok, mgr_stop_node(NodeName, Timeout, State)};
 handlex({kill_node, NodeName}, _From, State) ->
     {reply, ok, mgr_kill_node(NodeName, State)};
+handlex(dump_logs, _From, State) ->
+    ok = mgr_dump_logs(State),
+    {reply, ok, State};
 handlex(cleanup, _From, State) ->
     {reply, ok, mgr_cleanup(State)};
 handlex(stop, _From, State) ->
@@ -347,6 +351,18 @@ mgr_setup(DataDir, TempDir, LogFun) ->
 mgr_setup_backends(BackendMods, Opts) ->
     lists:foldl(fun(Mod, Acc) -> Acc#{Mod => Mod:start(Opts)} end,
                 #{}, BackendMods).
+
+mgr_dump_logs(#{nodes := Nodes1} = State) ->
+    maps:map(fun(Name, {Backend, NodeState}) ->
+        try
+            log(State, "Logs of node ~p:~n~s", [Name, Backend:node_logs(NodeState)])
+        catch
+            _:E ->
+                ST = erlang:get_stacktrace(),
+                log(State, "Error while dumping logs of node ~p: ~p~n~p", [Name, E, ST])
+        end
+    end, Nodes1),
+    ok.
 
 mgr_cleanup(State) ->
     %% So node cleanup can be disabled for debugging without commenting


### PR DESCRIPTION
Supersedes #902.
Depends on #911 (included in this PR). Hence the commits exclusive to this PR are only the couple most recent ones.

This PR aims at being the bare minimum initial structured approach for supporting hard fork without restarting chain ( https://www.pivotaltracker.com/story/show/153778514 ), i.e. an automated test for detecting if new node (shall be master branch) cannot load testnet chain. 

TODO:
* [ ] Understand why 0.9.0 node cannot sync from 0.9.0 node that was restored to testnet DB (please refer to commit message for details)
  * I think issue is expected_mine_rate passed to container though I did not check that
* [ ] Rebase on master once #911 is merged
