### PR TITLE
Spend tx: add payload

### DIFF
--- a/apps/aehttp/priv/swagger.json
+++ b/apps/aehttp/priv/swagger.json
@@ -2478,11 +2478,20 @@
         "nonce" : {
           "type" : "integer",
           "format" : "int64"
+        },
+        "payload" : {
+          "type" : "string"
+        },
+        "vsn" : {
+          "type" : "integer",
+          "format" : "int64"
         }
       },
       "example" : {
+        "vsn" : 5,
         "amount" : 0,
         "sender" : null,
+        "payload" : "payload",
         "fee" : 6,
         "recipient_pubkey" : { },
         "nonce" : 1

--- a/apps/aehttp/src/aehttp_dispatch_ext.erl
+++ b/apps/aehttp/src/aehttp_dispatch_ext.erl
@@ -307,6 +307,7 @@ handle_request('PostSpend', #{'SpendTx' := Req}, _Context) ->
                  read_required_params([sender,
                                        {recipient_pubkey, recipient},
                                        amount, fee]),
+                 read_optional_params([{payload, payload, <<>>}]),
                  base58_decode([{sender, sender, account_pubkey},
                                 {recipient, recipient, account_pubkey}]),
                  get_nonce(sender),

--- a/apps/aehttp/src/aehttp_dispatch_int.erl
+++ b/apps/aehttp/src/aehttp_dispatch_int.erl
@@ -20,7 +20,8 @@ handle_request('PostSpendTx', #{'SpendTx' := SpendTxObj}, _Context) ->
     #{<<"recipient_pubkey">> := EncodedRecipientPubkey,
       <<"amount">>           := Amount,
       <<"fee">>              := Fee} = SpendTxObj,
-    case aehttp_int_tx_logic:spend(EncodedRecipientPubkey, Amount, Fee) of
+    Payload = maps:get(<<"payload">>, SpendTxObj, <<>>),
+    case aehttp_int_tx_logic:spend(EncodedRecipientPubkey, Amount, Fee, Payload) of
         {ok, _} -> {200, [], #{}};
         {error, invalid_key} ->
             {404, [], #{reason => <<"Invalid key">>}};

--- a/apps/aehttp/src/aehttp_helpers.erl
+++ b/apps/aehttp/src/aehttp_helpers.erl
@@ -69,7 +69,7 @@ read_optional_params(Params) ->
             Val =
                 %% swagger puts an 'undefined' value for missing not reqired
                 %% params
-                case maps:get(Name, Req) of
+                case maps:get(Name, Req, undefined) of
                     undefined -> DefaultValue;
                     V -> V
                 end,

--- a/apps/aehttp/src/aehttp_int_tx_logic.erl
+++ b/apps/aehttp/src/aehttp_int_tx_logic.erl
@@ -4,7 +4,7 @@
 
 -export([sender_and_hash/1]).
 
--export([ spend/3
+-export([ spend/4
        ]).
 
 -export([ oracle_register/6
@@ -23,11 +23,11 @@
        ]).
 
 sender_and_hash(Tx) ->
-    Sender = aetx:origin(Tx), 
+    Sender = aetx:origin(Tx),
     TxHash = aetx:hash(Tx),
     {Sender, TxHash}.
 
-spend(EncodedRecipient, Amount, Fee) ->
+spend(EncodedRecipient, Amount, Fee, Payload) ->
     create_tx(
         fun(SenderPubkey, Nonce) ->
             case aec_chain:resolve_name(account_pubkey, EncodedRecipient) of
@@ -36,6 +36,7 @@ spend(EncodedRecipient, Amount, Fee) ->
                       #{sender    => SenderPubkey,
                         recipient => DecodedRecipientPubkey,
                         amount    => Amount,
+                        payload   => Payload,
                         fee       => Fee,
                         nonce     => Nonce});
                 {error, _} ->

--- a/apps/aetx/test/aetx_tests.erl
+++ b/apps/aetx/test/aetx_tests.erl
@@ -66,3 +66,36 @@ apply_signed_txs_test_() ->
                ?assertEqual(80 + 40, aec_accounts:balance(ResultRecipientAccount))
        end
       }]}.
+
+backwards_compatibility_test_() ->
+    {foreach,
+      fun() ->
+          TmpKeysDir = aec_test_utils:aec_keys_setup(),
+          ok = meck:new(aec_spend_tx, [passthrough]),
+          meck:expect(aec_spend_tx, version, 0, 1), %% test old version
+          TmpKeysDir
+      end,
+      fun(TmpKeysDir) ->
+          ok = aec_test_utils:aec_keys_cleanup(TmpKeysDir),
+          meck:unload(aec_spend_tx),
+          ok
+      end,
+    [{"Spend transaction backwards compatibility",
+      fun() ->
+          {ok, MinerPubkey} = aec_keys:pubkey(),
+          {ok, SpendTx} = aec_spend_tx:new(
+                            #{sender => MinerPubkey,
+                              recipient => ?RECIPIENT_PUBKEY,
+                              amount => 40,
+                              fee => 9,
+                              nonce => 1}),
+          Bin = aetx:serialize_to_binary(SpendTx),
+          %% serialization of old transaction works
+          ?assertEqual(SpendTx, aetx:deserialize_from_binary(Bin)),
+
+          %% existing old version signatures are still valid
+          {ok, SignedSpendTx} = aec_keys:sign(SpendTx),
+          ?assertEqual(ok, aetx_sign:verify(SignedSpendTx)),
+          ok
+      end}]}.
+

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -2084,6 +2084,11 @@ definitions:
       nonce:
         type: integer
         format: int64
+      payload:
+        type: string
+      vsn:
+        type: integer
+        format: int64
     required:
     - recipient_pubkey
     - amount


### PR DESCRIPTION
[Pivotal story](https://www.pivotaltracker.com/story/show/156942570)

In order to verify that this is a backwards compatible change, you can:
1) Checkout the branch
2) Configure config/sys.config so the peers section has one of the integration node's peers
```                                             
      {peers, [                                                                                       
        <<"aenode://pp$2Jx7N2qDUqu3ZNfd831Byiq4WofebBsSRHNTD79Tcsr9VTTt54@31.13.249.73:3015">> %% integration n0
      ]}, 
```   
3) Adapt `data/aecore/.genesis/accounts.json` to have the [correct integration preset account](https://github.com/aeternity/epoch/blob/master/deployment/ansible/group_vars/tag_env_integration/accounts.yml)

4) Build and start the node

