### PR TITLE
Clarify that hard forking test is up to date to 0.11.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,8 @@ all-tests: eunit test
 system-test:
 	@./rebar3 as system_test do ct --dir system_test --logdir system_test/logs --config system_test/cfg $(CT_TEST_FLAGS)
 
-system-test-deps: | system_test/aest_hard_fork_SUITE_data/db/mnesia_ae-uat-epoch_backup.tar ;
+system-test-deps: | system_test/aest_hard_fork_SUITE_data/db/mnesia_ae-uat-epoch_backup.tar
+	docker pull aeternity/epoch:v0.11.0
 
 system_test/aest_hard_fork_SUITE_data/db/mnesia_ae-uat-epoch_backup.tar: system_test/aest_hard_fork_SUITE_data/db/mnesia_ae-uat-epoch_backup
 	tar -c -C $(<D) -f $@ $(<F)

--- a/system_test/aest_hard_fork_SUITE.erl
+++ b/system_test/aest_hard_fork_SUITE.erl
@@ -35,6 +35,8 @@
 
 %=== MACROS ====================================================================
 
+-define(TESTED_DOCKER_IMAGE, "aeternity/epoch:v0.11.0").
+
 -define(DB_BACKUP_DEST_DIR, "/tmp/mnesia_backup").
 
 -define(GENESIS_PROTOCOL_VERSION, 9).
@@ -79,7 +81,7 @@
           name    => new_node1,
           peers   => [],
           backend => aest_docker,
-          source  => {pull, "aeternity/epoch:v0.11.0"},
+          source  => {pull, ?TESTED_DOCKER_IMAGE},
           mine_rate => default,
           hard_forks => ?PROTOCOLS(H)
          }).
@@ -88,7 +90,7 @@
           name    => new_node2,
           peers   => [new_node1],
           backend => aest_docker,
-          source  => {pull, "aeternity/epoch:v0.11.0"},
+          source  => {pull, ?TESTED_DOCKER_IMAGE},
           mine_rate => default,
           hard_forks => ?PROTOCOLS(H)
          }).
@@ -97,7 +99,7 @@
           name    => new_node3,
           peers   => [new_node1],
           backend => aest_docker,
-          source  => {pull, "aeternity/epoch:v0.11.0"},
+          source  => {pull, ?TESTED_DOCKER_IMAGE},
           mine_rate => default,
           hard_forks => ?PROTOCOLS(H)
          }).
@@ -106,7 +108,7 @@
           name    => new_node4,
           peers   => [new_node3],
           backend => aest_docker,
-          source  => {pull, "aeternity/epoch:v0.11.0"},
+          source  => {pull, ?TESTED_DOCKER_IMAGE},
           mine_rate => default,
           hard_forks => ?PROTOCOLS(H)
          }).
@@ -115,7 +117,7 @@
           name    => fast_new_node1,
           peers   => [],
           backend => aest_docker,
-          source  => {pull, "aeternity/epoch:v0.11.0"},
+          source  => {pull, ?TESTED_DOCKER_IMAGE},
           mine_rate => 1000,
           cuckoo_miner => ?CUCKOO_MINER(16),
           hard_forks => ?PROTOCOLS(H)
@@ -125,7 +127,7 @@
           name    => fast_new_node2,
           peers   => [fast_new_node1],
           backend => aest_docker,
-          source  => {pull, "aeternity/epoch:v0.11.0"},
+          source  => {pull, ?TESTED_DOCKER_IMAGE},
           mine_rate => 1000,
           cuckoo_miner => ?CUCKOO_MINER(16),
           hard_forks => ?PROTOCOLS(H)

--- a/system_test/aest_hard_fork_SUITE.erl
+++ b/system_test/aest_hard_fork_SUITE.erl
@@ -79,7 +79,7 @@
           name    => new_node1,
           peers   => [],
           backend => aest_docker,
-          source  => {pull, "aeternity/epoch:local"},
+          source  => {pull, "aeternity/epoch:v0.11.0"},
           mine_rate => default,
           hard_forks => ?PROTOCOLS(H)
          }).
@@ -88,7 +88,7 @@
           name    => new_node2,
           peers   => [new_node1],
           backend => aest_docker,
-          source  => {pull, "aeternity/epoch:local"},
+          source  => {pull, "aeternity/epoch:v0.11.0"},
           mine_rate => default,
           hard_forks => ?PROTOCOLS(H)
          }).
@@ -97,7 +97,7 @@
           name    => new_node3,
           peers   => [new_node1],
           backend => aest_docker,
-          source  => {pull, "aeternity/epoch:local"},
+          source  => {pull, "aeternity/epoch:v0.11.0"},
           mine_rate => default,
           hard_forks => ?PROTOCOLS(H)
          }).
@@ -106,7 +106,7 @@
           name    => new_node4,
           peers   => [new_node3],
           backend => aest_docker,
-          source  => {pull, "aeternity/epoch:local"},
+          source  => {pull, "aeternity/epoch:v0.11.0"},
           mine_rate => default,
           hard_forks => ?PROTOCOLS(H)
          }).
@@ -115,7 +115,7 @@
           name    => fast_new_node1,
           peers   => [],
           backend => aest_docker,
-          source  => {pull, "aeternity/epoch:local"},
+          source  => {pull, "aeternity/epoch:v0.11.0"},
           mine_rate => 1000,
           cuckoo_miner => ?CUCKOO_MINER(16),
           hard_forks => ?PROTOCOLS(H)
@@ -125,7 +125,7 @@
           name    => fast_new_node2,
           peers   => [fast_new_node1],
           backend => aest_docker,
-          source  => {pull, "aeternity/epoch:local"},
+          source  => {pull, "aeternity/epoch:v0.11.0"},
           mine_rate => 1000,
           cuckoo_miner => ?CUCKOO_MINER(16),
           hard_forks => ?PROTOCOLS(H)


### PR DESCRIPTION
Preparatory PR for next step in hard forking support https://www.pivotaltracker.com/story/show/156671329

A change that may affect test suite is non-deprecated HTTP APIs moving from internal to external https://github.com/aeternity/epoch/commit/bd8a10ba2b4d2102ad7ac9147352f220ef762d63 .