### PR TITLE
Check that creator account can pay deposit and burn the deposit

### DIFF
--- a/py/tests/integration/test_unsigned_tx.py
+++ b/py/tests/integration/test_unsigned_tx.py
@@ -69,6 +69,7 @@ def test_contract_create():
                   alice_balance
                   + test_settings["create_contract"]["fee"]
                   + test_settings["create_contract"]["gas_used"]
+                  + test_settings["create_contract"]["deposit"]
                   + test_settings["create_contract"]["amount"])
 
     print("Fee was consumed, transaction is part of the chain")
@@ -109,6 +110,7 @@ def test_contract_call():
                   alice_balance
                   + create_settings["create_contract"]["fee"]
                   + create_settings["create_contract"]["gas_used"]
+                  + create_settings["create_contract"]["deposit"]
                   + create_settings["create_contract"]["amount"])
 
     call_input = ContractCallInput("sophia", create_settings["create_contract"]["code"],\


### PR DESCRIPTION
I also did some refactoring so to make the deposit changes more clear, 
they are
1: Check that creator account can pay deposit

```patch
 @@ -136,8 +137,9 @@ check(#contract_create_tx{owner = OwnerPubKey,
                            amount     = Amount,
                            gas        = Gas,
                            gas_price  = GasPrice,
 +                          deposit    = Deposit,
                            fee = Fee}, _Context, Trees, _Height, _ConsensusVersion) ->
 -    TotalAmount = Fee + Amount + Gas * GasPrice,
 +    TotalAmount = Fee + Amount + Deposit + Gas * GasPrice,
      Checks =
          [fun() -> aetx_utils:check_account(OwnerPubKey, Trees, Nonce, TotalAmount) end
```

2: burn the deposit if the creation succeeds
Line 285: 
```Erlang
    %% Spend Gas and burn
     %% Deposit (the deposit is stored in the contract.)
     GasCost = aect_call:gas_used(CallRes) * GasPrice,
     Trees2 =
         spend(OwnerPubKey, ContractPubKey, 0, Deposit+GasCost, Nonce,
               Context, Height, Trees1,
               ConsensusVersion),
```