### PR TITLE
PT 157189489 Channels close TCP connections upon FSM death

### DIFF
--- a/apps/aechannel/src/aesc_close_mutual_tx.erl
+++ b/apps/aechannel/src/aesc_close_mutual_tx.erl
@@ -131,7 +131,7 @@ process(#channel_close_mutual_tx{channel_id       = ChannelId,
                                  initiator_amount = InitiatorAmount,
                                  responder_amount = ResponderAmount,
                                  ttl              = _TTL,
-                                 fee              = Fee,
+                                 fee              = _Fee,
                                  nonce            = _Nonce}, _Context, Trees, Height,
                                                   _ConsensusVersion) ->
     AccountsTree0 = aec_trees:accounts(Trees),

--- a/apps/aechannel/src/aesc_fsm.erl
+++ b/apps/aechannel/src/aesc_fsm.erl
@@ -602,10 +602,10 @@ error_binary(E) when is_atom(E) ->
     atom_to_binary(E, latin1).
 
 
-terminate(_Reason, _State, Data) ->
+terminate(Reason, _State, Data) ->
     #data{session = Sn} = Data,
     aesc_session_noise:close(Sn),
-    report_info(died, Data),
+    report_info({died, Reason}, Data),
     ok.
 
 code_change(_OldVsn, OldState, OldData, _Extra) ->

--- a/apps/aechannel/src/aesc_fsm.erl
+++ b/apps/aechannel/src/aesc_fsm.erl
@@ -603,8 +603,6 @@ error_binary(E) when is_atom(E) ->
 
 
 terminate(Reason, _State, Data) ->
-    #data{session = Sn} = Data,
-    aesc_session_noise:close(Sn),
     report_info({died, Reason}, Data),
     ok.
 

--- a/apps/aechannel/src/aesc_fsm.erl
+++ b/apps/aechannel/src/aesc_fsm.erl
@@ -7,7 +7,8 @@
 -export([initiate/3,     %% (host(), port(), Opts :: #{})
          respond/2,      %% (port(), Opts :: #{})
          upd_transfer/4, %% (fsm() , from(), to(), amount())
-         shutdown/1]).   %% (fsm())
+         shutdown/1,     %% (fsm())
+         client_died/1]).%% (fsm())
 
 %% Used by noise session
 -export([message/2]).
@@ -211,6 +212,11 @@ upd_transfer(Fsm, From, To, Amount) ->
 shutdown(Fsm) ->
     lager:debug("shutdown(~p)", [Fsm]),
     gen_statem:call(Fsm, shutdown).
+
+client_died(Fsm) ->
+    %TODO: possibility for reconnect
+    lager:debug("client died(~p)", [Fsm]),
+    ok = gen_statem:stop(Fsm).
 
 start_link(#{} = Arg) ->
     gen_statem:start_link(?MODULE, Arg, ?GEN_STATEM_OPTS).
@@ -597,6 +603,8 @@ error_binary(E) when is_atom(E) ->
 
 
 terminate(_Reason, _State, Data) ->
+    #data{session = Sn} = Data,
+    aesc_session_noise:close(Sn),
     report_info(died, Data),
     ok.
 

--- a/apps/aechannel/test/aesc_fsm_SUITE.erl
+++ b/apps/aechannel/test/aesc_fsm_SUITE.erl
@@ -139,8 +139,7 @@ create_channel_(Cfg) ->
              ttl              => 100,
              client           => self(),
              noise            => [{noise, Proto}],
-             timeouts         => #{idle => 20000,
-                                   awaiting_locked => 10000},
+             timeouts         => #{idle => 20000},
              report_info      => true},
 
     {ok, FsmR} = rpc(dev1, aesc_fsm, respond, [Port, Spec]),

--- a/apps/aecore/src/aec_blocks.erl
+++ b/apps/aecore/src/aec_blocks.erl
@@ -111,7 +111,7 @@ new_with_state(LastBlock, Txs, Trees0) ->
     %% We should not have any transactions with invalid signatures for
     %% creation of block candidate, as only txs with validated signatures should land in mempool.
     %% Let's hardcode this expectation for now.
-    Txs = aetx_sign:filter_invalid_signatures(Txs),
+    {Txs, _} = {aetx_sign:filter_invalid_signatures(Txs), Txs},
 
     {ok, Txs1, Trees} = aec_trees:apply_signed_txs(Txs, Trees0, Height, Version),
     {ok, TxsRootHash} = aec_txs_trees:root_hash(aec_txs_trees:from_txs(Txs1)),

