### PR TITLE
Feature state channels uw channel setup

### DIFF
--- a/apps/aechannel/src/aesc_codec.erl
+++ b/apps/aechannel/src/aesc_codec.erl
@@ -198,16 +198,21 @@ dec_fnd_signed(<< ChanId:32/binary
     #{ temporary_channel_id => ChanId
      , data                 => Data}.
 
--type fnd_locked_msg() :: #{temporary_channel_id := chan_id()}.
+-type fnd_locked_msg() :: #{ temporary_channel_id := chan_id()
+                           , channel_id           := chan_id()}.
 
 -spec enc_fnd_locked(fnd_locked_msg()) -> binary().
-enc_fnd_locked(#{temporary_channel_id := ChanId}) ->
+enc_fnd_locked(#{ temporary_channel_id := ChanId
+                , channel_id           := OnChainId }) ->
     << ?ID_FND_LOCKED:1 /unit:8
-     , ChanId        :32/binary >>.
+     , ChanId        :32/binary
+     , OnChainId     :32/binary >>.
 
 -spec dec_fnd_locked(binary()) -> fnd_locked_msg().
-dec_fnd_locked(<< ChanId:32/binary >>) ->
-    #{temporary_channel_id => ChanId}.
+dec_fnd_locked(<< ChanId:32/binary
+                , OnChainId:32/binary >>) ->
+    #{temporary_channel_id => ChanId,
+      channel_id           => OnChainId }.
 
 
 -type upd_deposit_msg() :: #{temporary_channel_id := chan_id()

--- a/apps/aechannel/src/aesc_codec.erl
+++ b/apps/aechannel/src/aesc_codec.erl
@@ -259,7 +259,6 @@ dec_upd_withdraw(<< ChanId:32/binary
     , data   => Data}.
 
 -type error_msg() :: #{ channel_id := chan_id()
-                      , length     := length()
                       , data       := binary() }.
 
 -spec enc_error(error_msg()) -> binary().
