### PR TITLE
remove test dependency from all `tag: only: /^v.*$/

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -522,7 +522,6 @@ workflows:
 
       - deploy_uat:
           requires:
-            - test
             - eunit
             - static_analysis
             - linux_package
@@ -535,7 +534,6 @@ workflows:
 
       - github_release_linux:
           requires:
-            - test
             - eunit
             - static_analysis
             - linux_package
@@ -548,7 +546,6 @@ workflows:
 
       - github_release_osx:
           requires:
-            - test
             - eunit
             - static_analysis
             - osx_package
@@ -561,7 +558,6 @@ workflows:
 
       - docker_push_tag:
           requires:
-            - test
             - eunit
             - static_analysis
             - hodl


### PR DESCRIPTION
PT: https://www.pivotaltracker.com/story/show/156798908

i think this should not block release with failing `test` job, and it should be left there to run

https://github.com/aeternity/epoch/blob/master/.circleci/config.yml#L428


