### PR TITLE
Improve supervision tree for connection servers

### DIFF
--- a/apps/aecore/src/aec_connection_sup.erl
+++ b/apps/aecore/src/aec_connection_sup.erl
@@ -1,0 +1,87 @@
+%%% -*- erlang-indent-level:4; indent-tabs-mode: nil -*-
+%%%=============================================================================
+%%% @copyright 2018, Aeternity Anstalt
+%%% @doc
+%%%    Supervisor for servers dealing with inter node communication.
+%%%
+%%%    Individual connections cannot bring down the central servers (aec_peers,
+%%%    aec_sync), but if one of those goes down, all connections are brought
+%%%    down, and the whole peer/sync handling is restarted.
+%%%
+%%%    It is the responsibility of aec_peers to handle that a connection
+%%%    (aec_peer_connections) goes down. And the strategy there is to
+%%%    re-establish connections where the node is the initiator, and delegate
+%%%    the corresponding responsibility to the remote node.
+%%%
+%%% @end
+%%%=============================================================================
+-module(aec_connection_sup).
+
+-behaviour(supervisor).
+
+%% API
+-export([start_link/0]).
+
+%% Supervisor callbacks
+-export([init/1]).
+
+%%====================================================================
+%% API functions
+%%====================================================================
+
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+%%====================================================================
+%% Supervisor callbacks
+%%====================================================================
+
+init([]) ->
+    %% We want all children brought down and restarted
+    SupFlags = #{ strategy => one_for_all
+                , intensity => 5
+                , period => 10},
+    ChildSpecs = [ aec_peer_connection_sup_spec()
+                 , worker(aec_peers)
+                 , worker(aec_sync)
+                 , aec_connection_listener_spec()
+                 ],
+    {ok, {SupFlags, ChildSpecs}}.
+
+worker(Mod) ->
+    child(Mod, worker, []).
+
+aec_peer_connection_sup_spec() ->
+    child(aec_peer_connection_sup, supervisor, [ext_sync_port()]).
+
+aec_connection_listener_spec() ->
+    child(aec_peer_connection_listener, worker,
+          [sync_port(), sync_listen_address()]).
+
+child(Mod, Type, Args) ->
+    #{ id => Mod
+     , start => {Mod, start_link, Args}
+     , restart => permanent
+     , shutdown => 5000
+     , type => Type
+     }.
+
+%%====================================================================
+%% Shared configs
+%%====================================================================
+
+-define(DEFAULT_SYNC_PORT, 3015).
+-define(DEFAULT_SYNC_LISTEN_ADDRESS, <<"0.0.0.0">>).
+
+sync_port() ->
+    aeu_env:user_config_or_env([<<"sync">>, <<"port">>], aecore, sync_port, ?DEFAULT_SYNC_PORT).
+
+ext_sync_port() ->
+    aeu_env:user_config_or_env([<<"sync">>, <<"external_port">>],
+        aecore, ext_sync_port, sync_port()).
+
+sync_listen_address() ->
+    Config = aeu_env:user_config_or_env([<<"sync">>, <<"listen_address">>],
+                aecore, sync_listen_address, ?DEFAULT_SYNC_LISTEN_ADDRESS),
+    {ok, IpAddress} = inet:parse_address(binary_to_list(Config)),
+    IpAddress.

--- a/apps/aecore/src/aec_peer_connection_listener.erl
+++ b/apps/aecore/src/aec_peer_connection_listener.erl
@@ -1,3 +1,4 @@
+%%% -*- erlang-indent-level:4; indent-tabs-mode: nil -*-
 %%%=============================================================================
 %%% @copyright 2018, Aeternity Anstalt
 %%% @doc
@@ -6,57 +7,103 @@
 %%%=============================================================================
 -module(aec_peer_connection_listener).
 
--export([start_link/0, stop/0]).
+-behaviour(gen_server).
 
