### PR TITLE
Add aevm tests to PR and master workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -476,6 +476,17 @@ workflows:
             tags:
               only: /^v.*$/
 
+      - aevm_tests:
+          requires:
+            - build
+          filters:
+            branches:
+              ignore:
+                - env/dev1
+                - env/dev2
+            tags:
+              only: /^v.*$/
+
       - uat_tests:
           requires:
             - build
@@ -510,6 +521,7 @@ workflows:
           requires:
             - test
             - eunit
+            - aevm_tests
             - uat_tests
             - static_analysis
             - linux_package
@@ -521,6 +533,7 @@ workflows:
           requires:
             - test
             - eunit
+            - aevm_tests
             - uat_tests
             - static_analysis
           filters:
@@ -595,17 +608,6 @@ workflows:
               ignore: /.*/
             tags:
               only: /^v.*$/
-
-  nightly:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only:
-                - master
-    jobs:
-      - aevm_tests
 
   chain_snapshots:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,6 +209,7 @@ jobs:
           name: AEVM Tests
           command: |
             make aevm-test
+      - *fail_notification
 
   static_analysis:
     <<: *container_config


### PR DESCRIPTION
Instead of running nightly AEVM tests and send fail notification, I think it's better to have this tests run on PR and master branches already.

https://www.pivotaltracker.com/story/show/156877392