### PR TITLE
Teach channel watcher to react to top changed for block pulled from network

### DIFF
--- a/apps/aechannel/src/aesc_fsm_min_depth_watcher.erl
+++ b/apps/aechannel/src/aesc_fsm_min_depth_watcher.erl
@@ -28,12 +28,15 @@ watch(Watcher, Type, TxHash, MinDepth) ->
 init(#{} = Arg) ->
     lager:debug("started min_depth watcher for ~p", [maps:get(fsm, Arg)]),
     true = aec_events:subscribe(top_changed),
+    true = aec_events:subscribe(top_synced),
     true = aec_events:subscribe(block_created),
-    lager:debug("subscribed to top_changed & block_created", []),
+    lager:debug("subscribed to top_changed & top_synced & block_created", []),
     self() ! check_status,
     {ok, Arg}.
 
 handle_info({gproc_ps_event, top_changed, _}, St) ->
+    check_status(St);
+handle_info({gproc_ps_event, top_synced, _}, St) ->
     check_status(St);
 handle_info({gproc_ps_event, block_created, _}, St) ->
     check_status(St);


### PR DESCRIPTION
Depends on PR #1206 (included in this PR) so the only relevant commit in this PR is 25f7e2d2415f87b0bd32270ca6148895bbd1e60b

TODO:
* [x] Rebase on master once #1206 merged