### PR TITLE
PT156910906 - Make sync target a fork rather than individual peers

### DIFF
--- a/config/dev1/sys.config
+++ b/config/dev1/sys.config
@@ -34,12 +34,11 @@
 
   {jobs,
    [{queues,
-     [{sync_jobs, [passive]},
-      {sync_workers, [{regulators,
-                       [{counter, [{limit, 10}]}
-                       ]},
-                      {producer, {aec_sync, sync_worker, []}}
-                     ]},
+     [{ping_workers, [{regulators, [{counter, [{limit, 3}]}]}]},
+      {mempool_workers, [{regulators, [{counter, [{limit, 1}]}]}]},
+      {sync_task_workers, [{regulators, [{counter, [{limit, 10}]}]}]},
+      {gossip_workers, [{regulators, [{counter, [{limit, 10}]}]}]},
+
       {ws_task_workers, [{regulators,
                       [{counter, [{limit, 100 }] }
                       ]}

--- a/config/dev2/sys.config
+++ b/config/dev2/sys.config
@@ -35,12 +35,11 @@
 
   {jobs,
    [{queues,
-     [{sync_jobs, [passive]},
-      {sync_workers, [{regulators,
-                       [{counter, [{limit, 10}]}
-                       ]},
-                      {producer, {aec_sync, sync_worker, []}}
-                     ]}
+     [{ping_workers, [{regulators, [{counter, [{limit, 3}]}]}]},
+      {mempool_workers, [{regulators, [{counter, [{limit, 1}]}]}]},
+      {sync_task_workers, [{regulators, [{counter, [{limit, 10}]}]}]},
+      {gossip_workers, [{regulators, [{counter, [{limit, 10}]}]}]}
+
      ]}
    ]},
 

--- a/config/dev3/sys.config
+++ b/config/dev3/sys.config
@@ -34,12 +34,11 @@
 
   {jobs,
    [{queues,
-     [{sync_jobs, [passive]},
-      {sync_workers, [{regulators,
-                       [{counter, [{limit, 10}]}
-                       ]},
-                      {producer, {aec_sync, sync_worker, []}}
-                     ]}
+     [{ping_workers, [{regulators, [{counter, [{limit, 3}]}]}]},
+      {mempool_workers, [{regulators, [{counter, [{limit, 1}]}]}]},
+      {sync_task_workers, [{regulators, [{counter, [{limit, 10}]}]}]},
+      {gossip_workers, [{regulators, [{counter, [{limit, 10}]}]}]}
+
      ]}
    ]},
 

--- a/config/sys.config
+++ b/config/sys.config
@@ -35,12 +35,11 @@
 
   {jobs,
    [{queues,
-     [{sync_jobs, [passive]},
-      {sync_workers, [{regulators,
-                       [{counter, [{limit, 20}]}
-                       ]},
-                      {producer, {aec_sync, sync_worker, []}}
-                     ]}
+     [{ping_workers, [{regulators, [{counter, [{limit, 3}]}]}]},
+      {mempool_workers, [{regulators, [{counter, [{limit, 1}]}]}]},
+      {sync_task_workers, [{regulators, [{counter, [{limit, 10}]}]}]},
+      {gossip_workers, [{regulators, [{counter, [{limit, 10}]}]}]}
+
      ]}
    ]},
 


### PR DESCRIPTION
When starting to sync against a PeerId we try really hard to identify the chain this Peer
is on -  and then we organise the work in sync tasks _per chain_