### PR TITLE
Pt 156410826 sync fixes

### DIFF
--- a/apps/aecore/src/aec_peer_connection.erl
+++ b/apps/aecore/src/aec_peer_connection.erl
@@ -547,7 +547,7 @@ get_header(Fun, Arg) ->
         {ok, Header} ->
             HH = aehttp_api_parser:encode(header, Header),
             #{result => ok, header => HH};
-        error ->
+        Err when Err == error orelse Err == {error, chain_too_short} ->
             #{result => error, reason => <<"Block not found">>}
     end.
 

--- a/apps/aecore/src/aec_peer_connection.erl
+++ b/apps/aecore/src/aec_peer_connection.erl
@@ -243,7 +243,11 @@ handle_info({tcp_closed, _}, S) ->
 handle_info(_Msg, S) ->
     {noreply, S}.
 
-terminate(_Reason, _State) ->
+terminate(normal, _State) ->
+    ok;
+terminate(NonNormal, State) ->
+    lager:info("Non-normal terminate, reason: ~p", [NonNormal]),
+    close_connection(State),
     ok.
 
 code_change(_OldVsn, State, _Extra) ->

--- a/apps/aecore/src/aec_peer_connection_listener.erl
+++ b/apps/aecore/src/aec_peer_connection_listener.erl
@@ -8,6 +8,7 @@
 
 -export([start_link/0, stop/0]).
 
+%% TODO: Make this a gen_server
 start_link() ->
     Pid = spawn_link(fun pc_listener/0),
     register(?MODULE, Pid),
@@ -22,6 +23,7 @@ pc_listener() ->
     {ok, SecKey} = aec_keys:peer_privkey(),
     {ok, PubKey} = aec_keys:peer_pubkey(),
     Port = aec_peers:sync_port(),
+    erlang:process_flag(trap_exit, true),
     lager:info("Starting peer_connection_listener at port ~p", [Port]),
     {ok, LSock} = gen_tcp:listen(Port, [{active, false}, binary, {reuseaddr, true}]),
     pc_listener(LSock, #{ seckey => SecKey, pubkey => PubKey, local_host => Host, local_port => Port }).
@@ -31,10 +33,17 @@ pc_listener(LSock, Opts) ->
     spawn_link(fun() -> acceptor(Self, LSock) end),
     receive
         {accept, {ok, TcpSock}} ->
+            %% TODO: should be started by/added to a supervisor
             aec_peer_connection:accept(TcpSock, Opts),
             pc_listener(LSock, Opts);
         {accept, Err = {error, _}} ->
             lager:error("accept failed with reason ~p", [Err]),
+            pc_listener(LSock, Opts);
+        {'EXIT', _From, shutdown} ->
+            gen_tcp:close(LSock),
+            exit(shutdown);
+        {'EXIT', From, Reason} ->
+            lager:info("~p terminated with reason ~p", [From, Reason]),
             pc_listener(LSock, Opts);
         stop ->
             gen_tcp:close(LSock)

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -2766,7 +2766,7 @@ peers(_Config) ->
 
     OkPeers = [ ok || P <- Peers, {ok, _} <- [aec_peers:parse_peer_address(P)] ],
 
-    length(OkPeers) == length(Peers),
+    true = (length(OkPeers) == length(Peers)),
 
     %% ensure no peers
     lists:foreach(


### PR DESCRIPTION
This addresses the following items from PT156410826:
- [x] There is a problem with aec_peer_connection it doesn't cleanup on crashes (connections are left behind)
- [x] There is a bug in aec_peer_connection, we fail to match on the right error message (trivial fix)
- [x] There is a bug in sync; it trips on itself, fetch_next times out while posting blocks
- [x] aec_peer_connection_listener should not link to peer_connections
