### PR TITLE
Pt 156569845 check signatures

### DIFF
--- a/apps/aecore/include/aec_crypto.hrl
+++ b/apps/aecore/include/aec_crypto.hrl
@@ -1,0 +1,7 @@
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2018, Aeternity
+%%%-------------------------------------------------------------------
+-define(CRYPTO_ALGO, ecdsa).
+-define(CRYPTO_KEYTYPE, ecdh).
+-define(CRYPTO_DIGEST, sha256).
+-define(CRYPTO_CURVE, secp256k1).

--- a/apps/aecore/src/aec_keys.erl
+++ b/apps/aecore/src/aec_keys.erl
@@ -13,6 +13,7 @@
 -behaviour(gen_server).
 
 -include("common.hrl").
+-include("aec_crypto.hrl").
 
 %% API
 -export([start_link/0,
@@ -28,11 +29,10 @@
 
 -export([peer_pubkey/0, peer_privkey/0, check_peer_keys/2]).
 
--export([verify/2]).
 -export([check_key_pair/0]).
 
 -ifdef(TEST).
--export([check_keys_pair/5, encrypt_peerkey/2]).
+-export([encrypt_peerkey/2, check_key_pair/2]).
 -endif.
 
 -define(SERVER, ?MODULE).
@@ -44,11 +44,6 @@
 -define(FILENAME_PEERPUB, "peer_key.pub").
 -define(FILENAME_PEERPRIV, "peer_key").
 
--record(crypto, {type   :: atom(),
-                 algo   :: atom(),
-                 digest :: atom(),
-                 curve  :: atom()}).
-
 -record(state, {
           pub       :: undefined | binary(),
           priv      :: undefined | binary(),
@@ -59,12 +54,8 @@
           pub_file  :: undefined | binary(),
           priv_file :: undefined | binary(),
           peer_pub_file  :: undefined | binary(),
-          peer_priv_file :: undefined | binary(),
-          crypto    :: #crypto{}}).
-          %% type   :: atom(),
-          %% algo   :: atom(),
-          %% digest :: atom(),
-          %% curve  :: atom()}).
+          peer_priv_file :: undefined | binary()
+         }).
 
 -type password() :: binary().
 
@@ -97,10 +88,6 @@ stop() ->
 -spec sign(tx()) -> {ok, signed_tx()} | {error, term()}.
 sign(Tx) ->
     gen_server:call(?MODULE, {sign, Tx}).
-
--spec verify([binary()], tx()) -> boolean().
-verify(Signatures, Tx) ->
-    gen_server:call(?MODULE, {verify, Signatures, Tx}).
 
 -spec pubkey() -> {ok, binary()} | {error, key_not_found}.
 pubkey() ->
@@ -150,12 +137,6 @@ delete() ->
 %%--------------------------------------------------------------------
 init([Password, KeysDir]) when is_binary(Password) ->
     lager:info("Initializing keys manager"),
-    %% TODO: consider moving the crypto config to config
-    C = #crypto{algo   = ecdsa,
-                type   = ecdh,
-                digest = sha256,
-                curve = secp256k1},
-
     %% Ensure there is directory for keys
     case filelib:is_dir(KeysDir) of
         false ->
@@ -168,12 +149,12 @@ init([Password, KeysDir]) when is_binary(Password) ->
     {Pub1, Priv1} =
         case from_local_dir(PubFile) of
             {error, enoent} ->
-                p_gen_new(Password, C, PubFile, PrivFile);
+                p_gen_new(Password, PubFile, PrivFile);
             {ok, Pub} ->
                 {ok, Priv} = from_local_dir(PrivFile),
                 Pub0 = decrypt_pubkey(Password, Pub),
                 Priv0 = decrypt_privkey(Password, Priv),
-                case check_keys_pair(Pub0, Priv0, C) of
+                case check_key_pair(Pub0, Priv0) of
                     true ->
                         {Pub0, Priv0};
                     false ->