-%% TODO: Make this a gen_server
-start_link() ->
-    Pid = spawn_link(fun pc_listener/0),
-    register(?MODULE, Pid),
-    {ok, Pid}.
+%% API
+-export([ start_link/2
+        ]).
 
-stop() ->
-    ?MODULE ! stop,
-    ok.
+%% gen_server callbacks
+-export([ init/1
+        , handle_call/3
+        , handle_cast/2
+        , handle_info/2
+        , terminate/2
+        , code_change/3
+        ]).
 
-pc_listener() ->
+-define(SERVER, ?MODULE).
+
+-record(state, { lsock
+               , opts
+               , acceptor
+               }).
+
+%%====================================================================
+%% API functions
+%%====================================================================
+
+start_link(SyncPort, Address) ->
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [SyncPort, Address], []).
+
+%%====================================================================
+%% gen_server callbacks
+%%====================================================================
+
+init([Port, Address]) ->
     {ok, SecKey} = aec_keys:peer_privkey(),
     {ok, PubKey} = aec_keys:peer_pubkey(),
-    Port = aec_peers:sync_port(),
-    Address = aec_peers:sync_listen_address(),
     erlang:process_flag(trap_exit, true),
-    lager:info("Starting peer_connection_listener at port ~p", [Port]),
+    lager:info("Starting peer_connection_listener at Address: ~p port ~p",
+               [Address, Port]),
     {ok, LSock} = gen_tcp:listen(Port, [{active, false}, binary,
                                         {reuseaddr, true},
                                         {ip, Address}]),
-    pc_listener(LSock, #{ seckey => SecKey, pubkey => PubKey }).
+    S = #state{ lsock = LSock
+              , opts = #{ seckey => SecKey
+                        , pubkey => PubKey
+                        }},
+    {ok, spawn_acceptor(S)}.
 
