### PR TITLE
Channels: broadcast on chain transactions to participants

### DIFF
--- a/docs/release-notes/RELEASE-NOTES-0.14.0.md
+++ b/docs/release-notes/RELEASE-NOTES-0.14.0.md
@@ -13,6 +13,7 @@ category info and up will still be directed to the console.
 * Enhances user HTTP API with fine tuning paths for getting account balance and transactions
 * Moves contract account balances to account state tree. Also removes height and contract ID from contract state trees. This impacts consensus.
 * Removes unneeded height from the account object in the block state. This impacts consensus.
+* Enhances user experience for Channels' websockets with broadcasting co-signed on-chain transactions to participants before posting. This allows them to track the progress of the transactions as well to store them locally in case of conflict resolution.
 
 [this-release]: https://github.com/aeternity/epoch/releases/tag/v0.14.0
 


### PR DESCRIPTION
[Pivotal story](https://www.pivotaltracker.com/story/show/157621529)
This PR:

* introduces new channels tag `on_chain_tx` for broadcasting transactions that ar going into mempool

* refactors WS tests so they're easier to write (most notably tests are auto unsubscribed to channels' events upon a test end)