### PR TITLE
Channel's state tree

### DIFF
--- a/apps/aechannel/include/channel_txs.hrl
+++ b/apps/aechannel/include/channel_txs.hrl
@@ -92,7 +92,7 @@
           initiator_amount   :: aesc_channels:amount(),
           responder_amount   :: aesc_channels:amount(),
           updates            :: [offchain_update()],
-          state              :: binary(),
+          state_hash         :: binary(),
           previous_round     :: non_neg_integer(),
           round              :: non_neg_integer()
          }).

--- a/apps/aechannel/src/aesc_offchain_state.erl
+++ b/apps/aechannel/src/aesc_offchain_state.erl
@@ -238,8 +238,8 @@ add_signed_tx(SignedTx, #state{signed_txs=Txs0}=State) ->
     Trees =
         lists:foldl(
             fun(Update, TrAccum) ->
-                {TAccum1, _, _} = modify_trees(Update, TrAccum),
-                TAccum1
+                {TrAccum1, _, _} = modify_trees(Update, TrAccum),
+                TrAccum1
             end,
             State#state.trees,
             Mod:updates(TxI)),
@@ -279,7 +279,6 @@ tx_round(Tx) ->
     Mod:round(TxI).
 
 -spec fallback_to_stable_state(state()) -> state().
-%% TODO: handle empty state?
 fallback_to_stable_state(#state{signed_txs=[_|_]}=State) ->
     State#state{half_signed_txs=[]}.
 

--- a/apps/aechannel/src/aesc_offchain_state.erl
+++ b/apps/aechannel/src/aesc_offchain_state.erl
@@ -1,27 +1,56 @@
 -module(aesc_offchain_state).
 
--export([ new/1                     %%  (Opts) -> Tx
-        , check_initial_state/2     %%  (SerializedTxElem, Tx) -> ok | {error,_}
-        , check_initial_update_tx/3 %%  (SignedTx, State, Opts)
-        , check_update_tx/3         %%  (SignedTx, State, Opts)
-        , apply_updates/3           %%  (Updates, Tx, Opts) -> Tx'
-        , get_latest_state_tx/1     %%  (State) -> {Round, SignedTx}
-        , get_fallback_state/1      %%  (State) -> {Round, State'}
-        , fallback_to_stable_state/1 %% (State) -> State'
+-include_lib("apps/aecore/include/common.hrl").
+-include_lib("apps/aecore/include/blocks.hrl").
+
+-record(state, { trees                  :: aesc_trees:trees()
+               , signed_txs = []        :: [aetx_sign:signed_tx()]
+               , half_signed_txs = []   :: [aetx_sign:signed_tx()]
+              }).
+
+-opaque state() :: #state{}.
+
+-define(OP_TRANSFER, 0).
+-define(OP_WITHDRAW, 1).
+-define(OP_DEPOSIT , 2).
+
+-type operation() :: ?OP_TRANSFER | ?OP_WITHDRAW | ?OP_DEPOSIT.
+
+-opaque update() :: {operation(), pubkey(), pubkey(), non_neg_integer()}. 
+
+-export_type([state/0, update/0]).
+
+-export([ new/1                       %%  (Opts) -> {ok, Tx, State}
+        , check_initial_update_tx/3   %%  (SignedTx, State, Opts)
+        , check_update_tx/3           %%  (SignedTx, State, Opts)
+        , make_update_tx/3            %%  (Updates, State, Opts) -> Tx
+        , add_signed_tx/2             %%  (SignedTx, State0) -> State
+        , add_half_signed_tx/2        %%  (SignedTx, State0) -> State
+        , get_latest_half_signed_tx/1 %%  (State) -> SignedTx
+        , get_latest_signed_tx/1      %%  (State) -> {Round, SignedTx}
+        , get_fallback_state/1        %%  (State) -> {Round, State'}
+        , fallback_to_stable_state/1  %%  (State) -> State'
+        , hash/1                      %%  (State) -> hash()
         ]).
 -export([ op_transfer/3
         , op_deposit/2
         , op_withdraw/2
         ]).
 
--define(OP_TRANSFER, 0).
--define(OP_WITHDRAW, 1).
--define(OP_DEPOSIT , 2).
-
-
+-spec new(map()) -> {ok, state()}.
 new(Opts) ->
     lager:debug("offchain_tx:new(~p)", [Opts]),
-    aesc_offchain_tx:new(Opts).
+    #{initiator          := InitiatorPubKey,
+      responder          := ResponderPubKey,
+      initiator_amount   := InitiatorAmount,
+      responder_amount   := ResponderAmount} = Opts,
+    Trees = aesc_trees:new([{InitiatorPubKey, InitiatorAmount},
+                            {ResponderPubKey, ResponderAmount}]),
+    {ok, #state{trees=Trees}}.
+
+-spec hash(state()) -> binary().
+hash(#state{trees=Trees}) ->
+    aesc_trees:hash(Trees).
 
 %% update_tx checks
 check_initial_state({previous_round, N}, _) ->
@@ -35,65 +64,73 @@ check_initial_state(_, _) -> ok.
 assert(true ,  _   ) -> ok;
 assert(false, Error) -> Error.
 
+-spec check_initial_update_tx(aetx_sign:signed_tx(), state(), map()) -> ok | {error, atom()}.
 check_initial_update_tx(SignedTx, State, Opts) ->
     check_update_tx(fun check_initial_state/2, SignedTx, State, Opts).
 
+-spec check_update_tx(aetx_sign:signed_tx(), state(), map()) -> ok | {error, atom()}.
 check_update_tx(SignedTx, State, Opts) ->
     check_update_tx(none, SignedTx, State, Opts).
 
-check_update_tx(F, SignedTx, State, Opts) ->
+check_update_tx(F, SignedTx, #state{signed_txs = Txs}=State, Opts) ->
     lager:debug("check_update_tx(State = ~p)", [State]),
     Tx = aetx_sign:tx(SignedTx),
     {Mod, TxI} = aetx:specialize_callback(Tx),
     lager:debug("Tx = ~p", [Tx]),
     case Mod:previous_round(TxI) of
-        0 when State == [] ->
+        0 when Txs == [] ->
             lager:debug("previous round = 0", []),
-            check_update_tx_(F, Mod, TxI, TxI, Opts);
+            check_update_tx_(F, Mod, TxI, TxI, State, Opts);
         PrevRound ->
             lager:debug("PrevRound = ~p", [PrevRound]),
-            {LastRound, LastSignedTx} = get_latest_state_tx(State),
+            {LastRound, LastSignedTx} = get_latest_signed_tx(State),
             LastTx = aetx_sign:tx(LastSignedTx),
             {Mod, LastTxI} = aetx:specialize_callback(LastTx),  %% Mod bound!
             lager:debug("LastRound = ~p", [LastRound]),
             case PrevRound == LastRound of
                 true ->
                     lager:debug("PrevRound == LastRound", []),
-                    check_update_tx_(F, Mod, TxI, LastTxI, Opts);
+                    check_update_tx_(F, Mod, TxI, LastTxI, State, Opts);
                 false -> {error, invalid_previous_round}
             end
     end.
 
-check_update_tx_(F, Mod, RefTx, LastTx, Opts) ->
+check_update_tx_(F, Mod, RefTx, LastTx, #state{trees=Trees}, Opts) ->
     Updates = Mod:updates(RefTx),
-    try  Tx1 = apply_updates(Updates, Mod, LastTx, Opts),
+    try  {Tx1, Trees1} = apply_updates(Updates, Mod, LastTx, Trees, Opts),
          case {{Mod:initiator_amount(RefTx), Mod:responder_amount(RefTx)},
-               {Mod:initiator_amount(Tx1)  , Mod:responder_amount(Tx1)}} of
-             {X, X} ->
+               {Mod:initiator_amount(Tx1)  , Mod:responder_amount(Tx1)},
+               Mod:state_hash(Tx1) =:= aesc_trees:hash(Trees1)} of
+             {X, X, true} ->
                  run_extra_checks(F, Mod, RefTx);
-             Other ->
-                 {error, {amount_mismatch, Other}}
+             {_, _, false} ->
+                 {error, state_hash_mismatch};
+             {X, Y, _} ->
+                 {error, {amount_mismatch, {X, Y}}}
          end
     catch
         error:Reason ->
             {error, Reason}
     end.
 
-apply_updates(Updates, Tx, Opts) ->
+-spec make_update_tx(list(update()), state(), map()) -> aetx:tx().
+make_update_tx(Updates, #state{signed_txs=[SignedTx|_], trees=Trees}, Opts) ->
+    Tx = aetx_sign:tx(SignedTx),
     {Mod, TxI} = aetx:specialize_callback(Tx),
-    TxI1 = apply_updates(Updates, Mod, TxI, Opts),
+    {TxI1, _Trees1} = apply_updates(Updates, Mod, TxI, Trees, Opts),
     aetx:update_tx(Tx, TxI1).
 
-apply_updates(Updates, Mod, Tx, Opts) ->
+apply_updates(Updates, Mod, Tx, Trees, Opts) ->
     Round = Mod:round(Tx),
-    Tx1 = apply_updates_(Updates, Mod, Tx, Opts),
-    set_tx_values([{round, Round+1},
-                   {previous_round, Round},
-                   {updates, Updates}], Mod, Tx1).
+    {Tx1, NewTrees} = apply_updates_(Updates, Mod, Tx, Trees, Opts),
+    Tx2 = set_tx_values([{round, Round+1},
+                         {previous_round, Round},
+                         {updates, Updates}], Mod, Tx1),
+    {Tx2, NewTrees}.
 
-apply_updates_([], _Mod, Tx, _Opts) ->
-    Tx;
-apply_updates_([{?OP_DEPOSIT, Acct, Acct, Amount}|Ds], Mod, Tx, Opts) ->
+apply_updates_([], _Mod, Tx, Trees, _Opts) ->
+    {Tx, Trees};
+apply_updates_([{?OP_DEPOSIT, Acct, Acct, Amount} = U | Ds], Mod, Tx, Trees, Opts) ->
     Initiator = Mod:initiator(Tx),
     Responder = Mod:responder(Tx),
     IAmt = Mod:initiator_amount(Tx),
@@ -103,9 +140,11 @@ apply_updates_([{?OP_DEPOSIT, Acct, Acct, Amount}|Ds], Mod, Tx, Opts) ->
             Initiator -> [{initiator_amount, IAmt + Amount}];
             Responder -> [{responder_amount, RAmt + Amount}]
         end,
+    {Trees1, _OldBalance, NewBalance} = modify_trees(U, Trees),
+    [{_, NewBalance}] = Vals, %% TODO: remove assert
     Tx1 = set_tx_values(Vals, Mod, Tx),
-    apply_updates_(Ds, Mod, Tx1, Opts);
-apply_updates_([{?OP_WITHDRAW, Acct, Acct, Amount}|Ds], Mod, Tx, Opts) ->
+    apply_updates_(Ds, Mod, Tx1, Trees1, Opts);
+apply_updates_([{?OP_WITHDRAW, Acct, Acct, Amount} = U | Ds], Mod, Tx, Trees, Opts) ->
     Initiator = Mod:initiator(Tx),
     Responder = Mod:responder(Tx),
     IAmt = Mod:initiator_amount(Tx),
@@ -115,9 +154,11 @@ apply_updates_([{?OP_WITHDRAW, Acct, Acct, Amount}|Ds], Mod, Tx, Opts) ->
             Initiator -> [{initiator_amount, check_min_amt(IAmt - Amount, Opts)}];
             Responder -> [{responder_amount, check_min_amt(RAmt - Amount, Opts)}]
         end,
+    {Trees1, _OldBalance, NewBalance} = modify_trees(U, Trees),
+    [{_, NewBalance}] = Vals, %% TODO: remove assert
     Tx1 = set_tx_values(Vals, Mod, Tx),
-    apply_updates_(Ds, Mod, Tx1, Opts);
-apply_updates_([{?OP_TRANSFER, From, To, Amount}|Ds], Mod, Tx, Opts)
+    apply_updates_(Ds, Mod, Tx1, Trees1, Opts);
+apply_updates_([{?OP_TRANSFER, From, To, Amount} = U | Ds], Mod, Tx, Trees, Opts)
   when is_binary(From), is_binary(To), is_integer(Amount) ->
     Initiator = Mod:initiator(Tx),
     Responder = Mod:responder(Tx),
@@ -134,9 +175,41 @@ apply_updates_([{?OP_TRANSFER, From, To, Amount}|Ds], Mod, Tx, Opts)
                 error(unknown_pubkeys)
         end,
     {A1, B1} = {check_min_amt(A - Amount, Opts), B + Amount},
+    {Trees1, FromBalance, ToBalance} = modify_trees(U, Trees),
+    {A, _} = {FromBalance, A}, %% TODO: remove assert
+    {B, _} = {ToBalance, B}, %% TODO: remove assert
+    {A1, B1} = {FromBalance - Amount, ToBalance + Amount},
+    StateHash = aesc_trees:hash(Trees1),
     Tx1 = set_tx_values([{FA, A1},
-                         {FB, B1}], Mod, Tx),
-    apply_updates_(Ds, Mod, Tx1, Opts).
+                          {FB, B1},
+                          {state_hash, StateHash}], Mod, Tx),
+    apply_updates_(Ds, Mod, Tx1, Trees1, Opts).
+
+-spec modify_trees(update(), aesc_trees:trees()) ->
+    {aesc_trees:trees(), non_neg_integer(), non_neg_integer()}.
+modify_trees({?OP_TRANSFER, From, To, Amount}, Trees) ->
+    {ok, AccFrom0} = aesc_trees:get_account(Trees, From),
+    {ok, AccTo0} = aesc_trees:get_account(Trees, To),
+    FromBalance = aec_accounts:balance(AccFrom0),
+    ToBalance = aec_accounts:balance(AccTo0),
+    {ok, AccFrom} = aec_accounts:spend(AccFrom0, Amount, 0),
+    {ok, AccTo} = aec_accounts:earn(AccTo0, Amount),
+    {lists:foldl(
+        fun(Acc, Accum) -> aesc_trees:set_account(Accum, Acc) end,
+        Trees,
+        [AccFrom, AccTo]), FromBalance, ToBalance};
+modify_trees({?OP_DEPOSIT, To, To, Amount}, Trees) ->
+    {ok, AccTo0} = aesc_trees:get_account(Trees, To),
+    ToBalance = aec_accounts:balance(AccTo0),
+    {ok, AccTo} = aec_accounts:earn(AccTo0, Amount),
+    NewBalance = ToBalance + Amount,
+    {aesc_trees:set_account(Trees, AccTo), ToBalance, NewBalance};
+modify_trees({?OP_WITHDRAW, From, From, Amount}, Trees) ->
+    {ok, AccFrom0} = aesc_trees:get_account(Trees, From),
+    FromBalance = aec_accounts:balance(AccFrom0),
+    {ok, AccFrom} = aec_accounts:spend(AccFrom0, Amount, 0),
+    NewBalance = FromBalance - Amount,
+    {aesc_trees:set_account(Trees, AccFrom), FromBalance, NewBalance}.
 
 check_min_amt(Amt, Opts) ->
     Reserve = maps:get(channel_reserve, Opts, 0),
@@ -157,20 +230,46 @@ run_extra_checks(F, Mod, Tx) when is_function(F, 2) ->
             {error, Errors}
     end.
 
-get_latest_state_tx(State) ->
-    [SignedTx|_] = drop_until_mutually_signed(State),
+-spec add_signed_tx(aetx_sign:signed_tx(), state()) -> state().
+add_signed_tx(SignedTx, #state{signed_txs=Txs0}=State) ->
+    true = mutually_signed(SignedTx), % ensure it is mutually signed
+    Tx = aetx_sign:tx(SignedTx),
+    {Mod, TxI} = aetx:specialize_callback(Tx),
+    Trees =
+        lists:foldl(
+            fun(Update, TrAccum) ->
+                {TAccum1, _, _} = modify_trees(Update, TrAccum),
+                TAccum1
+            end,
+            State#state.trees,
+            Mod:updates(TxI)),
+    State#state{signed_txs=[SignedTx | Txs0], half_signed_txs=[], trees=Trees}.
+
+-spec add_half_signed_tx(aetx_sign:signed_tx(), state()) -> state().
+add_half_signed_tx(SignedTx, #state{half_signed_txs=Txs0}=State) ->
+    State#state{half_signed_txs=[SignedTx | Txs0]}.
+
+-spec get_latest_half_signed_tx(state()) -> aetx_sign:signed_tx().
+get_latest_half_signed_tx(#state{half_signed_txs=[Tx| _]}) ->
+    Tx.
+
+-spec get_latest_signed_tx(state()) -> {non_neg_integer(), aetx_sign:signed_tx()}.
+get_latest_signed_tx(#state{signed_txs=[SignedTx|_]}) ->
     {tx_round(aetx_sign:tx(SignedTx)), SignedTx}.
 
-get_fallback_state(State) ->
-    [SignedTx|_] = L = drop_until_mutually_signed(State),
-    {tx_round(aetx_sign:tx(SignedTx)), L}.
+-spec get_fallback_state(state()) -> {non_neg_integer(), state()}.
+get_fallback_state(#state{signed_txs=[SignedTx|_]}=State) -> %% half_signed_txs= []?
+    {tx_round(aetx_sign:tx(SignedTx)), State#state{half_signed_txs=[]}}.
 
+-spec op_transfer(pubkey(), pubkey(), non_neg_integer()) -> update().
 op_transfer(From, To, Amount) ->
     {?OP_TRANSFER, From, To, Amount}.
 
+-spec op_deposit(pubkey(), non_neg_integer()) -> update().
 op_deposit(Acct, Amount) ->
     {?OP_DEPOSIT, Acct, Acct, Amount}.
 
+-spec op_withdraw(pubkey(), non_neg_integer()) -> update().
 op_withdraw(Acct, Amount) ->
     {?OP_WITHDRAW, Acct, Acct, Amount}.
 
@@ -179,19 +278,20 @@ tx_round(Tx) ->
     {Mod, TxI} = aetx:specialize_callback(Tx),
     Mod:round(TxI).
 
-fallback_to_stable_state(State) ->
-    [_|_] = drop_until_mutually_signed(State).
+-spec fallback_to_stable_state(state()) -> state().
+%% TODO: handle empty state?
+fallback_to_stable_state(#state{signed_txs=[_|_]}=State) ->
+    State#state{half_signed_txs=[]}.
 
-drop_until_mutually_signed([SignedTx|T] = State) ->
+-spec mutually_signed(aetx_sign:signed_tx()) -> boolean().
+mutually_signed(SignedTx) ->
     case aetx_sign:signatures(SignedTx) of
         [_, _] ->
             %% mutually signed
-            State;
+            true;
         _ ->
-            drop_until_mutually_signed(T)
-    end;
-drop_until_mutually_signed([]) ->
-    error(no_latest_state).
+           false
+    end.
 
 set_tx_values([{K, V}|T], Mod, Tx) ->
     set_tx_values(T, Mod, Mod:set_value(Tx, K, V));

--- a/apps/aechannel/src/aesc_trees.erl
+++ b/apps/aechannel/src/aesc_trees.erl
@@ -1,0 +1,95 @@
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2018, Aeternity Anstalt
+%%% @doc Channel Merkle trees.
+%%% @end
+%%%-------------------------------------------------------------------
+-module(aesc_trees).
+
+-include_lib("apps/aecore/include/common.hrl").
+-include_lib("apps/aecore/include/blocks.hrl").
+
+-export([accounts/1,
+         get_account/2,
+         set_account/2,
+         contracts/1,
+         calls/1,
+         hash/1,
+         new/1]).
+
+-record(trees, {
+          accounts  :: aec_accounts_trees:tree(),
+          calls     :: aect_call_state_tree:tree(),
+          contracts :: aect_state_tree:tree()}).
+
+-opaque trees() :: #trees{}.
+-export_type([trees/0]).
+
+%%%%=============================================================================
+%% API
+%%%=============================================================================
+
+-spec new([{pubkey(), integer()}]) -> trees().
+new(Accts) ->
+    Accounts =
+        lists:foldl(
+            fun({Pubkey, Amount}, AccTree) ->
+                Account = aec_accounts:new(Pubkey, Amount),
+                aec_accounts_trees:enter(Account, AccTree)
+            end,
+            aec_accounts_trees:empty(),
+            Accts),
+    #trees{accounts  = Accounts,
+           calls     = aect_call_state_tree:empty(),
+           contracts = aect_state_tree:empty()
+          }.
+
+-spec hash(trees()) -> binary().
+hash(Trees) ->
+    internal_hash(Trees).
+
+-spec accounts(trees()) -> aec_accounts_trees:tree().
+accounts(Trees) ->
+    Trees#trees.accounts.
+
+-spec get_account(trees(), pubkey()) -> {ok, aec_accounts:account()} |
+                                        {error, not_found}.
+get_account(#trees{accounts=Accs}, Pubkey) ->
+    case aec_accounts_trees:lookup(Pubkey, Accs) of
+        none -> {error, not_found};
+        {value, Account} -> {ok, Account}
+    end.
+
+-spec set_account(trees(), aec_accounts:account()) -> trees().
+set_account(#trees{accounts=Accs0}=Trees, Account) ->
+    Accs = aec_accounts_trees:enter(Account, Accs0),
+    Trees#trees{accounts=Accs}.
+
+-spec calls(trees()) -> aect_call_state_tree:tree().
+calls(Trees) ->
+    Trees#trees.calls.
+
+-spec contracts(trees()) -> aect_state_tree:tree().
+contracts(Trees) ->
+    Trees#trees.contracts.
+
+%%%=============================================================================
+%%% Internal functions
+%%%=============================================================================
+
+internal_hash(Trees) ->
+    AccountsHash = pad_empty(aec_accounts_trees:root_hash(accounts(Trees))),
+    CallsHash = pad_empty(aect_call_state_tree:root_hash(calls(Trees))),
+    ContractsHash = pad_empty(aect_state_tree:root_hash(contracts(Trees))),
+    List = lists:sort([ {<<"accounts"/utf8>> , AccountsHash}
+                      , {<<"calls"/utf8>>    , CallsHash}
+                      , {<<"contracts"/utf8>>, ContractsHash}
+                      ]),
+    TopTree = lists:foldl(fun({Key, Val}, Acc) ->
+                                  aeu_mtrees:enter(Key, Val, Acc)
+                          end,
+                         aeu_mtrees:empty(), List),
+    {ok, Hash} = aeu_mtrees:root_hash(TopTree),
+    Hash.
+
+pad_empty({ok, H}) when is_binary(H) -> H;
+pad_empty({error, empty}) -> <<0:?STATE_HASH_BYTES/unit:8>>.

--- a/apps/aecore/include/blocks.hrl
+++ b/apps/aecore/include/blocks.hrl
@@ -1,6 +1,6 @@
 -include("pow.hrl").
 
--define(PROTOCOL_VERSION, 13).
+-define(PROTOCOL_VERSION, 14).
 -define(GENESIS_VERSION, ?PROTOCOL_VERSION).
 -define(GENESIS_HEIGHT, 0).
 

--- a/apps/aecore/test/aec_mining_tests.erl
+++ b/apps/aecore/test/aec_mining_tests.erl
@@ -38,7 +38,7 @@ mine_block_test_() ->
                  % in order to find a proper nonce for your
                  % block uncomment the line below
                  %let_it_crash = generate_valid_test_data(TopBlock, 100000000000000),
-                 meck:expect(aec_pow, pick_nonce, 0, 5537317755641284530),
+                 meck:expect(aec_pow, pick_nonce, 0, 3650718748619880306),
 
                  {ok, BlockCandidate, Nonce} = ?TEST_MODULE:create_block_candidate(TopBlock, aec_trees:new(), []),
                  HeaderBin = aec_headers:serialize_to_binary(aec_blocks:to_header(BlockCandidate)),

--- a/apps/aeutils/test/data/epoch_full.yaml
+++ b/apps/aeutils/test/data/epoch_full.yaml
@@ -77,7 +77,7 @@ chain:
     db_path: .
     # Hard forks
     hard_forks:
-      "13": 0
+      "14": 0
 
 mining:
     # Start mining automatically.


### PR DESCRIPTION
[Pivotal story](https://www.pivotaltracker.com/story/show/157667084)
State channels have state tree that is being updated accordingly.

Must be rebased on top of #1180  and #1184 


What is left to do:
* Remove `initiator_balance` and `responder_balance` and substitute them with accounts' tree in all closing transactions
* Provide proof of inclusion for the accounts' tree for solo closing transactions (verifying that it is part of the tree having root `state_hash` of the last co-signded state)

These will be addressed in a subsequent PR tracked as [Closing txs provide proof of work](https://www.pivotaltracker.com/story/show/157838691)