### PR TITLE
run only one node in aesc_fsm_SUITE

### DIFF
--- a/apps/aecore/test/aecore_suite_utils.erl
+++ b/apps/aecore/test/aecore_suite_utils.erl
@@ -20,6 +20,8 @@
          delete_node_db_if_persisted/1,
          mine_blocks/2,
          mine_blocks/3,
+         spend/4,         %% (Node, FromPub, ToPub, Amount) -> ok
+         spend/5,         %% (Node, FromPub, ToPub, Amount, Fee) -> ok
          forks/0,
          latest_fork_height/0]).
 
@@ -182,6 +184,22 @@ mine_blocks_loop(Blocks, BlocksToMine) ->
                   "~p", [process_info(self(), messages)]),
             {error, timeout_waiting_for_block}
     end.
+
+spend(Node, FromPub, ToPub, Amount) ->
+    spend(Node, FromPub, ToPub, Amount, aec_governance:minimum_tx_fee()).
+
+spend(Node, FromPub, ToPub, Amount, Fee) ->
+    {ok, Nonce} = rpc:call(Node, aec_next_nonce, pick_for_account, [FromPub]),
+    Params = #{sender => FromPub,
+               recipient => ToPub,
+               amount => Amount,
+               fee => Fee,
+               nonce => Nonce,
+               payload => <<"foo">>},
+    {ok, Tx} = rpc:call(Node, aec_spend_tx, new, [Params]),
+    {ok, SignedTx} = rpc:call(Node, aec_keys, sign, [Tx]),
+    ok = rpc:call(Node, aec_tx_pool, push, [SignedTx]).
+
 
 forks() ->
     Vs = aec_governance:sorted_protocol_versions(),


### PR DESCRIPTION
This PR makes `aesc_fsm_SUITE` start only `dev1`, since `dev2` was only used to fetch the miner pubkey for the responder side (which was actually running on dev1).

Now instead, a second account is created on `dev1`, through a `spend_tx` transferring 10% of the initiator balance. This should speed up the test suite and also reduce the risk of a mining race, where one of the accounts might not be initialized (since its blocks are kicked off the chain).

A `spend/[3,4]` library function was added to `aecore_suite_utils.erl`.

See https://www.pivotaltracker.com/story/show/157875742