### PR TITLE
Set log level to warning of fast_integration

### DIFF
--- a/deployment/ansible/group_vars/tag_env_fast_integration/config.yml
+++ b/deployment/ansible/group_vars/tag_env_fast_integration/config.yml
@@ -1,4 +1,4 @@
-log_level: debug
+log_level: warning
 expected_mine_rate: 15000
 miner_executable: mean16s-generic
 miner_node_bits: 16


### PR DESCRIPTION
Because of the short time between blocks, the environment generates away
too much logs than usefull and cost effective.

https://www.pivotaltracker.com/story/show/156503281