### PR TITLE
Pt 156688109 improve forks

### DIFF
--- a/apps/aecore/src/aec_peer_connection.erl
+++ b/apps/aecore/src/aec_peer_connection.erl
@@ -464,10 +464,12 @@ handle_ping_msg(S, RemotePingObj) ->
             case {{LTHash, LDiff}, {RTHash, RDiff}} of
                 {{T, _}, {T, _}} ->
                     lager:debug("Same top blocks", []),
-                    aec_sync:server_get_missing_blocks(PeerId);
+                    aec_events:publish(chain_sync, {chain_sync_done, PeerId}),
+                    ok;
                 {{_, DL}, {_, DR}} when DL > DR ->
                     lager:debug("Our difficulty is higher", []),
-                    aec_sync:server_get_missing_blocks(PeerId);
+                    aec_events:publish(chain_sync, {chain_sync_done, PeerId}),
+                    ok;
                 {{_, _}, {_, DR}} ->
                     aec_sync:start_sync(PeerId, RTHash, DR)
             end,
@@ -503,7 +505,7 @@ ping_obj_rsp(S, RemotePingObj) ->
 
 local_ping_obj(#{ext_sync_port := Port}) ->
     GHash = aec_chain:genesis_hash(),
-    TopHash = aec_chain:top_header_hash(),
+    TopHash = aec_chain:top_block_hash(),
     {ok, Difficulty} = aec_chain:difficulty_at_top_block(),
     #{genesis_hash => GHash,
       best_hash    => TopHash,

--- a/apps/aecore/test/aec_conductor_tests.erl
+++ b/apps/aecore/test/aec_conductor_tests.erl
@@ -183,7 +183,7 @@ chain_test_() ->
       {"Start mining add a block.", fun test_start_mining_add_block/0},
       {"Test preemption of mining", fun test_preemption/0},
       {"Test chain genesis state" , fun test_chain_genesis_state/0},
-      {timeout, 20, {"Test block publishing"    , fun test_block_publishing/0}}
+      {timeout, 20, {"Test block publishing", fun test_block_publishing/0}}
      ]}.
 
 test_start_mining_add_block() ->
@@ -252,7 +252,6 @@ test_chain_genesis_state() ->
     ?assertEqual(aec_trees:hash(GBS1), aec_trees:hash(GBS)),
 
     %% Check that genesis is top
-    ?assertEqual(GHH, aec_chain:top_header_hash()),
     ?assertEqual(GHH, aec_chain:top_block_hash()),
 
     %% Check chain state functions

--- a/apps/aehttp/src/aehttp_dispatch_ext.erl
+++ b/apps/aehttp/src/aehttp_dispatch_ext.erl
@@ -625,7 +625,7 @@ get_block_hash_optionally_by_hash_or_height(Req) ->
                 {error, _} ->
                     {error, invalid_hash};
                 {ok, Hash} ->
-                    case aec_chain:has_header(Hash) of
+                    case aec_chain:has_block(Hash) of
                         false ->
                             {error, not_found};
                         true ->


### PR DESCRIPTION
Large rewrite of aec_chain_state: Remove ability to store headers in chain db
- No more headers as chain nodes in aec_chain_state
- No more difference between top_header_hash and top_block_hash
- When adding a block, the previous block either has state, or it is not connected to genesis.
- Use fork_id to find fork points and common ancestors
- Adapt to new chain interface
- Make sure adding a block is atomic with the state changes

https://www.pivotaltracker.com/n/projects/2124891/stories/156688109