### PR TITLE
Fix aetx_sign:verify/2 bug with a missing channel

### DIFF
--- a/apps/aetx/src/aetx_sign.erl
+++ b/apps/aetx/src/aetx_sign.erl
@@ -93,7 +93,8 @@ verify(#signed_tx{tx = Tx, signatures = Sigs}, Trees) ->
     case aetx:signers(Tx, Trees) of
         {ok, Signers} ->
             verify_signatures(Signers, Bin, Sigs);
-        {error, _Reason} = Err -> Err
+        {error, _Reason} ->
+            {error, signature_check_failed}
     end.
 
 verify_signatures([PubKey|Left], Bin, Sigs) ->


### PR DESCRIPTION
PT: [aetx_sign:verify/2 error with missing channel](https://www.pivotaltracker.com/story/show/157927820)

If the channel is not present in the trees the `aetx_sign:verify/2` returned an unexpected `{error, channel_missing}`. This is not according to the function `-spec` and results in a trees crash.