### PR TITLE
Plant support for hard forking with new tx types/versions

### DIFF
--- a/apps/aecontract/src/aect_call_tx.erl
+++ b/apps/aecontract/src/aect_call_tx.erl
@@ -17,8 +17,8 @@
          fee/1,
          nonce/1,
          origin/1,
-         check/4,
-         process/4,
+         check/5,
+         process/5,
          accounts/1,
          signers/1,
          serialization_template/1,
@@ -88,12 +88,12 @@ origin(#contract_call_tx{caller = CallerPubKey}) ->
 
 %% CallerAccount should exist, and have enough funds for the fee + gas cost
 %% Contract should exist and its vm_version should match the one in the call.
--spec check(tx(), aetx:tx_context(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()} | {error, term()}.
+-spec check(tx(), aetx:tx_context(), aec_trees:trees(), height(), non_neg_integer()) -> {ok, aec_trees:trees()} | {error, term()}.
 check(#contract_call_tx{caller = CallerPubKey, nonce = Nonce,
                         fee = Fee, amount = Value,
                         gas = GasLimit, gas_price = GasPrice,
                         call_stack = CallStack
-                       } = CallTx, Context, Trees, Height) ->
+                       } = CallTx, Context, Trees, Height, _ConsensusVersion) ->
     Checks =
         case Context of
             aetx_transaction ->
@@ -119,10 +119,10 @@ accounts(Tx) ->
 signers(Tx) ->
     [caller(Tx)].
 
--spec process(tx(), aetx:tx_context(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()}.
+-spec process(tx(), aetx:tx_context(), aec_trees:trees(), height(), non_neg_integer()) -> {ok, aec_trees:trees()}.
 process(#contract_call_tx{caller = CallerPubKey, contract = CalleePubKey, nonce = Nonce,
                           fee = Fee, gas_price = GasPrice, amount = Value
-                         } = CallTx, Context, Trees0, Height) ->
+                         } = CallTx, Context, Trees0, Height, _ConsensusVersion) ->
     AccountsTree0  = aec_trees:accounts(Trees0),
     ContractsTree0 = aec_trees:contracts(Trees0),
 

--- a/apps/aecontract/src/aect_create_tx.erl
+++ b/apps/aecontract/src/aect_create_tx.erl
@@ -17,8 +17,8 @@
          fee/1,
          nonce/1,
          origin/1,
-         check/4,
-         process/4,
+         check/5,
+         process/5,
          accounts/1,
          signers/1,
          serialization_template/1,
@@ -128,9 +128,9 @@ origin(#contract_create_tx{owner = OwnerPubKey}) ->
     OwnerPubKey.
 
 %% Owner should exist, and have enough funds for the fee
--spec check(tx(), aetx:tx_context(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()} | {error, term()}.
+-spec check(tx(), aetx:tx_context(), aec_trees:trees(), height(), non_neg_integer()) -> {ok, aec_trees:trees()} | {error, term()}.
 check(#contract_create_tx{owner = OwnerPubKey, nonce = Nonce,
-                          fee = Fee}, _Context, Trees, Height) ->
+                          fee = Fee}, _Context, Trees, Height, _ConsensusVersion) ->
     Checks =
         [fun() -> aetx_utils:check_account(OwnerPubKey, Trees, Height, Nonce, Fee) end],
 
@@ -147,10 +147,10 @@ accounts(#contract_create_tx{owner = OwnerPubKey}) ->
 signers(#contract_create_tx{owner = OwnerPubKey}) ->
     [OwnerPubKey].
 
--spec process(tx(), aetx:tx_context(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()}.
+-spec process(tx(), aetx:tx_context(), aec_trees:trees(), height(), non_neg_integer()) -> {ok, aec_trees:trees()}.
 process(#contract_create_tx{owner = OwnerPubKey,
                             nonce = Nonce,
-                            fee   = Fee} = CreateTx, _Context, Trees0, Height) ->
+                            fee   = Fee} = CreateTx, _Context, Trees0, Height, _ConsensusVersion) ->
     AccountsTree0  = aec_trees:accounts(Trees0),
     ContractsTree0 = aec_trees:contracts(Trees0),
 

--- a/apps/aecontract/test/aecontract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_SUITE.erl
@@ -20,6 +20,8 @@
 
 -include_lib("common_test/include/ct.hrl").
 
+-include_lib("apps/aecore/include/common.hrl").
+-include_lib("apps/aecore/include/blocks.hrl").
 -include_lib("apps/aecontract/include/contract_txs.hrl").
 
 %%%===================================================================
@@ -57,19 +59,19 @@ create_contract_negative(_Cfg) ->
     BadPrivKey        = aect_test_utils:priv_key(BadPubKey, BadS),
     RTx1      = aect_test_utils:create_tx(BadPubKey, S1),
     {_, [], S1}  = sign_and_apply_transaction(RTx1, BadPrivKey, S1),
-    {error, account_not_found} = aetx:check(RTx1, Trees, CurrHeight),
+    {error, account_not_found} = aetx:check(RTx1, Trees, CurrHeight, ?PROTOCOL_VERSION),
 
     %% Insufficient funds
     S2     = aect_test_utils:set_account_balance(PubKey, 0, S1),
     Trees2 = aect_test_utils:trees(S2),
     RTx2   = aect_test_utils:create_tx(PubKey, S2),
     {_, [], S2}  = sign_and_apply_transaction(RTx2, PrivKey, S2),
-    {error, insufficient_funds} = aetx:check(RTx2, Trees2, CurrHeight),
+    {error, insufficient_funds} = aetx:check(RTx2, Trees2, CurrHeight, ?PROTOCOL_VERSION),
 
     %% Test too high account nonce
     RTx3 = aect_test_utils:create_tx(PubKey, #{nonce => 0}, S1),
     {_, [], S1}  = sign_and_apply_transaction(RTx3, PrivKey, S1),
-    {error, account_nonce_too_high} = aetx:check(RTx3, Trees, CurrHeight),
+    {error, account_nonce_too_high} = aetx:check(RTx3, Trees, CurrHeight, ?PROTOCOL_VERSION),
 
     ok.
 
@@ -86,7 +88,7 @@ sign_and_apply_transaction(Tx, PrivKey, S1) ->
     SignedTx = aetx_sign:sign(Tx, PrivKey),
     Trees    = aect_test_utils:trees(S1),
     Height   = 1,
-    {ok, AcceptedTxs, Trees1} = aec_trees:apply_signed_txs([SignedTx], Trees, Height),
+    {ok, AcceptedTxs, Trees1} = aec_trees:apply_signed_txs([SignedTx], Trees, Height, ?PROTOCOL_VERSION),
     S2       = aect_test_utils:set_trees(Trees1, S1),
     {SignedTx, AcceptedTxs, S2}.
 

--- a/apps/aecore/src/aec_blocks.erl
+++ b/apps/aecore/src/aec_blocks.erl
@@ -28,6 +28,8 @@
          validate/1,
          cointains_coinbase_tx/1]).
 
