### PR TITLE
Preparation for moving coinbase to header

### DIFF
--- a/apps/aecontract/test/aecontract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_SUITE.erl
@@ -80,19 +80,22 @@ create_contract_negative(_Cfg) ->
     {BadPubKey, BadS} = aect_test_utils:setup_new_account(aect_test_utils:new_state()),
     BadPrivKey        = aect_test_utils:priv_key(BadPubKey, BadS),
     RTx1      = aect_test_utils:create_tx(BadPubKey, S1),
-    {error, S1}  = sign_and_apply_transaction(RTx1, BadPrivKey, S1),
+    {error, MaybeS1Mined} = sign_and_apply_transaction(RTx1, BadPrivKey, S1),
+    aect_test_utils:assert_state_equal(S1, MaybeS1Mined),
     {error, account_not_found} = aetx:check(RTx1, Trees, CurrHeight, ?PROTOCOL_VERSION),
 
     %% Insufficient funds
     S2     = aect_test_utils:set_account_balance(PubKey, 0, S1),
     Trees2 = aect_test_utils:trees(S2),
     RTx2   = aect_test_utils:create_tx(PubKey, S2),
-    {error, S2}  = sign_and_apply_transaction(RTx2, PrivKey, S2),
+    {error, MaybeS2Mined} = sign_and_apply_transaction(RTx2, PrivKey, S2),
+    aect_test_utils:assert_state_equal(S2, MaybeS2Mined),
     {error, insufficient_funds} = aetx:check(RTx2, Trees2, CurrHeight, ?PROTOCOL_VERSION),
 
     %% Test too high account nonce
     RTx3 = aect_test_utils:create_tx(PubKey, #{nonce => 0}, S1),
-    {error, S1}  = sign_and_apply_transaction(RTx3, PrivKey, S1),
+    {error, MaybeS1Mined2} = sign_and_apply_transaction(RTx3, PrivKey, S1),
+    aect_test_utils:assert_state_equal(S1, MaybeS1Mined2),
     {error, account_nonce_too_high} = aetx:check(RTx3, Trees, CurrHeight, ?PROTOCOL_VERSION),
 
     ok.

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -494,7 +494,7 @@ get_top_empty_chain(_Config) ->
     {ok, GenBlock} = aehttp_api_parser:decode(block, GenBlockMap),
     ExpectedMap = header_to_endpoint_top(aec_blocks:to_header(GenBlock)),
     ct:log("Cleaned top header = ~p", [ExpectedMap]),
-    HeaderMap = ExpectedMap,
+    {ExpectedMap, _} = {HeaderMap, {expected, ExpectedMap}},
 
     ForkHeight = aecore_suite_utils:latest_fork_height(),
     aecore_suite_utils:mine_blocks(aecore_suite_utils:node_name(?NODE),
@@ -507,7 +507,7 @@ get_top_non_empty_chain(_Config) ->
     ExpectedMap = header_to_endpoint_top(ExpectedH),
     ct:log("Cleaned top header = ~p", [ExpectedMap]),
     {ok, 200, HeaderMap} = get_top(),
-    HeaderMap = ExpectedMap,
+    {ExpectedMap, _} = {HeaderMap, {expected, ExpectedMap}},
     #{<<"height">> := Height} = HeaderMap,
     true = Height > 0,
     ok.
@@ -1557,7 +1557,9 @@ all_accounts_balances(_Config) ->
     AllTxsCnt = length(AllTxs),
     AllTxsCnt = Receivers + 1, % all spendTxs and a coinbaseTx
 
-    true = length(Balances) =:= length(ExpectedBalances),
+    case {length(Balances), length(ExpectedBalances)} of
+        {ExpectedBalancesCnt, ExpectedBalancesCnt} -> ok
+    end,
     true =
         lists:all(
             fun(#{<<"pub_key">> := PKEncoded, <<"balance">> := Bal}) ->
@@ -2707,7 +2709,7 @@ ws_get_genesis(_Config) ->
     {ok, 200, BlockMap} = get_block_by_height(0, message_pack),
     ExpectedBlockMap =
         maps:remove(<<"hash">>, maps:remove(<<"data_schema">>, BlockMap)),
-    Block = ExpectedBlockMap,
+    {ExpectedBlockMap, _} = {Block, {expected, ExpectedBlockMap}},
 
     ok = aehttp_ws_test_utils:stop(ConnPid),
     ok.

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -436,14 +436,16 @@ init_per_group(all_endpoints, Config) ->
 init_per_group(channel_websocket, Config) ->
     aecore_suite_utils:start_node(?NODE, Config),
     aecore_suite_utils:connect(aecore_suite_utils:node_name(?NODE)),
+    {ok, 404, _} = get_balance_at_top(),
     %% prepare participants
     {IPubkey, IPrivkey} = generate_key_pair(),
     {RPubkey, RPrivkey} = generate_key_pair(),
     IStartAmt = 50,
     RStartAmt = 50,
     Fee = 1,
+    BlocksToMine = 10,
 
-    aecore_suite_utils:mine_blocks(aecore_suite_utils:node_name(?NODE), 10),
+    aecore_suite_utils:mine_blocks(aecore_suite_utils:node_name(?NODE), BlocksToMine),
 
     {ok, 200, _} = post_spend_tx(IPubkey, IStartAmt, Fee),
     {ok, 200, _} = post_spend_tx(RPubkey, RStartAmt, Fee),
@@ -4507,4 +4509,3 @@ make_params([{K, V} | T], Accum) ->
 generate_key_pair() ->
     #{ public := Pubkey, secret := Privkey } = enacl:sign_keypair(),
     {Pubkey, Privkey}.
-

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -447,7 +447,8 @@ init_per_group(channel_websocket, Config) ->
 
     {ok, 200, _} = post_spend_tx(IPubkey, IStartAmt, Fee),
     {ok, 200, _} = post_spend_tx(RPubkey, RStartAmt, Fee),
-    aecore_suite_utils:mine_blocks(aecore_suite_utils:node_name(?NODE), 1),
+    {ok, [Block]} = aecore_suite_utils:mine_blocks(aecore_suite_utils:node_name(?NODE), 1),
+    [_Coinbase, _Spend1, _Spend2] = aec_blocks:txs(Block),
     assert_balance(IPubkey, IStartAmt),
     assert_balance(RPubkey, RStartAmt),
     Participants = #{initiator => #{pub_key => IPubkey,

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -1451,8 +1451,7 @@ post_broken_blocks(Config) ->
     lists:foreach(
         fun({BrokenField, BlockMap}) ->
             ct:log("Testing with a broken ~p", [BrokenField]),
-            {ok, Block} = aehttp_api_parser:decode(block, BlockMap),
-            {ok, 400, #{<<"reason">> := <<"Block rejected">>}} = post_block(Block),
+            {ok, 400, #{<<"reason">> := <<"Block rejected">>}} = post_block_map(BlockMap),
             H = rpc(aec_chain, top_header, []),
             0 = aec_headers:height(H) %chain is still empty
         end,
@@ -3762,9 +3761,10 @@ get_account_transactions(EncodedPubKey, Params) ->
                  Params).
 
 post_block(Block) ->
+    post_block_map(aehttp_api_parser:encode(block, Block)).
+
+post_block_map(BlockMap) ->
     Host = external_address(),
-    BlockMap =
-        aehttp_api_parser:encode(block, Block),
     http_request(Host, post, "block", BlockMap).
 
 post_tx(TxSerialized) ->


### PR DESCRIPTION
Preparatory PR for https://www.pivotaltracker.com/story/show/157214052 (several other preparatory commits were merged as part of https://github.com/aeternity/epoch/pull/1139 so this PR is small).

Please refer to commit messages for details.

The only functional changes in this PR are in the commit whose message says:
> Teach HTTP API to return error on undecodable block
> ... rather than crashing.
> Also lower severity from error, as dependent on client.
