### PR TITLE
Add seed peers

### DIFF
--- a/apps/aeutils/priv/epoch_config_schema.json
+++ b/apps/aeutils/priv/epoch_config_schema.json
@@ -5,7 +5,7 @@
     "properties" : {
         "peers" : {
             "description" :
-            "Pre-configured addresses of epoch nodes to contact",
+            "Pre-configured addresses of epoch nodes to contact. If not set TestNet seed peers will be used.",
             "type"  : "array",
             "items" : {
                 "type" : "string",

--- a/apps/aeutils/test/data/epoch_full.yaml
+++ b/apps/aeutils/test/data/epoch_full.yaml
@@ -2,10 +2,10 @@
 # Pre-configured addresses of epoch nodes to contact. If not set TestNet seed peers will be used.
 peers:
     # TestNet seed peers
-    - aenode://pp$QU9CvhAQH56a2kA15tCnWPRJ2srMJW8ZmfbbFTAy7eG4o16Bf@52.10.46.160:3015" # us-west-2
-    - aenode://pp$2vhFb3HtHd1S7ynbpbFnEdph1tnDXFSfu4NGtq46S2eM5HCdbC@18.195.109.60:3015" # eu-central-1
-    - aenode://pp$27xmgQ4N1E3QwHyoutLtZsHW5DSW4zneQJ3CxT5JbUejxtFuAu@13.250.162.250:3015" # ap-southeast-1
-    - aenode://pp$2i8N6XsjCGe1wkdMhDRs7t7xzijrjJDN4xA22RoNGCgt6ay9QB@31.13.249.70:3015 # eu-east
+    - "aenode://pp$QU9CvhAQH56a2kA15tCnWPRJ2srMJW8ZmfbbFTAy7eG4o16Bf@52.10.46.160:3015" # us-west-2
+    - "aenode://pp$2vhFb3HtHd1S7ynbpbFnEdph1tnDXFSfu4NGtq46S2eM5HCdbC@18.195.109.60:3015" # eu-central-1
+    - "aenode://pp$27xmgQ4N1E3QwHyoutLtZsHW5DSW4zneQJ3CxT5JbUejxtFuAu@13.250.162.250:3015" # ap-southeast-1
+    - "aenode://pp$2i8N6XsjCGe1wkdMhDRs7t7xzijrjJDN4xA22RoNGCgt6ay9QB@31.13.249.70:3015" # eu-east
 
 # Pre-configured addresses of epoch nodes NOT to contact
 blocked_peers:

--- a/apps/aeutils/test/data/epoch_full.yaml
+++ b/apps/aeutils/test/data/epoch_full.yaml
@@ -1,8 +1,11 @@
 ---
-# Pre-configured addresses of epoch nodes to contact
+# Pre-configured addresses of epoch nodes to contact. If not set TestNet seed peers will be used.
 peers:
-    # TestNet Addresses
-    - aenode://pp$ySU7cHqsymnuBP9iSe4rMnH1Rz2FStx5rnoewYMJcuPhdaqPk@31.13.249.1:3015
+    # TestNet seed peers
+    - aenode://pp$QU9CvhAQH56a2kA15tCnWPRJ2srMJW8ZmfbbFTAy7eG4o16Bf@52.10.46.160:3015" # us-west-2
+    - aenode://pp$2vhFb3HtHd1S7ynbpbFnEdph1tnDXFSfu4NGtq46S2eM5HCdbC@18.195.109.60:3015" # eu-central-1
+    - aenode://pp$27xmgQ4N1E3QwHyoutLtZsHW5DSW4zneQJ3CxT5JbUejxtFuAu@13.250.162.250:3015" # ap-southeast-1
+    - aenode://pp$2i8N6XsjCGe1wkdMhDRs7t7xzijrjJDN4xA22RoNGCgt6ay9QB@31.13.249.70:3015 # eu-east
 
 # Pre-configured addresses of epoch nodes NOT to contact
 blocked_peers:

--- a/apps/aeutils/test/data/epoch_testnet.yaml
+++ b/apps/aeutils/test/data/epoch_testnet.yaml
@@ -1,14 +1,6 @@
 ---
-# Minimal configuration file to join the TestNet with enabled chain persisting and mining
-peers:
-    # TestNet Addresses
-    - aenode://pp$ySU7cHqsymnuBP9iSe4rMnH1Rz2FStx5rnoewYMJcuPhdaqPk@31.13.249.1:3015
-
-sync:
-    # Port used for P2P communication
-    # Make sure this port is reachable from you public facing IP.
-    port: 3015
-
+# Minimal configuration file to join the TestNet with enabled chain persisting and mining.
+# Should not contain default values.
 keys:
     password: "top secret"
     dir: ./keys

--- a/config/sys.config
+++ b/config/sys.config
@@ -1,3 +1,4 @@
+
 [
 
   { epoch, [
@@ -19,6 +20,12 @@
   ]},
 
   {aecore, [
+      {peers, [
+        <<"aenode://pp$QU9CvhAQH56a2kA15tCnWPRJ2srMJW8ZmfbbFTAy7eG4o16Bf@52.10.46.160:3015">>, %% us-west-2
+        <<"aenode://pp$2vhFb3HtHd1S7ynbpbFnEdph1tnDXFSfu4NGtq46S2eM5HCdbC@18.195.109.60:3015">>, %% eu-central-1
+        <<"aenode://pp$27xmgQ4N1E3QwHyoutLtZsHW5DSW4zneQJ3CxT5JbUejxtFuAu@13.250.162.250:3015">>,%% ap-southeast-1
+        <<"aenode://pp$2i8N6XsjCGe1wkdMhDRs7t7xzijrjJDN4xA22RoNGCgt6ay9QB@31.13.249.70:3015">> %% eu-east
+      ]},
       {password, <<"secret">>},
       {db_path, "."},
       {persist, false},

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,12 +1,8 @@
 #!/bin/bash
 set -e
 
-# Allow changing peers address[0], defaults to testnet node1
-PEERS_ADDRESS_0="${PEERS_ADDRESS_0:-aenode://pp\$ySU7cHqsymnuBP9iSe4rMnH1Rz2FStx5rnoewYMJcuPhdaqPk@31.13.249.1:3015}"
-
 # Use TestNet example config as configuration template
-sed -e "s|aenode://pp\$ySU7cHqsymnuBP9iSe4rMnH1Rz2FStx5rnoewYMJcuPhdaqPk@31.13.249.1:3015|${PEERS_ADDRESS_0}|g" \
-    docs/examples/epoch_testnet.yaml > epoch.yaml
+cp docs/examples/epoch_testnet.yaml epoch.yaml
 
 # Using console with extra arguments because "foreground" does not handle SIGTERM/SIGQUIT
 exec ./bin/epoch console -noshell -noinput $@

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,9 +6,7 @@ This document describes how to configure your epoch node installed using a relea
 
 ### Peer-to-peer network
 
-In order for your node to join the testnet, you need to specify in the configuration file:
-* The initial network peers to join (`peers` parameter);
-* How peers (on the Internet) can contact your node - specifically the TCP port (`sync` > `port` parameter).
+In order for your node to join the testnet, you need to specify in the configuration file, how peers (on the Internet) can contact your node - specifically the TCP port (`sync` > `port` parameter).
 
 (You do not need to specify the host at which your node can be contacted from the Internet, as each peer you ping will infer that from the address of the inbound TCP connection.)
 
@@ -37,20 +35,13 @@ You shall not share the private key (or the password) with anyone.
 
 The instructions below assume that:
 * The node is deployed in directory `/tmp/node`;
-* The initial network peers to join are "aenode://pp$2eDAWTgveKp1C4dWhy9Hg59NCrg8TPUCKSXeEgvnPdro4ra177@31.13.249.1:3015",
-"aenode://pp$CjHH611sKocFxvrXrWjGJq5nNmbAxUYGhcyNbmvg6CwGEii2p@31.13.248.97:3015" and
-"aenode://pp$2Y6u5bx6pfVAx9B4faBMG1BV7WGGwzf3hvnXkV5MDZGuDGipfy@31.13.249.118:3015".
+* No custom peers are specified under the `peers:` key in the config. If the `peers:` key is undefined, the *testnet* seed peers (built-in in the package source) are used.
 
 If any of the assumptions does not hold, you need to amend the instructions accordingly.
 
 Create the file `/tmp/node/epoch.yaml` with the following content (amend the `sync` > `port` parameter with your actual value):
 ```yaml
 ---
-peers:
-    - "aenode://pp$2eDAWTgveKp1C4dWhy9Hg59NCrg8TPUCKSXeEgvnPdro4ra177@31.13.249.1:3015"
-    - "aenode://pp$CjHH611sKocFxvrXrWjGJq5nNmbAxUYGhcyNbmvg6CwGEii2p@31.13.248.97:3015"
-    - "aenode://pp$2Y6u5bx6pfVAx9B4faBMG1BV7WGGwzf3hvnXkV5MDZGuDGipfy@31.13.249.118:3015"
-
 sync:
     port: 3015
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -66,11 +66,7 @@ Please note that, if your node is behind a firewall, you need to open and map a 
 
 #### Peer addresses
 
-Docker image has packaged the address of one of the testnet nodes in the configuration. This can be changed by setting `PEERS_ADDRESS_0` Docker environment variable:
-
-```bash
-docker run -d -p 3013:3013 -e PEERS_ADDRESS_0=aenode://pp$CjHH611sKocFxvrXrWjGJq5nNmbAxUYGhcyNbmvg6CwGEii2p@31.13.248.97:3015 aeternity/epoch
-```
+Docker image has packaged the addresses of testnet seed peers in the configuration. To change the peers configuration (e.g. join other network) change the configuration file (see below).
 
 #### Changing the configuration file
 

--- a/docs/operation.md
+++ b/docs/operation.md
@@ -6,9 +6,7 @@ This document describes how to start your epoch node installed using a release b
 
 The instructions below assume that:
 * The node is deployed in directory `/tmp/node`;
-* The configured initial network peers to join are "aenode://pp$2eDAWTgveKp1C4dWhy9Hg59NCrg8TPUCKSXeEgvnPdro4ra177@31.13.249.1:3015",
-"aenode://pp$CjHH611sKocFxvrXrWjGJq5nNmbAxUYGhcyNbmvg6CwGEii2p@31.13.248.97:3015" and
-"aenode://pp$2Y6u5bx6pfVAx9B4faBMG1BV7WGGwzf3hvnXkV5MDZGuDGipfy@31.13.249.118:3015";
+* No custom peers are specified under the `peers:` key in the config. If the `peers:` key is undefined, the *testnet* seed peers (built-in in the package source) are used.
 * The external HTTP endpoint of the user API of the node can be contacted at 127.0.0.1 port 3003;
 * The internal HTTP endpoint of the user API of the node can be contacted at 127.0.0.1 port 3103.
 
@@ -68,7 +66,7 @@ Verify that your node sees the same longest blockchain as the testnet.
 
 Inspect the current top of the blockchain as seen by the testnet:
 ```bash
-curl http://31.13.249.1:3013/v2/top
+curl http://31.13.249.70:3013/v2/top
 ```
 
 Inspect the current top of the blockchain as seen by your node:
@@ -83,7 +81,7 @@ Verify that the height is the same; it may take a few minutes for your node to c
 After the node is successfully connected to the testnet, you could verify that it is mining on the same chain as the rest of the network.
 You can validate it observing the `hash` of the `/top` of the remote nodes:
 ```bash
-$ curl http://31.13.249.1:3013/v2/top
+$ curl http://31.13.249.70:3013/v2/top
 {"hash":"bh$2UWBL9BciGC1w2FUukJZinchGRrCuwEuFTkcVvpZcfcpjiAbUy","height":...}
 ```
 

--- a/py/tests/release.py
+++ b/py/tests/release.py
@@ -87,6 +87,9 @@ keys:
 sync:
     port: 9825
 
+peers:
+    - aenode://pp$Dxq41rJN33j26MLqryvh7AnhuZywefWKEPBiiYu2Da2vDWLBq@localhost:9835
+
 http:
     external:
         port: 9823
@@ -135,6 +138,9 @@ keys:
 
 sync:
     port: 9835
+
+peers:
+    - aenode://pp$28uQUgsPcsy7TQwnRxhF8GMKU4ykFLKsgf4TwDwPMNaSCXwWV8@localhost:9825
 
 http:
     external:


### PR DESCRIPTION
All seed peers has static IP addresses.

If `peers:` is not set in the configuration. The node will automatically join the testnet (seed peers beeing the default `peers` array)

https://www.pivotaltracker.com/story/show/156461368