### PR TITLE
Adapt aesc_close_mutual_tx to new spec

### DIFF
--- a/apps/aechannel/include/channel_txs.hrl
+++ b/apps/aechannel/include/channel_txs.hrl
@@ -44,8 +44,6 @@
 -record(channel_close_mutual_tx, {
           channel_id   :: binary(),
           amount       :: integer(),
-          initiator    :: pubkey(),
-          participant  :: pubkey(),
           fee          :: non_neg_integer(),
           nonce        :: non_neg_integer()
          }).

--- a/apps/aechannel/include/channel_txs.hrl
+++ b/apps/aechannel/include/channel_txs.hrl
@@ -42,10 +42,13 @@
          }).
 
 -record(channel_close_mutual_tx, {
-          channel_id   :: binary(),
-          amount       :: integer(),
-          fee          :: non_neg_integer(),
-          nonce        :: non_neg_integer()
+          channel_id        :: binary(),
+          from              :: pubkey(),
+          initiator_amount  :: non_neg_integer(),
+          responder_amount  :: non_neg_integer(),
+          ttl               :: non_neg_integer(),
+          fee               :: non_neg_integer(),
+          nonce             :: non_neg_integer()
          }).
 
 -record(channel_close_solo_tx, {

--- a/apps/aechannel/src/aesc_channels.erl
+++ b/apps/aechannel/src/aesc_channels.erl
@@ -36,7 +36,7 @@
 %%%===================================================================
 
 -type id()     :: binary().
--type amount() :: integer().
+-type amount() :: non_neg_integer().
 -type status()     :: 'active' | 'solo_closing'.
 -type seq_number() :: non_neg_integer().
 

--- a/apps/aechannel/src/aesc_close_mutual_tx.erl
+++ b/apps/aechannel/src/aesc_close_mutual_tx.erl
@@ -24,7 +24,7 @@
          serialize/1,
          deserialize/2,
          for_client/1,
-         verifiable/1
+         is_verifiable/1
         ]).
 
 %%%===================================================================
@@ -234,8 +234,8 @@ serialization_template(?CHANNEL_CLOSE_MUTUAL_TX_VSN) ->
     , {nonce            , int}
     ].
 
--spec verifiable(tx()) -> boolean().
-verifiable(#channel_close_mutual_tx{channel_id = ChannelId}) ->
+-spec is_verifiable(tx()) -> boolean().
+is_verifiable(#channel_close_mutual_tx{channel_id = ChannelId}) ->
     case aec_chain:get_channel(ChannelId) of
         {ok, _Channel} -> true;
         {error, not_found} -> false

--- a/apps/aechannel/src/aesc_close_mutual_tx.erl
+++ b/apps/aechannel/src/aesc_close_mutual_tx.erl
@@ -216,6 +216,7 @@ for_client(#channel_close_mutual_tx{channel_id  = ChannelId,
                                     fee         = Fee,
                                     nonce       = Nonce}) ->
     #{<<"data_schema">> => <<"ChannelCloseMutualTxJSON">>, % swagger schema name
+      <<"vsn">>               => version(),
       <<"channel_id">>        => aec_base58c:encode(channel, ChannelId),
       <<"from">>              => aec_base58c:encode(account_pubkey, From),
       <<"initiator_amount">>  => InitiatorAmount,

--- a/apps/aecore/src/aec_chain.erl
+++ b/apps/aecore/src/aec_chain.erl
@@ -52,6 +52,10 @@
         , get_oracles/2
         ]).
 