@@ -205,7 +186,6 @@ init([Password, KeysDir]) when is_binary(Password) ->
                 priv_file=PrivFile, pub_file=PubFile,
                 peer_priv=PeerPriv, peer_pub=PeerPub,
                 peer_priv_file=PeerPrivFile, peer_pub_file=PeerPubFile,
-                crypto = C,
                 pass=Password,
                 keys_dir=KeysDir}}.
 
@@ -226,26 +206,15 @@ init([Password, KeysDir]) when is_binary(Password) ->
 handle_call({sign, _}, _From, #state{priv=undefined} = State) ->
     {reply, {error, key_not_found}, State};
 handle_call({sign, Tx}, _From,
-            #state{pub = PubKey, priv=PrivKey,
-                   crypto = #crypto{algo=Algo,
-                                    digest=Digest,
-                                    curve=Curve}} = State) ->
+            #state{pub = PubKey, priv=PrivKey} = State) ->
     Signers = aetx:signers(Tx),
     case lists:member(PubKey, Signers) of
         false ->
             {reply, {error, not_a_signer}, State};
         true ->
-            CryptoMap = #{algo => Algo, digest => Digest, curve => Curve},
-            SignedTx = aetx_sign:sign(Tx, PrivKey, CryptoMap),
+            SignedTx = aetx_sign:sign(Tx, PrivKey),
             {reply, {ok, SignedTx}, State}
     end;
