### PR TITLE
Stop configuring UAT nodes with ALL peers

### DIFF
--- a/deployment/ansible/group_vars/tag_env_dev2/config.yml
+++ b/deployment/ansible/group_vars/tag_env_dev2/config.yml
@@ -1,1 +1,2 @@
 log_level: debug
+configure_peers: false

--- a/deployment/ansible/group_vars/tag_env_dev2/config.yml
+++ b/deployment/ansible/group_vars/tag_env_dev2/config.yml
@@ -1,2 +1,1 @@
 log_level: debug
-configure_peers: true

--- a/deployment/ansible/group_vars/tag_env_dev2/config.yml
+++ b/deployment/ansible/group_vars/tag_env_dev2/config.yml
@@ -1,2 +1,2 @@
 log_level: debug
-configure_peers: false
+configure_peers: true

--- a/deployment/ansible/group_vars/tag_env_uat/config.yml
+++ b/deployment/ansible/group_vars/tag_env_uat/config.yml
@@ -1,1 +1,2 @@
 log_level: warning
+configure_peers: false

--- a/deployment/ansible/templates/epoch.yaml.j2
+++ b/deployment/ansible/templates/epoch.yaml.j2
@@ -5,10 +5,12 @@ sync:
 peers:
 {% for host in groups[hosts_group] | difference([inventory_hostname]) %}
 {% set public_ip = hostvars[host]['ansible_ssh_host']|default(hostvars[host]['ansible_host']) -%}
+{% if hostvars[host]['configure_peers'] is defined  and %}
 {% if hostvars[host]['sync_public_key'] is defined %}
     - "aenode://{{ hostvars[host]['sync_public_key'] }}@{{ public_ip }}:{{ config.sync.port }}"
 {% else %}
     - "aenode://pp$nokeyfoundpeerwillbeignored@{{ public_ip }}:{{ config.sync.port }}"
+{% endif %}
 {% endif %}
 {% endfor %}
 

--- a/deployment/ansible/templates/epoch.yaml.j2
+++ b/deployment/ansible/templates/epoch.yaml.j2
@@ -5,7 +5,7 @@ sync:
 peers:
 {% for host in groups[hosts_group] | difference([inventory_hostname]) %}
 {% set public_ip = hostvars[host]['ansible_ssh_host']|default(hostvars[host]['ansible_host']) -%}
-{% if hostvars[host]['configure_peers'] is defined  and %}
+{% if hostvars[host]['configure_peers'] is defined  and hostvars[host]['configure_peers']%}
 {% if hostvars[host]['sync_public_key'] is defined %}
     - "aenode://{{ hostvars[host]['sync_public_key'] }}@{{ public_ip }}:{{ config.sync.port }}"
 {% else %}

--- a/deployment/ansible/templates/epoch.yaml.j2
+++ b/deployment/ansible/templates/epoch.yaml.j2
@@ -2,7 +2,7 @@
 sync:
     port: {{ config.sync.port }}
 
-{% if configure_peers|default(false) %}
+{% if configure_peers|default(true) %}
 peers:
 {% for host in groups[hosts_group] | difference([inventory_hostname]) %}
 {% set public_ip = hostvars[host]['ansible_ssh_host']|default(hostvars[host]['ansible_host']) -%}

--- a/deployment/ansible/templates/epoch.yaml.j2
+++ b/deployment/ansible/templates/epoch.yaml.j2
@@ -2,17 +2,18 @@
 sync:
     port: {{ config.sync.port }}
 
+{% if configure_peers|default(false) %}
 peers:
 {% for host in groups[hosts_group] | difference([inventory_hostname]) %}
 {% set public_ip = hostvars[host]['ansible_ssh_host']|default(hostvars[host]['ansible_host']) -%}
-{% if hostvars[host]['configure_peers'] is defined  and hostvars[host]['configure_peers']%}
+
 {% if hostvars[host]['sync_public_key'] is defined %}
     - "aenode://{{ hostvars[host]['sync_public_key'] }}@{{ public_ip }}:{{ config.sync.port }}"
 {% else %}
     - "aenode://pp$nokeyfoundpeerwillbeignored@{{ public_ip }}:{{ config.sync.port }}"
 {% endif %}
-{% endif %}
 {% endfor %}
+{% endif %}
 
 keys:
     dir: {{ config.keypair.dir }}

--- a/deployment/ansible/templates/epoch.yaml.j2
+++ b/deployment/ansible/templates/epoch.yaml.j2
@@ -6,7 +6,6 @@ sync:
 peers:
 {% for host in groups[hosts_group] | difference([inventory_hostname]) %}
 {% set public_ip = hostvars[host]['ansible_ssh_host']|default(hostvars[host]['ansible_host']) -%}
-
 {% if hostvars[host]['sync_public_key'] is defined %}
     - "aenode://{{ hostvars[host]['sync_public_key'] }}@{{ public_ip }}:{{ config.sync.port }}"
 {% else %}


### PR DESCRIPTION
pt: https://www.pivotaltracker.com/story/show/157246535

tested on dev2:

where config_peers: false

```
epoch@ae-dev2-epoch-n0:~$ cat node/epoch.yaml
---
sync:
    port: 3015


keys:
    dir: keys
    password: "secret"

http:
    external:
        port: 3013
    internal:
        listen_address: 127.0.0.1
        port: 3113
    debug: false

websocket:
    internal:
        listen_address: 127.0.0.1
        port: 3114

mining:
    autostart: true
    expected_mine_rate: 300000
    cuckoo:
        miner:
            executable: mean28s-generic
            extra_args: "-t 5"
            node_bits: 28

chain:
    persist: true
    db_path: ./db52

logging:
    level: debug

metrics:
    # StatsD server and port
    host: 127.0.0.1
    port: 8125
epoch@ae-dev2-epoch-n0:~$

```
where config_peers: true
```
epoch@ae-dev2-epoch-n0:~$ cat node/epoch.yaml
---
sync:
    port: 3015

peers:
    - "aenode://pp$YVBrmXq2VNZBYCLj1nymdodGmMHkczYkZLFKPPQ8aWMAWDST6@31.13.249.77:3015"

keys:
    dir: keys
    password: "secret"

http:
    external:
        port: 3013
    internal:
        listen_address: 127.0.0.1
        port: 3113
    debug: false

websocket:
    internal:
        listen_address: 127.0.0.1
        port: 3114

mining:
    autostart: true
    expected_mine_rate: 300000
    cuckoo:
        miner:
            executable: mean28s-generic
            extra_args: "-t 5"
            node_bits: 28

chain:
    persist: true
    db_path: ./db52

logging:
    level: debug

metrics:
    # StatsD server and port
    host: 127.0.0.1
    port: 8125
epoch@ae-dev2-epoch-n0:~$
```

without default to false: 
`
epoch@ae-dev2-epoch-n0:~$ cat node/epoch.yaml
---
sync:
    port: 3015


keys:
    dir: keys
    password: "secret"

http:
    external:
        port: 3013
    internal:
        listen_address: 127.0.0.1
        port: 3113
    debug: false

websocket:
    internal:
        listen_address: 127.0.0.1
        port: 3114

mining:
    autostart: true
    expected_mine_rate: 300000
    cuckoo:
        miner:
            executable: mean28s-generic
            extra_args: "-t 5"
            node_bits: 28

chain:
    persist: true
    db_path: ./db52

logging:
    level: debug

metrics:
    # StatsD server and port
    host: 127.0.0.1
    port: 8125
epoch@ae-dev2-epoch-n0:~$
`