### PR TITLE
Add smoke test and docker target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,6 +159,12 @@ eunit:
 
 all-tests: eunit test
 
+docker:
+	@docker build . -t aeternity/epoch:local
+
+smoke-test: system-test-deps docker
+	@./rebar3 as system_test do ct --dir system_test --logdir system_test/logs --config system_test/cfg --suite=aest_sync_SUITE,aest_commands_SUITE
+
 system-test:
 	@./rebar3 as system_test do ct --dir system_test --logdir system_test/logs --config system_test/cfg $(CT_TEST_FLAGS)
 
@@ -313,7 +319,8 @@ internal-distclean: $$(KIND)
 	dev3-start dev3-stop dev3-attach dev3-clean dev3-distclean \
 	internal-start internal-stop internal-attach internal-clean internal-compile-deps \
 	dialyzer \
-	test system-test system-test-deps aevm-test-deps\
+	docker \
+	test smoke-test system-test system-test-deps aevm-test-deps\
 	kill killall \
 	clean distclean \
 	swagger swagger-docs swagger-check \

--- a/system_test/aest_commands_SUITE.erl
+++ b/system_test/aest_commands_SUITE.erl
@@ -35,6 +35,8 @@
 
 %=== COMMON TEST FUNCTIONS =====================================================
 
+% Please note: this module is part of of the smoke-test target. The combined
+% runtime should be kept below 10 minutes.
 all() -> [
     epoch_commands
 ].

--- a/system_test/aest_sync_SUITE.erl
+++ b/system_test/aest_sync_SUITE.erl
@@ -115,6 +115,8 @@
 
 %=== COMMON TEST FUNCTIONS =====================================================
 
+% Please note: this module is part of of the smoke-test target. The combined
+% runtime should be kept below 10 minutes.
 all() -> [
     new_node_joins_network,
     docker_keeps_data,


### PR DESCRIPTION
This change adds a `smoke-test` and `docker` target to the make file. The smoke test runs the `aest_sync_SUITE` and `aest_commands_SUITE` to achieve a shorter system test run for local tests. In addition, it depends on the (new) `docker` and `system-test-deps` targets to always have an up-to-date build. Because this target is intended to be run on PRs before committing, it is better to be safe and always rebuild the `local` Docker tag.