### PR TITLE
Pt 156600645 resolve name at current height

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ erl_crash.dump
 logs
 _build
 .idea
+*.iml
 py/bin
 py/include
 py/lib
@@ -48,3 +49,4 @@ swagger/swagger-codegen-cli-*.jar
 *.retry
 system_test/logs
 system_test/aest_hard_fork_SUITE_data/db
+*.crashdump

--- a/apps/aecore/src/aec_chain.erl
+++ b/apps/aecore/src/aec_chain.erl
@@ -134,7 +134,7 @@ name_entry(Name) ->
                                         {error, atom()}.
 resolve_name(Type, Name) ->
     case get_top_state() of
-        {ok, Trees} -> aens:resolve(Type, Name, aec_trees:ns(Trees));
+        {ok, Trees} -> aens:resolve_encoded(Type, Name, aec_trees:ns(Trees));
         error -> {error, no_state_trees}
     end.
 

--- a/apps/aens/src/aens.erl
+++ b/apps/aens/src/aens.erl
@@ -8,7 +8,8 @@
 -module(aens).
 
 %% API
--export([resolve/3,
+-export([resolve_encoded/3,
+         resolve_decoded/3,
          get_commitment_hash/2,
          get_name_entry/2,
          get_name_hash/1]).
@@ -23,22 +24,13 @@
 %%% API
 %%%===================================================================
 
--spec resolve(atom(), binary(), aens_state_tree:tree()) -> {ok, binary()} | {error, atom()}.
-resolve(Type, Binary, NSTree) ->
-    case is_name(Binary) of
-        false ->
-            aec_base58c:safe_decode(Type, Binary);
-        true ->
-            case get_name(Binary, NSTree) of
-                {ok, #{<<"pointers">> := Pointers}} ->
-                    case proplists:get_value(atom_to_binary(Type, utf8), Pointers) of
-                        undefined -> {error, type_not_found};
-                        Val       -> aec_base58c:safe_decode(Type, Val)
-                    end;
-                {error, _Reason} = Error ->
-                    Error
-            end
-    end.
+-spec resolve_decoded(atom(), binary(), aens_state_tree:tree()) -> {ok, binary()} | {error, atom()}.
+resolve_decoded(Type, PubKeyOrName, NSTree) ->
+    resolve(Type, PubKeyOrName, NSTree, false).
+
+-spec resolve_encoded(atom(), binary(), aens_state_tree:tree()) -> {ok, binary()} | {error, atom()}.
+resolve_encoded(Type, PubKeyOrName, NSTree) ->
+    resolve(Type, PubKeyOrName, NSTree, true).
 
 -spec get_commitment_hash(binary(), integer()) -> {ok, aens_hash:commitment_hash()} |
                                                   {error, atom()}.
@@ -75,8 +67,25 @@ get_name_hash(Name) when is_binary(Name) ->
 %%% Internal functions
 %%%===================================================================
 
-is_name(Binary) ->
-    length(binary:split(Binary, ?LABEL_SEPARATOR)) > 1.
+-spec resolve(atom(), binary(), aens_state_tree:tree(), boolean()) -> {ok, binary()} | {error, atom()}.
+resolve(Type, PubKeyOrName, NSTree, IsEncoded) ->
+    case aens_utils:validate_name(PubKeyOrName) of
+        {error, _Reason} ->
+            case IsEncoded of
+                true -> aec_base58c:safe_decode(Type, PubKeyOrName);
+                false -> {ok, PubKeyOrName}
+            end;
+        ok ->
+            case get_name(PubKeyOrName, NSTree) of
+                {ok, #{<<"pointers">> := Pointers}} ->
+                    case proplists:get_value(atom_to_binary(Type, utf8), Pointers) of
+                        undefined -> {error, type_not_found};
+                        Val -> aec_base58c:safe_decode(Type, Val)
+                    end;
+                {error, _Reason} = Error ->
+                    Error
+            end
+    end.
 
 get_name(Name, NSTree) ->
     case get_name_hash(Name) of


### PR DESCRIPTION
Resolves names for SpendTx at current height while mining and validating.
 - account_pubkey pointer from naming system is used
 - if name is found but no account_pubkey, the transaction is rejected
 - if name is not valid, the transaction is rejected

https://www.pivotaltracker.com/story/show/156600645