### PR TITLE
add benchmark tests to aesc_fsm_SUITE

### DIFF
--- a/apps/aechannel/src/aesc_fsm.erl
+++ b/apps/aechannel/src/aesc_fsm.erl
@@ -611,7 +611,7 @@ wdraw_signed(enter, _OldSt, _D) -> keep_state_and_data;
 wdraw_signed(cast, {?WDRAW_LOCKED, Msg}, #data{latest = {withdraw, SignedTx}} = D) ->
     case check_withdraw_locked_msg(Msg, SignedTx, D) of
         {ok, D1} ->
-            report(info, deposit_locked, D1),
+            report(info, withdraw_locked, D1),
             withdraw_locked_complete(SignedTx, D1#data{latest = undefined});
         {error, _} = Error ->
             close(Error, D)

--- a/apps/aechannel/src/aesc_offchain_state.erl
+++ b/apps/aechannel/src/aesc_offchain_state.erl
@@ -273,7 +273,6 @@ op_deposit(Acct, Amount) ->
 op_withdraw(Acct, Amount) ->
     {?OP_WITHDRAW, Acct, Acct, Amount}.
 
-
 tx_round(Tx) ->
     {Mod, TxI} = aetx:specialize_callback(Tx),
     Mod:round(TxI).

--- a/apps/aechannel/src/aesc_session_noise.erl
+++ b/apps/aechannel/src/aesc_session_noise.erl
@@ -105,7 +105,7 @@ establish({accept, Port, Opts}, St) ->
     %% tell_fsm({accept, EConn}, St),
     St#st{econn = EConn};
 establish({connect, Host, Port, Opts}, St) ->
-    TcpOpts = tcp_opts(listen, Opts),
+    TcpOpts = tcp_opts(connect, Opts),
     lager:debug("connect: TcpOpts = ~p", [TcpOpts]),
     {ok, TcpSock} = connect_tcp(Host, Port, TcpOpts),
     %% TODO: extract/check something from FinalState?


### PR DESCRIPTION
See https://www.pivotaltracker.com/story/show/157871392

Two different timings are run:
* A tight loop on a single channel, transfering 1 token back and forth 1000 times
* Doing the same thing 100 times each in 10 concurrent channels

The timings appear as comments to the test cases (see below). `mspt` = milliseconds per transfer, `tps` = transfers per second.

Note that the Erlang client API is used, so the cost doesn't include WebSocket termination and handling. Also, the cost of signing messages is included. Running 200 channels, the multi-channel test seems to become CPU-bound on my Core i7 Macbook Pro (2 cores with 4 hyperthreads each).

<img width="863" alt="screenshot 2018-05-27 21 50 58" src="https://user-images.githubusercontent.com/160216/40590037-82a72968-61f8-11e8-8c66-18b80c8a2fe0.png">
