### PR TITLE
Ignore aevm_external in docker context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,4 @@ apps/aecuckoo/priv/lib
 apps/aecore/priv/keys
 system_test
 erl_crash.dump
+aevm_external


### PR DESCRIPTION
This is the aevm external tests repo witch is about 600MB and useless in docker context.