### PR TITLE
Double startup_timeout in system tests perf suite

### DIFF
--- a/system_test/aest_perf_SUITE.erl
+++ b/system_test/aest_perf_SUITE.erl
@@ -62,7 +62,7 @@ init_per_suite(Cfg) ->
         {mine_interval, {seconds, 30}}, % Interval to check mining height
         {mine_rate, MineRate},          % Mine rate configuration for nodes
         {mine_timeout, MineRate * 2},   % Per block
-        {startup_timeout, 10000},       % Timeout until HTTP API responds
+        {startup_timeout, 20000},       % Timeout until HTTP API responds
         {sync_timeout, 1000}            % Per block
     ].
 


### PR DESCRIPTION
3 successful builds based on this fix: https://circleci.com/gh/aeternity/workflows/epoch/tree/fix_system_tests_startup_timout