+-import(aec_hard_forks, [protocol_effective_at_height/1]).
+
 -ifdef(TEST).
 -compile([export_all, nowarn_export_all]).
 -endif.
@@ -111,7 +113,7 @@ new_with_state(LastBlock, Txs, Trees0) ->
     %% Let's hardcode this expectation for now.
     Txs = aetx_sign:filter_invalid_signatures(Txs),
 
-    {ok, Txs1, Trees} = aec_trees:apply_signed_txs(Txs, Trees0, Height),
+    {ok, Txs1, Trees} = aec_trees:apply_signed_txs(Txs, Trees0, Height, Version),
     {ok, TxsRootHash} = aec_txs_trees:root_hash(aec_txs_trees:from_txs(Txs1)),
     NewBlock =
         #block{height = Height,
@@ -123,9 +125,6 @@ new_with_state(LastBlock, Txs, Trees0) ->
                time = aeu_time:now_in_msecs(),
                version = Version},
     {NewBlock, Trees}.
-
-protocol_effective_at_height(H) ->
-    aec_hard_forks:protocol_effective_at_height(H, aec_hard_forks:protocols(aec_governance:protocols())).
 
 -spec to_header(block()) -> aec_headers:header().
 to_header(#block{height = Height,

--- a/apps/aecore/src/aec_chain_state.erl
+++ b/apps/aecore/src/aec_chain_state.erl
@@ -123,6 +123,8 @@ prev_hash(#node{header = H}) -> aec_headers:prev_hash(H).
 
 node_height(#node{header = H}) -> aec_headers:height(H).
 
+node_version(#node{header = H}) -> aec_headers:version(H).
+
 node_difficulty(#node{header = H}) -> aec_headers:difficulty(H).
 
 node_root_hash(#node{header = H}) -> aec_headers:root_hash(H).
@@ -397,7 +399,8 @@ assert_state_hash_valid(Trees, Node) ->
 apply_node_transactions(Node, Trees) ->
     Txs = db_get_txs(hash(Node)),
     Height = node_height(Node),
-    case aec_trees:apply_signed_txs_strict(Txs, Trees, Height) of
+    Version = node_version(Node),
+    case aec_trees:apply_signed_txs_strict(Txs, Trees, Height, Version) of
         {ok, _, NewTrees} -> NewTrees;
         {error,_What} -> internal_error(invalid_transactions_in_block)
     end.

--- a/apps/aecore/src/aec_coinbase_tx.erl
+++ b/apps/aecore/src/aec_coinbase_tx.erl
@@ -10,8 +10,8 @@
          fee/1,
          nonce/1,
          origin/1,
-         check/4,
-         process/4,
+         check/5,
+         process/5,
          accounts/1,
          signers/1,
          serialize/1,
@@ -58,12 +58,12 @@ nonce(#coinbase_tx{}) ->
 origin(#coinbase_tx{}) ->
     undefined.
 
--spec check(tx(), aetx:tx_context(), aec_trees:trees(), height()) ->
+-spec check(tx(), aetx:tx_context(), aec_trees:trees(), height(), non_neg_integer()) ->
                     {ok, aec_trees:trees()} | {error, term()}.
-check(#coinbase_tx{block_height = CBHeight}, _Context, _Trees, Height)
+check(#coinbase_tx{block_height = CBHeight}, _Context, _Trees, Height, _ConsensusVersion)
     when CBHeight =/= Height ->
     {error, wrong_height};
-check(#coinbase_tx{account = AccountPubkey, reward = Reward}, _Context, Trees, Height) ->
+check(#coinbase_tx{account = AccountPubkey, reward = Reward}, _Context, Trees, Height, _ConsensusVersion) ->
     ExpectedReward = aec_governance:block_mine_reward(),
     case Reward =:= ExpectedReward of
         true ->
@@ -74,9 +74,9 @@ check(#coinbase_tx{account = AccountPubkey, reward = Reward}, _Context, Trees, H
 
 %% Only aec_governance:block_mine_reward() is granted to miner's account here.
 %% Amount from all the fees of transactions included in the block
-%% is added to miner's account in aec_trees:apply_signed_txs/3.
--spec process(tx(), aetx:tx_context(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()}.
-process(#coinbase_tx{account = AccountPubkey, reward = Reward}, _Context, Trees0, Height) ->
+%% is added to miner's account in aec_trees:apply_signed_txs/4.
+-spec process(tx(), aetx:tx_context(), aec_trees:trees(), height(), non_neg_integer()) -> {ok, aec_trees:trees()}.
+process(#coinbase_tx{account = AccountPubkey, reward = Reward}, _Context, Trees0, Height, _ConsensusVersion) ->
     AccountsTrees0 = aec_trees:accounts(Trees0),
     {value, Account0} = aec_accounts_trees:lookup(AccountPubkey, AccountsTrees0),
 

--- a/apps/aecore/src/aec_hard_forks.erl
+++ b/apps/aecore/src/aec_hard_forks.erl
@@ -3,6 +3,7 @@
 -export([check_env/0]).
 -export([protocols/1,
          is_known_protocol/2,
+         protocol_effective_at_height/1,
          protocol_effective_at_height/2]).
 
 -include("common.hrl").
@@ -33,6 +34,10 @@ protocols(M) ->
 -spec is_known_protocol(version(), aec_governance:protocols()) -> boolean().
 is_known_protocol(V, Protocols) when ?is_version(V) ->
     maps:is_key(V, Protocols).
+
+-spec protocol_effective_at_height(height()) -> version().
+protocol_effective_at_height(H) ->
+    protocol_effective_at_height(H, protocols(aec_governance:protocols())).
 
 -spec protocol_effective_at_height(height(), aec_governance:protocols()) ->
                                           version().

--- a/apps/aecore/src/aec_headers.erl
+++ b/apps/aecore/src/aec_headers.erl
@@ -3,6 +3,7 @@
 %% API
 -export([prev_hash/1,
          height/1,
+         version/1,
          nonce/1,
          target/1,
          set_target/2,
@@ -34,6 +35,9 @@ prev_hash(Header) ->
 
 height(Header) ->
     Header#header.height.
+
+version(Header) ->
+    Header#header.version.
 
 nonce(Header) ->
     Header#header.nonce.

--- a/apps/aecore/src/aec_spend_tx.erl
+++ b/apps/aecore/src/aec_spend_tx.erl
@@ -11,8 +11,8 @@
          nonce/1,
          origin/1,
          recipient/1,
-         check/4,
-         process/4,
+         check/5,
+         process/5,
          accounts/1,
          signers/1,
          serialization_template/1,
@@ -76,8 +76,8 @@ origin(#spend_tx{sender = Sender}) ->
 recipient(#spend_tx{recipient = Recipient}) ->
     Recipient.
 
--spec check(tx(), aetx:tx_context(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()} | {error, term()}.
-check(#spend_tx{recipient = RecipientPubkey} = SpendTx, _Context, Trees0, Height) ->
+-spec check(tx(), aetx:tx_context(), aec_trees:trees(), height(), non_neg_integer()) -> {ok, aec_trees:trees()} | {error, term()}.
+check(#spend_tx{recipient = RecipientPubkey} = SpendTx, _Context, Trees0, Height, _ConsensusVersion) ->
     Checks = [fun check_tx_fee/3,
               fun check_sender_account/3],
     case aeu_validation:run(Checks, [SpendTx, Trees0, Height]) of
@@ -99,12 +99,12 @@ accounts(#spend_tx{sender = SenderPubKey, recipient = RecipientPubKey}) ->
 -spec signers(tx()) -> [pubkey()].
 signers(#spend_tx{sender = SenderPubKey}) -> [SenderPubKey].
 
--spec process(tx(), aetx:tx_context(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()}.
+-spec process(tx(), aetx:tx_context(), aec_trees:trees(), height(), non_neg_integer()) -> {ok, aec_trees:trees()}.
 process(#spend_tx{sender = SenderPubkey,
                   recipient = RecipientPubkey,
                   amount = Amount,
                   fee = Fee,
-                  nonce = Nonce}, _Context, Trees0, Height) ->
+                  nonce = Nonce}, _Context, Trees0, Height, _ConsensusVersion) ->
     AccountsTrees0 = aec_trees:accounts(Trees0),
 
     {value, SenderAccount0} = aec_accounts_trees:lookup(SenderPubkey, AccountsTrees0),

--- a/apps/aecore/src/aec_vm_chain.erl
+++ b/apps/aecore/src/aec_vm_chain.erl
@@ -74,6 +74,7 @@ call_contract(Target, Gas, Value, CallData, CallStack,
                               height  = Height,
                               account = ContractKey,
                               nonce   = Nonce }) ->
+    ConsensusVersion = aec_hard_forks:protocol_effective_at_height(Height),
     VmVersion = 0,  %% TODO
     {ok, CallTx} =
         aect_call_tx:new(#{ caller     => ContractKey,
@@ -86,10 +87,10 @@ call_contract(Target, Gas, Value, CallData, CallStack,
                             gas_price  => 0,
                             call_data  => CallData,
                             call_stack => CallStack }),
-    case aetx:check_from_contract(CallTx, Trees, Height) of
+    case aetx:check_from_contract(CallTx, Trees, Height, ConsensusVersion) of
         Err = {error, _} -> Err;
         {ok, Trees1} ->
-            {ok, Trees2} = aetx:process_from_contract(CallTx, Trees1, Height),
+            {ok, Trees2} = aetx:process_from_contract(CallTx, Trees1, Height, ConsensusVersion),
             CallId  = aect_call:id(ContractKey, Nonce, Target),
             Call    = aect_state_tree:get_call(Target, CallId, aec_trees:contracts(Trees2)),
             GasUsed = aect_call:gas_used(Call),

--- a/apps/aecore/test/aec_coinbase_tx_tests.erl
+++ b/apps/aecore/test/aec_coinbase_tx_tests.erl
@@ -37,7 +37,7 @@ coinbase_tx_existing_account_test_() ->
                        ?assertEqual(undefined, aetx:origin(CoinbaseTx)),
                        ?assertEqual(undefined, aetx:nonce(CoinbaseTx)),
                        ?assertEqual(0, aetx:fee(CoinbaseTx)),
-                       ?assertEqual({ok, Trees0}, aetx:check(CoinbaseTx, Trees0, 9))
+                       ?assertEqual({ok, Trees0}, aetx:check(CoinbaseTx, Trees0, 9, ?PROTOCOL_VERSION))
                end}
       end,
       fun({PubKey, Trees0}) ->
@@ -46,7 +46,7 @@ coinbase_tx_existing_account_test_() ->
                        {ok, CoinbaseTx} = aec_coinbase_tx:new(#{account => PubKey,
                                                                 block_height => 3}),
                        ?assertEqual({error, account_height_too_big},
-                                    aetx:check(CoinbaseTx, Trees0, 3))
+                                    aetx:check(CoinbaseTx, Trees0, 3, ?PROTOCOL_VERSION))
                end}
       end,
       fun({PubKey, Trees0}) ->
@@ -56,9 +56,9 @@ coinbase_tx_existing_account_test_() ->
                        {ok, CoinbaseTx} = aec_coinbase_tx:new(#{account => PubKey,
                                                                 block_height => Height}),
                        ?assertEqual({error, wrong_height},
-                                    aetx:check(CoinbaseTx, Trees0, Height - 1)),
+                                    aetx:check(CoinbaseTx, Trees0, Height - 1, ?PROTOCOL_VERSION)),
                        ?assertEqual({error, wrong_height},
-                                    aetx:check(CoinbaseTx, Trees0, Height + 1))
+                                    aetx:check(CoinbaseTx, Trees0, Height + 1, ?PROTOCOL_VERSION))
                end}
       end,
       fun({PubKey, Trees0}) ->
@@ -72,9 +72,9 @@ coinbase_tx_existing_account_test_() ->
                        CoinbaseTxSmallerReward = {aetx, coinbase_tx, aec_coinbase_tx,
                                       {coinbase_tx, PubKey, Height, Reward - 1}},
                        ?assertEqual({error, wrong_reward},
-                                    aetx:check(CoinbaseTxBiggerReward, Trees0, Height)),
+                                    aetx:check(CoinbaseTxBiggerReward, Trees0, Height, ?PROTOCOL_VERSION)),
                        ?assertEqual({error, wrong_reward},
-                                    aetx:check(CoinbaseTxSmallerReward, Trees0, Height))
+                                    aetx:check(CoinbaseTxSmallerReward, Trees0, Height, ?PROTOCOL_VERSION))
                end}
       end,
       fun({PubKey, Trees0}) ->
@@ -82,7 +82,7 @@ coinbase_tx_existing_account_test_() ->
                fun() ->
                        {ok, CoinbaseTx} = aec_coinbase_tx:new(#{account => PubKey,
                                                                 block_height => 9}),
-                       {ok, Trees} = aetx:process(CoinbaseTx, Trees0, 9),
+                       {ok, Trees} = aetx:process(CoinbaseTx, Trees0, 9, ?PROTOCOL_VERSION),
 
                        AccountsTree = aec_trees:accounts(Trees),
                        {value, Account} = aec_accounts_trees:lookup(PubKey, AccountsTree),
@@ -113,7 +113,7 @@ create_coinbase_tx_no_account_test() ->
      [fun({PubKey, Trees0, CoinbaseTx}) ->
               {"Check coinbase trx without existing account in state: shall create account",
                fun() ->
-                       {Succ, Trees} = aec_coinbase_tx:check(CoinbaseTx, Trees0, 9),
+                       {Succ, Trees} = aec_coinbase_tx:check(CoinbaseTx, Trees0, 9, ?PROTOCOL_VERSION),
                        ?assertEqual(ok, Succ),
                        AccountsTrees = aec_trees:accounts(Trees),
                        Account = aec_accounts:set_nonce(aec_accounts:new(PubKey, 0, 0), 9),
@@ -123,7 +123,7 @@ create_coinbase_tx_no_account_test() ->
       end,
       fun({_PubKey, Trees0, CoinbaseTx}) ->
               {"Process coinbase trx without existing account in state: shall fail",
-               ?assertEqual({error, account_not_found}, aec_coinbase_tx:process(CoinbaseTx, Trees0, 9))}
+               ?assertEqual({error, account_not_found}, aec_coinbase_tx:process(CoinbaseTx, Trees0, 9, ?PROTOCOL_VERSION))}
       end
      ]
     }.

--- a/apps/aecore/test/aec_mining_tests.erl
+++ b/apps/aecore/test/aec_mining_tests.erl
@@ -183,7 +183,7 @@ setup() ->
     aec_test_utils:create_state_tree_with_account(aec_accounts:new(?TEST_PUB, 0, 0)),
     meck:expect(aec_trees, hash, 1, <<>>),
     meck:expect(aetx_sign, filter_invalid_signatures, fun(X) -> X end),
-    meck:expect(aec_trees, apply_signed_txs, 3, {ok, [SignedTx], Trees}),
+    meck:expect(aec_trees, apply_signed_txs, 4, {ok, [SignedTx], Trees}),
     meck:expect(aec_keys, pubkey, 0, {ok, ?TEST_PUB}),
     %% We hardcode the signed_tx because crypto adds salt and gives
     %% non-deterministic result.

--- a/apps/aecore/test/aec_spend_tx_tests.erl
+++ b/apps/aecore/test/aec_spend_tx_tests.erl
@@ -20,14 +20,14 @@ check_test_() ->
               {ok, SpendTx} = spend_tx(#{fee => 0}), %% minimum governance fee = 1
               StateTree = aec_test_utils:create_state_tree(),
               ?assertEqual({error, too_low_fee},
-                           aetx:check(SpendTx, StateTree, 10))
+                           aetx:check(SpendTx, StateTree, 10, ?PROTOCOL_VERSION))
       end},
      {"Sender account does not exist in state trees",
       fun() ->
               {ok, SpendTx} = spend_tx(#{fee => 10, sender => <<42>>}),
               StateTree = aec_test_utils:create_state_tree(),
               ?assertEqual({error, account_not_found},
-                           aetx:check(SpendTx, StateTree, 10))
+                           aetx:check(SpendTx, StateTree, 10, ?PROTOCOL_VERSION))
       end},
      {"Sender account has insufficient funds to cover tx fee + amount",
       fun() ->
@@ -44,7 +44,7 @@ check_test_() ->
               SenderAccount = new_account(#{pubkey => ?SENDER_PUBKEY, balance => 55, nonce => 5, height => 10}),
               StateTree = aec_test_utils:create_state_tree_with_account(SenderAccount),
               ?assertEqual({error, insufficient_funds},
-                           aetx:check(SpendTx, StateTree, 20))
+                           aetx:check(SpendTx, StateTree, 20, ?PROTOCOL_VERSION))
       end},
      {"Sender account has nonce higher than tx nonce",
       fun() ->
@@ -56,7 +56,7 @@ check_test_() ->
               SenderAccount = new_account(#{pubkey => ?SENDER_PUBKEY, balance => 100, nonce => AccountNonce, height => 10}),
               StateTree = aec_test_utils:create_state_tree_with_account(SenderAccount),
               ?assertEqual({error, account_nonce_too_high},
-                           aetx:check(SpendTx, StateTree, 20))
+                           aetx:check(SpendTx, StateTree, 20, ?PROTOCOL_VERSION))
       end},
      {"Sender account has height higher than tx height",
       fun() ->
@@ -69,7 +69,7 @@ check_test_() ->
               SenderAccount = new_account(#{pubkey => ?SENDER_PUBKEY, balance => 100, nonce => 10, height => AccountHeight}),
               StateTree = aec_test_utils:create_state_tree_with_account(SenderAccount),
               ?assertEqual({error, sender_account_height_too_big},
-                           aetx:check(SpendTx, StateTree, BlockHeight))
+                           aetx:check(SpendTx, StateTree, BlockHeight, ?PROTOCOL_VERSION))
       end},
      {"Recipient account has height higher than tx height",
       fun() ->
@@ -86,7 +86,7 @@ check_test_() ->
               RecipientAccount = new_account(#{pubkey => ?RECIPIENT_PUBKEY, height => RecipientAccountHeight}),
               StateTree = aec_test_utils:create_state_tree_with_accounts([SenderAccount, RecipientAccount]),
               ?assertEqual({error, recipient_account_height_too_big},
-                           aetx:check(SpendTx, StateTree, BlockHeight))
+                           aetx:check(SpendTx, StateTree, BlockHeight, ?PROTOCOL_VERSION))
       end}].
 
 process_test_() ->
@@ -101,8 +101,8 @@ process_test_() ->
                                                  amount => 50,
                                                  fee => 10,
                                                  nonce => 11}),
-              {ok, StateTree0} = aetx:check(SpendTx, StateTree0, 20),
-              {ok, StateTree} = aetx:process(SpendTx, StateTree0, 20),
+              {ok, StateTree0} = aetx:check(SpendTx, StateTree0, 20, ?PROTOCOL_VERSION),
+              {ok, StateTree} = aetx:process(SpendTx, StateTree0, 20, ?PROTOCOL_VERSION),
 
               ResultAccountsTree = aec_trees:accounts(StateTree),
               {value, ResultSenderAccount} = aec_accounts_trees:lookup(?SENDER_PUBKEY, ResultAccountsTree),
@@ -125,8 +125,8 @@ process_test_() ->
                                                  amount => 50,
                                                  fee => 10,
                                                  nonce => 11}),
-              {ok, StateTree0} = aetx:check(SpendTx, StateTree0, 20),
-              {ok, StateTree} = aetx:process(SpendTx, StateTree0, 20),
+              {ok, StateTree0} = aetx:check(SpendTx, StateTree0, 20, ?PROTOCOL_VERSION),
+              {ok, StateTree} = aetx:process(SpendTx, StateTree0, 20, ?PROTOCOL_VERSION),
 
               ResultAccountsTree = aec_trees:accounts(StateTree),
               {value, ResultAccount} = aec_accounts_trees:lookup(?SENDER_PUBKEY, ResultAccountsTree),

--- a/apps/aens/src/aens_claim_tx.erl
+++ b/apps/aens/src/aens_claim_tx.erl
@@ -18,8 +18,8 @@
          fee/1,
          nonce/1,
          origin/1,
-         check/4,
-         process/4,
+         check/5,
+         process/5,
          accounts/1,
          signers/1,
          serialization_template/1,
@@ -76,9 +76,9 @@ nonce(#ns_claim_tx{nonce = Nonce}) ->
 origin(#ns_claim_tx{account = AccountPubKey}) ->
     AccountPubKey.
 
--spec check(tx(), aetx:tx_context(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()} | {error, term()}.
+-spec check(tx(), aetx:tx_context(), aec_trees:trees(), height(), non_neg_integer()) -> {ok, aec_trees:trees()} | {error, term()}.
 check(#ns_claim_tx{account = AccountPubKey, nonce = Nonce,
-                   fee = Fee, name = Name, name_salt = NameSalt}, _Context, Trees, Height) ->
+                   fee = Fee, name = Name, name_salt = NameSalt}, _Context, Trees, Height, _ConsensusVersion) ->
     case aens_utils:to_ascii(Name) of
         {ok, NameAscii} ->
             %% TODO: Maybe include burned fee in tx fee. To do so, mechanism determining
@@ -99,9 +99,9 @@ check(#ns_claim_tx{account = AccountPubKey, nonce = Nonce,
             {error, Reason}
     end.
 
--spec process(tx(), aetx:tx_context(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()}.
+-spec process(tx(), aetx:tx_context(), aec_trees:trees(), height(), non_neg_integer()) -> {ok, aec_trees:trees()}.
 process(#ns_claim_tx{account = AccountPubKey, nonce = Nonce, fee = Fee,
-                     name = PlainName, name_salt = NameSalt} = ClaimTx, _Context, Trees0, Height) ->
+                     name = PlainName, name_salt = NameSalt} = ClaimTx, _Context, Trees0, Height, _ConsensusVersion) ->
     AccountsTree0 = aec_trees:accounts(Trees0),
     NSTree0 = aec_trees:ns(Trees0),
 

--- a/apps/aens/src/aens_preclaim_tx.erl
+++ b/apps/aens/src/aens_preclaim_tx.erl
@@ -18,8 +18,8 @@
          fee/1,
          nonce/1,
          origin/1,
-         check/4,
-         process/4,
+         check/5,
+         process/5,
          accounts/1,
          signers/1,
          serialization_template/1,
@@ -74,9 +74,9 @@ nonce(#ns_preclaim_tx{nonce = Nonce}) ->
 origin(#ns_preclaim_tx{account = AccountPubKey}) ->
     AccountPubKey.
 
--spec check(tx(), aetx:tx_context(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()} | {error, term()}.
+-spec check(tx(), aetx:tx_context(), aec_trees:trees(), height(), non_neg_integer()) -> {ok, aec_trees:trees()} | {error, term()}.
 check(#ns_preclaim_tx{account = AccountPubKey, nonce = Nonce,
-                      fee = Fee, commitment = Commitment}, _Context, Trees, Height) ->
+                      fee = Fee, commitment = Commitment}, _Context, Trees, Height, _ConsensusVersion) ->
     Checks =
         [fun() -> aetx_utils:check_account(AccountPubKey, Trees, Height, Nonce, Fee) end,
          fun() -> check_not_commitment(Commitment, Trees) end],
@@ -86,9 +86,9 @@ check(#ns_preclaim_tx{account = AccountPubKey, nonce = Nonce,
         {error, Reason} -> {error, Reason}
     end.
 
--spec process(tx(), aetx:tx_context(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()}.
+-spec process(tx(), aetx:tx_context(), aec_trees:trees(), height(), non_neg_integer()) -> {ok, aec_trees:trees()}.
 process(#ns_preclaim_tx{account = AccountPubKey, fee = Fee,
-                        nonce = Nonce} = PreclaimTx, _Context, Trees0, Height) ->
+                        nonce = Nonce} = PreclaimTx, _Context, Trees0, Height, _ConsensusVersion) ->
     AccountsTree0 = aec_trees:accounts(Trees0),
     NSTree0 = aec_trees:ns(Trees0),
 

--- a/apps/aens/src/aens_revoke_tx.erl
+++ b/apps/aens/src/aens_revoke_tx.erl
@@ -17,8 +17,8 @@
          fee/1,
          nonce/1,
          origin/1,
-         check/4,
-         process/4,
+         check/5,
+         process/5,
          accounts/1,
          signers/1,
          serialization_template/1,
@@ -69,9 +69,9 @@ nonce(#ns_revoke_tx{nonce = Nonce}) ->
 origin(#ns_revoke_tx{account = AccountPubKey}) ->
     AccountPubKey.
 
--spec check(tx(), aetx:tx_context(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()} | {error, term()}.
+-spec check(tx(), aetx:tx_context(), aec_trees:trees(), height(), non_neg_integer()) -> {ok, aec_trees:trees()} | {error, term()}.
 check(#ns_revoke_tx{account = AccountPubKey, nonce = Nonce,
-                    fee = Fee, name_hash = NameHash}, _Context, Trees, Height) ->
+                    fee = Fee, name_hash = NameHash}, _Context, Trees, Height, _ConsensusVersion) ->
     Checks =
         [fun() -> aetx_utils:check_account(AccountPubKey, Trees, Height, Nonce, Fee) end,
          fun() -> aens_utils:check_name_claimed_and_owned(NameHash, AccountPubKey, Trees) end],
@@ -81,9 +81,9 @@ check(#ns_revoke_tx{account = AccountPubKey, nonce = Nonce,
         {error, Reason} -> {error, Reason}
     end.
 
--spec process(tx(), aetx:tx_context(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()}.
+-spec process(tx(), aetx:tx_context(), aec_trees:trees(), height(), non_neg_integer()) -> {ok, aec_trees:trees()}.
 process(#ns_revoke_tx{account = AccountPubKey, fee = Fee,
-                      name_hash = NameHash, nonce = Nonce}, _Context, Trees0, Height) ->
+                      name_hash = NameHash, nonce = Nonce}, _Context, Trees0, Height, _ConsensusVersion) ->
     AccountsTree0 = aec_trees:accounts(Trees0),
     NamesTree0 = aec_trees:ns(Trees0),
 

