### PR TITLE
PT-155124244 CI docker smoke tests local

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -426,7 +426,6 @@ workflows:
               ignore:
                 - env/dev1
                 - env/dev2
-                - master
 
       - deploy_api_docs:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -305,19 +305,18 @@ jobs:
     <<: *machine_config
     steps:
       - checkout
-      # - *setup_remote_docker
-      - *install_docker_client
       - run:
           name: Build Docker image
           command: |
-            ~/bin/docker build .
+            docker build .
       - run:
           name: Smoke test the nodes
           command: |
-            ./docker-compose up -d
+            docker-compose build node1
+            docker-compose up -d
             sleep 10
             curl -f -w "\n" localhost:300{1,2,3}/v2/top
-            ./docker-compose down -v
+            docker-compose down -v
 
   docker_push_tag:
     <<: *container_config

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -306,11 +306,7 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Build Docker image
-          command: |
-            docker build .
-      - run:
-          name: Smoke test the nodes
+          name: Build image and smoke test the nodes
           command: |
             docker-compose build node1
             docker-compose up -d

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,8 @@ references:
           https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_CLIENT_VERSION:?}.tgz
         tar -xz -C /tmp -f /tmp/docker-${DOCKER_CLIENT_VERSION:?}.tgz
         mkdir ~/bin && mv /tmp/docker/docker ~/bin
-        curl -L https://github.com/docker/compose/releases/download/1.19.0/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
+        curl -L https://github.com/docker/compose/releases/download/1.19.0/docker-compose-`uname -s`-`uname -m` -o docker-compose
+        chmod +x docker-compose
 
   rebar_cache_key: &rebar_cache_key rebar-cache-{{ checksum "rebar.lock" }}-{{ checksum "rebar.config" }}
   restore_rebar_cache: &restore_rebar_cache
@@ -305,10 +306,10 @@ jobs:
       - run:
           name: Smoke test the nodes
           command: |
-            docker-compose up -d
+            ./docker-compose up -d
             sleep 10
             curl -f -w "\n" localhost:300{1,2,3}/v2/top
-            docker-compose down -v
+            ./docker-compose down -v
 
   docker_push_tag:
     <<: *container_config

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,17 @@ references:
       DOCKER_CLIENT_VERSION: "17.09.0-ce"
       DOCKERHUB_REPO: aeternity/epoch
 
+
+  machine_config: &machine_config
+    machine: true
+    working_directory: ~/epoch
+    docker:
+      - image: aetrnty/builder
+        user: builder
+    environment:
+      DOCKER_CLIENT_VERSION: "17.09.0-ce"
+      DOCKERHUB_REPO: aetrnty/epoch
+
   setup_remote_docker: &setup_remote_docker
     setup_remote_docker:
       docker_layer_caching: true
@@ -294,10 +305,10 @@ jobs:
           destination: node3/
 
   docker_image_build:
-    <<: *container_config
+    <<: *machine_config
     steps:
       - checkout
-      - *setup_remote_docker
+      # - *setup_remote_docker
       - *install_docker_client
       - run:
           name: Build Docker image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,7 @@ references:
           https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_CLIENT_VERSION:?}.tgz
         tar -xz -C /tmp -f /tmp/docker-${DOCKER_CLIENT_VERSION:?}.tgz
         mkdir ~/bin && mv /tmp/docker/docker ~/bin
+        curl -L https://github.com/docker/compose/releases/download/1.19.0/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
 
   rebar_cache_key: &rebar_cache_key rebar-cache-{{ checksum "rebar.lock" }}-{{ checksum "rebar.config" }}
   restore_rebar_cache: &restore_rebar_cache
@@ -301,6 +302,13 @@ jobs:
           name: Build Docker image
           command: |
             ~/bin/docker build .
+      - run:
+          name: Smoke test the nodes
+          command: |
+            docker-compose up -d
+            sleep 10
+            curl -f -w "\n" localhost:300{1,2,3}/v2/top
+            docker-compose down -v
 
   docker_push_tag:
     <<: *container_config

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,9 +16,6 @@ references:
   machine_config: &machine_config
     machine: true
     working_directory: ~/epoch
-    docker:
-      - image: aetrnty/builder
-        user: builder
     environment:
       DOCKER_CLIENT_VERSION: "17.09.0-ce"
       DOCKERHUB_REPO: aetrnty/epoch


### PR DESCRIPTION
This PR should solve both smoke test related (devops) tickets: [PT-155124244](https://www.pivotaltracker.com/story/show/155124244) and [PT-155124252](https://www.pivotaltracker.com/story/show/155124252).

So first of all I needed to change the `docker_image_build` job to use the machine executor of CircleCI. This is due to limitations of the containerized executor (can't really open ports, can't use networking of host).

The job itself was modified to build using `docker-compose`, spin up all three nodes and run a simple `curl` check on all of them. If `curl` fails, the job will fail too.

Also the `docker_image_build` job will run on master too.

To my understanding the tickets differ in how the image should be used, once pulled from Docker Hub and once from the locally build version. I talked to @dincho and we could not figure out what the difference would be, since the locally build image will be published to Docker Hub anyways. So the test would be to build locally, push, pull (the pull would say that there is no difference to the local version) and then run the 'smoke test' itself. Maybe @lucafavatella can comment on why this test case is needed.