### PR TITLE
Prevent mining on stale block candidate

### DIFF
--- a/apps/aecore/src/aec_block_generator.erl
+++ b/apps/aecore/src/aec_block_generator.erl
@@ -58,6 +58,7 @@ init([]) ->
     aec_events:subscribe(tx_created),
     aec_events:subscribe(tx_received),
     aec_events:subscribe(block_created),
+    aec_events:subscribe(top_synced),
     aec_events:subscribe(top_changed),
     {ok, #state{}}.
 
@@ -99,6 +100,7 @@ handle_info({gproc_ps_event, Event, #{info := Info}}, State) ->
     State1 =
         case Event of
             block_created -> preempt_generation(State, Info);
+            top_synced    -> preempt_generation(State, Info);
             top_changed   -> preempt_generation(State, Info);
             tx_created    -> add_new_tx(State, Info);
             tx_received   -> add_new_tx(State, Info);

--- a/apps/aecore/src/aec_conductor.erl
+++ b/apps/aecore/src/aec_conductor.erl
@@ -565,7 +565,7 @@ start_mining(#state{new_candidate_available = true} = State) ->
     State1 =
         case aec_block_generator:get_candidate() of
             {ok, Block} ->
-                Candidate = make_candidate(Block, State#state.seen_top_block_hash),
+                Candidate = make_candidate(Block, aec_blocks:prev_hash(Block)),
                 State#state{block_candidate = Candidate};
             {error, no_candidate} ->
                 State

--- a/apps/aecore/src/aec_events.erl
+++ b/apps/aecore/src/aec_events.erl
@@ -16,9 +16,10 @@
 
 -include("blocks.hrl").
 
--type event() :: block_created
-               | start_mining
-               | top_changed
+-type event() :: start_mining
+               | block_created %% We created (mined) a new block. It usually becomes the new top block, though not necessarily.
+               | top_synced %% We received a block, pulled from a network peer, that became the new top.
+               | top_changed %% We received a block, pushed by a network peer, that became the new top.
                | tx_created
                | tx_received
                | candidate_block


### PR DESCRIPTION
Delivers https://www.pivotaltracker.com/story/show/157929767

TODO:
* [x] Add unit test if not too much effort
* [x] Check Python UAT tests and system tests pass
  * [CI workflow](https://circleci.com/workflow-run/7b9eb091-d8dd-438e-88f3-2457586cb4dc) on commit 3f828580 equivalent to 0eb5b447
    * UPDATE: Python UAT tests passed
    * UPDATE: System tests [~failed~ passed except for known issue](https://3837-110719633-gh.circle-artifacts.com/0/home/circleci/epoch/system_test/logs/ct_run.epoch_ct@localhost.2018-05-30_12.31.07/extras.system_test.logs/run.2018-05-30_12.31.07/suite.log.html) addressed in PR #1208
* [ ] Consider restructuring events UPDATE: Refactoring avoided as too involved. If needed for changing behaviour of any modules / subsystems it can be done in future PRs.
* [ ] Squash-and-merge