### PR TITLE
Relocate multiple internal block endpoints to external

### DIFF
--- a/apps/aehttp/priv/swagger.json
+++ b/apps/aehttp/priv/swagger.json
@@ -128,7 +128,7 @@
       "get" : {
         "tags" : [ "external", "gossip" ],
         "description" : "Get a block by height",
-        "operationId" : "GetBlockByHeight",
+        "operationId" : "GetBlockByHeightDeprecated",
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "height",
@@ -157,7 +157,7 @@
       "get" : {
         "tags" : [ "external", "gossip" ],
         "description" : "Get a block by hash",
-        "operationId" : "GetBlockByHash",
+        "operationId" : "GetBlockByHashDeprecated",
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "hash",
@@ -1527,9 +1527,9 @@
     },
     "/block/height/{height}" : {
       "get" : {
-        "tags" : [ "internal", "chain" ],
+        "tags" : [ "external", "chain" ],
         "description" : "Get a block by height",
-        "operationId" : "GetBlockByHeightInternal",
+        "operationId" : "GetBlockByHeight",
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "height",
@@ -1543,7 +1543,7 @@
           "description" : "Transactions encoding",
           "required" : false,
           "type" : "string",
-          "default" : "message_pack",
+          "default" : "json",
           "enum" : [ "message_pack", "json" ]
         } ],
         "responses" : {
@@ -1564,9 +1564,9 @@
     },
     "/block/hash/{hash}" : {
       "get" : {
-        "tags" : [ "internal", "chain" ],
+        "tags" : [ "external", "chain" ],
         "description" : "Get a block by hash",
-        "operationId" : "GetBlockByHashInternal",
+        "operationId" : "GetBlockByHash",
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "hash",
@@ -1580,7 +1580,7 @@
           "description" : "Transactions encoding",
           "required" : false,
           "type" : "string",
-          "default" : "message_pack",
+          "default" : "json",
           "enum" : [ "message_pack", "json" ]
         } ],
         "responses" : {
@@ -1607,7 +1607,7 @@
     },
     "/block/genesis" : {
       "get" : {
-        "tags" : [ "internal", "chain" ],
+        "tags" : [ "external", "chain" ],
         "description" : "Get the genesis block",
         "operationId" : "GetBlockGenesis",
         "produces" : [ "application/json" ],
@@ -1617,7 +1617,7 @@
           "description" : "Transactions encoding",
           "required" : false,
           "type" : "string",
-          "default" : "message_pack",
+          "default" : "json",
           "enum" : [ "message_pack", "json" ]
         } ],
         "responses" : {
@@ -1632,7 +1632,7 @@
     },
     "/block/latest" : {
       "get" : {
-        "tags" : [ "internal", "chain" ],
+        "tags" : [ "external", "chain" ],
         "description" : "Get the top block",
         "operationId" : "GetBlockLatest",
         "produces" : [ "application/json" ],
@@ -1642,7 +1642,7 @@
           "description" : "Transactions encoding",
           "required" : false,
           "type" : "string",
-          "default" : "message_pack",
+          "default" : "json",
           "enum" : [ "message_pack", "json" ]
         } ],
         "responses" : {
@@ -1657,7 +1657,7 @@
     },
     "/block/pending" : {
       "get" : {
-        "tags" : [ "internal", "chain" ],
+        "tags" : [ "external", "chain" ],
         "description" : "Get the block being mined",
         "operationId" : "GetBlockPending",
         "produces" : [ "application/json" ],
@@ -1667,7 +1667,7 @@
           "description" : "Transactions encoding",
           "required" : false,
           "type" : "string",
-          "default" : "message_pack",
+          "default" : "json",
           "enum" : [ "message_pack", "json" ]
         } ],
         "responses" : {

--- a/apps/aeutils/src/aeu_requests.erl
+++ b/apps/aeutils/src/aeu_requests.erl
@@ -120,7 +120,7 @@ get_block_by_height(Uri, Height) when is_integer(Height) ->
 -spec get_block(http_uri_uri(), binary()) -> response(aec_blocks:block()).
 get_block(Uri, Hash) ->
     EncHash = aec_base58c:encode(block_hash, Hash),
-    Response = process_request(Uri,'GetBlockByHash', [{"hash", EncHash}]),
+    Response = process_request(Uri,'GetBlockByHashDeprecated', [{"hash", EncHash}]),
     case Response of
         {ok, 200, Data} ->
             {ok, _Block} = aehttp_api_parser:decode(block, Data);

--- a/apps/aeutils/test/endpoints_tests.erl
+++ b/apps/aeutils/test/endpoints_tests.erl
@@ -12,13 +12,13 @@ path_without_test() ->
 
 path_with_params_test() ->
    ?assertEqual(<<"/v2/block/height/3">>,
-      iolist_to_binary(endpoints:path(get, 'GetBlockByHeightInternal',
+      iolist_to_binary(endpoints:path(get, 'GetBlockByHeight',
                                       #{"height" => 3, "tx_objects" => true}))),
    ?assertEqual(<<"/v2/block/height/3">>,
-      iolist_to_binary(endpoints:path(get, 'GetBlockByHeightInternal',
+      iolist_to_binary(endpoints:path(get, 'GetBlockByHeight',
                                       #{"height" => 3}))),
    ?assertThrow({error, _},
-      iolist_to_binary(endpoints:path(get, 'GetBlockByHeightInternal',
+      iolist_to_binary(endpoints:path(get, 'GetBlockByHeight',
                                       #{}))).
 
 -endif.

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -112,7 +112,7 @@ paths:
       tags:
         - external
         - gossip
-      operationId: GetBlockByHeight
+      operationId: GetBlockByHeightDeprecated
       description: 'Get a block by height'
       produces:
         - application/json
@@ -137,7 +137,7 @@ paths:
       tags:
         - external
         - gossip
-      operationId: GetBlockByHash
+      operationId: GetBlockByHashDeprecated
       description: 'Get a block by hash'
       produces:
         - application/json
@@ -1291,9 +1291,9 @@ paths:
   /block/height/{height}:
     get:
       tags:
-        - internal
+        - external
         - chain
-      operationId: GetBlockByHeightInternal
+      operationId: GetBlockByHeight
       description: 'Get a block by height'
       produces:
         - application/json
@@ -1308,7 +1308,7 @@ paths:
           description: 'Transactions encoding'
           type: string
           enum: [message_pack, json]
-          default: message_pack
+          default: json
       responses:
         '200':
           description: The block being found
@@ -1322,9 +1322,9 @@ paths:
   /block/hash/{hash}:
     get:
       tags:
-        - internal
+        - external
         - chain
-      operationId: GetBlockByHashInternal
+      operationId: GetBlockByHash
       description: 'Get a block by hash'
       produces:
         - application/json
@@ -1339,7 +1339,7 @@ paths:
           description: 'Transactions encoding'
           type: string
           enum: [message_pack, json]
-          default: message_pack
+          default: json
       responses:
         '200':
           description: The block being found
@@ -1357,7 +1357,7 @@ paths:
   /block/genesis:
     get:
       tags:
-        - internal
+        - external
         - chain
       operationId: GetBlockGenesis
       description: 'Get the genesis block'
@@ -1369,7 +1369,7 @@ paths:
           description: 'Transactions encoding'
           type: string
           enum: [message_pack, json]
-          default: message_pack
+          default: json
       responses:
         '200':
           description: The genesis block
@@ -1379,7 +1379,7 @@ paths:
   /block/latest:
     get:
       tags:
-        - internal
+        - external
         - chain
       operationId: GetBlockLatest
       description: 'Get the top block'
@@ -1391,7 +1391,7 @@ paths:
           description: 'Transactions encoding'
           type: string
           enum: [message_pack, json]
-          default: message_pack
+          default: json
       responses:
         '200':
           description: The top block
@@ -1401,7 +1401,7 @@ paths:
   /block/pending:
     get:
       tags:
-        - internal
+        - external
         - chain
       operationId: GetBlockPending
       description: 'Get the block being mined'
@@ -1413,7 +1413,7 @@ paths:
           description: 'Transactions encoding'
           type: string
           enum: [message_pack, json]
-          default: message_pack
+          default: json
       responses:
         '200':
           description: The pending block with invalid nonce and pow evidence


### PR DESCRIPTION
Mark old external end point as deprecated.
Fixes PT-156688336.

UAT tests were run successfully.