### PR TITLE
Check keys length before using enacl

### DIFF
--- a/apps/aetx/src/aetx_sign.erl
+++ b/apps/aetx/src/aetx_sign.erl
@@ -47,6 +47,9 @@
 -opaque signed_tx() :: #signed_tx{}.
 -type binary_signed_tx() :: binary().
 
+-define(VALID_PUBK(K), byte_size(K) =:= 32).
+-define(VALID_PRIVK(K), byte_size(K) =:= 64).
+
 %% @doc Given a transaction Tx, a private key or list of keys,
 %% return the cryptographically signed transaction using the default crypto
 %% parameters.
@@ -55,7 +58,8 @@ sign(Tx, PrivKey) when is_binary(PrivKey) ->
   sign(Tx, [PrivKey]);
 sign(Tx, PrivKeys) when is_list(PrivKeys) ->
     Bin = aetx:serialize_to_binary(Tx),
-    Signatures = [ enacl:sign_detached(Bin, PrivKey) || PrivKey <- PrivKeys ],
+    Signatures = [ enacl:sign_detached(Bin, PrivKey)
+                   || PrivKey <- PrivKeys, ?VALID_PRIVK(PrivKey)],
     #signed_tx{tx = Tx, signatures = lists:sort(Signatures)}.
 
 -spec hash(signed_tx()) -> binary().
@@ -103,12 +107,12 @@ verify_signatures(PubKeys,_Bin, Sigs) ->
 verify_one_pubkey(Sigs, PubKey, Bin) ->
     verify_one_pubkey(Sigs, PubKey, Bin, []).
 
-verify_one_pubkey([Sig|Left], PubKey, Bin, Acc) ->
+verify_one_pubkey([Sig|Left], PubKey, Bin, Acc) when ?VALID_PUBK(PubKey) ->
     case enacl:sign_verify_detached(Sig, Bin, PubKey) of
         {ok, _}    -> {ok, Acc ++ Left};
         {error, _} -> verify_one_pubkey(Left, PubKey, Bin, [Sig|Acc])
     end;
-verify_one_pubkey([],_PubKey,_Bin,_Acc) ->
+verify_one_pubkey(_,_PubKey,_Bin,_Acc) ->
     error.
 
 -define(SIG_TX_TYPE, signed_tx).

--- a/apps/aetx/src/aetx_sign.erl
+++ b/apps/aetx/src/aetx_sign.erl
@@ -58,8 +58,12 @@ sign(Tx, PrivKey) when is_binary(PrivKey) ->
   sign(Tx, [PrivKey]);
 sign(Tx, PrivKeys) when is_list(PrivKeys) ->
     Bin = aetx:serialize_to_binary(Tx),
+    case lists:any(fun(PrivKey) -> not (?VALID_PRIVK(PrivKey)) end, PrivKeys) of
+        true -> erlang:error(invalid_priv_key);
+        false -> pass
+    end,
     Signatures = [ enacl:sign_detached(Bin, PrivKey)
-                   || PrivKey <- PrivKeys, ?VALID_PRIVK(PrivKey)],
+                   || PrivKey <- PrivKeys],
     #signed_tx{tx = Tx, signatures = lists:sort(Signatures)}.
 
 -spec hash(signed_tx()) -> binary().