--- a/apps/aens/src/aens_transfer_tx.erl
+++ b/apps/aens/src/aens_transfer_tx.erl
@@ -18,8 +18,8 @@
          fee/1,
          nonce/1,
          origin/1,
-         check/4,
-         process/4,
+         check/5,
+         process/5,
          accounts/1,
          signers/1,
          serialization_template/1,
@@ -75,9 +75,9 @@ nonce(#ns_transfer_tx{nonce = Nonce}) ->
 origin(#ns_transfer_tx{account = AccountPubKey}) ->
     AccountPubKey.
 
--spec check(tx(), aetx:tx_context(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()} | {error, term()}.
+-spec check(tx(), aetx:tx_context(), aec_trees:trees(), height(), non_neg_integer()) -> {ok, aec_trees:trees()} | {error, term()}.
 check(#ns_transfer_tx{account = AccountPubKey, nonce = Nonce,
-                      fee = Fee, name_hash = NameHash}, _Context, Trees, Height) ->
+                      fee = Fee, name_hash = NameHash}, _Context, Trees, Height, _ConsensusVersion) ->
     Checks =
         [fun() -> aetx_utils:check_account(AccountPubKey, Trees, Height, Nonce, Fee) end,
          fun() -> aens_utils:check_name_claimed_and_owned(NameHash, AccountPubKey, Trees) end],
