### PR TITLE
Increase miner reward - smallest unit is atto-Aeternity-token

### DIFF
--- a/apps/aecore/src/aec_governance.erl
+++ b/apps/aecore/src/aec_governance.erl
@@ -27,7 +27,7 @@
 
 -define(BLOCKS_TO_CHECK_DIFFICULTY_COUNT, 10).
 -define(EXPECTED_BLOCK_MINE_RATE, 300000). %% 60secs * 1000ms * 5 = 300000msecs
--define(BLOCK_MINE_REWARD, 10).
+-define(BLOCK_MINE_REWARD, 10000000000000000000).
 
 
 %% Maps consensus protocol version to minimum height at which such

--- a/apps/aetx/test/aetx_tests.erl
+++ b/apps/aetx/test/aetx_tests.erl
@@ -68,7 +68,7 @@ apply_signed_txs_test_() ->
                {value, ResultRecipientAccount} = aec_accounts_trees:lookup(?RECIPIENT_PUBKEY, ResultAccountsTree),
 
                %% Initial balance - spend_tx amount - spend_tx fee + spend_tx fee + coinbase_tx reward
-               ?assertEqual(100 - 40 - 9 + 9 + 10, aec_accounts:balance(ResultMinerAccount)),
+               ?assertEqual(100 - 40 - 9 + 9 + aec_governance:block_mine_reward(), aec_accounts:balance(ResultMinerAccount)),
                ?assertEqual(80 + 40, aec_accounts:balance(ResultRecipientAccount))
        end
       }]}.

--- a/deployment/ansible/deploy.yml
+++ b/deployment/ansible/deploy.yml
@@ -66,7 +66,7 @@
           port: 3114
       chain:
         persist: true
-        db_path: "./db54"
+        db_path: "./db55"
       keypair:
         dir: "keys"
         password: "{{ vault_keys_password|default('secret') }}"

--- a/docs/release-notes/RELEASE-NOTES-0.14.0.md
+++ b/docs/release-notes/RELEASE-NOTES-0.14.0.md
@@ -9,6 +9,7 @@ category info and up will still be directed to the console.
 * Does that. This impacts the persisted DB.
 * Does that.
 * Stops using hashes of unsigned transactions, and uses the hash of the signed transaction instead. This reduces the memory footprint of the system (removes one index). This affects the API by removing the transaction hash when constructing unsigned transactions. This affects the API by returning the hash of the signed transaction in all other applicable places. The latter should not affects users of the API as all transaction hashes are now constructed from the signed transaction. Note that this does not affect consensus, only the http and websocket API:s. This impacts the persisted DB.
+* Changes the miner reward to 10,000,000,000,000,000,000 atto-Aeternity-tokens. This impacts consensus.
 * Improves the stability of the testnet.
 * Enhances user HTTP API with fine tuning paths for getting account balance and transactions
 * Moves contract account balances to account state tree. Also removes height and contract ID from contract state trees. This impacts consensus.

--- a/py/tests/integration/common.py
+++ b/py/tests/integration/common.py
@@ -186,7 +186,7 @@ def genesis_hash(api):
     return block.prev_hash
 
 def wait_until_height(api, height):
-    wait(lambda: api.get_top().height >= height, timeout_seconds=600, sleep_seconds=0.25)
+    wait(lambda: api.get_top().height >= height, timeout_seconds=120, sleep_seconds=0.25)
 
 def get_account_balance(api, int_api, pub_key=None):
     return _balance_from_get_account_balance(

--- a/py/tests/integration/setup.yaml
+++ b/py/tests/integration/setup.yaml
@@ -28,7 +28,7 @@ nodes:
       external_api: 3033
       internal_api: 3133
       internal_ws: 3134
-coinbase_reward: 10
+coinbase_reward: 10000000000000000000
 tests: # test specific settings
   test_use_cases:
     test_syncing:
@@ -78,7 +78,7 @@ tests: # test specific settings
       blocks_to_mine: 3
       spend_tx:
         alice_pubkey: ak$v6kQV2Z6uXv2PsUJdv955gE
-        amount: 1000
+        amount: 1000000000000000000000
         fee: 20
     test_send_by_name:
     # Bob registers a name 'bob.aet'
@@ -107,7 +107,7 @@ tests: # test specific settings
     test_contract_create:
       nodes:
         node: dev1
-      blocks_to_mine: 115
+      blocks_to_mine: 5
       alice:
         amount: 1120
         fee: 1
@@ -124,7 +124,7 @@ tests: # test specific settings
     test_contract_call:
       nodes:
         node: dev1
-      blocks_to_mine: 123
+      blocks_to_mine: 7
       alice:
         amount: 1200
         fee: 1


### PR DESCRIPTION
For now go with 10^-18, will be easy to adjust if we decide on something different.