### PR TITLE
Fallback to old version of port compiler

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -45,6 +45,7 @@
         {idna, {git, "https://github.com/aeternity/erlang-idna", {ref, "24bf647"}}}
        ]}.
 
+%% pc needed for erlexec and version 1.6.0 works, but 1.9.1 does not.
 {plugins, [{swagger_endpoints, {git, "https://github.com/aeternity/swagger_endpoints", {tag, "v0.2.0"}}}, {pc, "1.6.0"}]}.
 {swagger_endpoints, [{src, "config/swagger.yaml"}, {dst, "apps/aeutils/src/endpoints.erl"}]}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -45,7 +45,7 @@
         {idna, {git, "https://github.com/aeternity/erlang-idna", {ref, "24bf647"}}}
        ]}.
 
-{plugins, [{swagger_endpoints, {git, "https://github.com/aeternity/swagger_endpoints", {tag, "v0.2.0"}}}]}.
+{plugins, [{swagger_endpoints, {git, "https://github.com/aeternity/swagger_endpoints", {tag, "v0.2.0"}}}, {pc, "1.6.0"}]}.
 {swagger_endpoints, [{src, "config/swagger.yaml"}, {dst, "apps/aeutils/src/endpoints.erl"}]}.
 
 {relx, [{release, { epoch, "version value comes from VERSION" },


### PR DESCRIPTION
Fix compilation problems in quick and dirty way.
We need a ticket upstream

Somewhere above version 1.6.0 of pc (port_compiler) the environment variables are passed down to pc. This causes error in compilation stating that -o flag cannot have multiple out files.