@@ -87,9 +87,9 @@ check(#ns_transfer_tx{account = AccountPubKey, nonce = Nonce,
         {error, Reason} -> {error, Reason}
     end.
 
--spec process(tx(), aetx:tx_context(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()}.
+-spec process(tx(), aetx:tx_context(), aec_trees:trees(), height(), non_neg_integer()) -> {ok, aec_trees:trees()}.
 process(#ns_transfer_tx{account = AccountPubKey, fee = Fee,
-                        name_hash = NameHash, nonce = Nonce} = TransferTx, _Context, Trees0, Height) ->
+                        name_hash = NameHash, nonce = Nonce} = TransferTx, _Context, Trees0, Height, _ConsensusVersion) ->
     AccountsTree0 = aec_trees:accounts(Trees0),
     NamesTree0 = aec_trees:ns(Trees0),
 

--- a/apps/aens/src/aens_update_tx.erl
+++ b/apps/aens/src/aens_update_tx.erl
@@ -18,8 +18,8 @@
          fee/1,
          nonce/1,
          origin/1,
-         check/4,
-         process/4,
+         check/5,
+         process/5,
          accounts/1,
          signers/1,
          serialization_template/1,
@@ -81,9 +81,9 @@ nonce(#ns_update_tx{nonce = Nonce}) ->
 origin(#ns_update_tx{account = AccountPubKey}) ->
     AccountPubKey.
 
--spec check(tx(), aetx:tx_context(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()} | {error, term()}.
+-spec check(tx(), aetx:tx_context(), aec_trees:trees(), height(), non_neg_integer()) -> {ok, aec_trees:trees()} | {error, term()}.
 check(#ns_update_tx{account = AccountPubKey, nonce = Nonce,
-                    fee = Fee, name_hash = NameHash, ttl = TTL}, _Context, Trees, Height) ->
+                    fee = Fee, name_hash = NameHash, ttl = TTL}, _Context, Trees, Height, _ConsensusVersion) ->
     Checks =
         [fun() -> check_ttl(TTL) end,
          fun() -> aetx_utils:check_account(AccountPubKey, Trees, Height, Nonce, Fee) end,
@@ -94,9 +94,9 @@ check(#ns_update_tx{account = AccountPubKey, nonce = Nonce,
         {error, Reason} -> {error, Reason}
     end.
 
--spec process(tx(), aetx:tx_context(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()}.
+-spec process(tx(), aetx:tx_context(), aec_trees:trees(), height(), non_neg_integer()) -> {ok, aec_trees:trees()}.
 process(#ns_update_tx{account = AccountPubKey, nonce = Nonce, fee = Fee,
-                      name_hash = NameHash} = UpdateTx, _Context, Trees0, Height) ->
+                      name_hash = NameHash} = UpdateTx, _Context, Trees0, Height, _ConsensusVersion) ->
     AccountsTree0 = aec_trees:accounts(Trees0),
     NSTree0 = aec_trees:ns(Trees0),
 

