### PR TITLE
Don't close the socket to early, the same port can be returned

### DIFF
--- a/system_test/helpers/aest_docker.erl
+++ b/system_test/helpers/aest_docker.erl
@@ -397,12 +397,12 @@ uid2postfix(Uid) -> <<"_", Uid/binary>>.
 free_port() ->
     {ok, Socket} = gen_tcp:listen(0, [{reuseaddr, true}]),
     {ok, Port} = inet:port(Socket),
-    gen_tcp:close(Socket),
     {ok, Port, Socket}.
 
 allocate_ports(Labels) -> allocate_ports(Labels, #{}, []).
 
-allocate_ports([], Ports, Sockets) -> {Ports, Sockets};
+allocate_ports([], Ports, Sockets) ->
+    {Ports, Sockets};
 allocate_ports([Label | Labels], Ports, Sockets) ->
     {ok, Port, Socket} = free_port(),
     allocate_ports(Labels, Ports#{Label => Port}, [Socket | Sockets]).


### PR DESCRIPTION
We need 4 different TCP ports per container to map configured ports to actually used ports.

The way to get a port is to open a socket and use inets:port on this socket. That should give a unique port for that moment. However, when the socket is closed, that port may be re-used when inets:port is called again.

This does not solve the complete port unicity. Since we create nodes in setup, we may in the second setup accidently get the same port.
