### PR TITLE
Isolate junit.xml report in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -226,8 +226,15 @@ jobs:
           command: |
             epmd -daemon
             make test CT_TEST_FLAGS="--suite=$(.circleci/split_suites.sh)"
+      # Isolates the junit.xml report because additional files in _build/test/logs
+      # are somehow causing issue with xunit report upload, parsing and merging
+      - run:
+          name: move test report
+          command: |
+            mkdir _build/test/reports
+            mv _build/test/logs/junit.xml _build/test/reports/
       - store_test_results:
-          path: _build/test/logs
+          path: _build/test/reports
       - store_artifacts:
           path: _build/test/logs
       - *fail_notification


### PR DESCRIPTION
The CircleCI support replied that the behaviour is weird and may indicate for issues on their end.
They suggested this workaround (PR changes).

Unfortunately we can't prove it will work on master, until we merge it.

https://www.pivotaltracker.com/story/show/157731163