### PR TITLE
CT suit utils bugfix

### DIFF
--- a/apps/aecore/test/aecore_suite_utils.erl
+++ b/apps/aecore/test/aecore_suite_utils.erl
@@ -351,9 +351,7 @@ setup_node(N, Top, Epoch, Config) ->
     Version = binary_to_list(VerB),
     %%
     CfgD = filename:join([Top, "config/", N]),
-    RelD = filename:dirname(
-             hd(filelib:wildcard(
-                    filename:join([DDir, "releases", Version, "epoch.rel"])))),
+    RelD = filename:dirname(filename:join([DDir, "releases", Version, "epoch.rel"])),
     cp_file(filename:join(CfgD, "sys.config"),
             filename:join(RelD, "sys.config")),
     cp_file(filename:join(CfgD, "vm.args"),

--- a/apps/aecore/test/aecore_suite_utils.erl
+++ b/apps/aecore/test/aecore_suite_utils.erl
@@ -346,11 +346,14 @@ setup_node(N, Top, Epoch, Config) ->
     cp_dir(filename:join(Epoch, "bin"), DDir ++ "/"),
     symlink(filename:join(Epoch, "lib"), filename:join(DDir, "lib")),
     symlink(filename:join(Epoch, "patches"), filename:join(DDir, "patches")),
+    {ok, VerContents} = file:read_file(filename:join(Epoch, "VERSION")),
+    [VerB |_ ] = binary:split(VerContents, [<<"\n">>], [global]),
+    Version = binary_to_list(VerB),
     %%
     CfgD = filename:join([Top, "config/", N]),
     RelD = filename:dirname(
              hd(filelib:wildcard(
-                    filename:join(DDir, "releases/*/epoch.rel")))),
+                    filename:join([DDir, "releases", Version, "epoch.rel"])))),
     cp_file(filename:join(CfgD, "sys.config"),
             filename:join(RelD, "sys.config")),
     cp_file(filename:join(CfgD, "vm.args"),


### PR DESCRIPTION
[Pivotal story](https://www.pivotaltracker.com/story/show/157143855)
There used to be a mismatch between dirs: when there had been a bump in `VERSION` file and there are a couple of relases in the tests dir the following can occur

Prepare dir for `0.12.0`
```
*** User 2018-04-27 10:09:46.469 ***
cp_dir("/home/vlz/projects/aeternity/epoch/_build/test/rel/epoch/releases/0.12.0", "/home/vlz/projects/aeternity/epoch/_build/test/logs/latest.aesc_fsm/dev2/releases/0.12.0") 
```
But yet copy the sys.config and vm.args to the wrong location (for release `0.11.0`)
```
*** User 2018-04-27 10:09:46.475 ***
Copied /home/vlz/projects/aeternity/epoch/config/dev2/sys.config to /home/vlz/projects/aeternity/epoch/_build/test/logs/latest.aesc_fsm/dev2/releases/0.11.0/sys.config


*** User 2018-04-27 10:09:46.475 ***
Copied /home/vlz/projects/aeternity/epoch/config/dev2/vm.args to /home/vlz/projects/aeternity/epoch/_build/test/logs/latest.aesc_fsm/dev2/releases/0.11.0/vm.args
```