-pc_listener(LSock, Opts) ->
-    Self = self(),
-    spawn_link(fun() -> acceptor(Self, LSock) end),
-    receive
-        {accept, {ok, TcpSock}} ->
-            %% TODO: should be started by/added to a supervisor
-            aec_peer_connection:accept(TcpSock, Opts),
-            pc_listener(LSock, Opts);
-        {accept, Err = {error, _}} ->
-            lager:error("accept failed with reason ~p", [Err]),
-            pc_listener(LSock, Opts);
-        {'EXIT', _From, shutdown} ->
-            gen_tcp:close(LSock),
-            exit(shutdown);
-        {'EXIT', From, Reason} ->
-            lager:info("~p terminated with reason ~p", [From, Reason]),
-            pc_listener(LSock, Opts);
-        stop ->
-            gen_tcp:close(LSock)
+handle_cast(What, State) ->
+    lager:error("Got unxpected cast: ~p", [What]),
+    {noreply, State}.
+
+handle_call(What,_From, State) ->
+    lager:error("Got unxpected call: ~p", [What]),
+    {reply, {nyi, What}, State}.
+
+handle_info({APid, accept, {ok, TcpSock}}, #state{acceptor = APid} = S) ->
+    aec_peer_connection:accept(TcpSock, S#state.opts),
+    {noreply, spawn_acceptor(S)};
+handle_info({APid, accept, Err = {error, _}}, #state{acceptor = APid} = S) ->
+    lager:error("accept failed with reason ~p", [Err]),
+    {noreply, spawn_acceptor(S)};
+handle_info({'EXIT', _, normal}, S) ->
+    {noreply, S};
+handle_info({'EXIT', Pid, Reason}, S) ->
+    lager:info("~p terminated with reason ~p", [Pid, Reason]),
+    case Pid =:= S#state.acceptor of
+        true -> {noreply, spawn_acceptor(S)};
+        false -> {noreply, S}
+    end;
+handle_info(What, S) ->
+    lager:info("Got unexpected: ~p", [What]),
+    {noreply, S}.
+
+terminate(_Reason, State) ->
+    try
+        gen_tcp:close(State#state.lsock),
+        ok
+    catch _:_ -> ok
     end.
+
+code_change(_OldVsn, State,_Extra) ->
+    {ok, State}.
+
+%%====================================================================
+%% Acceptor process
+%%====================================================================
+
+spawn_acceptor(#state{lsock = LSock} = S) ->
+    Self = self(),
+    S#state{acceptor = spawn_link(fun() -> acceptor(Self, LSock) end)}.
 
 acceptor(Parent, LSock) ->
     Res = gen_tcp:accept(LSock),
     case Res of
-        {ok, Sock} ->
-            ok = gen_tcp:controlling_process(Sock, Parent);
+        {ok, Sock} -> ok = gen_tcp:controlling_process(Sock, Parent);
         {error, _} -> ok
     end,
-    Parent ! {accept, Res}.
+    Parent ! {self(), accept, Res}.
 

--- a/apps/aecore/src/aec_peer_connection_sup.erl
+++ b/apps/aecore/src/aec_peer_connection_sup.erl
@@ -1,0 +1,48 @@
+%%% -*- erlang-indent-level:4; indent-tabs-mode: nil -*-
+%%%=============================================================================
+%%% @copyright 2018, Aeternity Anstalt
+%%% @doc
+%%%    Supervisor for peer connections
+%%% @end
+%%%=============================================================================
+-module(aec_peer_connection_sup).
+
+-behaviour(supervisor).
+
+%% API
+-export([ start_link/1
+        , start_peer_connection/1
+        ]).
+
+%% Supervisor callbacks
+-export([init/1]).
+
+-define(SERVER, ?MODULE).
+
+%%====================================================================
+%% API functions
+%%====================================================================
+
+start_link(Port) ->
+    supervisor:start_link({local, ?SERVER}, ?MODULE, [Port]).
+
+start_peer_connection(Opts) ->
+    supervisor:start_child(?SERVER, [Opts]).
+
+%%====================================================================
+%% Supervisor callbacks
+%%====================================================================
+
+init([Port]) ->
+    SupFlags = #{ strategy => simple_one_for_one
+                , intensity => 5
+                , period => 10},
+    ChildSpecs = [#{ id => aec_peer_connection
+                   , start => {aec_peer_connection, start_link, [Port]}
+                   , type => worker
+                   , restart => temporary
+                   , shutdown => 5000
+                   }],
+    {ok, {SupFlags, ChildSpecs}}.
+
+

--- a/apps/aecore/src/aec_peers.erl
+++ b/apps/aecore/src/aec_peers.erl
@@ -45,11 +45,6 @@
         , ppp/1
         ]).
 
-%% API used by aec_peer_connection and aec_peer_connection_listener
--export([ sync_port/0
-        , ext_sync_port/0
-        , sync_listen_address/0]).
-
 -export([check_env/0]).
 
 %% gen_server callbacks
@@ -59,9 +54,6 @@
 -ifdef(TEST).
 -compile([export_all, nowarn_export_all]).
 -endif.
-
--define(DEFAULT_SYNC_PORT, 3015).
--define(DEFAULT_SYNC_LISTEN_ADDRESS, <<"0.0.0.0">>).
 
 -define(DEFAULT_PING_INTERVAL, 120 * 1000).
 -define(BACKOFF_TIMES, [5, 15, 30, 60, 120, 300, 600]).
@@ -673,19 +665,6 @@ backoff_timeout(#peer{ retries = Retries, trusted = Trusted }) ->
 ping_interval() ->
     aeu_env:user_config_or_env([<<"sync">>, <<"ping_interval">>],
                                aecore, ping_interval, ?DEFAULT_PING_INTERVAL).
-
-sync_port() ->
-    aeu_env:user_config_or_env([<<"sync">>, <<"port">>], aecore, sync_port, ?DEFAULT_SYNC_PORT).
-
-ext_sync_port() ->
-    aeu_env:user_config_or_env([<<"sync">>, <<"external_port">>],
-        aecore, ext_sync_port, sync_port()).
-
-sync_listen_address() ->
-    Config = aeu_env:user_config_or_env([<<"sync">>, <<"listen_address">>],
-                aecore, sync_listen_address, ?DEFAULT_SYNC_LISTEN_ADDRESS),
-    {ok, IpAddress} = inet:parse_address(binary_to_list(Config)),
-    IpAddress.
 
 parse_peer_address(PeerAddress) ->
     case http_uri:parse(PeerAddress) of

--- a/apps/aecore/src/aecore_sup.erl
+++ b/apps/aecore/src/aecore_sup.erl
@@ -1,3 +1,30 @@
+%%% -*- erlang-indent-level:4; indent-tabs-mode: nil -*-
+%%%=============================================================================
+%%% @copyright 2018, Aeternity Anstalt
+%%% @doc
+%%%    Supervisor for the core application
+%%%
+%%%  Full supervision tree is
+%%%```
+%%%       aecore_sup  (one_for_one)
+%%%           |
+%%%           ------------------------------------------------------------
+%%%           |         |         |           |            |             |
+%%%           |   aec_metrics  aec_keys  aec_tx_pool aec_conductor aec_subscribe
+%%%           |
+%%%   aec_connection_sup  (one_for_all)
+%%%           |
+%%%           -------------------------------------------------------
+%%%           |                                          |          |
+%%%   aec_peer_connection_sup (simple_one_for_one)   aec_peers   aec_sync
+%%%           |
+%%%           --------------------
+%%%           |             |
+%%%   aec_peer_connection  ...
+%%%'''
+%%%
+%%% @end
+%%%=============================================================================
 -module(aecore_sup).
 
 -behaviour(supervisor).
@@ -31,12 +58,10 @@ init([]) ->
     {ok, {{one_for_one, 5, 10}, [watchdog_childspec(),
                                  ?CHILD(aec_metrics_rpt_dest, 5000, worker),
                                  ?CHILD(aec_keys, 5000, worker),
-                                 ?CHILD(aec_peer_connection_listener, 5000, worker),
-                                 ?CHILD(aec_peers, 5000, worker),
                                  ?CHILD(aec_tx_pool, 5000, worker),
-                                 ?CHILD(aec_sync, 5000, worker),
                                  ?CHILD(aec_conductor, 5000, worker),
-                                 ?CHILD(aec_subscribe, 5000, worker)
+                                 ?CHILD(aec_subscribe, 5000, worker),
+                                 ?CHILD(aec_connection_sup, 5000, supervisor)
                                 ]
          }}.
 

--- a/apps/aecore/src/aecore_sup.erl
+++ b/apps/aecore/src/aecore_sup.erl
@@ -14,9 +14,10 @@
 %%%           |
 %%%   aec_connection_sup  (one_for_all)
 %%%           |
-%%%           -------------------------------------------------------
-%%%           |                                          |          |
-%%%   aec_peer_connection_sup (simple_one_for_one)   aec_peers   aec_sync
+%%%           ---------------------------------------------------
+%%%           |                     |          |                |
+%%%   aec_peer_connection_sup   aec_peers   aec_sync  aec_connection_listener
+%%%     (simple_one_for_one)
 %%%           |
 %%%           --------------------
 %%%           |             |


### PR DESCRIPTION
* Make a new supervisor, aec_connection_sup to collect peer/sync
  servers
* Make a new supervisor, aec_peer_connection_sup, to keep track of all
  aec_peer_connection servers
* Cut off the links between individual aec_peer_connections and
  aec_peers to avoid bringing down aec_peers (and all other
  connections) if one connection fails
* Cut off the links between individual aec_peer_connections and
  aec_peer_connection_listener to avoid bringing it down if one connection fails
* Protect aec_sync from calling a aec_peer_connection that is no
  longer around
*  Make aec_peers aware of the aec_peer_connection by monitoring them and remove failing connections.

https://www.pivotaltracker.com/n/projects/2124891/stories/156460780