### PR TITLE
PT-156609771: Test synchronizing far ahead node

### DIFF
--- a/system_test/aest_perf_SUITE.erl
+++ b/system_test/aest_perf_SUITE.erl
@@ -1,0 +1,157 @@
+-module(aest_perf_SUITE).
+
+%=== EXPORTS ===================================================================
+
+% Common Test exports
+-export([all/0]).
+-export([groups/0]).
+-export([init_per_suite/1]).
+-export([init_per_group/2]).
+-export([init_per_testcase/2]).
+-export([end_per_testcase/2]).
+-export([end_per_group/2]).
+-export([end_per_suite/1]).
+
+% Test cases
+-export([
+    startup_speed/1,
+    sync_speed/1
+]).
+
+-import(aest_nodes, [
+    setup_nodes/2,
+    start_node/2,
+    stop_node/2, stop_node/3,
+    kill_node/2,
+    connect_node/3, disconnect_node/3,
+    http_get/5,
+    request/4,
+    wait_for_value/4,
+    assert_synchronized/2
+]).
+
+%=== INCLUDES ==================================================================
+
+-include_lib("eunit/include/eunit.hrl").
+
+%=== MACROS ====================================================================
+
+-define(BASE, #{
+    backend => aest_docker,
+    source  => {pull, "aeternity/epoch:local"}
+}).
+
+%=== COMMON TEST FUNCTIONS =====================================================
+
+all() -> [
+    {group, long_chain}
+].
+
+groups() ->
+    [{long_chain, [], [
+        startup_speed,
+        sync_speed
+    ]}].
+
+init_per_suite(Cfg) ->
+    MineRate = 100,
+    Cfg ++ [
+        {height, 10000},              % Length of chain to test
+        {mine_rate, MineRate},        % Mine rate configuration for nodes
+        {mine_timeout, MineRate * 2}, % Per block
+        {startup_timeout, 10000},     % Timeout until HTTP API responds
+        {sync_timeout, 100}           % Per block
+    ].
+
+init_per_group(long_chain, InitCfg) ->
+    %% Some parameters depend on the speed and capacity of the docker containers:
+    Cfg = aest_nodes:ct_setup(InitCfg),
+
+    Nodes = [n1, n2, n3],
+    Height = proplists:get_value(height, Cfg),
+    MineRate = proplists:get_value(mine_rate, Cfg),
+    MineTimeout = proplists:get_value(mine_timeout, Cfg),
+
+    setup_nodes(cluster(Nodes, #{mine_rate => MineRate}), Cfg),
+    [start_node(N, Cfg) || N <- Nodes],
+    wait_for_startup(Nodes, 0, Cfg),
+    wait_for_value({height, Height}, Nodes, MineTimeout * Height, Cfg),
+    Tag = io_lib:format("local-h~b", [Height]),
+    Ref = aest_nodes:export(n1, Tag, Cfg),
+    [kill_node(N, Cfg) || N <- Nodes],
+    aest_nodes:ct_cleanup(Cfg),
+    [{source, Ref}, {height, Height}, {mine_rate, MineRate}|Cfg].
+
+end_per_group(long_chain, _Cfg) -> ok.
+
+init_per_testcase(_TC, Cfg) -> aest_nodes:ct_setup(Cfg).
+
+end_per_testcase(_TC, Cfg) -> aest_nodes:ct_cleanup(Cfg).
+
+end_per_suite(_Cfg) -> ok.
+
+%=== TEST CASES ================================================================
+
+startup_speed(Cfg) ->
+    Height = proplists:get_value(height, Cfg),
+    Source = proplists:get_value(source, Cfg),
+    StartupTimeout = proplists:get_value(startup_timeout, Cfg),
+
+    setup_nodes([spec(node, [], #{source => Source})], Cfg),
+    start_node(node, Cfg),
+    wait_for_startup([node], Height, Cfg),
+    wait_for_value({height, Height}, [node], StartupTimeout, Cfg).
+
+sync_speed(Cfg) ->
+    Height = proplists:get_value(height, Cfg),
+    Source = proplists:get_value(source, Cfg),
+    MineRate = proplists:get_value(mine_rate, Cfg),
+
+    InitialNodes = [n1, n2, n3, n4],
+
+    InitialNodeSpecs = cluster(InitialNodes, #{
+        mine_rate => MineRate,
+        source => Source
+    }),
+    NewNodesSpec = [
+        spec(N, InitialNodes, #{mine_rate => MineRate})
+        || N <- [n5, n6]
+    ],
+
+    setup_nodes(InitialNodeSpecs ++ NewNodesSpec, Cfg),
+    [start_node(N, Cfg) || N <- InitialNodes],
+    wait_for_startup(InitialNodes, Height, Cfg),
+
+    InitialBlocks = [get_block(N, Height, Cfg) || N <- InitialNodes],
+
+    start_node(n5, Cfg),
+    wait_for_startup([n5], 0, Cfg),
+    wait_for_sync([n5], Height, Cfg),
+    N5Block = get_block(n5, Height, Cfg),
+
+    start_node(n6, Cfg),
+    wait_for_startup([n6], 0, Cfg),
+    wait_for_sync([n6], Height, Cfg),
+    N6Block = get_block(n6, Height, Cfg),
+
+    AllBlocks = InitialBlocks ++ [N5Block, N6Block],
+
+    [?assertEqual(A, B) || A <- AllBlocks, B <- AllBlocks, A =/= B].
+
+%=== INTERNAL FUNCTIONS ========================================================
+
+cluster(Names, Spec) -> [spec(N, Names -- [N], Spec) || N <- Names].
+
+spec(Name, Peers, Spec) ->
+    maps:merge(maps:merge(?BASE, Spec), #{name => Name, peers => Peers}).
+
+wait_for_startup(Nodes, Height, Cfg) ->
+    StartupTimeout = proplists:get_value(startup_timeout, Cfg),
+    wait_for_value({height, Height}, Nodes, StartupTimeout, Cfg).
+
+wait_for_sync(Nodes, Height, Cfg) ->
+    SyncTimeout = proplists:get_value(sync_timeout, Cfg),
+    wait_for_value({height, Height}, Nodes, SyncTimeout * Height, Cfg).
+
+get_block(NodeName, Height, Cfg) ->
+    request(NodeName, [v2, 'block-by-height'], #{height => Height}, Cfg).

--- a/system_test/aest_perf_SUITE_data/epoch.yaml.mustache
+++ b/system_test/aest_perf_SUITE_data/epoch.yaml.mustache
@@ -1,0 +1,37 @@
+{{#epoch_config}}
+---
+peers: {{^peers}}[]{{/peers}}
+{{#peers}}
+    - {{peer}}
+{{/peers}}
+
+sync:
+    port: {{services.sync.port}}
+
+http:
+    external:
+        port: {{services.ext_http.port}}
+    internal:
+        listen_address: 0.0.0.0
+        port: {{services.int_http.port}}
+
+websocket:
+    internal:
+        listen_address: 0.0.0.0
+        port: {{services.int_ws.port}}
+
+keys:
+    password: {{key_password}}
+    dir: ./keys
+
+chain:
+    persist: true
+
+mining:
+    autostart: true
+    cuckoo:
+        miner:
+            executable: mean16s-generic
+            extra_args: ""
+            node_bits: 16
+{{/epoch_config}}

--- a/system_test/helpers/aest_docker.erl
+++ b/system_test/helpers/aest_docker.erl
@@ -315,7 +315,7 @@ node_logs(#{container_id := ID} = _NodeState) ->
 get_peer_address(NodeState) ->
     #{hostname := Hostname,
       exposed_ports := #{sync := Port},
-      sync_pubkey := Key} = NodeState,
+      pubkey := Key} = NodeState,
     aec_peers:encode_peer_address(#{host => Hostname,
                                     port => Port,
                                     pubkey => Key}).

--- a/system_test/helpers/aest_docker.erl
+++ b/system_test/helpers/aest_docker.erl
@@ -21,6 +21,7 @@
 -export([connect_node/2]).
 -export([disconnect_node/2]).
 -export([get_log_path/1]).
+-export([export/2]).
 
 %=== MACROS ====================================================================
 
@@ -372,6 +373,9 @@ disconnect_node(NetName, NodeState) ->
 -spec get_log_path(node_state()) -> binary().
 get_log_path(#{log_path := LogPath}) -> LogPath.
 
+export(#{container_id := ID} = _NodeState, Name) ->
+    #{'Id' := ImageID} = aest_docker_api:commit(ID, Name),
+    {pull, ImageID}.
 
 %=== INTERNAL FUNCTIONS ========================================================
 

--- a/system_test/helpers/aest_docker_api.erl
+++ b/system_test/helpers/aest_docker_api.erl
@@ -23,6 +23,7 @@
 -export([exec/3]).
 -export([extract_archive/3]).
 -export([container_logs/1]).
+-export([commit/2]).
 
 %=== MACROS ====================================================================
 
@@ -205,6 +206,11 @@ container_logs(ID) ->
         {ok, 404, _} -> throw({container_not_found, ID});
         {ok, 500, Response} ->
             throw({docker_error, maps:get(message, decode_json(Response))})
+    end.
+
+commit(ID, Tag) ->
+    case docker_post([commit], #{container => ID, repo => "aeternity/epoch", tag => Tag}, #{}, #{}) of
+        {ok, 201, Response} -> Response
     end.
 
 %=== INTERNAL FUNCTIONS ========================================================

--- a/system_test/helpers/aest_nodes.erl
+++ b/system_test/helpers/aest_nodes.erl
@@ -202,7 +202,7 @@ eqc_cleanup(Ctx) ->
 %% @doc Creates and setups a list of nodes.
 %% The nodes are not started, use `start_node/2` for that.
 -spec setup_nodes([node_spec()], test_ctx()) -> ok.
-setup_nodes(NodeSpecs, Ctx) ->
+setup_nodes(NodeSpecs, Ctx) when is_list(NodeSpecs) ->
     call(ctx2pid(Ctx), {setup_nodes, NodeSpecs}).
 
 %% @doc Starts a node previously setup.
@@ -331,8 +331,6 @@ wait_for_value({height, MinHeight}, NodeNames, Timeout, Ctx) ->
     ct:log("Height ~p reached on nodes ~p after ~.2f seconds",
         [MinHeight, NodeNames, Duration]
     ).
-
-
 
 %=== INTERNAL FUNCTIONS ========================================================
 

--- a/system_test/helpers/aest_nodes.erl
+++ b/system_test/helpers/aest_nodes.erl
@@ -24,6 +24,7 @@
 -export([get_node_pubkey/2]).
 -export([http_get/5]).
 -export([http_post/7]).
+-export([export/3]).
 
 %% Helper function exports
 -export([request/4]).
@@ -260,6 +261,9 @@ http_get(NodeName, Service, Path, Query, Ctx) ->
 http_post(NodeName, Service, Path, Query, Headers, Body, Ctx) ->
     Addr = get_service_address(NodeName, Service, Ctx),
     http_addr_post(Addr, Path, Query, Headers, Body).
+
+export(NodeName, Name, Ctx) ->
+    call(ctx2pid(Ctx), {export, NodeName, Name}).
 
 %=== HELPER FUNCTIONS ==========================================================
 

--- a/system_test/helpers/aest_nodes_mgr.erl
+++ b/system_test/helpers/aest_nodes_mgr.erl
@@ -116,6 +116,9 @@ handle_call({disconnect_node, NodeName, NetName}, _From, State) ->
     {reply, ok, mgr_disconnect_node(NodeName, NetName, State)};
 handle_call({log, Format, Params}, _From, State) ->
     {reply, ok, mgr_log(Format, Params, State)};
+handle_call({export, NodeName, Name}, _From, State) ->
+    {ok, Reply, NewState} = mgr_export_node(NodeName, Name, State),
+    {reply, Reply, NewState};
 handle_call(Request, From, _State) ->
     erlang:error({unknown_request, Request, From}).
 
@@ -238,3 +241,7 @@ mgr_setup_node(#{backend := Mod, name := Name} = NodeSpec, Backends) ->
 mgr_log(Format, Params, #{log_fun := LogFun} = State) ->
     log(LogFun, Format, Params),
     State.
+
+mgr_export_node(NodeName, Name, #{nodes := Nodes} = State) ->
+    {Mod, NodeState} = maps:get(NodeName, Nodes),
+    {ok, Mod:export(NodeState, Name), State}.


### PR DESCRIPTION
A new performance suite is added, and the existing sync speed test is moved there. A new startup speed test is added.

Faster `smoke-test` target will be added in a separate PR.