### PR TITLE
Use epoch peer key facts instead of custom fetch

### DIFF
--- a/deployment/ansible/deploy.yml
+++ b/deployment/ansible/deploy.yml
@@ -20,16 +20,6 @@
       with_items: "{{ groups[hosts_group] }}"
       # http://docs.ansible.com/ansible/latest/user_guide/playbooks_tags.html#special-tags
       tags: [always]
-    - name: Fetch node sync public key
-      command: "{{ ansible_env.HOME }}/node/bin/epoch peer_key"
-      ignore_errors: yes
-      register: key_command
-      tags: [always]
-    - name: Register sync public key as fact
-      set_fact:
-        sync_public_key: "{{ key_command.stdout }}"
-      when: key_command.rc == 0
-      tags: [always]
 
 - name: Deploy epoch package
   hosts: all
@@ -208,14 +198,8 @@
         connection: local
         tags: [health-check]
 
-      - name: Read app version
-        command: "cat {{ project_root }}/VERSION"
-        register: version_output
-        tags: [datadog-event]
-
-      - name: Read app revision
-        command: "cat {{ project_root }}/REVISION"
-        register: revision_output
+      - name: Refresh epoch facts
+        setup:
         tags: [datadog-event]
 
       - name: Send Datadog event
@@ -225,14 +209,14 @@
           title: Deploy
           text: |
             %%%
-            Revision: [{{ revision_output.stdout }}](https://github.com/aeternity/epoch/commit/{{ revision_output.stdout }})
+            Revision: [{{ ansible_local.epoch.revision }}](https://github.com/aeternity/epoch/commit/{{ ansible_local.epoch.revision }})
             Package: {{ package }}
             %%%
           api_key: "{{ vault_datadog_api_key }}"
           app_key: "{{ vault_datadog_app_key }}"
           tags:
             - "env:{{ env }}"
-            - "version:{{ version_output.stdout }}"
+            - "version:{{ ansible_local.epoch.version }}"
         connection: local
         tags: [datadog-event]
       rescue:

--- a/deployment/ansible/templates/epoch.yaml.j2
+++ b/deployment/ansible/templates/epoch.yaml.j2
@@ -6,8 +6,8 @@ sync:
 peers:
 {% for host in groups[hosts_group] | difference([inventory_hostname]) %}
 {% set public_ip = hostvars[host]['ansible_ssh_host']|default(hostvars[host]['ansible_host']) -%}
-{% if hostvars[host]['sync_public_key'] is defined %}
-    - "aenode://{{ hostvars[host]['sync_public_key'] }}@{{ public_ip }}:{{ config.sync.port }}"
+{% if hostvars[host]['ansible_local']['epoch']['peer_key'] is defined %}
+    - "aenode://{{ hostvars[host]['ansible_local']['epoch']['peer_key'] }}@{{ public_ip }}:{{ config.sync.port }}"
 {% else %}
     - "aenode://pp$nokeyfoundpeerwillbeignored@{{ public_ip }}:{{ config.sync.port }}"
 {% endif %}


### PR DESCRIPTION
After https://github.com/aeternity/infrastructure/pull/59 few (custom) epoch facts can be used on host that has the custom facts scripts deployed - in our case all hosts.

Deployment prove: https://circleci.com/workflow-run/8eb695b5-1a59-4503-82de-28a6b68d3f18

https://www.pivotaltracker.com/story/show/156535422

EDIT2: new prove workflow - https://circleci.com/workflow-run/4f43610b-da8e-496a-83bf-e2179e7556d9