--- a/apps/aeoracle/include/oracle_txs.hrl
+++ b/apps/aeoracle/include/oracle_txs.hrl
@@ -1,5 +1,3 @@
--include_lib("apps/aecore/include/common.hrl").
-
 -define(ttl_delta_int, 0).
 -define(ttl_delta_atom, delta).
 -define(ttl_block_int, 1).

--- a/apps/aeoracle/src/aeo_extend_tx.erl
+++ b/apps/aeoracle/src/aeo_extend_tx.erl
@@ -6,6 +6,7 @@
 %%%=============================================================================
 -module(aeo_extend_tx).
 
+-include_lib("apps/aecore/include/common.hrl").
 -include("oracle_txs.hrl").
 
 -behavior(aetx).
@@ -16,8 +17,8 @@
          fee/1,
          nonce/1,
          origin/1,
-         check/4,
-         process/4,
+         check/5,
+         process/5,
          accounts/1,
          signers/1,
          serialize/1,
@@ -75,9 +76,9 @@ origin(#oracle_extend_tx{oracle = OraclePK}) ->
 
 %% Account should exist, and have enough funds for the fee
 %% Oracle should exist.
--spec check(tx(), aetx:tx_context(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()} | {error, term()}.
+-spec check(tx(), aetx:tx_context(), aec_trees:trees(), height(), non_neg_integer()) -> {ok, aec_trees:trees()} | {error, term()}.
 check(#oracle_extend_tx{oracle = OraclePK, nonce = Nonce,
-                        ttl = TTL, fee = Fee}, _Context, Trees, Height) ->
+                        ttl = TTL, fee = Fee}, _Context, Trees, Height, _ConsensusVersion) ->
     Checks =
         [fun() -> aetx_utils:check_account(OraclePK, Trees, Height, Nonce, Fee) end,
          fun() -> ensure_oracle(OraclePK, Trees) end,
@@ -96,9 +97,9 @@ accounts(#oracle_extend_tx{oracle = OraclePK}) ->
 signers(#oracle_extend_tx{oracle = OraclePK}) ->
     [OraclePK].
 
--spec process(tx(), aetx:tx_context(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()}.
+-spec process(tx(), aetx:tx_context(), aec_trees:trees(), height(), non_neg_integer()) -> {ok, aec_trees:trees()}.
 process(#oracle_extend_tx{oracle = OraclePK, nonce = Nonce, fee = Fee, ttl = TTL},
-        _Context, Trees0, Height) ->
+        _Context, Trees0, Height, _ConsensusVersion) ->
     AccountsTree0 = aec_trees:accounts(Trees0),
     OraclesTree0  = aec_trees:oracles(Trees0),
 

--- a/apps/aeoracle/src/aeo_query_tx.erl
+++ b/apps/aeoracle/src/aeo_query_tx.erl
@@ -6,6 +6,7 @@
 %%%=============================================================================
 -module(aeo_query_tx).
 
+-include_lib("apps/aecore/include/common.hrl").
 -include("oracle_txs.hrl").
 
 -behavior(aetx).
@@ -16,8 +17,8 @@
          fee/1,
          nonce/1,
          origin/1,
-         check/4,
-         process/4,
+         check/5,
+         process/5,
          accounts/1,
          signers/1,
          serialization_template/1,
@@ -105,10 +106,10 @@ origin(#oracle_query_tx{sender = SenderPubKey}) ->
 %% SenderAccount should exist, and have enough funds for the fee + the query_fee.
 %% Oracle should exist, and query_fee should be enough
 %% Fee should cover TTL
--spec check(tx(), aetx:tx_context(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()} | {error, term()}.
+-spec check(tx(), aetx:tx_context(), aec_trees:trees(), height(), non_neg_integer()) -> {ok, aec_trees:trees()} | {error, term()}.
 check(#oracle_query_tx{sender = SenderPubKey, nonce = Nonce,
                        oracle = OraclePubKey, query_fee = QFee,
-                       query_ttl = TTL, response_ttl = RTTL, fee = Fee} = Q, _Context, Trees, Height) ->
+                       query_ttl = TTL, response_ttl = RTTL, fee = Fee} = Q, _Context, Trees, Height, _ConsensusVersion) ->
     Checks =
         [fun() -> aetx_utils:check_account(SenderPubKey, Trees, Height, Nonce, Fee + QFee) end,
          fun() -> aeo_utils:check_ttl_fee(Height, TTL, Fee - ?ORACLE_QUERY_TX_FEE) end,
@@ -130,9 +131,9 @@ accounts(#oracle_query_tx{sender = SenderPubKey,
 signers(#oracle_query_tx{sender = SenderPubKey}) ->
     [SenderPubKey].
 
--spec process(tx(), aetx:tx_context(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()}.
+-spec process(tx(), aetx:tx_context(), aec_trees:trees(), height(), non_neg_integer()) -> {ok, aec_trees:trees()}.
 process(#oracle_query_tx{sender = SenderPubKey, nonce = Nonce, fee = Fee,
-                         query_fee = QueryFee} = QueryTx, _Context, Trees0, Height) ->
+                         query_fee = QueryFee} = QueryTx, _Context, Trees0, Height, _ConsensusVersion) ->
     AccountsTree0 = aec_trees:accounts(Trees0),
     OraclesTree0  = aec_trees:oracles(Trees0),
 

--- a/apps/aeoracle/src/aeo_register_tx.erl
+++ b/apps/aeoracle/src/aeo_register_tx.erl
@@ -6,6 +6,7 @@
 %%%=============================================================================
 -module(aeo_register_tx).
 
+-include_lib("apps/aecore/include/common.hrl").
 -include("oracle_txs.hrl").
 
 -behavior(aetx).
@@ -16,8 +17,8 @@
          fee/1,
          nonce/1,
          origin/1,
-         check/4,
-         process/4,
+         check/5,
+         process/5,
          accounts/1,
          signers/1,
          serialization_template/1,
@@ -95,9 +96,9 @@ origin(#oracle_register_tx{account = AccountPubKey}) ->
     AccountPubKey.
 
 %% Account should exist, and have enough funds for the fee.
--spec check(tx(), aetx:tx_context(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()} | {error, term()}.
+-spec check(tx(), aetx:tx_context(), aec_trees:trees(), height(), non_neg_integer()) -> {ok, aec_trees:trees()} | {error, term()}.
 check(#oracle_register_tx{account = AccountPubKey, nonce = Nonce,
-                          ttl = TTL, fee = Fee}, _Context, Trees, Height) ->
+                          ttl = TTL, fee = Fee}, _Context, Trees, Height, _ConsensusVersion) ->
     Checks =
         [fun() -> aetx_utils:check_account(AccountPubKey, Trees, Height, Nonce, Fee) end,
          fun() -> ensure_not_oracle(AccountPubKey, Trees) end,
@@ -116,10 +117,10 @@ accounts(#oracle_register_tx{account = AccountPubKey}) ->
 signers(#oracle_register_tx{account = AccountPubKey}) ->
     [AccountPubKey].
 
--spec process(tx(), aetx:tx_context(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()}.
+-spec process(tx(), aetx:tx_context(), aec_trees:trees(), height(), non_neg_integer()) -> {ok, aec_trees:trees()}.
 process(#oracle_register_tx{account       = AccountPubKey,
                             nonce         = Nonce,
-                            fee           = Fee} = RegisterTx, _Context, Trees0, Height) ->
+                            fee           = Fee} = RegisterTx, _Context, Trees0, Height, _ConsensusVersion) ->
     AccountsTree0 = aec_trees:accounts(Trees0),
     OraclesTree0  = aec_trees:oracles(Trees0),
 

--- a/apps/aeoracle/src/aeo_response_tx.erl
+++ b/apps/aeoracle/src/aeo_response_tx.erl
@@ -6,6 +6,7 @@
 %%%=============================================================================
 -module(aeo_response_tx).
 
+-include_lib("apps/aecore/include/common.hrl").
 -include("oracle_txs.hrl").
 
 -behavior(aetx).
@@ -16,8 +17,8 @@
          fee/1,
          nonce/1,
          origin/1,
-         check/4,
-         process/4,
+         check/5,
+         process/5,
          accounts/1,
          signers/1,
          serialization_template/1,
@@ -83,9 +84,9 @@ origin(#oracle_response_tx{oracle = OraclePubKey}) ->
 
 %% Oracle should exist, and have enough funds for the fee.
 %% QueryId id should match oracle.
--spec check(tx(), aetx:tx_context(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()} | {error, term()}.
+-spec check(tx(), aetx:tx_context(), aec_trees:trees(), height(), non_neg_integer()) -> {ok, aec_trees:trees()} | {error, term()}.
 check(#oracle_response_tx{oracle = OraclePubKey, nonce = Nonce,
-                          query_id = QId, fee = Fee}, _Context, Trees, Height) ->
+                          query_id = QId, fee = Fee}, _Context, Trees, Height, _ConsensusVersion) ->
     case fetch_query(OraclePubKey, QId, Trees) of
         {value, I} ->
             ResponseTTL = aeo_query:response_ttl(I),
@@ -113,10 +114,10 @@ accounts(#oracle_response_tx{oracle = OraclePubKey}) ->
 signers(#oracle_response_tx{oracle = OraclePubKey}) ->
     [OraclePubKey].
 
--spec process(tx(), aetx:tx_context(), aec_trees:trees(), height()) -> {ok, aec_trees:trees()}.
+-spec process(tx(), aetx:tx_context(), aec_trees:trees(), height(), non_neg_integer()) -> {ok, aec_trees:trees()}.
 process(#oracle_response_tx{oracle = OraclePubKey, nonce = Nonce,
                             query_id = QId, response = Response,
-                            fee = Fee}, _Context, Trees0, Height) ->
+                            fee = Fee}, _Context, Trees0, Height, _ConsensusVersion) ->
     AccountsTree0 = aec_trees:accounts(Trees0),
     OraclesTree0  = aec_trees:oracles(Trees0),
 

--- a/apps/aeoracle/test/aeo_test_utils.erl
+++ b/apps/aeoracle/test/aeo_test_utils.erl
@@ -23,6 +23,8 @@
         , trees/1
         ]).
 
