### PR TITLE
Fix failing UATs

### DIFF
--- a/py/tests/integration/test_contracts.py
+++ b/py/tests/integration/test_contracts.py
@@ -7,7 +7,6 @@ import time
 from nose.tools import assert_equals, assert_not_equals, assert_regexp_matches, with_setup
 import common
 from waiting import wait
-from swagger_client.models.ping import Ping 
 from swagger_client.models.contract import Contract
 from swagger_client.models.contract_call_input import ContractCallInput
 from swagger_client.rest import ApiException


### PR DESCRIPTION
[Pivotal story](https://www.pivotaltracker.com/story/show/156497687)
The python was importing (now gone) Ping structure. This structure is not needed anymore and it is removed from `swagger.yaml` so the python module being imported was missing. The module itself is not being used anymore so the import is removed.

How to test locally:
1. rm -rf py/tests/swagger_client/
2. make swagger
3. make python-env
4. make multi-build
5. make python-uats <- not crashing :)