### PR TITLE
Introduce aenode URI format for configuration of remote peers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ WORKDIR /home/epoch/node
 # Erl handle SIGQUIT instead of the default SIGINT
 STOPSIGNAL SIGQUIT
 
-EXPOSE 3013 3113 3114
+EXPOSE 3013 3015 3113 3114
 
 COPY ./docker/entrypoint.sh /docker-entrypoint.sh
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/apps/aecore/test/aecore_suite_utils.erl
+++ b/apps/aecore/test/aecore_suite_utils.erl
@@ -471,8 +471,8 @@ hostname() ->
     H.
 
 peer_info(N) ->
-    #{ host => iolist_to_binary(hostname()), port => port_number(N),
-       pubkey => aec_base58c:encode(peer_pubkey, pubkey(N)) }.
+    list_to_binary(["aenode://", aec_base58c:encode(peer_pubkey, pubkey(N)),
+                  "@", hostname(), ":", integer_to_list(port_number(N))]).
 
 port_number(dev1) -> 3015;
 port_number(dev2) -> 3025;

--- a/apps/aehttp/priv/swagger.json
+++ b/apps/aehttp/priv/swagger.json
@@ -3315,25 +3315,8 @@
       }
     },
     "Peer" : {
-      "type" : "object",
-      "properties" : {
-        "host" : {
-          "type" : "string",
-          "description" : "Peer's hostname/IP"
-        },
-        "port" : {
-          "type" : "integer"
-        },
-        "pubkey" : {
-          "type" : "string",
-          "description" : "Base58 check encoded public key of the peer"
-        }
-      },
-      "example" : {
-        "port" : 0,
-        "host" : "host",
-        "pubkey" : "pubkey"
-      }
+      "type" : "string",
+      "description" : "Aeternity node"
     },
     "Peers" : {
       "type" : "object",
@@ -3354,24 +3337,8 @@
         }
       },
       "example" : {
-        "blocked" : [ {
-          "port" : 0,
-          "host" : "host",
-          "pubkey" : "pubkey"
-        }, {
-          "port" : 0,
-          "host" : "host",
-          "pubkey" : "pubkey"
-        } ],
-        "peers" : [ {
-          "port" : 0,
-          "host" : "host",
-          "pubkey" : "pubkey"
-        }, {
-          "port" : 0,
-          "host" : "host",
-          "pubkey" : "pubkey"
-        } ]
+        "blocked" : [ null, null ],
+        "peers" : [ { }, { } ]
       }
     },
     "ContractCreateData" : {

--- a/apps/aehttp/src/aehttp_dispatch_int.erl
+++ b/apps/aehttp/src/aehttp_dispatch_int.erl
@@ -373,10 +373,9 @@ handle_request('GetPeers', _Req, _Context) ->
         true ->
             Peers = aehttp_logic:all_peers(),
             Blocked = aehttp_logic:blocked_peers(),
-            Enc = fun(Xs) -> [ X#{ pubkey := aec_base58c:encode(peer_pubkey, PK) }
-                               || X = #{ pubkey := PK } <- Xs ] end,
-            {200, [], #{peers => Enc(Peers),
-                        blocked => Enc(Blocked)}};
+
+            {200, [], #{peers => lists:map(fun aec_peers:encode_peer_address/1, Peers),
+                        blocked => lists:map(fun aec_peers:encode_peer_address/1, Blocked)}};
         false ->
             {403, [], #{reason => <<"Call not enabled">>}}
     end;

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -2764,8 +2764,9 @@ peers(_Config) ->
     rpc(application, set_env, [aehttp, enable_debug_endpoints, true]),
     {ok, 200, #{<<"blocked">> := [], <<"peers">> := Peers}} = get_peers(),
 
-    [<<"host">>, <<"port">>, <<"pubkey">>] =
-      lists:sort(maps:keys(hd(Peers))),
+    OkPeers = [ ok || P <- Peers, {ok, _} <- [aec_peers:parse_peer_address(P)] ],
+
+    length(OkPeers) == length(Peers),
 
     %% ensure no peers
     lists:foreach(

--- a/apps/aeutils/priv/epoch_config_schema.json
+++ b/apps/aeutils/priv/epoch_config_schema.json
@@ -8,31 +8,10 @@
             "Pre-configured addresses of epoch nodes to contact",
             "type"  : "array",
             "items" : {
-                "type" : "object",
-                "properties" : {
-                    "peer" : {
-                        "type" : "object",
-                        "additionalProperties" : false,
-                        "properties" : {
-                            "host" : {
-                                "type"    : "string",
-                                "pattern" : "^[^:\\.\"!#$%^&*()',/]+(\\.[^:\\.\"!#$%^&*()',/]+)*",
-                               "example" : "somehost.somedomain:123"
-                            },
-
-                            "port" : {
-                                "type" : "integer",
-                                "minimum" : 1,
-                                "maximum" : 65535
-                            },
-
-                           "pubkey" : {
-                               "type" : "string",
-                               "description" : "base58c encoded public key"
-                          }
-                        }
-                    }
-                }
+                "type" : "string",
+                "description" : "Aeternity Node address",
+                "example" : "aenode://pp$ySU7cHqsymnuBP9iSe4rMnH1Rz2FStx5rnoewYMJcuPhdaqPk@192.168.1.1:3015",
+                "pattern": "^aenode://pp\$[a-zA-Z0-9]+@[^:\\.\"!#$%^&*()',/]+(\\.[^:\\.\"!#$%^&*()',/]+)*:[0-9]+/*$"
             }
         },
         "blocked_peers" : {
@@ -40,31 +19,10 @@
             "Pre-configured addresses of epoch nodes NOT to contact",
             "type"  : "array",
             "items" : {
-                "type" : "object",
-                "properties" : {
-                    "peer" : {
-                        "type" : "object",
-                        "additionalProperties" : false,
-                        "properties" : {
-                            "host" : {
-                                "type"    : "string",
-                                "pattern" : "^[^:\\.\"!#$%^&*()',/]+(\\.[^:\\.\"!#$%^&*()',/]+)*",
-                               "example" : "somehost.somedomain:123"
-                            },
-
-                            "port" : {
-                                "type" : "integer",
-                                "minimum" : 1,
-                                "maximum" : 65535
-                            },
-
-                           "pubkey" : {
-                               "type" : "string",
-                               "description" : "base58c encoded public key"
-                          }
-                        }
-                    }
-                }
+                "type" : "string",
+                "description" : "Aeternity Node address",
+                "example" : "aenode://pp$ySU7cHqsymnuBP9iSe4rMnH1Rz2FStx5rnoewYMJcuPhdaqPk@192.168.1.1:3015",
+                "pattern": "^aenode://pp\$[a-zA-Z0-9]+@[^:\\.\"!#$%^&*()',/]+(\\.[^:\\.\"!#$%^&*()',/]+)*:[0-9]+/*$"
             }
         },
         "sync" : {

--- a/apps/aeutils/test/data/epoch_full.yaml
+++ b/apps/aeutils/test/data/epoch_full.yaml
@@ -2,17 +2,11 @@
 # Pre-configured addresses of epoch nodes to contact
 peers:
     # TestNet Addresses
-    - peer:
-        host: "31.13.249.1"
-        port: 3013
-        pubkey: "pp$ySU7cHqsymnuBP9iSe4rMnH1Rz2FStx5rnoewYMJcuPhdaqPk"
+    - aenode://pp$ySU7cHqsymnuBP9iSe4rMnH1Rz2FStx5rnoewYMJcuPhdaqPk@31.13.249.1:3015
 
 # Pre-configured addresses of epoch nodes NOT to contact
 blocked_peers:
-    - peer:
-        host: "some-really-bad-peer-address"
-        port: 3013
-        pubkey: "pp$2M9oPohzsWgJrBBCFeYi3PVT4YF7F2botBtq6J1EGcVkiutx3R"
+    - aenode://pp$2M9oPohzsWgJrBBCFeYi3PVT4YF7F2botBtq6J1EGcVkiutx3R@some-really-bad-peer-address:3015
 
 sync:
     port: 3015

--- a/apps/aeutils/test/data/epoch_testnet.yaml
+++ b/apps/aeutils/test/data/epoch_testnet.yaml
@@ -2,10 +2,7 @@
 # Minimal configuration file to join the TestNet with enabled chain persisting and mining
 peers:
     # TestNet Addresses
-    - peer:
-        host: "31.13.249.1"
-        port: 3013
-        pubkey: "pp$ySU7cHqsymnuBP9iSe4rMnH1Rz2FStx5rnoewYMJcuPhdaqPk"
+    - aenode://pp$ySU7cHqsymnuBP9iSe4rMnH1Rz2FStx5rnoewYMJcuPhdaqPk@31.13.249.1:3015
 
 http:
     external:
@@ -13,6 +10,7 @@ http:
         peer_address: http://127.0.0.1:3013/
 
 keys:
+    password: "top secret"
     dir: ./keys
 
 chain:

--- a/config/dev1/sys.config
+++ b/config/dev1/sys.config
@@ -20,11 +20,8 @@
   {aecore, [
       {sync_port, 3015},
 
-      {peers, [#{<<"host">> => <<"localhost">>, <<"port">> => 3025,
-                 <<"pubkey">> => <<"pp$23YdvfRPQ1b1AMWmkKZUGk2cQLqygQp55FzDWZSEUicPjhxtp5">>},
-               #{<<"host">> => <<"localhost">>, <<"port">> => 3035,
-                 <<"pubkey">> => <<"pp$2M9oPohzsWgJrBBCFeYi3PVT4YF7F2botBtq6J1EGcVkiutx3R">>}
-              ]},
+      {peers, [<<"aenode://pp$23YdvfRPQ1b1AMWmkKZUGk2cQLqygQp55FzDWZSEUicPjhxtp5@localhost:3025">>,
+               <<"aenode://pp$2M9oPohzsWgJrBBCFeYi3PVT4YF7F2botBtq6J1EGcVkiutx3R@localhost:3035">>]},
 
       {metrics_port, 0},
       {password, <<"secret">>},

--- a/config/dev2/sys.config
+++ b/config/dev2/sys.config
@@ -19,11 +19,9 @@
 
   {aecore, [
       {sync_port, 3025},
-      {peers, [#{<<"host">> => <<"localhost">>, <<"port">> => 3015,
-                 <<"pubkey">> => <<"pp$ySU7cHqsymnuBP9iSe4rMnH1Rz2FStx5rnoewYMJcuPhdaqPk">>},
-               #{<<"host">> => <<"localhost">>, <<"port">> => 3035,
-                 <<"pubkey">> => <<"pp$2M9oPohzsWgJrBBCFeYi3PVT4YF7F2botBtq6J1EGcVkiutx3R">>}
-              ]},
+
+      {peers, [<<"aenode://pp$ySU7cHqsymnuBP9iSe4rMnH1Rz2FStx5rnoewYMJcuPhdaqPk@localhost:3015">>,
+               <<"aenode://pp$2M9oPohzsWgJrBBCFeYi3PVT4YF7F2botBtq6J1EGcVkiutx3R@localhost:3035">>]},
 
       {metrics_port, 0},
       {password, <<"secret">>},

--- a/config/dev3/sys.config
+++ b/config/dev3/sys.config
@@ -19,11 +19,9 @@
 
   {aecore, [
       {sync_port, 3035},
-      {peers, [#{<<"host">> => <<"localhost">>, <<"port">> => 3015,
-                 <<"pubkey">> => <<"pp$ySU7cHqsymnuBP9iSe4rMnH1Rz2FStx5rnoewYMJcuPhdaqPk">>},
-               #{<<"host">> => <<"localhost">>, <<"port">> => 3025,
-                 <<"pubkey">> => <<"pp$23YdvfRPQ1b1AMWmkKZUGk2cQLqygQp55FzDWZSEUicPjhxtp5">>}
-              ]},
+
+      {peers, [<<"aenode://pp$ySU7cHqsymnuBP9iSe4rMnH1Rz2FStx5rnoewYMJcuPhdaqPk@localhost:3015">>,
+               <<"aenode://pp$23YdvfRPQ1b1AMWmkKZUGk2cQLqygQp55FzDWZSEUicPjhxtp5@localhost:3025">>]},
 
       {metrics_port, 0},
       {password, <<"secret">>},

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -2684,16 +2684,8 @@ definitions:
       calldata:
         type: string
   Peer:
-    type: object
-    properties:
-      host:
-        type: string
-        description: 'Peer''s hostname/IP'
-      port:
-        type: integer
-      pubkey:
-        type: string
-        description: 'Base58 check encoded public key of the peer'
+    type: string
+    description: 'Aeternity node'
   Peers:
     type: object
     properties:

--- a/deployment/ansible/templates/epoch.yaml.j2
+++ b/deployment/ansible/templates/epoch.yaml.j2
@@ -5,15 +5,9 @@ sync:
 peers:
 {% for host in groups[hosts_group] | difference([inventory_hostname]) %}
 {% if hostvars[host]['sync_public_key'] is defined %}
-    - peer:
-        host: {{ hostvars[host]['ansible_default_ipv4']['address'] }}
-        port: {{ config.sync.port }}
-        pubkey: {{ hostvars[host]['sync_public_key'] }}
+    - "aenode://{{ hostvars[host]['sync_public_key'] }}@{{ hostvars[host]['ansible_default_ipv4']['address'] }}:{{ config.sync.port }}"
 {% else %}
-    - peer:
-        host: {{ hostvars[host]['ansible_default_ipv4']['address'] }}
-        port: {{ config.sync.port }}
-        pubkey: "no-key-found-peer-will-be-ignored"
+    - "aenode://no-key-found-peer-will-be-ignored@{{ hostvars[host]['ansible_default_ipv4']['address'] }}:{{ config.sync.port }}"
 {% endif %}
 {% endfor %}
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -5,11 +5,11 @@ set -e
 EXTERNAL_PEER_ADDRESS="${EXTERNAL_PEER_ADDRESS:-http://$(curl -s https://api.ipify.org):3013/}"
 
 # Allow changing peers address[0], defaults to testnet node1
-PEERS_ADDRESS_0="${PEERS_ADDRESS_0:-http://31.13.249.1:3013/}"
+PEERS_ADDRESS_0="${PEERS_ADDRESS_0:-aenode://pp\$ySU7cHqsymnuBP9iSe4rMnH1Rz2FStx5rnoewYMJcuPhdaqPk@31.13.249.1:3015}"
 
 # Use TestNet example config as configuration template
 sed -e "s|peer_address: http://127.0.0.1:3013/|peer_address: ${EXTERNAL_PEER_ADDRESS}|g" \
-    -e "s|http://31.13.249.1:3013/|${PEERS_ADDRESS_0}|g" \
+    -e "s|aenode://pp\$ySU7cHqsymnuBP9iSe4rMnH1Rz2FStx5rnoewYMJcuPhdaqPk@31.13.249.1:3015|${PEERS_ADDRESS_0}|g" \
     docs/examples/epoch_testnet.yaml > epoch.yaml
 
 # Using console with extra arguments because "foreground" does not handle SIGTERM/SIGQUIT

--- a/docker/epoch_node1_mean16.yaml
+++ b/docker/epoch_node1_mean16.yaml
@@ -1,7 +1,7 @@
 ---
 peers:
-    - peer: {host: node2, port: 3015, pubkey: "pp$28uQUgsPcsy7TQwnRxhF8GMKU4ykFLKsgf4TwDwPMNaSCXwWV8"}
-    - peer: {host: node3, port: 3015, pubkey: "pp$Dxq41rJN33j26MLqryvh7AnhuZywefWKEPBiiYu2Da2vDWLBq"}
+    - aenode://pp$28uQUgsPcsy7TQwnRxhF8GMKU4ykFLKsgf4TwDwPMNaSCXwWV8@node2:3015
+    - aenode://pp$Dxq41rJN33j26MLqryvh7AnhuZywefWKEPBiiYu2Da2vDWLBq@node3:3015
 
 http:
     external:

--- a/docker/epoch_node2_mean16.yaml
+++ b/docker/epoch_node2_mean16.yaml
@@ -1,7 +1,7 @@
 ---
 peers:
-    - peer: {host: node1, port: 3015, pubkey: "pp$HdcpgTX2C1aZ5sjGGysFEuup67K9XiFsWqSPJs4RahEcSyF7X"}
-    - peer: {host: node3, port: 3015, pubkey: "pp$Dxq41rJN33j26MLqryvh7AnhuZywefWKEPBiiYu2Da2vDWLBq"}
+    - aenode://pp$HdcpgTX2C1aZ5sjGGysFEuup67K9XiFsWqSPJs4RahEcSyF7X@node1:3015
+    - aenode://pp$Dxq41rJN33j26MLqryvh7AnhuZywefWKEPBiiYu2Da2vDWLBq@node3:3015
 
 http:
     external:

--- a/docker/epoch_node3_mean16.yaml
+++ b/docker/epoch_node3_mean16.yaml
@@ -1,7 +1,7 @@
 ---
 peers:
-    - peer: {host: node1, port: 3015, pubkey: "pp$HdcpgTX2C1aZ5sjGGysFEuup67K9XiFsWqSPJs4RahEcSyF7X"}
-    - peer: {host: node2, port: 3015, pubkey: "pp$28uQUgsPcsy7TQwnRxhF8GMKU4ykFLKsgf4TwDwPMNaSCXwWV8"}
+    - aenode://pp$HdcpgTX2C1aZ5sjGGysFEuup67K9XiFsWqSPJs4RahEcSyF7X@node1:3015
+    - aenode://pp$28uQUgsPcsy7TQwnRxhF8GMKU4ykFLKsgf4TwDwPMNaSCXwWV8@node2:3015
 
 http:
     external:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -36,7 +36,9 @@ You shall not share the private key (or the password) with anyone.
 
 The instructions below assume that:
 * The node is deployed in directory `/tmp/node`;
-* The initial network peer to join is "http://31.13.249.1:3013/".
+* The initial network peers to join are "aenode://pp$2eDAWTgveKp1C4dWhy9Hg59NCrg8TPUCKSXeEgvnPdro4ra177@31.13.249.1:3015",
+"aenode://pp$CjHH611sKocFxvrXrWjGJq5nNmbAxUYGhcyNbmvg6CwGEii2p@31.13.248.97:3015" and
+"aenode://pp$2Y6u5bx6pfVAx9B4faBMG1BV7WGGwzf3hvnXkV5MDZGuDGipfy@31.13.249.118:3015".
 
 If any of the assumptions does not hold, you need to amend the instructions accordingly.
 
@@ -44,7 +46,9 @@ Create the file `/tmp/node/epoch.yaml` with the following content (amend the `ht
 ```yaml
 ---
 peers:
-    - "http://31.13.249.1:3013/"
+    - "aenode://pp$2eDAWTgveKp1C4dWhy9Hg59NCrg8TPUCKSXeEgvnPdro4ra177@31.13.249.1:3015"
+    - "aenode://pp$CjHH611sKocFxvrXrWjGJq5nNmbAxUYGhcyNbmvg6CwGEii2p@31.13.248.97:3015"
+    - "aenode://pp$2Y6u5bx6pfVAx9B4faBMG1BV7WGGwzf3hvnXkV5MDZGuDGipfy@31.13.249.118:3015"
 
 keys:
     dir: keys

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -74,7 +74,7 @@ docker run -d -p 3013:3013 -e EXTERNAL_PEER_ADDRESS=http://1.2.3.4:3013/ aeterni
 Docker image has packaged the address of one of the testnet nodes in the configuration. This can be changed by setting `PEERS_ADDRESS_0` Docker environment variable:
 
 ```bash
-docker run -d -p 3013:3013 -e PEERS_ADDRESS_0=http://31.13.249.0:3013/ aeternity/epoch
+docker run -d -p 3013:3013 -e PEERS_ADDRESS_0=aenode://pp$CjHH611sKocFxvrXrWjGJq5nNmbAxUYGhcyNbmvg6CwGEii2p@31.13.248.97:3015 aeternity/epoch
 ```
 
 #### Changing the configuration file

--- a/docs/operation.md
+++ b/docs/operation.md
@@ -6,7 +6,9 @@ This document describes how to start your epoch node installed using a release b
 
 The instructions below assume that:
 * The node is deployed in directory `/tmp/node`;
-* The configured initial network peer to join is "http://31.13.249.1:3013/";
+* The configured initial network peers to join are "aenode://pp$2eDAWTgveKp1C4dWhy9Hg59NCrg8TPUCKSXeEgvnPdro4ra177@31.13.249.1:3015",
+"aenode://pp$CjHH611sKocFxvrXrWjGJq5nNmbAxUYGhcyNbmvg6CwGEii2p@31.13.248.97:3015" and
+"aenode://pp$2Y6u5bx6pfVAx9B4faBMG1BV7WGGwzf3hvnXkV5MDZGuDGipfy@31.13.249.118:3015";
 * The HTTP external API of the node can be contacted at 127.0.0.1 port 3003;
 * The HTTP internal API of the node can be contacted at 127.0.0.1 port 3103.
 

--- a/docs/release-notes/RELEASE-NOTES-0.10.0.md
+++ b/docs/release-notes/RELEASE-NOTES-0.10.0.md
@@ -2,8 +2,7 @@
 
 [This release][this-release] is focused on an encrypted Peer-to-Peer protocol and consistent serialization of chain objects.
 It:
-* Moves Peer-to-Peer communication from HTTP to encrypted channels (Noise is used to negoitiate cryptographic material).
-* Introduces a consistent and deterministic serialization using RLP, moving away from MessagePack and internal format.
+* Moves Peer-to-Peer communication from HTTP to encrypted TCP channels (Noise is used to negoitiate cryptographic material).
 * Improves chain handling by storing accumulated difficulty in the db rather than recomputing it. This impacts the persisted DB.
 * Enable user configuration of HTTP API acceptors pool
 * Restructure the transaction root hash in the block header for stricter validation. This impacts consensus and the persisted DB.
@@ -41,7 +40,7 @@ You can run a node by using either:
 The user configuration is documented in the [wiki](https://github.com/aeternity/epoch/wiki/User-provided-configuration).
 For specifying configuration using the Docker image, please refer to [its documentation][docker].
 
-The node API - i.e. peer-to-peer network API and user API - is documented:
+The node user API is documented:
 * HTTP API endpoints are specified [online in swagger.yaml][swagger-yaml];
   * A JSON version of same specification is located in the node at path `lib/aehttp-0.1.0/priv/swagger.json`;
   * An interactive visualization of the same specification is available [online][swagger-ui].

--- a/py/tests/integration/test_use_cases.py
+++ b/py/tests/integration/test_use_cases.py
@@ -141,14 +141,12 @@ def test_node_discovery():
                             alice_peer_url, "node1", "3015", '{peers, []},', mining=True)
     print("\nAlice has address " + alice_peer_url + " and no peers")
     # Bob's config: only peer is Alice
-    bob_peers = ' {peers, [#{<<"host">> => <<"localhost">>, <<"port">> => 3015, ' + \
-                '            <<"pubkey">> => <<"pp$HdcpgTX2C1aZ5sjGGysFEuup67K9XiFsWqSPJs4RahEcSyF7X">> }]},'
+    bob_peers = ' {peers, [<<"aenode://pp$HdcpgTX2C1aZ5sjGGysFEuup67K9XiFsWqSPJs4RahEcSyF7X@localhost:3015">>]}, '
     bob_sys_config = make_peers_config(root_dir, "bob.config",
                             bob_peer_url, "node2", "3025", bob_peers, mining=False)
     print("Bob has address " + bob_peer_url + " and peers [" + alice_peer_url + "]")
     # Carol's config: only peer is Bob
-    carol_peers = ' {peers, [#{<<"host">> => <<"localhost">>, <<"port">> => 3025, ' + \
-                  '            <<"pubkey">> => <<"pp$28uQUgsPcsy7TQwnRxhF8GMKU4ykFLKsgf4TwDwPMNaSCXwWV8">> }]},'
+    carol_peers = ' {peers, [<<"aenode://pp$28uQUgsPcsy7TQwnRxhF8GMKU4ykFLKsgf4TwDwPMNaSCXwWV8@localhost:3025">>]}, '
     carol_sys_config = make_peers_config(root_dir, "carol.config",
                             carol_peer_url, "node3", "3035", carol_peers, mining=False)
     print("Carol has address " + carol_peer_url + " and peers [" + bob_peer_url + "]")
@@ -175,11 +173,11 @@ def test_node_discovery():
 
     # Check that Carol discovers Alice as a peer
     carol_int_api = common.internal_api(carol_node)
-    def carol_peer_ports():
-        ports = [p.port for p in carol_int_api.get_peers().peers]
-        print("Ports: " + str(ports))
-        return ports
-    wait(lambda: 3015 in carol_peer_ports(), timeout_seconds=20, sleep_seconds=1)
+    def carol_peers():
+        peers = carol_int_api.get_peers().peers
+        print("Peers: " + str(peers))
+        return peers
+    wait(lambda: 'aenode://pp$HdcpgTX2C1aZ5sjGGysFEuup67K9XiFsWqSPJs4RahEcSyF7X@localhost:3015' in carol_peers(), timeout_seconds=20, sleep_seconds=1)
 
     # cleanup
     common.stop_node(alice_node)
@@ -232,8 +230,7 @@ def make_fast_mining_config(root_dir, file_name):
 
     conf ='[{aecore, [' + \
                     ' {sync_port, 3015},' + \
-                    ' {peers, [#{<<"host">> => <<"localhost">>, <<"port">> => 3025, ' + \
-                    '            <<"pubkey">> => <<"pp$28uQUgsPcsy7TQwnRxhF8GMKU4ykFLKsgf4TwDwPMNaSCXwWV8">> }]}, ' + \
+                    ' {peers, [<<"aenode://pp$28uQUgsPcsy7TQwnRxhF8GMKU4ykFLKsgf4TwDwPMNaSCXwWV8@localhost:3025">>]}, ' + \
                     ' {keys_dir, "' + key_dir + '"}, ' + \
                     ' {password, <<"top secret">>}, ' + \
                     ' {autostart, true},' + \
@@ -250,8 +247,7 @@ def make_no_mining_config(root_dir, file_name):
     key_dir = copy_peer_keys(root_dir, "node2")
     conf ='[{aecore, [' + \
                     ' {sync_port, 3025},' + \
-                    ' {peers, [#{<<"host">> => <<"localhost">>, <<"port">> => 3015, ' + \
-                    '            <<"pubkey">> => <<"pp$HdcpgTX2C1aZ5sjGGysFEuup67K9XiFsWqSPJs4RahEcSyF7X">> }]}, ' + \
+                    ' {peers, [<<"aenode://pp$HdcpgTX2C1aZ5sjGGysFEuup67K9XiFsWqSPJs4RahEcSyF7X@localhost:3015">>]}, ' + \
                     ' {keys_dir, "' + key_dir + '"}, ' + \
                     ' {password, <<"top secret">>}, ' + \
                     ' {autostart, false},' + \

--- a/py/tests/release.py
+++ b/py/tests/release.py
@@ -35,14 +35,8 @@ sync:
     port: 9815
 
 peers:
-    - peer:
-        port: 9825
-        host: "localhost"
-        pubkey: "pp$28uQUgsPcsy7TQwnRxhF8GMKU4ykFLKsgf4TwDwPMNaSCXwWV8"
-    - peer:
-        port: 9835
-        host: "localhost"
-        pubkey: "pp$Dxq41rJN33j26MLqryvh7AnhuZywefWKEPBiiYu2Da2vDWLBq"
+    - aenode://pp$28uQUgsPcsy7TQwnRxhF8GMKU4ykFLKsgf4TwDwPMNaSCXwWV8@localhost:9825
+    - aenode://pp$Dxq41rJN33j26MLqryvh7AnhuZywefWKEPBiiYu2Da2vDWLBq@localhost:9835
 
 http:
     external:

--- a/system_test/helpers/aest_docker.erl
+++ b/system_test/helpers/aest_docker.erl
@@ -130,8 +130,9 @@ setup_node(Spec, BackendState) ->
     PeerVars = lists:map(fun
         (PeerName) when is_atom(PeerName) ->
             PeerHostname = format("~s~s", [PeerName, Postfix]),
-            PeerInfo = format("peer: {host: ~s, port: ~w, pubkey: ~s}",
-                              [PeerHostname, ?EXT_SYNC_PORT, pubkey(PeerName)]),
+            PeerInfo = aec_peers:encode_peer_address(
+                          #{ host => PeerHostname, port => ?EXT_SYNC_PORT,
+                             pubkey => pubkey(PeerName)}),
             #{peer => PeerInfo}
     end, Peers),
     ct:log("PeerVars: ~p", [PeerVars]),
@@ -241,8 +242,8 @@ write_template(TemplateFile, OutputFile, Context) ->
     file:write_file(OutputFile, Data).
 
 pubkey(node1) ->
-    "pp$HdcpgTX2C1aZ5sjGGysFEuup67K9XiFsWqSPJs4RahEcSyF7X";
+    <<37,195,115,246,90,69,150,234,253,209,246,49,199,88,5,116,191,57,106,189,48,134,209,227,116,85,44,59,51,41,245,55>>;
 pubkey(node2) ->
-    "pp$28uQUgsPcsy7TQwnRxhF8GMKU4ykFLKsgf4TwDwPMNaSCXwWV8";
+    <<149,164,91,254,32,218,238,174,159,207,156,5,246,182,63,10,57,70,109,226,193,2,33,168,116,32,244,228,169,122,154,94>>;
 pubkey(node3) ->
-    "pp$Dxq41rJN33j26MLqryvh7AnhuZywefWKEPBiiYu2Da2vDWLBq".
+    <<29,110,222,56,140,83,227,182,7,100,207,18,240,52,200,151,221,151,247,213,94,191,198,219,184,33,139,118,35,95,157,120>>.


### PR DESCRIPTION
This includes changes to user documentation and examples

Covers implementation, tests, deployment, python-uats, system-test, docker-compose example, etc..