@@ -271,7 +270,7 @@ enc_error(#{ channel_id := ChanId
      , Length    :2 /unit:8
      , Data      :Length/bytes >>.
 
--spec dec_error(binary8) -> error_msg().
+-spec dec_error(binary()) -> error_msg().
 dec_error(<< ChanId:32/binary
            , Length:2 /unit:8
            , Data/bytes >>) ->

--- a/apps/aechannel/src/aesc_codec.hrl
+++ b/apps/aechannel/src/aesc_codec.hrl
@@ -8,6 +8,7 @@
 -define(FND_LOCKED  , funding_locked).
 -define(UPD_DEPOSIT , update_deposit).
 -define(UPD_WITHDRAW, update_withdrawal).
+-define(ERROR       , error).
 -define(SHUTDOWN    , shutdown).
 
 -define(ID_CH_OPEN     , 1).
@@ -18,5 +19,6 @@
 -define(ID_FND_LOCKED  , 6).
 -define(ID_UPD_DEPOSIT , 7).
 -define(ID_UPD_WITHDRAW, 8).
+-define(ID_ERROR       , 98).
 -define(ID_SHUTDOWN    , 99).
 

--- a/apps/aechannel/src/aesc_create_tx.erl
+++ b/apps/aechannel/src/aesc_create_tx.erl
@@ -252,12 +252,6 @@ check_not_channel(InitiatorPubKey, Nonce, ParticipantPubKey, Trees) ->
         none              -> ok
     end.
 
-check_push_amount(PushAmount, InitiatorAmount) ->
-    case PushAmount =< InitiatorAmount of
-        true  -> ok;
-        false -> {error, push_amount_exceeds_initiator_amount}
-    end.
-
 check_reserve_amount(Reserve, InitiatorAmount,
                      ParticipantAmount) when is_integer(Reserve) ->
     case (Reserve =< InitiatorAmount) of

--- a/apps/aechannel/src/aesc_create_tx.erl
+++ b/apps/aechannel/src/aesc_create_tx.erl
@@ -252,6 +252,12 @@ check_not_channel(InitiatorPubKey, Nonce, ParticipantPubKey, Trees) ->
         none              -> ok
     end.
 
+check_push_amount(PushAmount, InitiatorAmount) ->
+    case PushAmount =< InitiatorAmount of
+        true  -> ok;
+        false -> {error, push_amount_exceeds_initiator_amount}
+    end.
+
 check_reserve_amount(Reserve, InitiatorAmount,
                      ParticipantAmount) when is_integer(Reserve) ->
     case (Reserve =< InitiatorAmount) of

--- a/apps/aechannel/src/aesc_fsm.erl
+++ b/apps/aechannel/src/aesc_fsm.erl
@@ -207,7 +207,7 @@ awaiting_open(enter, _OldSt, D) ->
 awaiting_open(cast, {channel_open, Msg}, D) ->
     case check_open_msg(Msg, D) of
         {ok, D1} ->
-            gproc_register(D),
+            gproc_register(D1),
             {next_state, accepted, send_channel_accept(D1)};
         {error, _} = Error ->
             close(Error, D)
@@ -222,7 +222,7 @@ initialized(enter, _OldSt, D) ->
 initialized(cast, {channel_accept, Msg}, D) ->
     case check_accept_msg(Msg, D) of
         {ok, D1} ->
-            gproc_register(D),
+            gproc_register(D1),
             {ok, CTx} = create_tx_for_signing(D1),
             D2 = request_signing(create_tx, CTx, D1),
             {next_state, awaiting_signature, D2};

--- a/apps/aechannel/src/aesc_fsm.erl
+++ b/apps/aechannel/src/aesc_fsm.erl
@@ -4,8 +4,8 @@
 -export([start_link/1]).
 
 %% API
--export([initiate/2,        %% (host(), port(), Opts :: #{})
-         participate/3]).   %% (port(), Opts :: #{})
+-export([initiate/3,        %% (host(), port(), Opts :: #{})
+         participate/2]).   %% (port(), Opts :: #{})
 
 %% Used by noise session
 -export([message/2]).
@@ -107,7 +107,8 @@ callback_mode() -> [state_functions, state_enter].
 %%   |                                                                          |
 %%   +--------------------------------------------------------------------------+
 
-message(Fsm, {T, _} = Msg) when T =:= channel_accept
+message(Fsm, {T, _} = Msg) when T =:= channel_open
+                              ; T =:= channel_accept
                               ; T =:= funding_created
                               ; T =:= funding_signed
                               ; T =:= funding_locked
@@ -116,6 +117,7 @@ message(Fsm, {T, _} = Msg) when T =:= channel_accept
                               ; T =:= disconnect
                               ; T =:= shutdown
                               ; T =:= channel_reestablish ->
+    lager:debug("message(~p, ~p)", [Fsm, Msg]),
     gen_statem:cast(Fsm, Msg).
 
 %% Signing requests are sent as plain messages to the Client (normally, the
@@ -140,49 +142,57 @@ where(ChanId) ->
     gproc:where(gproc_name(ChanId)).
 
 %% ======================================================================
-%% Timer values
+%% Default timer values
 
-timer(Name) ->
-    {timeout, Name, timeout(Name), Name}.
+timer(Name, #data{opts = #{timeouts := TOs}}) ->
+    {timeout, maps:get(Name, TOs), Name}.
 
-timeout(open)           -> 10000;
-timeout(accept)         -> 10000;
-timeout(funding_create) -> 10000;
-timeout(funding_sign)   -> 10000;
-timeout(funding_lock)   -> 10000;
-timeout(idle)           -> 10000;
-timeout(sign)           -> 10000.
+default_timeouts() ->
+    #{ open           => 5000
+     , accept         => 2000
+     , funding_create => 2000
+     , funding_sign   => 2000
+     , funding_lock   => 30000
+     , idle           => 60000
+     , sign           => 5000
+     }.
 
 %%
 %% ======================================================================
 
-initiate(Port, #{} = Opts) ->
-    start_link(#{role   => initiator
-               , port   => Port
-               , opts   => Opts}).
+initiate(Host, Port, #{} = Opts0) ->
+    lager:debug("initiate(~p, ~p, ~p)", [Host, Port, Opts0]),
+    Opts = maps:merge(#{client => self()}, Opts0),
+    start_link(#{role => initiator
+               , host => Host
+               , port => Port
+               , opts => Opts}).
 
-participate(Host, Port, #{} = Opts) ->
-    start_link(#{role   => participant
-               , host   => Host, port => Port
-               , opts   => Opts}).
+participate(Port, #{} = Opts0) ->
+    lager:debug("participate(~p, ~p)", [Port, Opts0]),
+    Opts = maps:merge(#{client => self()}, Opts0),
+    start_link(#{role => participant
+               , port => Port
+               , opts => Opts}).
 
-start_link(#{} = Arg0) ->
-    Arg = maps:merge(Arg0, #{client => self()}),
+start_link(#{} = Arg) ->
     gen_statem:start_link(?MODULE, Arg, [{debug, [trace]}]).
 
 
-init(#{role := Role, client := Client} = Arg) ->
-    Opts = maps:get(opts, Arg, []),
+init(#{role := Role} = Arg) ->
+    #{client := Client} = Opts0 = maps:get(opts, Arg, #{}),
     DefMinDepth = default_minimum_depth(Role),
-    Opts1 = case {maps:find(minimum_depth, Opts), Role} of
-                {error, participant} -> Opts#{minimum_depth => DefMinDepth};
-                _                    -> Opts
-            end,
-    Session = start_session(Arg, Opts1),
+    Opts = check_opts(
+             [
+              fun(O) -> check_minimum_depth_opt(DefMinDepth, Role, O) end,
+              fun check_timeout_opt/1
+             ], Opts0),
+    Session = start_session(Arg, Opts),
     Data = #data{role = Role,
                  client = Client,
                  session = Session,
-                 opts = Opts1},
+                 opts = Opts},
+    lager:debug("Session started, Data = ~p", [Data]),
     %% TODO: Amend the fsm above to include this step. We have transport-level
     %% connectivity, but not yet agreement on the channel parameters. We will next send
     %% a channel_open() message and await a channel_accept().
@@ -193,122 +203,158 @@ init(#{role := Role, client := Client} = Arg) ->
             {ok, awaiting_open, Data}
     end.
 
+check_opts([H|T], Opts) ->
+    check_opts(T, H(Opts));
+check_opts([], Opts) ->
+    Opts.
+
+check_minimum_depth_opt(DefMinDepth, Role, Opts) ->
+    case {maps:find(minimum_depth, Opts), Role} of
+        {error, participant} -> Opts#{minimum_depth => DefMinDepth};
+        _                    -> Opts
+    end.
+
+check_timeout_opt(Opts) ->
+    case maps:find(timeouts, Opts) of
+        {ok, TOs} ->
+            TOs1 = maps:merge(default_timeouts(), TOs),
+            Opts#{timeouts => TOs1};
+        error ->
+            Opts#{timeouts => default_timeouts()}
+    end.
+
 %% As per CHANNELS.md, the participant is regarded as the one typically
 %% providing the service, and the initiator connects.
 start_session(#{role := participant, port := Port}, Opts) ->
-    ok(aesc_session_noise:accept(Port, Opts));
+    NoiseOpts = maps:get(noise, Opts, []),
+    ok(aesc_session_noise:accept(Port, NoiseOpts));
 start_session(#{role := initiator, host := Host, port := Port}, Opts) ->
-    ok(aesc_session_noise:connect(Host, Port, Opts)).
+    NoiseOpts = maps:get(noise, Opts, []),
+    ok(aesc_session_noise:connect(Host, Port, NoiseOpts)).
 
 ok({ok, X}) -> X.
 
 awaiting_open(enter, _OldSt, D) ->
-    {keep_state, D, [timer(open)]};
-awaiting_open(cast, {channel_open, Msg}, D) ->
+    {keep_state, D, [timer(open, D)]};
+awaiting_open(cast, {channel_open, Msg}, #data{role = participant} = D) ->
     case check_open_msg(Msg, D) of
         {ok, D1} ->
-            gproc_register(D1),
+            report_info(channel_open, D1),
+            %% gproc_register(D1),
             {next_state, accepted, send_channel_accept(D1)};
         {error, _} = Error ->
             close(Error, D)
     end;
-awaiting_open({timeout, open} = T, _Msg, D) ->
-    close(T, D);
+awaiting_open(timeout, open = T, D) ->
+    close({timeout, T}, D);
 awaiting_open(cast, {disconnect, _Msg}, D) ->
     close(disconnect, D).
 
 initialized(enter, _OldSt, D) ->
-    {keep_state, D, [timer(accept)]};
-initialized(cast, {channel_accept, Msg}, D) ->
+    {keep_state, D, [timer(accept, D)]};
+initialized(cast, {channel_accept, Msg}, #data{role = initiator} = D) ->
     case check_accept_msg(Msg, D) of
         {ok, D1} ->
-            gproc_register(D1),
+            %% gproc_register(D1),
+            report_info(channel_accept, D1),
             {ok, CTx} = create_tx_for_signing(D1),
-            D2 = request_signing(create_tx, CTx, D1),
+            ok = request_signing(create_tx, CTx, D1),
+            D2 = D1#data{latest = {sign, create_tx, CTx}},
             {next_state, awaiting_signature, D2};
         {error, _} = Error ->
             close(Error, D)
     end;
-initialized({timeout, accept} = T, _Msg, D) ->
-    close(T, D);
+initialized(timeout, accept = T, D) ->
+    close({timeout, T}, D);
 initialized(cast, {disconnect, _Msg}, D) ->
     close(disconnect, D).
 
 awaiting_signature(enter, _OldSt, D) ->
-    {keep_state, D, [timer(sign)]};
+    {keep_state, D, [timer(sign, D)]};
 awaiting_signature(cast, {signed, create_tx, Tx},
-                   #data{latest = {signed, create_tx, _CTx}} = D) ->
+                   #data{role = initiator, latest = {sign, create_tx, _CTx}} = D) ->
     {next_state, half_signed,
      send_funding_created_msg(Tx, D#data{latest = undefined})};
-awaiting_signature(cast, {signed, funding_created, Tx},
-                   #data{latest = {signed, funding_created, _CTx}} = D) ->
-    {next_state, signed,
-     send_funding_signed_msg(Tx, D#data{latest = undefined})};
-awaiting_signature({timeout, sign} = T, _Msg, D) ->
-    close(T, D);
+awaiting_signature(cast, {signed, funding_created, SignedTx},
+                   #data{role = participant,
+                         latest = {sign, funding_created, HSCTx}} = D) ->
+    NewSignedTx = aetx_sign:add_signatures(
+                    HSCTx, aetx_sign:signatures(SignedTx)),
+    D1 = send_funding_signed_msg(NewSignedTx, D#data{create_tx = NewSignedTx}),
+    {ok, Watcher, D2} = start_min_depth_watcher(D1),
+    {next_state, awaiting_locked, D2#data{latest = {watcher, Watcher}}};
+awaiting_signature(timeout, sign = T, D) ->
+    close({timeout, T}, D);
 awaiting_signature(cast, {disconnect, _Msg}, D) ->
     close(disconnect, D).
 
 accepted(enter, _OldSt, D) ->
-    {keep_state, D, [timer(funding_create)]};
-accepted(cast, {funding_created, Msg}, D) ->
+    {keep_state, D, [timer(funding_create, D)]};
+accepted(cast, {funding_created, Msg}, #data{role = participant} = D) ->
     case check_funding_created_msg(Msg, D) of
-        {ok, CTx, D1} ->
-            D2 = request_signing(funding_created, CTx, D1),
+        {ok, SignedTx, D1} ->
+            report_info(funding_created, D1),
+            lager:debug("funding_created: ~p", [SignedTx]),
+            ok = request_signing(funding_created, aetx_sign:tx(SignedTx), D1),
+            D2 = D1#data{latest = {sign, funding_created, SignedTx}},
             {next_state, awaiting_signature, D2}
         %% {error, _} = Error ->
         %%     close(Error, D)
     end;
 accepted(cast, {disconnect, _Msg}, D) ->
     close(disconnect, D);
-accepted({timeout, funding_create} = T, _Msg, D) ->
-    close(T, D).
+accepted(timeout, funding_create = T, D) ->
+    close({timeout, T}, D).
 
 half_signed(enter, _OldSt, D) ->
-    {keep_state, D, [timer(funding_sign)]};
-half_signed(cast, {funding_signed, Msg}, D) ->
+    {keep_state, D, [timer(funding_sign, D)]};
+half_signed(cast, {funding_signed, Msg}, #data{role = initiator} = D) ->
     case check_funding_signed_msg(Msg, D) of
-        {ok, Tx, D1} ->
-            D2 = D1#data{create_tx = Tx},
-            {ok, Watcher} = start_min_depth_watcher(D2),
-            {next_state, awaiting_locked, D2#data{latest = {watcher, Watcher}}}
+        {ok, SignedTx, D1} ->
+            report_info(funding_signed, D1),
+            ok = aec_tx_pool:push(SignedTx),
+            D2 = D1#data{create_tx = SignedTx},
+            {ok, Watcher, D3} = start_min_depth_watcher(D2),
+            {next_state, awaiting_locked, D3#data{latest = {watcher, Watcher}}}
         %% {error, _} = Error ->
         %%     close(Error, D)
     end;
-half_signed({timeout, funding_sign} = T, _Msg, D) ->
-    close(T, D);
+half_signed(timeout, funding_sign = T, D) ->
+    close({timeout, T}, D);
 half_signed(cast, {disconnect, _Msg}, D) ->
     close(disconnect, D).
 
 awaiting_locked(enter, _OldSt, D) ->
-    {keep_state, D, [timer(funding_lock)]};
+    {keep_state, D, [timer(funding_lock, D)]};
 awaiting_locked(cast, {own_funding_locked, ChainId}, D) ->
+    report_info(own_funding_locked, D),
     {next_state, signed,
      send_funding_locked_msg(D#data{on_chain_id = ChainId,
                                     latest = undefined})};
 awaiting_locked(cast, {disconnect, _Msg}, D) ->
     close(disconnect, D);
-awaiting_locked({timeout, funding_lock} = T, _Msg, D) ->
-    close(T, D).
+awaiting_locked(timeout, funding_lock = T, D) ->
+    close({timeout, T}, D).
 
 signed(enter, _OldSt, D) ->
-    {keep_state, D, [timer(funding_lock)]};
+    {keep_state, D, [timer(funding_lock, D)]};
 signed(cast, {funding_locked, Msg}, D) ->
     case check_funding_locked_msg(Msg, D) of
         {ok, D1} ->
+            report_info(funding_locked, D1),
             {next_state, open, D1};
         {error, _} = Error ->
             close(Error, D)
     end;
-signed({timeout, funding_lock} = T, _Msg, D) ->
-    close(T, D);
+signed(timeout, funding_lock = T, D) ->
+    close({timeout, T}, D);
 signed(cast, {shutdown, _Msg}, D) ->
     {next_state, closing, D};
 signed(cast, {disconnect, _Msg}, D) ->
     {next_state, disconnected, D}.
 
 open(enter, _OldSt, D) ->
-    {keep_state, D, [timer(idle)]};
+    {keep_state, D, [timer(idle, D)]};
 open(cast, {Upd, _Msg}, D) when Upd =:= update_deposit;
                                 Upd =:= update_withdrawal ->
     {keep_state, D};
@@ -316,8 +362,8 @@ open(cast, {shutdown, _Msg}, D) ->
     {next_state, closing, D};
 open(cast, {disconnect, _Msg}, D) ->
     {next_state, disconnected, D};
-open({timeout, idle} = T, _Msg, D) ->
-    close(T, D).
+open(timeout, idle = T, D) ->
+    close({timeout, T}, D).
 
 closing(cast, {disconnect, _Msg}, D) ->
     {next_state, disconnected, D};
@@ -328,7 +374,34 @@ disconnected(cast, {channel_reestablish, _Msg}, D) ->
     {next_state, closing, D}.
 
 close(Reason, D) ->
+    try send_error_msg(Reason, D)
+    catch error:_ -> ignore
+    end,
     {stop, Reason, D}.
+
+send_error_msg(Reason, #data{session = Sn} = D) ->
+    case cur_channel_id(D) of
+        undefined -> no_msg;
+        ChId ->
+            case Reason of
+                {error, E} ->
+                    Msg = #{ channel_id => ChId
+                           , data       => error_binary(E) },
+                    aesc_session_noise:error(Sn, Msg);
+                _ ->
+                    no_msg
+            end
+    end.
+
+cur_channel_id(#data{channel_id = TChId,
+                     on_chain_id = PChId}) ->
+    case PChId == undefined of
+        true  -> TChId;
+        false -> PChId
+    end.
+
+error_binary(E) when is_atom(E) ->
+    atom_to_binary(E, latin1).
 
 
 terminate(_Reason, _State, _Data) ->
@@ -363,6 +436,7 @@ send_open_msg(#data{opts       = Opts,
            , initiator_amount     => InitiatorAmount
            , participant_amount   => ParticipantAmount
            , channel_reserve      => ChannelReserve
+           , initiator            => Initiator
            },
     aesc_session_noise:channel_open(Sn, Msg),
     Data#data{channel_id = ChannelId}.
@@ -395,43 +469,53 @@ check_open_msg(#{ chain_hash           := ChainHash
 send_channel_accept(#data{opts          = Opts,
                           session       = Sn,
                           channel_id    = ChanId} = Data) ->
-    #{ lock_period        := LockPeriod
-     , push_amount        := PushAmt
-     , minimum_depth      := MinDepth
+    #{ minimum_depth      := MinDepth
+     , participant        := Participant
      , initiator_amount   := InitiatorAmt
-     , participant_amount := ParticipantAmt } = Opts,
+     , participant_amount := ParticipantAmt
+     , channel_reserve    := ChanReserve } = Opts,
     ChainHash = aec_chain:genesis_hash(),
     Msg = #{ chain_hash           => ChainHash
            , temporary_channel_id => ChanId
            , minimum_depth        => MinDepth
-           , lock_period          => LockPeriod
-           , push_amount          => PushAmt
            , initiator_amount     => InitiatorAmt
            , participant_amount   => ParticipantAmt
+           , channel_reserve      => ChanReserve
+           , participant          => Participant
            },
     aesc_session_noise:channel_accept(Sn, Msg),
     Data.
 
-check_accept_msg(#{ temporary_channel_id := ChanId
-                  , chain_hash           := ChainHash
+check_accept_msg(#{ chain_hash           := ChainHash
+                  , temporary_channel_id := ChanId
                   , minimum_depth        := MinDepth
                   , initiator_amount     := _InitiatorAmt
-                  , responder_amount     := _ResponderAmt
+                  , participant_amount   := _ParticipantAmt
                   , channel_reserve      := _ChanReserve
-                  , initiator            := _InitiatorPubkey},
+                  , participant          := Participant},
                  #data{channel_id = ChanId,
                        opts = Opts} = Data) ->
     %% TODO: implement more checks
     case aec_chain:genesis_hash() of
         ChainHash ->
-            {ok, Data#data{opts = Opts#{minimum_depth => MinDepth}}};
+            {ok, Data#data{opts = Opts#{ minimum_depth => MinDepth
+                                       , participant   => Participant}}};
         _ ->
             {error, chain_hash_mismatch}
     end.
 
-create_tx_for_signing(#data{opts = Opts}) ->
-    {ok, _} = Ok = aesc_create_tx:new(Opts),
+create_tx_for_signing(#data{opts = #{initiator := Initiator} = Opts}) ->
+    Def = create_tx_defaults(Initiator),
+    Opts1 = maps:merge(Def, Opts),
+    lager:debug("create_tx Opts = ~p", [Opts1]),
+    {ok, _} = Ok = aesc_create_tx:new(Opts1),
     Ok.
+
+create_tx_defaults(Initiator) ->
+    {ok, Nonce} = aec_next_nonce:pick_for_account(Initiator),
+    Fee = aec_governance:minimum_tx_fee(),
+    #{ fee   => Fee
+     , nonce => Nonce }.
 
 send_funding_created_msg(SignedTx, #data{channel_id = Ch,
                                          session   = Sn} = Data) ->
@@ -487,10 +571,10 @@ check_funding_locked_msg(#{ temporary_channel_id := TmpChanId
 
 
 request_signing(Tag, Obj, #data{client    = Client,
-                               channel_id = ChanId} = Data) ->
+                                channel_id = ChanId}) ->
     Msg = {sign, Tag, Obj},
     Client ! {?MODULE, self(), ChanId, Msg},
-    Data#data{latest = Msg}.
+    ok.
 
 default_minimum_depth(initiator  ) -> undefined;
 default_minimum_depth(participant) -> ?MINIMUM_DEPTH.
@@ -500,14 +584,43 @@ start_min_depth_watcher(#data{create_tx = SignedTx,
                                        participant   := Participant,
                                        minimum_depth := MinDepth}} = Data) ->
     Tx = aetx_sign:tx(SignedTx),
-    {_Type, CTx} = aetx:specialize_type(Tx),
+    TxHash = aetx:hash(Tx),
+    evt({tx_hash, TxHash}),
+    {_Type, CTx} = Sp = aetx:specialize_type(Tx),
+    evt({specialize_type, Sp}),
     Nonce = aesc_create_tx:nonce(CTx),
+    evt({nonce, Nonce}),
     OnChainId = aesc_channels:id(Initiator, Nonce, Participant),
-    {ok, _Watcher} = aesc_fsm_min_depth_watcher:start_link(OnChainId, MinDepth),
-    {ok, Data#data{on_chain_id = OnChainId}}.
+    evt({on_chain_id, OnChainId}),
+    {ok, Watcher} = aesc_fsm_min_depth_watcher:start_link(TxHash, OnChainId, MinDepth),
+    evt({watcher, Watcher}),
+    {ok, Watcher, Data#data{on_chain_id = OnChainId}}.
 
-gproc_register(#data{channel_id = ChanId}) ->
-    gproc:reg(gproc_name(ChanId)).
+%% gproc_register(#data{channel_id = ChanId}) ->
+%%     gproc:reg(gproc_name(ChanId)).
 
 gproc_name(Id) ->
     {n, l, {aesc_channel, Id}}.
+
+
+%% start_trace() ->
+%%     dbg:tracer(),
+%%     dbg:tpl(?MODULE, x),
+%%     dbg:tp(aetx_sign, add_signatures, x),
+%%     dbg:tp(aesc_channels, id, 3, x),
+%%     dbg:tp(aesc_fsm_min_depth_watcher, x),
+%%     dbg:p(all,[c]).
+
+%% stop_trace() ->
+%%     dbg:ctpl(?MODULE),
+%%     dbg:stop().
+
+evt(_Msg) ->
+    ok.
+
+report_info(St, #data{client = Client, channel_id = ChanId,
+                       opts = #{report_info := DoRpt}}) ->
+    lager:debug("report_info(~p, ~p, ~p)", [DoRpt, ChanId, St]),
+    if DoRpt -> Client ! {?MODULE, self(), ChanId, {info, St}};
+       true  -> ok
+    end.

--- a/apps/aechannel/src/aesc_fsm_min_depth_watcher.erl
+++ b/apps/aechannel/src/aesc_fsm_min_depth_watcher.erl
@@ -1,7 +1,7 @@
 -module(aesc_fsm_min_depth_watcher).
 -behaviour(gen_server).
 
--export([start_link/2]).
+-export([start_link/3]).
 
 -export([init/1,
          handle_call/3,
@@ -10,39 +10,60 @@
          terminate/2,
          code_change/3]).
 
-start_link(ChanId, MinDepth) ->
-    gen_server:start_link(?MODULE, #{chan_id   => ChanId,
+start_link(TxHash, ChanId, MinDepth) ->
+    gen_server:start_link(?MODULE, #{tx_hash   => TxHash,
+                                     chan_id   => ChanId,
                                      fsm       => self(),
-                                     min_depth => MinDepth}, []).
+                                     min_depth => MinDepth}, [{debug,[trace]}]).
 
 init(#{} = Arg) ->
+    lager:debug("started min_depth watcher for ~p", [maps:get(fsm, Arg)]),
     true = aec_events:subscribe(top_changed),
+    true = aec_events:subscribe(block_created),
+    lager:debug("subscribed to top_changed & block_created", []),
+    self() ! check_status,
     {ok, Arg}.
 
-handle_info({gproc_ps_event, top_changed, #{info := Block}},
-            #{chan_id   := ChanId,
-              min_depth := MinDepth,
-              fsm       := Fsm} = St) ->
-    CurHeight = aec_blocks:height(Block),
-    case maps:find(channel_at, St) of
-        {ok, ChHeight} when CurHeight - ChHeight >= MinDepth ->
-            aesc_fsm:own_funding_locked(Fsm, ChanId),
-            {stop, normal, St};
-        {ok, ChHeight} when CurHeight - ChHeight < MinDepth ->
-            {noreply, St};
-        error ->
-            case block_has_channel(ChanId, Block) of
-                true when MinDepth == 0 ->
-                    aesc_fsm:own_funding_locked(Fsm, ChanId),
-                    {stop, normal, St};
-                true ->
-                    {noreply, St#{channel_at => CurHeight}};
-                false ->
-                    {noreply, St}
-            end
-    end;
+%% handle_info({gproc_ps_event, top_changed, #{info := Block}},
+%%             #{chan_id   := ChanId,
+%%               min_depth := MinDepth,
+%%               fsm       := Fsm} = St) ->
+    %% CurHeight = aec_blocks:height(Block),
+    %% lager:debug("got top_changed, block at height ~p", [CurHeight]),
+    %% case maps:find(channel_at, St) of
+    %%     {ok, ChHeight} when CurHeight - ChHeight >= MinDepth ->
+    %%         lager:debug("reached minimum height (~p - ~p >= ~p",
+    %%                     [CurHeight, ChHeight, MinDepth]),
+    %%         aesc_fsm:own_funding_locked(Fsm, ChanId),
+    %%         {stop, normal, St};
+    %%     {ok, ChHeight} when CurHeight - ChHeight < MinDepth ->
+    %%         lager:debug("not yet mininum height (~p - ~p < ~p)",
+    %%                     [CurHeight, ChHeight, MinDepth]),
+    %%         {noreply, St};
+    %%     error ->
+    %%         lager:debug("haven't yet found the tx", []),
+    %%         case block_has_channel(ChanId, Block) of
+    %%             true when MinDepth == 0 ->
+    %%                 lager:debug("block has channel tx, MinDepth = 0", []),
+    %%                 aesc_fsm:own_funding_locked(Fsm, ChanId),
+    %%                 {stop, normal, St};
+    %%             true ->
+    %%                 lager:debug("block has channel tx", []),
+    %%                 {noreply, St#{channel_at => CurHeight}};
+    %%             false ->
+    %%                 lager:debug("block doesn't have channel tx", []),
+    %%                 {noreply, St}
+    %%         end
+    %% end;
+handle_info({gproc_ps_event, top_changed, _}, St) ->
+    check_status(St);
+handle_info({gproc_ps_event, block_created, _}, St) ->
+    check_status(St);
+handle_info(check_status, St) ->
+    check_status(St);
 handle_info(_Msg, St) ->
-    {noreply, St}.
+    lager:debug("got unknown Msg: ~p", [_Msg]),
+    {noreply, St, 1000}.
 
 
 handle_call(_Req, _From, St) ->
@@ -57,24 +78,70 @@ terminate(_Reason, _St) ->
 code_change(_FromVsn, St, _Extra) ->
     {ok, St}.
 
-
-block_has_channel(ChanId, Block) ->
-    Txs = aec_blocks:txs(Block),
-    has_chan_id(Txs, ChanId).
-
-has_chan_id([], _) ->
-    false;
-has_chan_id([SignedTx|T], ChanId) ->
-    Tx = aetx_sign:tx(SignedTx),
-    case aetx:specialize_type(Tx) of
-        {channel_create_tx, CTx} ->
-            Initiator   = aesc_create_tx:initiator(CTx),
-            Participant = aesc_create_tx:participant(CTx),
-            Nonce       = aesc_create_tx:nonce(CTx),
-            case aesc_channels:id(Initiator, Nonce, Participant) of
-                ChanId -> true;
-                _      -> has_chan_id(T, ChanId)
-            end;
+check_status(#{fsm := Fsm, chan_id := ChanId,
+               tx_hash := TxHash, min_depth := MinDepth} = St) ->
+    lager:debug("check_status(~p)", [Fsm]),
+    case min_depth_achieved(TxHash, MinDepth) of
+        true ->
+            lager:debug("min_depth achieved", []),
+            aesc_fsm:own_funding_locked(Fsm, ChanId),
+            {stop, normal, St};
         _ ->
-            has_chan_id(T, ChanId)
+            lager:debug("min_depth not yet achieved", []),
+            {noreply, St, 5000}
     end.
+
+min_depth_achieved(TxHash, MinDepth) ->
+    case aec_chain:find_transaction_in_main_chain_or_mempool(TxHash) of
+        none ->
+            lager:debug("couldn't find tx hash", []),
+            undefined;
+        {mempool, _} ->
+            lager:debug("tx still in mempool", []),
+            undefined;
+        {BlockHash, _} ->
+            lager:debug("tx in Block ~p", [BlockHash]),
+            determine_depth(BlockHash, MinDepth)
+    end.
+
+determine_depth(BHash, MinDepth) ->
+    case aec_chain:get_header(BHash) of
+        {ok, Hdr} ->
+            Height = aec_headers:height(Hdr),
+            lager:debug("tx at height ~p", [Height]),
+            determine_depth_(Height, MinDepth);
+        error ->
+            undefined
+    end.
+
+determine_depth_(Height, MinDepth) ->
+    case aec_chain:top_block_header() of
+        undefined ->
+            undefined;
+        TopHdr ->
+            TopHeight = aec_headers:height(TopHdr),
+            lager:debug("top height = ~p", [TopHeight]),
+            (TopHeight - Height) >= MinDepth
+    end.
+
+
+%% block_has_channel(ChanId, Block) ->
+%%     Txs = aec_blocks:txs(Block),
+%%     has_chan_id(Txs, ChanId).
+
+%% has_chan_id([], _) ->
+%%     false;
+%% has_chan_id([SignedTx|T], ChanId) ->
+%%     Tx = aetx_sign:tx(SignedTx),
+%%     case aetx:specialize_type(Tx) of
+%%         {channel_create_tx, CTx} ->
+%%             Initiator   = aesc_create_tx:initiator(CTx),
+%%             Participant = aesc_create_tx:participant(CTx),
+%%             Nonce       = aesc_create_tx:nonce(CTx),
+%%             case aesc_channels:id(Initiator, Nonce, Participant) of
+%%                 ChanId -> true;
+%%                 _      -> has_chan_id(T, ChanId)
+%%             end;
+%%         _ ->
+%%             has_chan_id(T, ChanId)
+%%     end.

--- a/apps/aechannel/src/aesc_fsm_min_depth_watcher.erl
+++ b/apps/aechannel/src/aesc_fsm_min_depth_watcher.erl
@@ -1,0 +1,80 @@
+-module(aesc_fsm_min_depth_watcher).
+-behaviour(gen_server).
+
+-export([start_link/2]).
+
+-export([init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         terminate/2,
+         code_change/3]).
+
+start_link(ChanId, MinDepth) ->
+    gen_server:start_link(?MODULE, #{chan_id   => ChanId,
+                                     fsm       => self(),
+                                     min_depth => MinDepth}, []).
+
+init(#{} = Arg) ->
+    true = aec_events:subscribe(top_changed),
+    {ok, Arg}.
+
+handle_info({gproc_ps_event, top_changed, #{info := Block}},
+            #{chan_id   := ChanId,
+              min_depth := MinDepth,
+              fsm       := Fsm} = St) ->
+    CurHeight = aec_blocks:height(Block),
+    case maps:find(channel_at, St) of
+        {ok, ChHeight} when CurHeight - ChHeight >= MinDepth ->
+            aesc_fsm:own_funding_locked(Fsm, ChanId),
+            {stop, normal, St};
+        {ok, ChHeight} when CurHeight - ChHeight < MinDepth ->
+            {noreply, St};
+        error ->
+            case block_has_channel(ChanId, Block) of
+                true when MinDepth == 0 ->
+                    aesc_fsm:own_funding_locked(Fsm, ChanId),
+                    {stop, normal, St};
+                true ->
+                    {noreply, St#{channel_at => CurHeight}};
+                false ->
+                    {noreply, St}
+            end
+    end;
+handle_info(_Msg, St) ->
+    {noreply, St}.
+
+
+handle_call(_Req, _From, St) ->
+    {reply, {error, unknown_request}, St}.
+
+handle_cast(_Msg, St) ->
+    {noreply, St}.
+
+terminate(_Reason, _St) ->
+    ok.
+
+code_change(_FromVsn, St, _Extra) ->
+    {ok, St}.
+
+
+block_has_channel(ChanId, Block) ->
+    Txs = aec_blocks:txs(Block),
+    has_chan_id(Txs, ChanId).
+
+has_chan_id([], _) ->
+    false;
+has_chan_id([SignedTx|T], ChanId) ->
+    Tx = aetx_sign:tx(SignedTx),
+    case aetx:specialize_type(Tx) of
+        {channel_create_tx, CTx} ->
+            Initiator   = aesc_create_tx:initiator(CTx),
+            Participant = aesc_create_tx:participant(CTx),
+            Nonce       = aesc_create_tx:nonce(CTx),
+            case aesc_channels:id(Initiator, Nonce, Participant) of
+                ChanId -> true;
+                _      -> has_chan_id(T, ChanId)
+            end;
+        _ ->
+            has_chan_id(T, ChanId)
+    end.

--- a/apps/aechannel/test/aesc_fsm_SUITE.erl
+++ b/apps/aechannel/test/aesc_fsm_SUITE.erl
@@ -1,0 +1,193 @@
+%%%=============================================================================
+%%% @copyright (C) 2018, Aeternity Anstalt
+%%% @doc
+%%%    Test utils for State Channels
+%%% @end
+%%%=============================================================================
+
+-module(aesc_fsm_SUITE).
+
+-export([all/0,
+         groups/0,
+         suite/0,
+         init_per_suite/1,
+         end_per_suite/1,
+         init_per_group/2,
+         end_per_group/2
+        ]).
+
+%% test case exports
+-export([create_channel/1]).
+
+-include_lib("common_test/include/ct.hrl").
+
+-include_lib("apps/aechannel/include/channel_txs.hrl").
+
+-define(TIMEOUT, 10000).
+
+all() ->
+    [{group, all_tests}].
+
+groups() ->
+    [
+     {all_tests, [sequence], [{group, transactions}]},
+     {transactions, [sequence],
+      [create_channel]
+     }
+    ].
+
+suite() ->
+    [].
+
+init_per_suite(Config) ->
+    ok = application:ensure_started(erlexec),
+    DataDir = ?config(data_dir, Config),
+    TopDir = aecore_suite_utils:top_dir(DataDir),
+    Config1 = [{symlink_name, "latest.aesc_fsm"},
+               {top_dir, TopDir},
+               {test_module, ?MODULE}] ++ Config,
+    aecore_suite_utils:make_shortcut(Config1),
+    ct:log("Environment = ~p", [[{args, init:get_arguments()},
+                                 {node, node()},
+                                 {cookie, erlang:get_cookie()}]]),
+    aecore_suite_utils:create_configs(
+      Config1, #{<<"chain">> => #{<<"persist">> => false}}),
+    aecore_suite_utils:make_multi(Config1, [dev1, dev2]),
+    [{nodes, [aecore_suite_utils:node_tuple(N)
+              || N <- [dev1, dev2]]} | Config1].
+
+end_per_suite(_Config) ->
+    ok.
+
+init_per_group(_Group, Config) ->
+    aecore_suite_utils:start_node(dev1, Config),
+    aecore_suite_utils:start_node(dev2, Config),
+    aecore_suite_utils:connect(aecore_suite_utils:node_name(dev1)),
+    ct:log("dev1 connected", []),
+    aecore_suite_utils:connect(aecore_suite_utils:node_name(dev2)),
+    ct:log("dev2 connected", []),
+    try [{initiator, prep_account(initiator, dev1)},
+         {participant, prep_account(participant, dev2)}
+         | Config]
+    catch
+        error:Reason ->
+            Trace = erlang:get_stacktrace(),
+            catch stop_node(dev1, Config),
+            catch stop_node(dev2, Config),
+            error(Reason, Trace)
+    end.
+
+end_per_group(_Group, Config) ->
+    Config1 = stop_node(dev1, Config),
+    _Config2 = stop_node(dev2, Config1),
+    ok.
+
+stop_node(N, Config) ->
+    aecore_suite_utils:stop_node(N, Config),
+    Config.
+
+
+%%%===================================================================
+%%% Test state
+%%%===================================================================
+
+create_channel(Cfg) ->
+    I = ?config(initiator, Cfg),
+    P = ?config(participant, Cfg),
+
+    Port = proplists:get_value(port, Cfg, 9325),
+
+    %% dynamic key negotiation
+    Proto = <<"Noise_NN_25519_ChaChaPoly_BLAKE2b">>,
+
+    Spec = #{initiator          => maps:get(pub, I),
+             participant        => maps:get(pub, P),
+             initiator_amount   => 5,
+             participant_amount => 5,
+             push_amount        => 2,
+             lock_period        => 10,
+             channel_reserve    => 3,
+             minimum_depth      => 3,
+             client             => self(),
+             noise              => [{noise, Proto}],
+             report_info        => true},
+
+    {ok, FsmP} = rpc(dev1, aesc_fsm, participate, [Port, Spec]),
+    {ok, FsmI} = rpc(dev1, aesc_fsm, initiate, ["localhost", Port, Spec]),
+
+    ct:log("FSMs, I = ~p, P = ~p", [FsmI, FsmP]),
+
+    I1 = I#{fsm => FsmI},
+    P1 = P#{fsm => FsmP},
+
+    try await_create_tx_i(I1, P1)
+    catch
+        error:Err ->
+            ct:log("Caught Err = ~p~nMessages = ~p",
+                   [Err, element(2, process_info(self(), messages))]),
+            error(Err, erlang:get_stacktrace())
+    end.
+
+await_create_tx_i(I, P) ->
+    {I1, _} = await_signing_request(create_tx, I),
+    await_funding_created_p(I1, P).
+
+await_funding_created_p(I, P) ->
+    {P1, _} = await_signing_request(funding_created, P),
+    await_funding_signed_i(I, P1).
+
+await_funding_signed_i(I, P) ->
+    receive_info(I, funding_signed),
+    await_funding_locked(I, P).
+
+await_funding_locked(I, P) ->
+    ct:log("mining blocks on dev1 for minimum depth", []),
+    aecore_suite_utils:mine_blocks(aecore_suite_utils:node_name(dev1), 4),
+    receive_info(P, own_funding_locked),
+    receive_info(I, own_funding_locked),
+    receive_info(P, funding_locked),
+    receive_info(I, funding_locked).
+
+await_signing_request(Tag, #{fsm := Fsm, priv := Priv} = P) ->
+    check_info(),
+    receive {aesc_fsm, Fsm, ChanId, {sign, Tag, Tx}} = Msg ->
+            ct:log("await_signing(~p, ~p) <- ~p", [Tag, Fsm, Msg]),
+            SignedTx = aetx_sign:sign(Tx, [Priv]),
+            aesc_fsm:signing_response(Fsm, Tag, SignedTx),
+            {P#{chan_id => ChanId}, SignedTx}
+    after ?TIMEOUT ->
+            error(timeout)
+    end.
+
+receive_info(#{role := Role, fsm := Fsm}, Msg) ->
+    receive
+        {aesc_fsm, Fsm, _ChanId, {info, Msg}} ->
+            ct:log("~p: received info:~p", [Role, Msg]),
+            ok
+    after ?TIMEOUT ->
+            error(timeout)
+    end.
+
+check_info() ->
+    receive
+        {aesc_fsm, Fsm, ChanId, {info, Msg}} = Info ->
+            ct:log("Received info: ~p", [Info]),
+            [{Fsm, ChanId, Msg}|check_info()]
+    after 0 ->
+            []
+    end.
+
+prep_account(Role, Node) ->
+    {ok, PubKey} = rpc(Node, aec_keys, pubkey, []),
+    {ok, PrivKey} = rpc(Node, aec_keys, privkey, []),
+    ct:log("~p: Pubkey = ~p", [Role, PubKey]),
+    aecore_suite_utils:mine_blocks(aecore_suite_utils:node_name(Node), 3),
+    ct:log("~p: 3 blocks mined on ~p", [Role, Node]),
+    {ok, Balance} = rpc(Node, aehttp_logic, get_account_balance, [PubKey]),
+    #{role => Role,
+      priv => PrivKey,
+      pub  => PubKey,
+      balance => Balance}.
+
+rpc(Node, Mod, Fun, Args) ->
+    rpc:call(aecore_suite_utils:node_name(Node), Mod, Fun, Args, 5000).

--- a/apps/aechannel/test/aesc_test_utils.erl
+++ b/apps/aechannel/test/aesc_test_utils.erl
@@ -107,6 +107,7 @@ create_tx_spec(InitiatorPubKey, ParticipantPubKey, Spec0, State) ->
       participant_amount => maps:get(participant_amount, Spec),
       channel_reserve    => maps:get(channel_reserve, Spec),
       lock_period        => maps:get(lock_period, Spec),
+      channel_reserve    => maps:get(channel_reserve, Spec),
       fee                => maps:get(fee, Spec),
       nonce              => maps:get(nonce, Spec)}.
 
@@ -115,5 +116,6 @@ create_tx_default_spec(InitiatorPubKey, State) ->
       participant_amount => 50,
       channel_reserve    => 20,
       lock_period        => 100,
+      channel_reserve    => 10,
       fee                => 3,
       nonce              => try next_nonce(InitiatorPubKey, State) catch _:_ -> 0 end}.

--- a/apps/aecore/src/aec_keys.erl
+++ b/apps/aecore/src/aec_keys.erl
@@ -93,9 +93,11 @@ sign(Tx) ->
 pubkey() ->
     gen_server:call(?MODULE, pubkey).
 
+-ifdef(TEST).
 -spec privkey() -> {ok, binary()} | {error, key_not_found}.
 privkey() ->
     gen_server:call(?MODULE, privkey).
+-endif.
 
 -spec peer_pubkey() -> {ok, binary()} | {error, key_not_found}.
 peer_pubkey() ->

--- a/apps/aecore/src/aec_keys.erl
+++ b/apps/aecore/src/aec_keys.erl
@@ -32,7 +32,7 @@
 -export([check_key_pair/0]).
 
 -ifdef(TEST).
--export([encrypt_peerkey/2, check_key_pair/2]).
+-export([encrypt_peerkey/2, check_key_pair/2, privkey/0]).
 -endif.
 
 -define(SERVER, ?MODULE).
@@ -92,6 +92,10 @@ sign(Tx) ->
 -spec pubkey() -> {ok, binary()} | {error, key_not_found}.
 pubkey() ->
     gen_server:call(?MODULE, pubkey).
+
+-spec privkey() -> {ok, binary()} | {error, key_not_found}.
+privkey() ->
+    gen_server:call(?MODULE, privkey).
 
 -spec peer_pubkey() -> {ok, binary()} | {error, key_not_found}.
 peer_pubkey() ->
@@ -219,6 +223,11 @@ handle_call(pubkey, _From, #state{pub=undefined} = State) ->
     {reply, {error, key_not_found}, State};
 handle_call(pubkey, _From, #state{pub=PubKey} = State) ->
     {reply, {ok, PubKey}, State};
+handle_call(privkey, _From, #state{priv=PrivKey} = State) ->
+    case PrivKey of
+        undefined -> {reply, {error, key_not_found}, State};
+        _         -> {reply, {ok, PrivKey}, State}
+    end;
 handle_call(peer_pubkey, _From, #state{peer_pub=undefined} = State) ->
     {reply, {error, key_not_found}, State};
 handle_call(peer_pubkey, _From, #state{peer_pub=PubKey} = State) ->

--- a/apps/aetx/src/aetx_sign.erl
+++ b/apps/aetx/src/aetx_sign.erl
@@ -19,7 +19,6 @@
 
 %% API
 -export([sign/2,
-         sign/3,
          add_signatures/2,
          tx/1,
          verify/1,

--- a/apps/aetx/src/aetx_sign.erl
+++ b/apps/aetx/src/aetx_sign.erl
@@ -19,6 +19,8 @@
 
 %% API
 -export([sign/2,
+         sign/3,
+         add_signatures/2,
          tx/1,
          verify/1,
          signatures/1,
@@ -62,6 +64,10 @@ sign(Tx, PrivKeys) when is_list(PrivKeys) ->
     #signed_tx{tx = Tx,
                signatures = lists:sort(Signatures)}.
 
+-spec add_signatures(signed_tx(), list(binary())) -> signed_tx().
+add_signatures(#signed_tx{signatures = OldSigs} = Tx, NewSigs)
+  when is_list(NewSigs) ->
+    Tx#signed_tx{signatures = lists:usort(NewSigs ++ OldSigs)}.
 
 -spec tx(signed_tx()) -> tx().
 %% @doc Get the original transaction from a signed transaction.


### PR DESCRIPTION
This commit includes a test suite case that negotiates an off-chain channel, including committing to the chain and ensuring a `minimum_depth` number of blocks on top.

The key length was temporarily increased in the off-chain messages. This needs to be changed to use 32bytes (compressed) `Curve25519` key representation.

Next up: adding channel update messages for the continuous use of the channel. Also, documenting the configuration options of the channel setup.

The test case setup: The test process `aesc_fsm_SUITE:create_channel/1` starts two nodes, using the miner pubkeys of each as peers. However, both ends of the channel are set up on `dev1`, and the test case process sets itself as a (signing) client for both ends.