### PR TITLE
Minimize repetition of consensus protocol versions in repo

### DIFF
--- a/apps/aeutils/priv/epoch_config_schema.json
+++ b/apps/aeutils/priv/epoch_config_schema.json
@@ -227,24 +227,8 @@
                     "description" : "The consensus protocol versions with respective effective heights",
                     "type" : "object",
                     "additionalProperties" : false,
-                    "required" : [
-                        "9",
-                        "10",
-                        "11"
-                    ],
-                    "properties" : {
-                        "9" : {
-                            "description" : "Minimum height at which protocol is effective",
-                            "type" : "integer",
-                            "minimum" : 0,
-                            "maximum" : 0
-                        },
-                        "10" : {
-                            "description" : "Minimum height at which protocol is effective",
-                            "type" : "integer",
-                            "minimum" : 0
-                        },
-                        "11" : {
+                    "patternProperties" : {
+                        "^[1-9][0-9]*$": {
                             "description" : "Minimum height at which protocol is effective",
                             "type" : "integer",
                             "minimum" : 0

--- a/apps/aeutils/src/aeu_env.erl
+++ b/apps/aeutils/src/aeu_env.erl
@@ -224,7 +224,7 @@ check_config_({'EXIT', Reason}) ->
     ShortError = pp_error(Reason),
     {error, ShortError};
 check_config_([Vars]) ->
-    {ok, to_tree_(expand_maps(Vars))}.
+    {ok, {Vars, to_tree(Vars)}}.
 
 pp_error({{validation_failed, Errors}, _}) ->
     [pp_error_(E) || E <- Errors],

--- a/apps/aeutils/test/aeu_env_tests.erl
+++ b/apps/aeutils/test/aeu_env_tests.erl
@@ -10,13 +10,26 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-all_test_() ->
+schema_test_() ->
     {setup,
      fun setup/0,
      fun teardown/1,
-     [{"Example configuration tests",
+     [{"Example user configuration files pass schema validation",
        [fun() ->
           ?assertMatch({ok, _}, aeu_env:check_config(Config))
+        end || Config <- test_data_config_files()]
+       }]
+    }.
+
+extra_checks_test_() ->
+    {setup,
+     fun() -> ok = meck:new(setup, [passthrough]), setup() end,
+     fun(R) -> teardown(R), ok = meck:unload(setup) end,
+     [{"Example user configuration files pass checks further to the schema", %% For enabling files to be linked from wiki as examples.
+       [fun() ->
+                {ok, {UserMap, UserConfig}} = aeu_env:check_config(Config),
+                ok = mock_user_config(UserMap, UserConfig),
+                ?assertEqual(ok, aec_hard_forks:check_env())
         end || Config <- test_data_config_files()]
        }]
     }.
@@ -47,5 +60,15 @@ teardown(_) ->
     application:stop(jesse),
     application:stop(yamerl),
     application:stop(jsx).
+
+mock_user_config(UserMap, UserConfig) ->
+    F = fun
+            (aeutils, '$user_config') -> UserConfig;
+            (aeutils, '$user_map') -> UserMap;
+            (_A, _K) -> meck:passthrough()
+        end,
+    ok = meck:expect(setup, get_env, F),
+    ok = meck:expect(setup, get_env, fun(A, K, _Default) -> F(A, K) end),
+    ok.
 
 -endif.


### PR DESCRIPTION
In scope of https://www.pivotaltracker.com/story/show/156960045

Addresses https://github.com/aeternity/epoch/pull/1015#issuecomment-383529414

Remaining consensus protocol versions are in:
* blocks.hrl inevitable for macros
* aec_governance.erl - inevitable for default height of each hard fork (maybe could be in config - though shall be somewhere)
* aest_hard_fork_SUITE.erl - ~inevitable for tests as config instantiated~ minimized in PR #1015