### PR TITLE
[RFC] Application of txs only post genesis

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -480,6 +480,8 @@ workflows:
           requires:
             - build
 
+      - aevm_tests: {}
+
       - static_analysis:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -479,9 +479,6 @@ workflows:
       - uat_tests:
           requires:
             - build
-          filters:
-            branches:
-              only: master
 
       - static_analysis:
           requires:

--- a/apps/aecore/src/aec_block_genesis.erl
+++ b/apps/aecore/src/aec_block_genesis.erl
@@ -27,6 +27,8 @@
           genesis_block_with_state/0,
           populated_trees/0 ]).
 
+-export([genesis_difficulty/0]).
+
 -export([prev_hash/0,
          height/0,
          pow/0,
@@ -99,3 +101,8 @@ populated_trees(Map) ->
 
 height() ->
     ?GENESIS_HEIGHT.
+
+%% Returns the difficulty of the genesis block meant to be used in the
+%% computation of the chain difficulty.
+genesis_difficulty() ->
+    0. %% Genesis block is unmined.

--- a/apps/aecore/src/aec_block_genesis.erl
+++ b/apps/aecore/src/aec_block_genesis.erl
@@ -24,11 +24,11 @@
 
 %% API
 -export([ genesis_header/0,
-          height/0,
           genesis_block_with_state/0,
           populated_trees/0 ]).
 
 -export([prev_hash/0,
+         height/0,
          pow/0,
          txs_hash/0,
          transactions/0]).
@@ -72,7 +72,7 @@ genesis_block_with_state(Map) ->
     Block =
         #block{
            version = ?GENESIS_VERSION,
-           height = ?GENESIS_HEIGHT,
+           height = height(),
            prev_hash = prev_hash(),
            txs_hash = txs_hash(),
            root_hash = aec_trees:hash(Trees),

--- a/apps/aecore/src/aec_chain_state.erl
+++ b/apps/aecore/src/aec_chain_state.erl
@@ -363,7 +363,11 @@ update_next_state_tree_children([{Child, ForkId}|Left], Trees, Difficulty, Max, 
 
 get_state_trees_in(Node, State) ->
     case node_is_genesis(Node, State) of
-        true  -> {ok, aec_block_genesis:populated_trees(), 0, hash(Node)};
+        true  ->
+            {ok,
+             aec_block_genesis:populated_trees(),
+             aec_block_genesis:genesis_difficulty(),
+             hash(Node)};
         false -> db_find_state(prev_hash(Node))
     end.
 

--- a/apps/aecore/src/aec_chain_state.erl
+++ b/apps/aecore/src/aec_chain_state.erl
@@ -373,11 +373,14 @@ get_state_trees_in(Node, State) ->
     end.
 
 apply_and_store_state_trees(Node, TreesIn, DifficultyIn, ForkId,
-                            #{currently_adding := Hash}) ->
+                            #{currently_adding := Hash} = State) ->
     NodeHash = hash(Node),
     try
         assert_previous_height(Node),
-        Trees = apply_node_transactions(Node, TreesIn),
+        Trees = case node_is_genesis(Node, State) of
+                    true -> TreesIn;
+                    false -> apply_node_transactions(Node, TreesIn)
+                end,
         assert_state_hash_valid(Trees, Node),
         assert_calculated_target(Node),
         Difficulty = DifficultyIn + node_difficulty(Node),

--- a/apps/aecore/src/aec_chain_state.erl
+++ b/apps/aecore/src/aec_chain_state.erl
@@ -208,8 +208,6 @@ node_is_in_main_chain(Node, TopNode) ->
 %%%-------------------------------------------------------------------
 
 internal_insert(Node, Block) ->
-    %% Keep track of which node we are actually adding to avoid giving
-    %% spurious error messages.
     case db_find_node(hash(Node)) of
         error ->
             %% To preserve the invariants of the chain,
@@ -218,6 +216,9 @@ internal_insert(Node, Block) ->
             %% trees, and update the pointers)
             Fun = fun() ->
                           State = new_state_from_persistence(),
+                          %% Keep track of which node we are actually
+                          %% adding to avoid giving spurious error
+                          %% messages.
                           State1 = State#{ currently_adding => hash(Node)},
                           assert_not_new_genesis(Node, State1),
                           ok = db_put_node(Block, hash(Node)),

--- a/apps/aecore/src/aec_trees.erl
+++ b/apps/aecore/src/aec_trees.erl
@@ -84,8 +84,8 @@ oracles(Trees) ->
 set_oracles(Trees, Oracles) ->
     Trees#trees{oracles = Oracles}.
 
--spec perform_pre_transformations(trees(), non_neg_integer()) -> trees().
-perform_pre_transformations(Trees, Height) ->
+-spec perform_pre_transformations(trees(), height()) -> trees().
+perform_pre_transformations(Trees, Height) when Height > ?GENESIS_HEIGHT ->
     Trees0 = aect_call_state_tree:prune(Height, Trees),
     Trees1 = aeo_state_tree:prune(Height, Trees0),
     set_ns(Trees1, aens_state_tree:prune(Height, ns(Trees1))).
@@ -106,14 +106,14 @@ contracts(Trees) ->
 set_contracts(Trees, Contracts) ->
     Trees#trees{contracts = Contracts}.
 
--spec apply_signed_txs_strict(list(aetx_sign:signed_tx()), trees(), non_neg_integer(),
+-spec apply_signed_txs_strict(list(aetx_sign:signed_tx()), trees(), height(),
                               non_neg_integer()) ->
                                  {ok, list(aetx_sign:signed_tx()), trees()}
                                | {'error', atom()}.
 apply_signed_txs_strict(SignedTxs, Trees, Height, ConsensusVersion) ->
     apply_signed_txs_common(SignedTxs, Trees, Height, ConsensusVersion, true).
 
--spec apply_signed_txs(list(aetx_sign:signed_tx()), trees(), non_neg_integer(),
+-spec apply_signed_txs(list(aetx_sign:signed_tx()), trees(), height(),
                        non_neg_integer()) ->
                           {ok, list(aetx_sign:signed_tx()), trees()}.
 apply_signed_txs(SignedTxs, Trees, Height, ConsensusVersion) ->

--- a/apps/aecore/src/aec_trees.erl
+++ b/apps/aecore/src/aec_trees.erl
@@ -18,7 +18,6 @@
          oracles/1,
 	 calls/1,
          contracts/1,
-         perform_pre_transformations/2,
          set_accounts/2,
          set_oracles/2,
 	 set_calls/2,
@@ -155,7 +154,7 @@ internal_commit_to_db(Trees) ->
                }.
 
 apply_signed_txs_common(SignedTxs, Trees0, Height, ConsensusVersion, Strict) ->
-    Trees1 = aec_trees:perform_pre_transformations(Trees0, Height),
+    Trees1 = perform_pre_transformations(Trees0, Height),
     case apply_txs_on_state_trees(SignedTxs, Trees1, Height, ConsensusVersion, Strict) of
         {ok, SignedTxs1, Trees2} ->
             TotalFee = calculate_total_fee(SignedTxs1),

--- a/apps/aens/src/aens_state_tree.erl
+++ b/apps/aens/src/aens_state_tree.erl
@@ -78,7 +78,7 @@ empty_with_backend() ->
     #ns_tree{mtree = MTree, cache = Cache}.
 
 -spec prune(block_height(), tree()) -> tree().
-prune(NextBlockHeight, #ns_tree{} = Tree) ->
+prune(NextBlockHeight, #ns_tree{} = Tree) when NextBlockHeight > 0 ->
     {Tree1, ExpiredActions} = int_prune(NextBlockHeight - 1, Tree),
     run_elapsed(ExpiredActions, Tree1, NextBlockHeight).
 

--- a/apps/aeoracle/src/aeo_state_tree.erl
+++ b/apps/aeoracle/src/aeo_state_tree.erl
@@ -85,7 +85,7 @@ empty_with_backend() ->
                 }.
 
 -spec prune(block_height(), aec_trees:trees()) -> aec_trees:trees().
-prune(Height, Trees) ->
+prune(Height, Trees) when Height > 0 ->
     %% Oracle information should be around for the expiry block
     %% since we prune before the block, use Height - 1 for pruning.
     int_prune(Height - 1, Trees).


### PR DESCRIPTION
This is a preparatory PR in scope of https://www.pivotaltracker.com/story/show/157214052 and I am opening it for receiving comments.

The problem is that when removing coinbase tx (to be done in future PR for https://www.pivotaltracker.com/story/show/157214052) the reward of the miner needs to be assigned as part of trees transformation, hence attempting to apply the genesis txs on the genesis trees would change the trees.

I recommend not to merge this PR yet, because:
* It does not bring any benefit in its own;
* I did not perform extensive testing of it yet (e.g. is attempt to post genesis block from a peer covered by tests?);
* A handful of tests fail (I did not validate yet if the tests or the code are wrong);
* The branch contains a couple of test-only commits that shall be removed (enabling aevm_tests and Python UAT tests).
