### PR TITLE
Relax time allowed for aehttp app to start in tests

### DIFF
--- a/apps/aecore/test/aecore_suite_utils.erl
+++ b/apps/aecore/test/aecore_suite_utils.erl
@@ -326,7 +326,7 @@ await_aehttp(N) ->
                 {app_started, #{info := aehttp}} ->
                     ct:log("aehttp started", []),
                     ok
-            after 20000 ->
+            after 30000 ->
                     error(timeout_waiting_for_aehttp)
             end;
         [_|_] ->


### PR DESCRIPTION
Delivers https://www.pivotaltracker.com/story/show/157662906

Please refer to commit message for details.