--- a/apps/aetx/test/aetx_sign_tests.erl
+++ b/apps/aetx/test/aetx_sign_tests.erl
@@ -1,0 +1,60 @@
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2018, Aeternity Anstalt
+%%%-------------------------------------------------------------------
+
+-module(aetx_sign_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-include_lib("apps/aecore/include/common.hrl").
+-include_lib("apps/aecore/include/blocks.hrl").
+
+-define(TEST_MODULE, aetx_sign).
+
+sign_txs_test_() ->
+    {setup,
+     fun() ->
+             aec_test_utils:aec_keys_setup()
+     end,
+     fun(TmpKeysDir) ->
+             ok = aec_test_utils:aec_keys_cleanup(TmpKeysDir)
+     end,
+     [{"Key pair is able to sign and validate transaction",
+       fun() ->
+               #{ public := Pubkey, secret := Privkey } = enacl:sign_keypair(),
+               {ok, CB} = aec_coinbase_tx:new(#{account => Pubkey,
+                                                block_height => 1}),
+               Signed = ?TEST_MODULE:sign(CB, Privkey),
+               ?assertEqual(ok, ?TEST_MODULE:verify(Signed)),
+               ok
+      end},
+      {"Mismatched keys do produce invalid signatures",
+       fun() ->
+               #{ public :=  PubkeyA, secret := _PrivkeyA } = enacl:sign_keypair(),
+               #{ public := _PubkeyB, secret :=  PrivkeyB } = enacl:sign_keypair(),
+               {ok, CB} = aec_coinbase_tx:new(#{account => PubkeyA,
+                                                block_height => 1}),
+               Signed = ?TEST_MODULE:sign(CB, PrivkeyB),
+               ?assertEqual({error, signature_check_failed}, ?TEST_MODULE:verify(Signed)),
+               ok
+      end},
+      {"Broken pub key does not validate signatures",
+       fun() ->
+               #{ public := _Pubkey, secret := Privkey } = enacl:sign_keypair(),
+               {ok, CB} = aec_coinbase_tx:new(#{account => <<0:42/unit:8>>,
+                                                block_height => 1}),
+               Signed = ?TEST_MODULE:sign(CB, Privkey),
+               ?assertEqual({error, signature_check_failed}, ?TEST_MODULE:verify(Signed)),
+               ok
+      end},
+      {"Broken priv key does not produce signatures",
+       fun() ->
+               #{ public := Pubkey, secret := _Privkey } = enacl:sign_keypair(),
+               {ok, CB} = aec_coinbase_tx:new(#{account => Pubkey,
+                                                block_height => 1}),
+               Signed = ?TEST_MODULE:sign(CB, <<0:42/unit:8>>),
+               ?assertEqual({error, signature_check_failed}, ?TEST_MODULE:verify(Signed)),
+               ?assertEqual([], ?TEST_MODULE:signatures(Signed)),
+               ok
+      end}
+     ]}.

--- a/apps/aetx/test/aetx_sign_tests.erl
+++ b/apps/aetx/test/aetx_sign_tests.erl
@@ -25,7 +25,7 @@ sign_txs_test_() ->
                {ok, CB} = aec_coinbase_tx:new(#{account => Pubkey,
                                                 block_height => 1}),
                Signed = ?TEST_MODULE:sign(CB, Privkey),
-               ?assertEqual(ok, ?TEST_MODULE:verify(Signed)),
+               ?assertEqual(ok, ?TEST_MODULE:verify(Signed, aec_trees:new())),
                ok
       end},
       {"Mismatched keys do produce invalid signatures",
@@ -35,7 +35,8 @@ sign_txs_test_() ->
                {ok, CB} = aec_coinbase_tx:new(#{account => PubkeyA,
                                                 block_height => 1}),
                Signed = ?TEST_MODULE:sign(CB, PrivkeyB),
-               ?assertEqual({error, signature_check_failed}, ?TEST_MODULE:verify(Signed)),
+               ?assertEqual({error, signature_check_failed},
+                            ?TEST_MODULE:verify(Signed, aec_trees:new())),
                ok
       end},
       {"Broken pub key does not validate signatures",
@@ -44,7 +45,8 @@ sign_txs_test_() ->
                {ok, CB} = aec_coinbase_tx:new(#{account => <<0:42/unit:8>>,
                                                 block_height => 1}),
                Signed = ?TEST_MODULE:sign(CB, Privkey),
-               ?assertEqual({error, signature_check_failed}, ?TEST_MODULE:verify(Signed)),
+               ?assertEqual({error, signature_check_failed},
+                            ?TEST_MODULE:verify(Signed, aec_trees:new())),
                ok
       end},
       {"Broken priv key does not produce signatures",
@@ -52,9 +54,8 @@ sign_txs_test_() ->
                #{ public := Pubkey, secret := _Privkey } = enacl:sign_keypair(),
                {ok, CB} = aec_coinbase_tx:new(#{account => Pubkey,
                                                 block_height => 1}),
-               Signed = ?TEST_MODULE:sign(CB, <<0:42/unit:8>>),
-               ?assertEqual({error, signature_check_failed}, ?TEST_MODULE:verify(Signed)),
-               ?assertEqual([], ?TEST_MODULE:signatures(Signed)),
+               ?_assertException(error, invalid_priv_key,
+                                 ?TEST_MODULE:sign(CB, <<0:42/unit:8>>)),
                ok
       end}
      ]}.


### PR DESCRIPTION
[Pivotal story](https://www.pivotaltracker.com/story/show/157389930)

Guard the `enacl` nif from keys with unexpected sizes.
Added some tests.