### PR TITLE
Add network split recovery system test

### DIFF
--- a/system_test/aest_sync_SUITE.erl
+++ b/system_test/aest_sync_SUITE.erl
@@ -286,6 +286,11 @@ crash_and_continue_sync(Cfg) ->
             ?assertEqual(B1, B2)
     end.
 
+%% Test that two disconnected clusters of nodes are able to recover and merge
+%% there chain when connected back together.
+%% It tests both case of the chain being started from scratch in different
+%% network partitions, and that the network is partitiioned when the chain
+%% is already shared.
 net_split_recovery(Cfg) ->
     Length = 10,
 

--- a/system_test/aest_sync_SUITE.erl
+++ b/system_test/aest_sync_SUITE.erl
@@ -64,6 +64,9 @@
 }).
 
 
+%% By default, this node only connects to network `net1` even though
+%% it has a `net2_node1` as a peer. It means that if it is not connected
+%% explicitly to `net2` it will not be able to connect to `net2_node1`.
 -define(NET1_NODE1, #{
     name     => net1_node1,
     peers    => [net1_node2, net2_node1],
@@ -72,6 +75,9 @@
     networks => [net1]
 }).
 
+%% By default, this node only connects to network `net1` even though
+%% it has a `net2_node2` as a peer. It means that if it is not connected
+%% explicitly to `net2` it will not be able to connect to `net2_node2`.
 -define(NET1_NODE2, #{
     name    => net1_node2,
     peers   => [net1_node1, net2_node2],
@@ -80,6 +86,9 @@
     networks => [net1]
 }).
 
+%% By default, this node only connects to network `net2` even though
+%% it has a `net1_node1` as a peer. It means that if it is not connected
+%% explicitly to `net1` it will not be able to connect to `net1_node1`.
 -define(NET2_NODE1, #{
     name    => net2_node1,
     peers   => [net1_node1, net2_node2],
@@ -88,6 +97,9 @@
     networks => [net2]
 }).
 
+%% By default, this node only connects to network `net2` even though
+%% it has a `net1_node2` as a peer. It means that if it is not connected
+%% explicitly to `net1` it will not be able to connect to `net1_node2`.
 -define(NET2_NODE2, #{
     name    => net2_node2,
     peers   => [net1_node2, net2_node1],


### PR DESCRIPTION
After rebasing this branch on top of master, the test `new_node_joins_network` do not pass anymore with `aeternity/epoch:v0.10.1`. Is it expected or is it a regression that needs to be fixed ?