### PR TITLE
Fix allow showing transactions to a new accounts

### DIFF
--- a/apps/aehttp/priv/swagger.json
+++ b/apps/aehttp/priv/swagger.json
@@ -1570,12 +1570,6 @@
             "schema" : {
               "$ref" : "#/definitions/Error"
             }
-          },
-          "404" : {
-            "description" : "Account not found",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
           }
         }
       }

--- a/apps/aehttp/src/aehttp_dispatch_ext.erl
+++ b/apps/aehttp/src/aehttp_dispatch_ext.erl
@@ -468,22 +468,16 @@ handle_request('GetAccountsBalances', _Req, _Context) ->
 handle_request('GetAccountTransactions', Req, _Context) ->
     case aec_base58c:safe_decode(account_pubkey, maps:get('account_pubkey', Req)) of
         {ok, AccountPubkey} ->
-            {ok, TopBlockHash} = aehttp_logic:get_top_hash(),
-            case aehttp_logic:get_account_balance_at_hash(AccountPubkey, TopBlockHash) of
-                {error, account_not_found} ->
-                    {404, [], #{reason => <<"Account not found">>}};
-                {ok, _} ->
-                    case get_account_transactions(AccountPubkey, Req) of
-                        {error, unknown_type} ->
-                            {400, [], #{reason => <<"Unknown transaction type">>}};
-                        {ok, HeaderTxs} ->
-                            case encode_txs(HeaderTxs, Req) of
-                                {error, Err} ->
-                                    Err;
-                                {ok, EncodedTxs, DataSchema} ->
-                                    {200, [], #{transactions => EncodedTxs,
-                                                data_schema => DataSchema}}
-                            end
+            case get_account_transactions(AccountPubkey, Req) of
+                {error, unknown_type} ->
+                    {400, [], #{reason => <<"Unknown transaction type">>}};
+                {ok, HeaderTxs} ->
+                    case encode_txs(HeaderTxs, Req) of
+                        {error, Err} ->
+                            Err;
+                        {ok, EncodedTxs, DataSchema} ->
+                            {200, [], #{transactions => EncodedTxs,
+                                        data_schema => DataSchema}}
                     end
             end;
         _ ->

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -1312,10 +1312,6 @@ paths:
           description: Invalid account hash
           schema:
             $ref: '#/definitions/Error'
-        '404':
-          description: Account not found
-          schema:
-            $ref: '#/definitions/Error'
 
 ## CAUTION: debug endpoints, implementation may be inefficient
   /balances:


### PR DESCRIPTION
[Pivotal story](https://www.pivotaltracker.com/story/show/157316134)

If an account address is new (not yet persisted in trees) - we used to not show account transactions.
#### Ex. scenario
Alice has an account, Bob has not yet.
Alice posts a `spend_tx` to Bob. Transaction is not yet mined but rather in mempool.
Bob wants to get all transactions related to his address