### PR TITLE
Enable HTTP API debug endpoint in fast_integration env

### DIFF
--- a/deployment/ansible/deploy.yml
+++ b/deployment/ansible/deploy.yml
@@ -57,6 +57,7 @@
         internal:
           listen_address: "{{ api_internal_listen_address|default('127.0.0.1') }}"
           port: 3113
+        debug: "{{ http_debug|default(false) }}"
       websocket:
         internal:
           listen_address: "{{ ws_internal_listen_address|default('127.0.0.1') }}"

--- a/deployment/ansible/group_vars/tag_env_fast_integration/config.yml
+++ b/deployment/ansible/group_vars/tag_env_fast_integration/config.yml
@@ -4,3 +4,4 @@ miner_executable: mean16s-generic
 miner_node_bits: 16
 api_internal_listen_address: 0.0.0.0
 ws_internal_listen_address: 0.0.0.0
+http_debug: true

--- a/deployment/ansible/templates/epoch.yaml.j2
+++ b/deployment/ansible/templates/epoch.yaml.j2
@@ -22,6 +22,7 @@ http:
     internal:
         listen_address: {{ config.http.internal.listen_address }}
         port: {{ config.http.internal.port }}
+    debug: {{ config.http.debug | bool | lower }}
 
 websocket:
     internal:


### PR DESCRIPTION
Depends on https://github.com/aeternity/epoch/pull/933

https://www.pivotaltracker.com/story/show/156500364