### PR TITLE
HTTP Parser: removing an unused section

### DIFF
--- a/apps/aehttp/src/aehttp_api_parser.erl
+++ b/apps/aehttp/src/aehttp_api_parser.erl
@@ -12,9 +12,7 @@
                                         {ok, aec_headers:deserialize_pow_evidence(Pow)}
                                     end}},
                      {<<"txs_hash">>, block_tx_hash}]).
--define(OBJECTS, #{ping => [{<<"genesis_hash">>, block_hash},
-                            {<<"best_hash">>, block_hash}],
-                   header_map => ?HEADER_OBJ,
+-define(OBJECTS, #{header_map => ?HEADER_OBJ,
                    block_map => [ {<<"transactions">>, {list, tx}} | ?HEADER_OBJ],
                    block => {fun(Block) ->
                                 BMap = aehttp_logic:cleanup_genesis(


### PR DESCRIPTION
Since PING is part of the independent sync protocol now, this snippet is deprecated.