### PR TITLE
Tests parallelism

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,6 +171,7 @@ jobs:
 
   test:
     <<: *container_config
+    parallelism: 2
     steps:
       - checkout
       - *restore_rebar_cache
@@ -179,7 +180,7 @@ jobs:
           name: Test
           command: |
             epmd -daemon
-            make test
+            make test CT_TEST_FLAGS="--suite=$(.circleci/split_suites.sh)"
       - store_test_results:
           path: _build/test/logs
       - store_artifacts:

--- a/.circleci/split_suites.sh
+++ b/.circleci/split_suites.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+
+ls -1 apps/*/test/*SUITE.erl test/*SUITE.erl > suites.txt
+cat suites.txt | sed 's/.*\///g' | sed 's/.erl//g' > classes.txt
+circleci tests split --split-by=timings --timings-type=classname classes.txt > batch.txt
+grep -f batch.txt suites.txt | paste -s -d ',' -

--- a/.circleci/split_suites.sh
+++ b/.circleci/split_suites.sh
@@ -3,6 +3,6 @@
 set -e
 
 ls -1 apps/*/test/*SUITE.erl test/*SUITE.erl > suites.txt
-cat suites.txt | sed 's/.*\///g' | sed 's/.erl//g' > classes.txt
+xargs -I {} basename {} .erl < suites.txt > classes.txt
 circleci tests split --split-by=timings --timings-type=classname classes.txt > batch.txt
 grep -f batch.txt suites.txt | paste -s -d ',' -

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 CORE = rel/epoch/bin/epoch
 VER := $(shell cat VERSION)
+
 EUNIT_VM_ARGS = $(CURDIR)/config/eunit.vm.args
-CT_TEST_FLAGS =
-EUNIT_TEST_FLAGS =
+CT_TEST_FLAGS ?=
+EUNIT_TEST_FLAGS ?=
+
 ifdef SUITE
 CT_TEST_FLAGS += --suite=$(SUITE)_SUITE
 unexport SUITE


### PR DESCRIPTION
This changes greatly decreases total build time from ~20min to ~14min capped by aehttp_integration_SUITE. If/once this suite is split the runtime will decrease more.

The suites are split by runtime statistics collected from previous builds. [CircleCI documentation on this topic](https://circleci.com/docs/2.0/parallelism-faster-jobs/).

[PT ticket](https://www.pivotaltracker.com/story/show/156500609)