### PR TITLE
Fix mempool to delete channel transactions when included

### DIFF
--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -3412,7 +3412,7 @@ sc_ws_close_mutual(Config, Closer) when Closer =:= initiator
 
     {ok, SSignedMutualTx} = aec_base58c:safe_decode(transaction, EncodedSignedMutualTx),
     SignedMutualTx = aetx_sign:deserialize_from_binary(SSignedMutualTx),
-    %% same transaction 
+    %% same transaction
     ShutdownTx = aetx_sign:tx(SignedMutualTx),
 
     {channel_close_mutual_tx, MutualTx} = aetx:specialize_type(ShutdownTx),
@@ -3430,6 +3430,8 @@ sc_ws_close_mutual(Config, Closer) when Closer =:= initiator
     assert_balance(IPubkey, IStartB + IChange),
     assert_balance(RPubkey, RStartB + RChange),
 
+    % ensure tx is not hanging in mempool
+    {ok, 200, []} = get_transactions(),
     ok.
 
 wait_for_signed_transaction_in_pool(SignedTx) ->


### PR DESCRIPTION
[Pivotal story](https://www.pivotaltracker.com/story/show/157919113)
Txs are put into mempool's ETS using a complex key, including the `aetx:origin/1`. If a channel is closed, it will not be present in channels' tree so the origin is unobtainable and thus we can not construct the ETS key.

This PR includes a fourth element in the key, being the tx hash and a function to find a key using it. It is worth noting that the transaction can be not in the mempool at all.