+%%% Channels API
+-export([ get_channel/1
+        ]).
+
 %%% Difficulty API
 -export([ difficulty_at_hash/1
         , difficulty_at_top_block/0
@@ -117,6 +121,24 @@ get_oracles(From, Max) ->
     case get_top_state() of
         {ok, Trees} ->
             {ok, aeo_state_tree:get_oracles(From, Max, aec_trees:oracles(Trees))};
+        error ->
+            {error, no_state_trees}
+    end.
+
+%%%===================================================================
+%%% State channels
+%%%===================================================================
+
+-spec get_channel(aesc_channels:id()) ->
+                         {'ok', aesc_channels:channel()} |
+                         {'error', 'no_state_trees'|'not_found'}.
+get_channel(ChannelId) ->
+    case get_top_state() of
+        {ok, Trees} ->
+            case aesc_state_tree:lookup(ChannelId, aec_trees:channels(Trees)) of
+                {value, Channel} -> {ok, Channel};
+                none -> {error, not_found}
+            end;
         error ->
             {error, no_state_trees}
     end.

--- a/apps/aecore/src/aec_tx_pool.erl
+++ b/apps/aecore/src/aec_tx_pool.erl
@@ -71,7 +71,7 @@ push([_|_] = Txs, Event) when ?PUSH_EVENT(Event) ->
     Txs1 =
         lists:filter(
             fun(SignedTx) ->
-                aetx:verifiable(aetx_sign:tx(SignedTx))
+                aetx:is_verifiable(aetx_sign:tx(SignedTx))
             end,
             Txs), 
     gen_server:call(?SERVER, {push, Txs1, Event});

--- a/apps/aecore/src/aec_tx_pool.erl
+++ b/apps/aecore/src/aec_tx_pool.erl
@@ -66,10 +66,17 @@ push(Tx) ->
 
 -spec push(aetx_sign:signed_tx()|list(aetx_sign:signed_tx()), event()) -> ok.
 push([_|_] = Txs, Event) when ?PUSH_EVENT(Event) ->
-    gen_server:call(?SERVER, {push, Txs, Event});
+    % ignore those are not verifiable
+    Txs1 =
+        lists:filter(
+            fun(SignedTx) ->
+                aetx:verifiable(aetx_sign:tx(SignedTx))
+            end,
+            Txs), 
+    gen_server:call(?SERVER, {push, Txs1, Event});
 push([], _) -> ok;
 push(Tx, Event) when ?PUSH_EVENT(Event) ->
-    gen_server:call(?SERVER, {push, [Tx], Event}).
+    push([Tx], Event).
 
 -spec delete(aetx_sign:signed_tx()|list(aetx_sign:signed_tx())) -> ok.
 delete(Txs) when is_list(Txs) ->

--- a/apps/aecore/src/aec_tx_pool.erl
+++ b/apps/aecore/src/aec_tx_pool.erl
@@ -66,7 +66,8 @@ push(Tx) ->
 
 -spec push(aetx_sign:signed_tx()|list(aetx_sign:signed_tx()), event()) -> ok.
 push([_|_] = Txs, Event) when ?PUSH_EVENT(Event) ->
-    % ignore those are not verifiable
+    % TODO: Add currently not verifiable transactions to a tx limbo
+    % currently ignore those are not verifiable
     Txs1 =
         lists:filter(
             fun(SignedTx) ->

--- a/apps/aehttp/priv/swagger.json
+++ b/apps/aehttp/priv/swagger.json
@@ -3273,12 +3273,25 @@
     },
     "ChannelCloseMutualTx" : {
       "type" : "object",
-      "required" : [ "amount", "channel_id", "fee", "nonce" ],
+      "required" : [ "channel_id", "fee", "from", "initiator_amount", "nonce", "responder_amount", "ttl" ],
       "properties" : {
         "channel_id" : {
           "type" : "string"
         },
-        "amount" : {
+        "from" : {
+          "$ref" : "#/definitions/EncodedHash"
+        },
+        "initiator_amount" : {
+          "type" : "integer",
+          "format" : "int64",
+          "minimum" : 0
+        },
+        "responder_amount" : {
+          "type" : "integer",
+          "format" : "int64",
+          "minimum" : 0
+        },
+        "ttl" : {
           "type" : "integer",
           "format" : "int64",
           "minimum" : 0
@@ -3295,9 +3308,12 @@
         }
       },
       "example" : {
-        "amount" : 0,
+        "responder_amount" : 0,
+        "initiator_amount" : 0,
         "fee" : 0,
+        "from" : { },
         "channel_id" : "channel_id",
+        "ttl" : 0,
         "nonce" : 0
       }
     },

--- a/apps/aehttp/priv/swagger.json
+++ b/apps/aehttp/priv/swagger.json
@@ -3273,7 +3273,7 @@
     },
     "ChannelCloseMutualTx" : {
       "type" : "object",
-      "required" : [ "amount", "channel_id", "fee", "initiator", "nonce", "participant" ],
+      "required" : [ "amount", "channel_id", "fee", "nonce" ],
       "properties" : {
         "channel_id" : {
           "type" : "string"
@@ -3282,12 +3282,6 @@
           "type" : "integer",
           "format" : "int64",
           "minimum" : 0
-        },
-        "initiator" : {
-          "$ref" : "#/definitions/EncodedHash"
-        },
-        "participant" : {
-          "$ref" : "#/definitions/EncodedHash"
         },
         "fee" : {
           "type" : "integer",
@@ -3302,11 +3296,9 @@
       },
       "example" : {
         "amount" : 0,
-        "initiator" : { },
         "fee" : 0,
         "channel_id" : "channel_id",
-        "nonce" : 0,
-        "participant" : null
+        "nonce" : 0
       }
     },
     "ChannelCloseSoloTx" : {

--- a/apps/aehttp/src/aehttp_dispatch_ext.erl
+++ b/apps/aehttp/src/aehttp_dispatch_ext.erl
@@ -338,11 +338,8 @@ handle_request('PostChannelCloseMutual', #{'ChannelCloseMutualTx' := Req}, _Cont
     ParseFuns = [parse_map_to_atom_keys(),
                  read_required_params([channel_id,
                                        amount,
-                                       initiator, participant,
                                        fee, nonce]),
-                 base58_decode([{channel_id, channel_id, channel},
-                                {initiator, initiator, account_pubkey},
-                                {participant, participant, account_pubkey}]),
+                 base58_decode([{channel_id, channel_id, channel}]),
                  unsigned_tx_response(fun aesc_close_mutual_tx:new/1)
                 ],
     process_request(ParseFuns, Req);

--- a/apps/aehttp/src/aehttp_dispatch_ext.erl
+++ b/apps/aehttp/src/aehttp_dispatch_ext.erl
@@ -336,10 +336,12 @@ handle_request('PostChannelWithdrawal', #{'ChannelWithdrawalTx' := Req}, _Contex
 
 handle_request('PostChannelCloseMutual', #{'ChannelCloseMutualTx' := Req}, _Context) ->
     ParseFuns = [parse_map_to_atom_keys(),
-                 read_required_params([channel_id,
-                                       amount,
+                 read_required_params([channel_id, from,
+                                       initiator_amount, responder_amount,
+                                       ttl,
                                        fee, nonce]),
-                 base58_decode([{channel_id, channel_id, channel}]),
+                 base58_decode([{channel_id, channel_id, channel},
+                                {from, from, account_pubkey}]),
                  unsigned_tx_response(fun aesc_close_mutual_tx:new/1)
                 ],
     process_request(ParseFuns, Req);

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -1110,10 +1110,14 @@ state_channels_withdrawal(ChannelId, MinerPubkey, ParticipantPubkey) ->
 
 state_channels_close_mutual(ChannelId, SenderPubkey) ->
     Encoded = #{channel_id => aec_base58c:encode(channel, ChannelId),
-                amount => 2,
+                from => aec_base58c:encode(account_pubkey, SenderPubkey),
+                initiator_amount => 4,
+                responder_amount => 3,
+                ttl => 100,
                 fee => 1},
     Decoded = maps:merge(Encoded,
-                        #{channel_id => ChannelId}),
+                        #{channel_id => ChannelId,
+                          from => SenderPubkey}),
     unsigned_tx_positive_test(Decoded, Encoded,
                                fun get_channel_close_mutual/1,
                                fun aesc_close_mutual_tx:new/1, SenderPubkey,
@@ -1122,6 +1126,7 @@ state_channels_close_mutual(ChannelId, SenderPubkey) ->
                             SenderPubkey},
     Encoded1 = maps:put(nonce, NextNonce, Encoded),
     test_invalid_hash(ChannelId, channel_id, Encoded1, fun get_channel_close_mutual/1),
+    test_invalid_hash(SenderPubkey, from, Encoded1, fun get_channel_close_mutual/1),
     ok.
 
 state_channels_close_solo(ChannelId, MinerPubkey) ->

--- a/apps/aetx/src/aetx.erl
+++ b/apps/aetx/src/aetx.erl
@@ -16,7 +16,7 @@
         , new/2
         , nonce/1
         , origin/1
-        , verifiable/1
+        , is_verifiable/1
         , process/3
         , serialize_for_client/1
         , serialize_to_binary/1
@@ -120,10 +120,10 @@
 -callback for_client(Tx :: tx_instance()) ->
     map().
 
--callback verifiable(Tx :: tx_instance()) ->
+-callback is_verifiable(Tx :: tx_instance()) ->
     boolean().
 
--optional_callbacks([verifiable/1]).
+-optional_callbacks([is_verifiable/1]).
 
 %% -- ADT Implementation -----------------------------------------------------
 
@@ -196,9 +196,9 @@ deserialize_from_binary(Bin) ->
     Fields = aec_object_serialization:decode_fields(Template, RawFields),
     #aetx{cb = CB, type = Type, tx = CB:deserialize(Vsn, Fields)}.
 
--spec verifiable(Tx :: tx()) -> boolean().
-verifiable(Tx) ->
-    call_optional_callback(Tx, verifiable, [], true).
+-spec is_verifiable(Tx :: tx()) -> boolean().
+is_verifiable(Tx) ->
+    call_optional_callback(Tx, is_verifiable, [], true).
 
 
 call_optional_callback(#aetx{ cb = CB, tx = Tx }, FunAtom, Params0, Default) ->

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -2623,7 +2623,17 @@ definitions:
     properties:
       channel_id:
         type: string
-      amount:
+      from:
+        $ref: '#/definitions/EncodedHash'
+      initiator_amount:
+        type: integer
+        format: int64
+        minimum: 0
+      responder_amount:
+        type: integer
+        format: int64
+        minimum: 0
+      ttl:
         type: integer
         format: int64
         minimum: 0
@@ -2637,7 +2647,10 @@ definitions:
         minimum: 0
     required:
     - channel_id
-    - amount
+    - from
+    - initiator_amount
+    - responder_amount
+    - ttl
     - fee
     - nonce
   ChannelCloseSoloTx:

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -2627,10 +2627,6 @@ definitions:
         type: integer
         format: int64
         minimum: 0
-      initiator:
-        $ref: '#/definitions/EncodedHash'
-      participant:
-        $ref: '#/definitions/EncodedHash'
       fee:
         type: integer
         format: int64
@@ -2642,8 +2638,6 @@ definitions:
     required:
     - channel_id
     - amount
-    - initiator
-    - participant
     - fee
     - nonce
   ChannelCloseSoloTx:


### PR DESCRIPTION
[Pivotal story](https://www.pivotaltracker.com/story/show/156570763)

Since the [description of channel_close_mutual](https://github.com/aeternity/protocol/blob/channels/channels/ON-CHAIN.md#channel_close_mutual) has changed not to include initiatior and participant, this PR is addressing that.

Most notable change is getting peers in the channel: now they're fetched from the DB (whenever possible - from state trees)