5) Observe as the node syncs correctly with the existing network

6) Verify that there are _some_ spend transactions
```
(epoch@localhost)2> [Tx || {aec_tx, {_, _}, {signed_tx, {aetx, Type, _, _}, _}}= Tx   <-mnesia:dirty_select(aec_tx, [{'_',[],['$_']}]), Type =/= coinbase_tx].
[{aec_tx,{<<166,125,217,115,13,250,74,254,129,143,244,146,
            87,156,129,18,163,114,230,235,1,81,159,37,211,
            ...>>,
          <<177,27,82,183,23,159,84,91,184,8,30,114,95,47,222,137,
            208,221,76,95,210,47,64,173,...>>},
         {signed_tx,{aetx,spend_tx,aec_spend_tx,
                          {spend_tx,<<4,44,86,165,206,116,7,63,150,169,2,93,238,212,
                                      158,238,155,...>>,
                                    <<4,112,190,180,76,136,225,221,31,4,225,193,217,251,226,2,
                                      ...>>,
                                    42,10,1,<<>>,1}},
                    [<<48,69,2,33,0,230,58,191,240,128,198,90,255,98,24,12,
                       17,109,88,38,51,...>>]}},
 {aec_tx,{<<162,220,6,156,207,97,226,193,118,49,23,149,134,
            38,43,66,60,198,112,246,223,24,42,179,...>>,
          <<177,27,82,183,23,159,84,91,184,8,30,114,95,47,222,137,
            208,221,76,95,210,47,64,...>>},
         {signed_tx,{aetx,spend_tx,aec_spend_tx,
                          {spend_tx,<<4,44,86,165,206,116,7,63,150,169,2,93,238,212,
                                      158,238,...>>,
                                    <<4,112,190,180,76,136,225,221,31,4,225,193,217,251,226,
                                      ...>>,
                                    42,10,2,<<>>,1}},
                    [<<48,70,2,33,0,195,65,182,2,64,95,203,201,69,218,11,
                       124,128,32,77,...>>]}},
 {aec_tx,{<<146,230,61,178,177,40,22,53,108,244,164,76,167,
            99,74,76,253,24,81,121,190,198,40,...>>,
          []},
         {signed_tx,{aetx,spend_tx,aec_spend_tx,
                          {spend_tx,<<4,44,86,165,206,116,7,63,150,169,2,93,238,212,
                                      158,...>>,
                                    <<4,112,190,180,76,136,225,221,31,4,225,193,217,251,...>>,
                                    42,10,3,<<>>,1}},
                    [<<48,69,2,32,78,143,230,251,32,222,93,136,8,62,26,11,
                       29,241,222,...>>]}}]
```
Note that the `<<>>,1` in the transaction body is actually the empty payload and version `1` of the spend tranaction. This means that these are some version 1 transactions that had been successfully downloaded, deserialized and their signatures are correct.