--- a/apps/aehttp/src/sc_ws_handler.erl
+++ b/apps/aehttp/src/sc_ws_handler.erl
@@ -252,7 +252,12 @@ process_incoming(Msg, _State) ->
     {error, unhandled}.
 
 -spec process_fsm(term()) -> no_reply | {reply, map()} | {error, atom()}.
-process_fsm({info, Event}) ->
+process_fsm({info, Event0}) ->
+    Event =
+        case Event0 of
+            {died, _} -> died;
+            _ -> Event0
+        end,
     {reply, #{action => <<"info">>,
               payload => #{event => Event}}};
 process_fsm({sign, Tag, Tx}) when Tag =:= create_tx

--- a/apps/aehttp/src/sc_ws_handler.erl
+++ b/apps/aehttp/src/sc_ws_handler.erl
@@ -81,8 +81,12 @@ websocket_info(_Info, State) ->
 	  {ok, State}.
 
 terminate(_Reason, _PartialReq, #{} = _State) ->
+    % not initialized yet
     ok;
 terminate(_Reason, _PartialReq, State) ->
+    FsmPid = fsm_pid(State),
+    true = unlink(FsmPid),
+    ok = aesc_fsm:client_died(FsmPid),
     jobs:done(job_id(State)),
     ok.
 

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -397,6 +397,9 @@ groups() ->
       [sc_ws_timeout_open,
        sc_ws_open,
        sc_ws_update,
+       sc_ws_close
+       sc_ws_open,
+       sc_ws_update,
        sc_ws_close_mutual
       ]}
     ].
@@ -3000,12 +3003,15 @@ channel_sign_tx(ConnPid, Privkey, Tag) ->
 
 sc_ws_open(Config) ->
     #{initiator := #{pub_key := IPubkey,
-                    priv_key := IPrivkey,
-                    start_amt := IStartAmt},
+                    priv_key := IPrivkey},
       responder := #{pub_key := RPubkey,
-                    priv_key := RPrivkey,
-                    start_amt := RStartAmt}} = proplists:get_value(participants, Config),
+                    priv_key := RPrivkey}} = proplists:get_value(participants, Config),
 
+
+    {ok, 200, #{<<"balance">> := IStartAmt}} =
+                 get_balance_at_top(aec_base58c:encode(account_pubkey, IPubkey)),
+    {ok, 200, #{<<"balance">> := RStartAmt}} =
+                 get_balance_at_top(aec_base58c:encode(account_pubkey, RPubkey)),
     IAmt = 7,
     RAmt = 3,
 

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -205,7 +205,9 @@
    [sc_ws_timeout_open/1,
     sc_ws_open/1,
     sc_ws_update/1,
-    sc_ws_close_mutual/1
+    sc_ws_close/1,
+    sc_ws_close_mutual_inititator/1,
+    sc_ws_close_mutual_responder/1
    ]).
 
 -include_lib("common_test/include/ct.hrl").
@@ -395,12 +397,14 @@ groups() ->
       ]},
      {channel_websocket, [sequence],
       [sc_ws_timeout_open,
+      % initiator can start close mutual
        sc_ws_open,
        sc_ws_update,
-       sc_ws_close
+       sc_ws_close_mutual_inititator,
+       % responder can start close mutual
        sc_ws_open,
        sc_ws_update,
-       sc_ws_close_mutual
+       sc_ws_close_mutual_responder
       ]}
     ].
 
@@ -3007,13 +3011,18 @@ sc_ws_open(Config) ->
       responder := #{pub_key := RPubkey,
                     priv_key := RPrivkey}} = proplists:get_value(participants, Config),
 
