### PR TITLE
Add table version to each db table

### DIFF
--- a/deployment/ansible/deploy.yml
+++ b/deployment/ansible/deploy.yml
@@ -61,7 +61,7 @@
           port: 3114
       chain:
         persist: true
-        db_path: "./db43"
+        db_path: "./db44"
       keypair:
         dir: "keys"
         password: "{{ vault_keys_password|default('secret') }}"

--- a/docs/release-notes/RELEASE-NOTES-0.12.0.md
+++ b/docs/release-notes/RELEASE-NOTES-0.12.0.md
@@ -4,6 +4,7 @@
 It:
 * Regulate the maximum number of concurrent connections (`sync` > `max_connections`) and the number of processes accepting connections (`sync` > `acceptors`).
 * Expose more configuration previously hard-coded, (`sync` > `connect_timeout`), (`sync` > `first_ping_timeout`) and (`sync` > `noise_hs_timeout`).
+* Introduce database table versions and a startup check to handle old versions.
 * Does this;
 * Does that;
 * TODO Improves the stability of the testnet.


### PR DESCRIPTION
Abort setup if the table versions are not correct.

https://www.pivotaltracker.com/n/projects/2124891/stories/155656073

The node is not going down with a user friendly message, but rather with a crashdump. This is  the intended behavior of the setup app, and if we want to change this we need a PR towards setup. 

There is an error log telling what the problem is, though.