+-include_lib("apps/aecore/include/common.hrl").
+-include_lib("apps/aecore/include/blocks.hrl").
 -include_lib("apps/aeoracle/include/oracle_txs.hrl").
 
 %%%===================================================================

--- a/apps/aetx/src/aetx.erl
+++ b/apps/aetx/src/aetx.erl
@@ -7,8 +7,8 @@
 -include_lib("apps/aecore/include/common.hrl").
 
 -export([ accounts/1
-        , check/3
-        , check_from_contract/3
+        , check/4
+        , check_from_contract/4
         , deserialize_from_binary/1
         , fee/1
         , hash/1
@@ -17,8 +17,8 @@
         , new/2
         , nonce/1
         , origin/1
-        , process/3
-        , process_from_contract/3
+        , process/4
+        , process_from_contract/4
         , serialize_for_client/1
         , serialize_to_binary/1
         , signers/1
@@ -93,11 +93,13 @@
     [pubkey()].
 
 -callback check(Tx :: tx_instance(), Context :: tx_context(),
-                Trees :: aec_trees:trees(), Height :: non_neg_integer()) ->
+                Trees :: aec_trees:trees(), Height :: non_neg_integer(),
+                ConsensusVersion :: non_neg_integer()) ->
     {ok, NewTrees :: aec_trees:trees()} | {error, Reason :: term()}.
 
 -callback process(Tx :: tx_instance(), Context :: tx_context(),
-                  Trees :: aec_trees:trees(), Height :: non_neg_integer()) ->
+                  Trees :: aec_trees:trees(), Height :: non_neg_integer(),
+                  ConsensusVersion :: non_neg_integer()) ->
     {ok, NewTrees :: aec_trees:trees()}.
 
 -callback serialize(Tx :: tx_instance()) ->