-
-    {ok, 200, #{<<"balance">> := IStartAmt}} =
-                 get_balance_at_top(aec_base58c:encode(account_pubkey, IPubkey)),
-    {ok, 200, #{<<"balance">> := RStartAmt}} =
-                 get_balance_at_top(aec_base58c:encode(account_pubkey, RPubkey)),
     IAmt = 7,
     RAmt = 3,
+
+    Balances =
+        fun() ->
+            {ok, 200, #{<<"balance">> := BalI}} =
+                get_balance_at_top(aec_base58c:encode(account_pubkey, IPubkey)),
+            {ok, 200, #{<<"balance">> := BalR}} =
+                get_balance_at_top(aec_base58c:encode(account_pubkey, RPubkey)),
+            {BalI, BalR}
+        end,
+    {IStartAmt, RStartAmt} = Balances(),
 
     ChannelOpts = channel_options(IPubkey, RPubkey, IAmt, RAmt),
     {ok, IConnPid} = channel_ws_start(initiator,
@@ -3160,14 +3169,21 @@ sc_ws_close(Config) ->
     ok = ?WS:stop(RConnPid),
     ok.
 
-sc_ws_close_mutual(Config) ->
+
+sc_ws_close_mutual_inititator(Config) ->
+    sc_ws_close_mutual(Config, initiator).
+
+sc_ws_close_mutual_responder(Config) ->
+    sc_ws_close_mutual(Config, responder).
+
+sc_ws_close_mutual(Config, Closer) when Closer =:= initiator
+                                 orelse Closer =:= responder ->
     {sc_ws_update, ConfigList} = ?config(saved_config, Config),
     #{initiator := #{pub_key := IPubkey,
                     priv_key := IPrivkey},
       responder := #{pub_key := RPubkey,
                     priv_key := RPrivkey}} = proplists:get_value(participants,
                                                                  ConfigList),
-
     Balances =
         fun() ->
             {ok, 200, #{<<"balance">> := BalI}} =
@@ -3185,10 +3201,19 @@ sc_ws_close_mutual(Config) ->
     ok = ?WS:register_test_for_channel_event(IConnPid, info),
     ok = ?WS:register_test_for_channel_event(RConnPid, info),
 
-    ?WS:send(IConnPid, <<"shutdown">>, #{}),
+    CloseMutual =
+        fun(CloserConn, CloserPrivkey, OtherConn, OtherPrivkey) ->
+            ?WS:send(CloserConn, <<"shutdown">>, #{}),
 
-    ShutdownTx = channel_sign_tx(IConnPid, IPrivkey, <<"shutdown_sign">>),
-    ShutdownTx = channel_sign_tx(RConnPid, RPrivkey, <<"shutdown_sign_ack">>),
+            ShTx = channel_sign_tx(CloserConn, CloserPrivkey, <<"shutdown_sign">>),
+            ShTx = channel_sign_tx(OtherConn, OtherPrivkey, <<"shutdown_sign_ack">>)
+        end,
+    ShutdownTx =
+        case Closer of
+            initiator -> CloseMutual(IConnPid, IPrivkey, RConnPid, RPrivkey);
+            responder -> CloseMutual(RConnPid, RPrivkey, IConnPid, IPrivkey)
+        end,
+
     {channel_close_mutual_tx, MutualTx} = aetx:specialize_type(ShutdownTx),
 
     timer:sleep(100), % as aesc_fsm_SUITE
@@ -3209,6 +3234,30 @@ sc_ws_close_mutual(Config) ->
     assert_balance(IPubkey, IStartB + IChange),
     assert_balance(RPubkey, RStartB + RChange),
 
+    %% There is an issue in the mempool processing mutual close transactions
+    %% remove after mempool refactoring 
+    RpcFun = fun(M, F, A) -> rpc(?NODE, M, F, A) end,
+    {ok, DbCfg} = aecore_suite_utils:get_node_db_config(RpcFun),
+    aecore_suite_utils:stop_node(?NODE, Config),
+    aecore_suite_utils:delete_node_db_if_persisted(DbCfg),
+
+    aecore_suite_utils:start_node(?NODE, Config),
+    aecore_suite_utils:connect(aecore_suite_utils:node_name(?NODE)),
+    ToMine = aecore_suite_utils:latest_fork_height(),
+    aecore_suite_utils:mine_blocks(aecore_suite_utils:node_name(?NODE),
+                                   ToMine),
+    %% prepare participants
+    IStartAmt = 20,
+    RStartAmt = 10,
+    Fee = 1,
+
+    aecore_suite_utils:mine_blocks(aecore_suite_utils:node_name(?NODE), 4),
+
+    {ok, 200, _} = post_spend_tx(IPubkey, IStartAmt, Fee),
+    {ok, 200, _} = post_spend_tx(RPubkey, RStartAmt, Fee),
+    aecore_suite_utils:mine_blocks(aecore_suite_utils:node_name(?NODE), 1),
+    assert_balance(IPubkey, IStartAmt),
+    assert_balance(RPubkey, RStartAmt),
     ok.
 
 sc_ws_timeout_open(Config) ->


### PR DESCRIPTION
[Pivotal story](https://www.pivotaltracker.com/story/show/157189489)
Test opens a channel, updates it and closes the WSs. This should result in FSMs death and release of the socket being used. The state channel itself is not closed. Then test opens a second channel on the same port and host to verify that the port is available.