### PR TITLE
Pt 157355749 path and query parameters

### DIFF
--- a/apps/aehttp/priv/swagger.json
+++ b/apps/aehttp/priv/swagger.json
@@ -106,7 +106,8 @@
           "in" : "query",
           "description" : "Height of the header to fetch",
           "required" : true,
-          "type" : "integer"
+          "type" : "integer",
+          "minimum" : 0
         } ],
         "responses" : {
           "200" : {
@@ -124,70 +125,6 @@
         }
       }
     },
-    "/block-by-height" : {
-      "get" : {
-        "tags" : [ "external", "gossip" ],
-        "description" : "Get a block by height",
-        "operationId" : "GetBlockByHeightDeprecated",
-        "produces" : [ "application/json" ],
-        "parameters" : [ {
-          "name" : "height",
-          "in" : "query",
-          "description" : "Height of the block to fetch",
-          "required" : true,
-          "type" : "integer"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "The block being found",
-            "schema" : {
-              "$ref" : "#/definitions/Block"
-            }
-          },
-          "404" : {
-            "description" : "Block not found",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          }
-        }
-      }
-    },
-    "/block-by-hash" : {
-      "get" : {
-        "tags" : [ "external", "gossip" ],
-        "description" : "Get a block by hash",
-        "operationId" : "GetBlockByHashDeprecated",
-        "produces" : [ "application/json" ],
-        "parameters" : [ {
-          "name" : "hash",
-          "in" : "query",
-          "description" : "Hash of the block to fetch",
-          "required" : true,
-          "type" : "string"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "The block being found",
-            "schema" : {
-              "$ref" : "#/definitions/Block"
-            }
-          },
-          "400" : {
-            "description" : "Invalid hash",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Block not found",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          }
-        }
-      }
-    },
     "/block" : {
       "post" : {
         "tags" : [ "external", "gossip" ],
@@ -198,7 +135,7 @@
         "parameters" : [ {
           "in" : "body",
           "name" : "body",
-          "description" : "Put a new block to node",
+          "description" : "A new block",
           "required" : true,
           "schema" : {
             "$ref" : "#/definitions/Block"
@@ -227,7 +164,7 @@
         "parameters" : [ {
           "in" : "body",
           "name" : "body",
-          "description" : "Put a new transaction to node",
+          "description" : "A new transaction",
           "required" : true,
           "schema" : {
             "$ref" : "#/definitions/Tx"
@@ -295,7 +232,7 @@
     "/tx/contract/create" : {
       "post" : {
         "tags" : [ "external", "dev" ],
-        "description" : "Get a contract_create transaction",
+        "description" : "Get a contract_create transaction object",
         "operationId" : "PostContractCreate",
         "consumes" : [ "application/json" ],
         "produces" : [ "application/json" ],
@@ -332,7 +269,7 @@
     "/tx/contract/call" : {
       "post" : {
         "tags" : [ "external", "dev" ],
-        "description" : "Get a contract_call transaction",
+        "description" : "Get a contract_call transaction object",
         "operationId" : "PostContractCall",
         "consumes" : [ "application/json" ],
         "produces" : [ "application/json" ],
@@ -369,7 +306,7 @@
     "/tx/contract/call/compute" : {
       "post" : {
         "tags" : [ "external", "dev" ],
-        "description" : "Compute the call_data for SOPHIA and get contract_call transaction",
+        "description" : "Compute the call_data for SOPHIA and get contract_call transaction object",
         "operationId" : "PostContractCallCompute",
         "consumes" : [ "application/json" ],
         "produces" : [ "application/json" ],
@@ -406,7 +343,7 @@
     "/tx/oracle/register" : {
       "post" : {
         "tags" : [ "external", "dev" ],
-        "description" : "Get a oracle_register transaction",
+        "description" : "Get a oracle_register transaction object",
         "operationId" : "PostOracleRegister",
         "consumes" : [ "application/json" ],
         "produces" : [ "application/json" ],
@@ -443,7 +380,7 @@
     "/tx/oracle/extend" : {
       "post" : {
         "tags" : [ "external", "dev" ],
-        "description" : "Get an oracle_extend transaction",
+        "description" : "Get an oracle_extend transaction object",
         "operationId" : "PostOracleExtend",
         "consumes" : [ "application/json" ],
         "produces" : [ "application/json" ],
@@ -480,7 +417,7 @@
     "/tx/oracle/query" : {
       "post" : {
         "tags" : [ "external", "dev" ],
-        "description" : "Get a oracle_query transaction",
+        "description" : "Get an oracle_query transaction object",
         "operationId" : "PostOracleQuery",
         "consumes" : [ "application/json" ],
         "produces" : [ "application/json" ],
@@ -517,7 +454,7 @@
     "/tx/oracle/response" : {
       "post" : {
         "tags" : [ "external", "dev" ],
-        "description" : "Get a oracle_response transaction",
+        "description" : "Get an oracle_response transaction object",
         "operationId" : "PostOracleResponse",
         "consumes" : [ "application/json" ],
         "produces" : [ "application/json" ],
@@ -554,7 +491,7 @@
     "/tx/name/preclaim" : {
       "post" : {
         "tags" : [ "external", "dev" ],
-        "description" : "Get a name_preclaim transaction",
+        "description" : "Get a name_preclaim transaction object",
         "operationId" : "PostNamePreclaim",
         "produces" : [ "application/json" ],
         "parameters" : [ {
@@ -590,7 +527,7 @@
     "/tx/name/claim" : {
       "post" : {
         "tags" : [ "external", "dev" ],
-        "description" : "Get a name_claim transaction",
+        "description" : "Get a name_claim transaction object",
         "operationId" : "PostNameClaim",
         "produces" : [ "application/json" ],
         "parameters" : [ {
@@ -626,7 +563,7 @@
     "/tx/name/update" : {
       "post" : {
         "tags" : [ "external", "dev" ],
-        "description" : "Get a name_update transaction",
+        "description" : "Get a name_update transaction object",
         "operationId" : "PostNameUpdate",
         "produces" : [ "application/json" ],
         "parameters" : [ {
@@ -662,7 +599,7 @@
     "/tx/name/transfer" : {
       "post" : {
         "tags" : [ "external", "dev" ],
-        "description" : "Get a name_transfer transaction",
+        "description" : "Get a name_transfer transaction object",
         "operationId" : "PostNameTransfer",
         "produces" : [ "application/json" ],
         "parameters" : [ {
@@ -698,7 +635,7 @@
     "/tx/name/revoke" : {
       "post" : {
         "tags" : [ "external", "dev" ],
-        "description" : "Get a name_revoke transaction",
+        "description" : "Get a name_revoke transaction object",
         "operationId" : "PostNameRevoke",
         "produces" : [ "application/json" ],
         "parameters" : [ {
@@ -734,13 +671,14 @@
     "/tx/spend" : {
       "post" : {
         "tags" : [ "external", "dev" ],
-        "description" : "Get a spend transaction",
+        "description" : "Get a spend transaction object",
         "operationId" : "PostSpend",
         "consumes" : [ "application/json" ],
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "in" : "body",
           "name" : "body",
+          "description" : "A spend transaction",
           "required" : true,
           "schema" : {
             "$ref" : "#/definitions/SpendTx"
@@ -771,7 +709,7 @@
     "/tx/channel/create" : {
       "post" : {
         "tags" : [ "external", "dev" ],
-        "description" : "Get a channel_create transaction",
+        "description" : "Get a channel_create transaction object",
         "operationId" : "PostChannelCreate",
         "produces" : [ "application/json" ],
         "parameters" : [ {
@@ -807,7 +745,7 @@
     "/tx/channel/deposit" : {
       "post" : {
         "tags" : [ "external", "dev" ],
-        "description" : "Get a channel_deposit transaction",
+        "description" : "Get a channel_deposit transaction object",
         "operationId" : "PostChannelDeposit",
         "produces" : [ "application/json" ],
         "parameters" : [ {
@@ -837,7 +775,7 @@
     "/tx/channel/withdrawal" : {
       "post" : {
         "tags" : [ "external", "dev" ],
-        "description" : "Get a channel_withdrawal transaction",
+        "description" : "Get a channel_withdrawal transaction object",
         "operationId" : "PostChannelWithdrawal",
         "produces" : [ "application/json" ],
         "parameters" : [ {
@@ -867,7 +805,7 @@
     "/tx/channel/close/mutual" : {
       "post" : {
         "tags" : [ "external", "dev" ],
-        "description" : "Get a channel_close_mutual transaction",
+        "description" : "Get a channel_close_mutual transaction object",
         "operationId" : "PostChannelCloseMutual",
         "produces" : [ "application/json" ],
         "parameters" : [ {
@@ -897,7 +835,7 @@
     "/tx/channel/close/solo" : {
       "post" : {
         "tags" : [ "external", "dev" ],
-        "description" : "Get a channel_close_solo transaction",
+        "description" : "Get a channel_close_solo transaction object",
         "operationId" : "PostChannelCloseSolo",
         "produces" : [ "application/json" ],
         "parameters" : [ {
@@ -927,7 +865,7 @@
     "/tx/channel/slash" : {
       "post" : {
         "tags" : [ "external", "dev" ],
-        "description" : "Get a channel_slash transaction",
+        "description" : "Get a channel_slash transaction object",
         "operationId" : "PostChannelSlash",
         "produces" : [ "application/json" ],
         "parameters" : [ {
@@ -957,7 +895,7 @@
     "/tx/channel/settle" : {
       "post" : {
         "tags" : [ "external", "dev" ],
-        "description" : "Get a channel_settle transaction",
+        "description" : "Get a channel_settle transaction object",
         "operationId" : "PostChannelSettle",
         "produces" : [ "application/json" ],
         "parameters" : [ {
@@ -1532,7 +1470,8 @@
           "in" : "query",
           "description" : "Height of the block to show balance at",
           "required" : false,
-          "type" : "integer"
+          "type" : "integer",
+          "minimum" : 0
         }, {
           "name" : "hash",
           "in" : "query",

--- a/apps/aehttp/test/aehttp_client.erl
+++ b/apps/aehttp/test/aehttp_client.erl
@@ -13,7 +13,7 @@ request(OpId, Params, Cfg) ->
     {Method, Interface} = operation_spec(Op),
     BaseUrl = string:trim(proplists:get_value(Interface, Cfg), trailing, "/"),
     Path = endpoints:path(Method, OpId, Params),
-    Query = endpoints:query(get, OpId, Params),
+    Query = endpoints:query(Method, OpId, Params),
     inets:start(httpc, [{profile, test_browser}]),
     Response = request(Method, BaseUrl, Path, Query, Params, [], [{timeout, 15000}], [], Cfg),
     inets:stop(httpc, test_browser),

--- a/apps/aehttp/test/aehttp_client.erl
+++ b/apps/aehttp/test/aehttp_client.erl
@@ -1,9 +1,6 @@
 -module(aehttp_client).
 
--export([
-         request/3,
-         request/8
-        ]).
+-export([ request/3 ]).
 
 %%=============================================================================
 %% API
@@ -14,21 +11,21 @@
 request(OpId, Params, Cfg) ->
     Op = endpoints:operation(OpId),
     {Method, Interface} = operation_spec(Op),
-    BaseUrl = make_base_url(proplists:get_value(Interface, Cfg)),
-    Path = operation_path(Method, OpId, convert_params(Params)),
+    BaseUrl = string:trim(proplists:get_value(Interface, Cfg), trailing, "/"),
+    Path = endpoints:path(Method, OpId, Params),
+    Query = endpoints:query(get, OpId, Params),
     inets:start(httpc, [{profile, test_browser}]),
-    Response = request(Method, BaseUrl, Path, Params, [], [{timeout, 15000}], [], Cfg),
+    Response = request(Method, BaseUrl, Path, Query, Params, [], [{timeout, 15000}], [], Cfg),
     inets:stop(httpc, test_browser),
     Response.
 
-request(get, BaseUrl, Path, QueryParams, Headers, HttpOpts, Opts, Cfg) ->
-    Url = make_url(BaseUrl, Path, QueryParams),
+request(get, BaseUrl, Path, Query, _Params, Headers, HttpOpts, Opts, Cfg) ->
+    Url = binary_to_list(iolist_to_binary([BaseUrl, Path, Query])),
     log("GET ~p", [Url], Cfg),
-    Resp = httpc:request(get, {Url, Headers}, 
-                         HttpOpts, Opts, test_browser),
+    Resp = httpc:request(get, {Url, Headers}, HttpOpts, Opts, test_browser),
     process_response(Resp, Cfg);
-request(post, BaseUrl, Path, BodyParams, Headers, HttpOpts, Opts, Cfg) ->
-    Url = make_url(BaseUrl, Path, #{}),
+request(post, BaseUrl, Path, _Query, BodyParams, Headers, HttpOpts, Opts, Cfg) ->
+    Url = binary_to_list(iolist_to_binary([BaseUrl, Path])),
     {ContentType, Body} = make_body(BodyParams, Path),
     log("POST ~p~nContentType ~p~n~p", [Url, ContentType, BodyParams], Cfg),
     Resp = httpc:request(post, {Url, Headers, ContentType, Body},
@@ -75,53 +72,8 @@ operation_interface(#{tags := Tags}) ->
         {_, true} -> int_http
     end.
 
-%% Swagger spec requires keys to be of type list and non-numeric values
-%% must be converted to list as well.
-convert_params(Params) ->
-    ConvF =
-        fun(K, V, Acc) when is_binary(V) ->
-                maps:put(atom_to_list(K), binary_to_list(V), Acc);
-           (K, V, Acc) when is_atom(V) ->
-                maps:put(atom_to_list(K), atom_to_list(V), Acc);
-           (K, V, Acc) ->
-                maps:put(atom_to_list(K), V, Acc)
-        end,
-    maps:fold(ConvF, #{}, Params).
-
-%% Remove the '/' at the end of base URL.
-make_base_url(BaseUrl) when is_binary(BaseUrl) ->
-    make_base_url(binary_to_list(BaseUrl));
-make_base_url(BaseUrl) ->
-    case lists:last(BaseUrl) of
-        $/ -> lists:droplast(BaseUrl);
-        _ -> BaseUrl
-    end.
-
-operation_path(Method, OpId, Params) ->
-    %% The path includes the leading '/'.
-    case endpoints:path(Method, OpId, Params) of
-        <<Path/binary>> ->
-            Path;
-        [<<Part1/binary>>, Part2, Part3] ->
-            iolist_to_binary([Part1, Part2, Part3])
-    end.
-
-make_url(BaseUrl, Path, Params) ->
-    Url = [BaseUrl, Path, make_query(maps:to_list(Params))],
-    binary_to_list(iolist_to_binary(Url)).
-
-make_query([{K, V} | T]) ->
-    [$?, [encode(K), $= , encode(V)
-          | [[$&, encode(K1), $=, encode(V1)] || {K1, V1} <- T]]];
-make_query([]) ->
-    [].
-
 make_body(Params, _Path) when is_map(Params) ->
     {"application/json", jsx:encode(Params)};
 make_body([], Path) ->
     {"application/x-www-form-urlencoded", http_uri:encode(Path)}.
-
-encode(X) when is_atom(X) -> encode(atom_to_list(X));
-encode(X) when is_integer(X) -> encode(integer_to_list(X));
-encode(X) when is_list(X); is_binary(X) -> http_uri:encode(X).
 

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -106,61 +106,7 @@ paths:
           description: Header not found
           schema:
             $ref: '#/definitions/Error'
-      security:
-  /block-by-height:
-    get:
-      tags:
-        - external
-        - gossip
-      operationId: GetBlockByHeightDeprecated
-      description: 'Get a block by height'
-      produces:
-        - application/json
-      parameters:
-        - in: query
-          name: height
-          description: 'Height of the block to fetch'
-          required: true
-          type : integer
-      responses:
-        '200':
-          description: The block being found
-          schema:
-            $ref: '#/definitions/Block'
-        '404':
-          description: Block not found
-          schema:
-            $ref: '#/definitions/Error'
-      security:
-  /block-by-hash:
-    get:
-      tags:
-        - external
-        - gossip
-      operationId: GetBlockByHashDeprecated
-      description: 'Get a block by hash'
-      produces:
-        - application/json
-      parameters:
-        - in: query
-          name: hash
-          description: 'Hash of the block to fetch'
-          required: true
-          type : string
-      responses:
-        '200':
-          description: The block being found
-          schema:
-            $ref: '#/definitions/Block'
-        '400':
-          description: Invalid hash
-          schema:
-            $ref: '#/definitions/Error'
-        '404':
-          description: Block not found
-          schema:
-            $ref: '#/definitions/Error'
-      security:
+      security:        
   /block:
     post:
       tags:

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -97,6 +97,7 @@ paths:
           description: 'Height of the header to fetch'
           required: true
           type: integer
+          minimum: 0
       responses:
         '200':
           description: The header found
@@ -121,7 +122,7 @@ paths:
       parameters:
         - in: body
           name: body
-          description: Put a new block to node
+          description: A new block
           required: true
           schema:
             $ref: '#/definitions/Block'
@@ -147,7 +148,7 @@ paths:
       parameters:
         - in: body
           name: body
-          description: Put a new transaction to node
+          description: A new transaction
           required: true
           schema:
             $ref: '#/definitions/Tx'
@@ -202,7 +203,7 @@ paths:
         - external
         - dev
       operationId: PostContractCreate
-      description: 'Get a contract_create transaction'
+      description: 'Get a contract_create transaction object'
       consumes:
         - application/json
       produces:
@@ -232,7 +233,7 @@ paths:
         - external
         - dev
       operationId: PostContractCall
-      description: 'Get a contract_call transaction'
+      description: 'Get a contract_call transaction object'
       consumes:
         - application/json
       produces:
@@ -262,7 +263,7 @@ paths:
         - external
         - dev
       operationId: PostContractCallCompute
-      description: 'Compute the call_data for SOPHIA and get contract_call transaction'
+      description: 'Compute the call_data for SOPHIA and get contract_call transaction object'
       consumes:
         - application/json
       produces:
@@ -292,7 +293,7 @@ paths:
         - external
         - dev
       operationId: PostOracleRegister
-      description: 'Get a oracle_register transaction'
+      description: 'Get a oracle_register transaction object'
       consumes:
         - application/json
       produces:
@@ -322,7 +323,7 @@ paths:
         - external
         - dev
       operationId: PostOracleExtend
-      description: 'Get an oracle_extend transaction'
+      description: 'Get an oracle_extend transaction object'
       consumes:
         - application/json
       produces:
@@ -352,7 +353,7 @@ paths:
         - external
         - dev
       operationId: PostOracleQuery
-      description: 'Get a oracle_query transaction'
+      description: 'Get an oracle_query transaction object'
       consumes:
         - application/json
       produces:
@@ -382,7 +383,7 @@ paths:
         - external
         - dev
       operationId: PostOracleResponse
-      description: 'Get a oracle_response transaction'
+      description: 'Get an oracle_response transaction object'
       consumes:
         - application/json
       produces:
@@ -412,7 +413,7 @@ paths:
         - external
         - dev
       operationId: PostNamePreclaim
-      description: 'Get a name_preclaim transaction'
+      description: 'Get a name_preclaim transaction object'
       produces:
         - application/json
       parameters:
@@ -440,7 +441,7 @@ paths:
         - external
         - dev
       operationId: PostNameClaim
-      description: 'Get a name_claim transaction'
+      description: 'Get a name_claim transaction object'
       produces:
         - application/json
       parameters:
@@ -468,7 +469,7 @@ paths:
         - external
         - dev
       operationId: PostNameUpdate
-      description: 'Get a name_update transaction'
+      description: 'Get a name_update transaction object'
       produces:
         - application/json
       parameters:
@@ -496,7 +497,7 @@ paths:
         - external
         - dev
       operationId: PostNameTransfer
-      description: 'Get a name_transfer transaction'
+      description: 'Get a name_transfer transaction object'
       produces:
         - application/json
       parameters:
@@ -524,7 +525,7 @@ paths:
         - external
         - dev
       operationId: PostNameRevoke
-      description: 'Get a name_revoke transaction'
+      description: 'Get a name_revoke transaction object'
       produces:
         - application/json
       parameters:
@@ -552,7 +553,7 @@ paths:
         - external
         - dev
       operationId: PostSpend
-      description: 'Get a spend transaction'
+      description: 'Get a spend transaction object'
       consumes:
         - application/json
       produces:
@@ -560,6 +561,7 @@ paths:
       parameters:
         - in: body
           name: body
+          description: A spend transaction
           required: true
           schema:
             $ref: '#/definitions/SpendTx'
@@ -582,7 +584,7 @@ paths:
         - external
         - dev 
       operationId: PostChannelCreate
-      description: 'Get a channel_create transaction'
+      description: 'Get a channel_create transaction object'
       produces:
         - application/json
       parameters:
@@ -610,7 +612,7 @@ paths:
         - external
         - dev
       operationId: PostChannelDeposit
-      description: 'Get a channel_deposit transaction'
+      description: 'Get a channel_deposit transaction object'
       produces:
         - application/json
       parameters:
@@ -634,7 +636,7 @@ paths:
         - external
         - dev
       operationId: PostChannelWithdrawal
-      description: 'Get a channel_withdrawal transaction'
+      description: 'Get a channel_withdrawal transaction object'
       produces:
         - application/json
       parameters:
@@ -658,7 +660,7 @@ paths:
         - external
         - dev
       operationId: PostChannelCloseMutual
-      description: 'Get a channel_close_mutual transaction'
+      description: 'Get a channel_close_mutual transaction object'
       produces:
         - application/json
       parameters:
@@ -682,7 +684,7 @@ paths:
         - external
         - dev
       operationId: PostChannelCloseSolo
-      description: 'Get a channel_close_solo transaction'
+      description: 'Get a channel_close_solo transaction object'
       produces:
         - application/json
       parameters:
@@ -706,7 +708,7 @@ paths:
         - external
         - dev
       operationId: PostChannelSlash
-      description: 'Get a channel_slash transaction'
+      description: 'Get a channel_slash transaction object'
       produces:
         - application/json
       parameters:
@@ -730,7 +732,7 @@ paths:
         - external
         - dev
       operationId: PostChannelSettle
-      description: 'Get a channel_settle transaction'
+      description: 'Get a channel_settle transaction object'
       produces:
         - application/json
       parameters:
@@ -1231,6 +1233,7 @@ paths:
           description: 'Height of the block to show balance at'
           required: false
           type: integer
+          minimum: 0
         - in: query
           name: hash
           description: 'Hash of the block to show balance at'

--- a/docs/release-notes/RELEASE-NOTES-0.14.0.md
+++ b/docs/release-notes/RELEASE-NOTES-0.14.0.md
@@ -10,6 +10,10 @@ It:
 
 [this-release]: https://github.com/aeternity/epoch/releases/tag/v0.14.0
 
+This release removes deprecated http API endpoints block-by-height
+and block-by-hash. Instead use the endpoints as defined
+[online in swagger.yaml][swagger-yaml].
+
 This release introduces backward incompatible changes in the chain format:
 * After upgrading your node, you will not have your previous balance (even if you keep your key pair);
 * Please ensure that you do not reuse a persisted blockchain produced by the previous releases "v0.13.x".

--- a/rebar.config
+++ b/rebar.config
@@ -46,7 +46,7 @@
        ]}.
 
 %% pc needed for erlexec and version 1.6.0 works, but 1.9.1 does not.
-{plugins, [{swagger_endpoints, {git, "https://github.com/aeternity/swagger_endpoints", {tag, "v0.2.0"}}}, {pc, "1.6.0"}]}.
+{plugins, [{swagger_endpoints, {git, "https://github.com/aeternity/swagger_endpoints", {tag, "0.2.1"}}}, {pc, "1.6.0"}]}.
 {swagger_endpoints, [{src, "config/swagger.yaml"}, {dst, "apps/aeutils/src/endpoints.erl"}]}.
 
 {relx, [{release, { epoch, "version value comes from VERSION" },


### PR DESCRIPTION
Use the fix in the swagger_endpoints plugin version 0.2.1 to create URL from path and query maps.

And remove deprecated APIs from the swagger.yaml file as well as the tests related to it.