### PR TITLE
Add /api as endpoint for retrieving yaml spec

### DIFF
--- a/apps/aehttp/src/aehttp_api_validate.erl
+++ b/apps/aehttp/src/aehttp_api_validate.erl
@@ -2,15 +2,23 @@
 
 -export([request/4]).
 -export([response/5]).
--export([validator/0]).
+-export([validator/0, validator/1]).
+-export([json_spec/0]).
 
-
--spec validator() -> jesse_state:state().
-
-validator() ->
+-spec json_spec() -> jsx:json_text().
+json_spec() ->
     {ok, AppName} = application:get_application(?MODULE),
     Filename = filename:join(code:priv_dir(AppName), "swagger.json"),
-    R = jsx:decode(element(2, file:read_file(Filename))),
+    {ok, Json} = file:read_file(Filename),
+    Json.
+
+-spec validator() -> jesse_state:state().
+validator() ->
+    validator(json_spec()).
+
+-spec validator(jsx:json_text()) -> jesse_state:state().
+validator(Json) ->
+    R = jsx:decode(Json),
     jesse_state:new(R, [{default_schema_ver, <<"http://json-schema.org/draft-04/schema#">>}]).
 
 -spec response(

--- a/apps/aehttp/src/aehttp_spec_handler.erl
+++ b/apps/aehttp/src/aehttp_spec_handler.erl
@@ -1,0 +1,44 @@
+%% Cowboy handler for endpoint /api to obtain the specification
+%% of the endpoints as JSON object.
+
+-module(aehttp_spec_handler).
+
+-behaviour(cowboy_rest).
+
+-export([allowed_methods/2]).
+-export([init/2]).
+-export([content_types_accepted/2]).
+-export([content_types_provided/2]).
+-export([handle_request_json/2]).
+
+-record(state, {
+    operation_id :: atom(),
+    allowed_method :: binary(),
+    spec :: jsx:json_text()
+}).
+
+init(Req, {OperationId, AllowedMethod, Spec}) ->
+    State = #state{
+        operation_id = OperationId,
+        allowed_method = AllowedMethod,
+        spec = Spec
+    },
+    {cowboy_rest, Req, State}.
+
+
+allowed_methods(Req, State = #state{ allowed_method = Method }) ->
+    {[Method], Req, State}.
+
+content_types_accepted(Req, State) ->
+    {[{<<"application/json">>, handle_request_json}], Req, State}.
+
+content_types_provided(Req, State) ->
+    {[{<<"application/json">>, handle_request_json}], Req, State}.
+
+handle_request_json(Req, State = #state{
+        operation_id = 'Api',
+        spec = Spec
+    }) ->
+    Repl = cowboy_req:reply(200, #{}, Spec, Req),
+    {stop, Repl, State}.
+

--- a/apps/aehttp/test/aehttp_spec_SUITE.erl
+++ b/apps/aehttp/test/aehttp_spec_SUITE.erl
@@ -1,0 +1,94 @@
+-module(aehttp_spec_SUITE).
+
+%%
+%% simple tests to verify functionality of /api endpoint
+%%
+
+-include_lib("common_test/include/ct.hrl").
+-define(NODE, dev1).
+
+%% common_test exports
+-export(
+   [
+    all/0,
+    init_per_suite/1, end_per_suite/1,
+    init_per_testcase/2, end_per_testcase/2
+   ]).
+
+%% test case exports
+-export(
+   [ get_api/1 ]).
+
+
+
+all() ->
+    [
+     get_api
+    ].
+
+init_per_suite(Config) ->
+    ok = application:ensure_started(erlexec),
+    DataDir = ?config(data_dir, Config),
+    TopDir = aecore_suite_utils:top_dir(DataDir),
+    Config1 = [{symlink_name, "latest.spec_endpoint"},
+               {top_dir, TopDir},
+               {test_module, ?MODULE}] ++ Config,
+    aecore_suite_utils:make_shortcut(Config1),
+    ct:log("Environment = ~p", [[{args, init:get_arguments()},
+                                 {node, node()},
+                                 {cookie, erlang:get_cookie()}]]),
+
+    aecore_suite_utils:create_config(?NODE, Config1, #{}, []),
+    aecore_suite_utils:make_multi(Config1, [?NODE]),
+    [{nodes, [aecore_suite_utils:node_tuple(?NODE)]}]  ++ Config1.
+
+end_per_suite(_Config) ->
+    ok.
+
+init_per_testcase(_Case, Config) ->
+    aecore_suite_utils:start_node(?NODE, Config),
+    [{tc_start, os:timestamp()}|Config].
+
+end_per_testcase(_Case, Config) ->
+    aecore_suite_utils:stop_node(?NODE, Config),
+    Ts0 = ?config(tc_start, Config),
+    ct:log("Events during TC: ~p", [[{N, aecore_suite_utils:all_events_since(N, Ts0)}
+                                     || {_,N} <- ?config(nodes, Config)]]),
+    ok.
+
+%% ============================================================
+%% Test cases
+%% ============================================================
+get_api(Config) ->
+    %% ensure http interface is up and running
+    aecore_suite_utils:connect(aecore_suite_utils:node_name(?NODE)),
+
+    SpecFile = filename:join([proplists:get_value(top_dir, Config),
+                              "apps/aehttp/priv/swagger.json"]),
+
+    Host = external_address(),
+    URL = binary_to_list(iolist_to_binary([Host, "/api"])),
+    Repl1 = httpc:request(URL),
+
+    {ok, {{"HTTP/1.1", 200, "OK"}, _, Json}} = Repl1,
+    ct:log("~p returned spec: ~p", [?NODE, Json]),
+    {ok, Spec} = file:read_file(SpecFile),
+    ct:log("read spec file ~s", [SpecFile]),
+
+    JsonObj = jsx:decode(Spec),
+    JsonObj = jsx:decode(list_to_binary(Json)),
+    Type = "application/json",
+    Body = <<"{broken_json">>,
+
+    {ok,{{"HTTP/1.1",405,"Method Not Allowed"},_,_}} = 
+         httpc:request(post, {URL, [], Type, Body}, [], []),
+    ok.
+
+
+external_address() ->
+    Port = 
+        rpc:call(aecore_suite_utils:node_name(?NODE), 
+                 aeu_env, user_config_or_env,
+                 [ [<<"http">>, <<"external">>, <<"port">>],
+                   aehttp, [external, port], 8043]),
+    "http://127.0.0.1:" ++ integer_to_list(Port).     % good enough for requests


### PR DESCRIPTION
This new endpoint at /api provides the yaml spec in json format. It is not part of the yaml file itself, because then it would take the configured base path from there /v2/api. Since the base path may change (in version update or so), this endpoint is not related to that path.