-handle_call({verify, Sigs, Tx}, _From, #state{crypto = C} = State) ->
-    Signers = aetx:signers(Tx),
-    Bin = aetx:serialize_to_binary(Tx),
-    Res = lists:any(fun(Sig) ->
-                            try_verify(Bin, Sig, Signers, C)
-                    end, Sigs),
-    {reply, Res, State};
 handle_call(pubkey, _From, #state{pub=undefined} = State) ->
     {reply, {error, key_not_found}, State};
 handle_call(pubkey, _From, #state{pub=PubKey} = State) ->
@@ -258,9 +227,8 @@ handle_call(peer_privkey, _From, #state{peer_priv=undefined} = State) ->
     {reply, {error, key_not_found}, State};
 handle_call(peer_privkey, _From, #state{peer_priv=PrivKey} = State) ->
     {reply, {ok, PrivKey}, State};
-handle_call(check_key_pair, _From, #state{pub = PubKey, priv = PrivKey,
-                                          crypto = C} = State) ->
-    {reply, check_keys_pair(PubKey, PrivKey, C), State};
+handle_call(check_key_pair, _From, #state{pub = PubKey, priv = PrivKey} = State) ->
+    {reply, check_key_pair(PubKey, PrivKey), State};
 handle_call(delete, _From, #state{pub_file=PubFile, priv_file=PrivFile} = State) ->
     try
         ok = file:delete(PubFile),
@@ -288,15 +256,6 @@ code_change(_OldVsn, State, _Extra) ->
 %%%===================================================================
 %%% Internal functions
 %%%===================================================================
-
-try_verify(Bin, S, Signers, #crypto{algo = Algo,
-                                    digest = Digest,
-                                    curve = Curve}) ->
-    lists:any(
-      fun(PubKey) ->
-              crypto:verify(
-                Algo, Digest, Bin, S, [PubKey, crypto:ec_curve(Curve)])
-      end, Signers).
 
 hash(Bin) ->
     crypto:hash(sha256, Bin).
@@ -333,11 +292,10 @@ p_gen_filename(KeysDir) ->
     PrivFile = filename:join(KeysDir, ?FILENAME_PRIV),
     {PubFile, PrivFile}.
 
-p_gen_new(Password, #crypto{type = KeyType, curve = Curve} = C,
-          PubFilename, PrivFilename) ->
+p_gen_new(Password, PubFilename, PrivFilename) ->
     {NewPubKey, NewPrivKey} =
-        crypto:generate_key(KeyType, crypto:ec_curve(Curve)),
-    case check_keys_pair(NewPubKey, NewPrivKey, C) of
+        crypto:generate_key(?CRYPTO_KEYTYPE, crypto:ec_curve(?CRYPTO_CURVE)),
+    case check_key_pair(NewPubKey, NewPrivKey) of
         true ->
             EncPub = encrypt_pubkey(Password, NewPubKey),
             lager:debug("New PubKey: ~p", [EncPub]),
@@ -365,19 +323,13 @@ to_local_dir(NewFile, Bin) ->
 from_local_dir(NewFile) ->
     file:read_file(NewFile).
 
-
--spec check_keys_pair(binary(), binary(), #crypto{}) -> boolean().
-check_keys_pair(PubKey, PrivKey, #crypto{algo   = Algo,
-                                         digest = Digest,
-                                         curve  = Curve}) ->
-    check_keys_pair(PubKey, PrivKey, Algo, Digest, Curve).
-
-check_keys_pair(PubKey, PrivKey, Algo, Digest, Curve) ->
+check_key_pair(PubKey, PrivKey) ->
     SampleMsg = <<"random message">>,
-    Signature = crypto:sign(Algo, Digest, SampleMsg,
-                            [PrivKey, crypto:ec_curve(Curve)]),
-    crypto:verify(Algo, Digest, SampleMsg, Signature,
-                  [PubKey, crypto:ec_curve(Curve)]).
+    Curve = crypto:ec_curve(?CRYPTO_CURVE),
+    Signature = crypto:sign(?CRYPTO_ALGO, ?CRYPTO_DIGEST, SampleMsg,
+                            [PrivKey, Curve]),
+    crypto:verify(?CRYPTO_ALGO, ?CRYPTO_DIGEST, SampleMsg, Signature,
+                  [PubKey, Curve]).
 
 check_env() ->
     DefaultFile =  filename:join(aeu_env:data_dir(aecore), "keys"),

--- a/apps/aecore/test/aec_keys_tests.erl
+++ b/apps/aecore/test/aec_keys_tests.erl
@@ -47,18 +47,14 @@ all_test_() ->
                {"Keys validation (positive case)",
                 fun() ->
                         {Pubkey, PrivKey} = crypto:generate_key(ecdh, crypto:ec_curve(secp256k1)),
-                        ValidPair = aec_keys:check_keys_pair(Pubkey, PrivKey,
-                                                         ecdsa, sha256,
-                                                         secp256k1),
+                        ValidPair = aec_keys:check_key_pair(Pubkey, PrivKey),
                         ?assertEqual(true, ValidPair)
                 end},
                {"Keys validation (negative case)",
                 fun() ->
                         Pubkey = <<"invalid">>,
                         Privkey = <<"key pair">>,
-                        ValidPair = aec_keys:check_keys_pair(Pubkey, Privkey,
-                                                         ecdsa, sha256,
-                                                         secp256k1),
+                        ValidPair = aec_keys:check_key_pair(Pubkey, Privkey),
                         ?assertEqual(false, ValidPair)
                 end},
                 {"Peer key validation (positive case)",

--- a/apps/aeoracle/test/aeoracle_SUITE.erl
+++ b/apps/aeoracle/test/aeoracle_SUITE.erl
@@ -264,7 +264,8 @@ query_response(Cfg) ->
 
     %% Test that ResponseTX is accepted
     RTx      = aeo_test_utils:response_tx(OracleKey, ID, <<"42">>, S1),
-    SignedTx = aetx_sign:sign(RTx, <<"pkey1">>),
+    PrivKey  = aeo_test_utils:priv_key(OracleKey, S1),
+    SignedTx = aetx_sign:sign(RTx, PrivKey),
     {ok, [SignedTx], Trees2} =
         aec_trees:apply_signed_txs([SignedTx], Trees, CurrHeight),
     S2 = aeo_test_utils:set_trees(Trees2, S1),


### PR DESCRIPTION
Check signatures on transactions before applying them to state trees.

Also, move signature verification out of aec_keys and to aetx_sign instead.

https://www.pivotaltracker.com/n/projects/2124891/stories/156569845