### PR TITLE
Properly deserialize older blocks

### DIFF
--- a/apps/aecore/src/aec_blocks.erl
+++ b/apps/aecore/src/aec_blocks.erl
@@ -193,7 +193,7 @@ deserialize_from_binary(Bin) ->
             Err
     end.
 
-serialization_template(Vsn) when Vsn >= 9 andalso Vsn =< ?PROTOCOL_VERSION ->
+serialization_template(Vsn) when Vsn >= ?GENESIS_VERSION andalso Vsn =< ?PROTOCOL_VERSION ->
     {ok, [{header, binary}, {txs, [binary]}]};
 serialization_template(Vsn) ->
     {error, {bad_block_vsn, Vsn}}.


### PR DESCRIPTION
If we want to be backwards compatible we should understand old blocks...