@@ -150,25 +152,29 @@ accounts(#aetx{ cb = CB, tx = Tx }) ->
 signers(#aetx{ cb = CB, tx = Tx }) ->
     CB:signers(Tx).
 
--spec check(Tx :: tx(), Trees :: aec_trees:trees(), Height :: non_neg_integer()) ->
+-spec check(Tx :: tx(), Trees :: aec_trees:trees(), Height :: non_neg_integer(),
+            ConsensusVersion :: non_neg_integer()) ->
     {ok, NewTrees :: aec_trees:trees()} | {error, Reason :: term()}.
-check(#aetx{ cb = CB, tx = Tx }, Trees, Height) ->
-    CB:check(Tx, aetx_transaction, Trees, Height).
+check(#aetx{ cb = CB, tx = Tx }, Trees, Height, ConsensusVersion) ->
+    CB:check(Tx, aetx_transaction, Trees, Height, ConsensusVersion).
 
--spec check_from_contract(Tx :: tx(), Trees :: aec_trees:trees(), Height :: non_neg_integer()) ->
+-spec check_from_contract(Tx :: tx(), Trees :: aec_trees:trees(), Height :: non_neg_integer(),
+                          ConsensusVersion :: non_neg_integer()) ->
     {ok, NewTrees :: aec_trees:trees()} | {error, Reason :: term()}.
-check_from_contract(#aetx{ cb = CB, tx = Tx }, Trees, Height) ->
-    CB:check(Tx, aetx_contract, Trees, Height).
+check_from_contract(#aetx{ cb = CB, tx = Tx }, Trees, Height, ConsensusVersion) ->
+    CB:check(Tx, aetx_contract, Trees, Height, ConsensusVersion).
 
--spec process(Tx :: tx(), Trees :: aec_trees:trees(), Height :: non_neg_integer()) ->
+-spec process(Tx :: tx(), Trees :: aec_trees:trees(), Height :: non_neg_integer(),
+              ConsensusVersion :: non_neg_integer()) ->
     {ok, NewTrees :: aec_trees:trees()}.
-process(#aetx{ cb = CB, tx = Tx }, Trees, Height) ->
-    CB:process(Tx, aetx_transaction, Trees, Height).
+process(#aetx{ cb = CB, tx = Tx }, Trees, Height, ConsensusVersion) ->
+    CB:process(Tx, aetx_transaction, Trees, Height, ConsensusVersion).
 
--spec process_from_contract(Tx :: tx(), Trees :: aec_trees:trees(), Height :: non_neg_integer()) ->
+-spec process_from_contract(Tx :: tx(), Trees :: aec_trees:trees(), Height :: non_neg_integer(),
+                            ConsensusVersion :: non_neg_integer()) ->
     {ok, NewTrees :: aec_trees:trees()}.
-process_from_contract(#aetx{ cb = CB, tx = Tx }, Trees, Height) ->
-    CB:process(Tx, aetx_contract, Trees, Height).
+process_from_contract(#aetx{ cb = CB, tx = Tx }, Trees, Height, ConsensusVersion) ->
+    CB:process(Tx, aetx_contract, Trees, Height, ConsensusVersion).
 
 -spec serialize_for_client(Tx :: tx()) -> map().
 serialize_for_client(#aetx{ cb = CB, type = Type, tx = Tx }) ->

--- a/apps/aetx/test/aetx_tests.erl
+++ b/apps/aetx/test/aetx_tests.erl
@@ -7,6 +7,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 -include_lib("apps/aecore/include/common.hrl").
+-include_lib("apps/aecore/include/blocks.hrl").
 
 -define(TEST_MODULE, aetx).
 
@@ -54,7 +55,7 @@ apply_signed_txs_test_() ->
                SignedTxs = [SignedCoinbase, SignedSpendTx, SignedOverBalanceTx],
 
                {ok, ValidSignedTxs, StateTree} =
-                  aec_trees:apply_signed_txs(SignedTxs, StateTree0, BlockHeight),
+                  aec_trees:apply_signed_txs(SignedTxs, StateTree0, BlockHeight, ?PROTOCOL_VERSION),
                ?assertEqual([SignedCoinbase, SignedSpendTx], ValidSignedTxs),
 
                ResultAccountsTree = aec_trees:accounts(StateTree),

--- a/test/aevm_chain_SUITE.erl
+++ b/test/aevm_chain_SUITE.erl
@@ -17,6 +17,9 @@
 
 -include_lib("common_test/include/ct.hrl").
 
+-include_lib("apps/aecore/include/common.hrl").
+-include_lib("apps/aecore/include/blocks.hrl").
+
 %%%===================================================================
 %%% Common test framework
 %%%===================================================================
@@ -63,7 +66,7 @@ sign_and_apply_transaction(Tx, PrivKey, S1) ->
     SignedTx = aetx_sign:sign(Tx, PrivKey),
     Trees    = aect_test_utils:trees(S1),
     Height   = 1,
-    {ok, AcceptedTxs, Trees1} = aec_trees:apply_signed_txs([SignedTx], Trees, Height),
+    {ok, AcceptedTxs, Trees1} = aec_trees:apply_signed_txs([SignedTx], Trees, Height, ?PROTOCOL_VERSION),
     S2       = aect_test_utils:set_trees(Trees1, S1),
     {SignedTx, AcceptedTxs, S2}.
 


### PR DESCRIPTION
Delivers https://www.pivotaltracker.com/story/show/156959557

[CI workflow passing](https://circleci.com/workflow-run/a9880b4e-31f1-472b-a831-05e4d1c884e0) (including Python UAT tests and aevm_tests).

This PR contains no functional changes - it is meant to be used by spend tx with payload.