### PR TITLE
Make transaction TTL optional

### DIFF
--- a/apps/aechannel/include/channel_txs.hrl
+++ b/apps/aechannel/include/channel_txs.hrl
@@ -13,7 +13,7 @@
           responder_amount   :: non_neg_integer(),
           channel_reserve    :: non_neg_integer(),
           lock_period        :: non_neg_integer(),
-          ttl                :: aec_blocks:height(),
+          ttl                :: aetx:tx_ttl(),
           fee                :: non_neg_integer(),
           nonce              :: non_neg_integer()
          }).
@@ -22,7 +22,7 @@
           channel_id  :: binary(),
           from        :: aec_keys:pubkey(),
           amount      :: non_neg_integer(),
-          ttl         :: aec_blocks:height(),
+          ttl         :: aetx:tx_ttl(),
           fee         :: non_neg_integer(),
           nonce       :: non_neg_integer()
          }).
@@ -31,7 +31,7 @@
           channel_id  :: binary(),
           to          :: aec_keys:pubkey(),
           amount      :: non_neg_integer(),
-          ttl         :: non_neg_integer(),
+          ttl         :: aetx:tx_ttl(),
           fee         :: non_neg_integer(),
           nonce       :: non_neg_integer()
          }).
@@ -40,7 +40,7 @@
           channel_id        :: binary(),
           initiator_amount  :: non_neg_integer(),
           responder_amount  :: non_neg_integer(),
-          ttl               :: aec_blocks:height(),
+          ttl               :: aetx:tx_ttl(),
           fee               :: non_neg_integer(),
           nonce             :: non_neg_integer()
          }).
@@ -49,7 +49,7 @@
           channel_id :: binary(),
           from       :: aec_keys:pubkey(),
           payload    :: binary(),
-          ttl        :: aec_blocks:height(),
+          ttl        :: aetx:tx_ttl(),
           fee        :: non_neg_integer(),
           nonce      :: non_neg_integer()
          }).
@@ -58,7 +58,7 @@
           channel_id :: binary(),
           from       :: aec_keys:pubkey(),
           payload    :: binary(),
-          ttl        :: aec_blocks:height(),
+          ttl        :: aetx:tx_ttl(),
           fee        :: non_neg_integer(),
           nonce      :: non_neg_integer()
          }).
@@ -68,7 +68,7 @@
           from       :: aec_keys:pubkey(),
           initiator_amount  :: non_neg_integer(),
           responder_amount  :: non_neg_integer(),
-          ttl        :: aec_blocks:height(),
+          ttl        :: aetx:tx_ttl(),
           fee        :: non_neg_integer(),
           nonce      :: non_neg_integer()
          }).

--- a/apps/aechannel/src/aesc_close_mutual_tx.erl
+++ b/apps/aechannel/src/aesc_close_mutual_tx.erl
@@ -49,14 +49,13 @@
 new(#{channel_id        := ChannelId,
       initiator_amount  := InitiatorAmount,
       responder_amount  := ResponderAmount,
-      ttl               := TTL,
       fee               := Fee,
-      nonce             := Nonce}) ->
+      nonce             := Nonce} = Args) ->
     Tx = #channel_close_mutual_tx{
             channel_id        = ChannelId,
             initiator_amount  = InitiatorAmount,
             responder_amount  = ResponderAmount,
-            ttl               = TTL,
+            ttl               = maps:get(ttl, Args, 0),
             fee               = Fee,
             nonce             = Nonce},
     {ok, aetx:new(?MODULE, Tx)}.
@@ -68,7 +67,7 @@ type() ->
 fee(#channel_close_mutual_tx{fee = Fee}) ->
     Fee.
 
--spec ttl(tx()) -> aec_blocks:height().
+-spec ttl(tx()) -> aetx:tx_ttl().
 ttl(#channel_close_mutual_tx{ttl = Ttl}) ->
     Ttl.
 

--- a/apps/aechannel/src/aesc_create_tx.erl
+++ b/apps/aechannel/src/aesc_create_tx.erl
@@ -58,16 +58,15 @@ new(#{initiator          := InitiatorPubKey,
       responder_amount   := ResponderAmount,
       channel_reserve    := ChannelReserve,
       lock_period        := LockPeriod,
-      ttl                := TTL,
       fee                := Fee,
-      nonce              := Nonce}) ->
+      nonce              := Nonce} = Args) ->
     Tx = #channel_create_tx{initiator          = InitiatorPubKey,
                             responder          = ResponderPubKey,
                             initiator_amount   = InitiatorAmount,
                             responder_amount   = ResponderAmount,
                             channel_reserve    = ChannelReserve,
                             lock_period        = LockPeriod,
-                            ttl                = TTL,
+                            ttl                = maps:get(ttl, Args, 0),
                             fee                = Fee,
                             nonce              = Nonce},
     {ok, aetx:new(?MODULE, Tx)}.
@@ -79,7 +78,7 @@ type() ->
 fee(#channel_create_tx{fee = Fee}) ->
     Fee.
 
--spec ttl(tx()) -> aec_blocks:height().
+-spec ttl(tx()) -> aetx:tx_ttl().
 ttl(#channel_create_tx{ttl = TTL}) ->
     TTL.
 

--- a/apps/aechannel/src/aesc_deposit_tx.erl
+++ b/apps/aechannel/src/aesc_deposit_tx.erl
@@ -48,14 +48,13 @@
 new(#{channel_id  := ChannelId,
       from        := FromPubKey,
       amount      := Amount,
-      ttl         := TTL,
       fee         := Fee,
-      nonce       := Nonce}) ->
+      nonce       := Nonce} = Args) ->
     try Tx = #channel_deposit_tx{
                 channel_id  = ChannelId,
                 from        = FromPubKey,
                 amount      = Amount,
-                ttl         = TTL,
+                ttl         = maps:get(ttl, Args, 0),
                 fee         = Fee,
                 nonce       = Nonce},
          {ok, aetx:new(?MODULE, Tx)}
@@ -71,7 +70,7 @@ type() ->
 fee(#channel_deposit_tx{fee = Fee}) ->
     Fee.
 
--spec ttl(tx()) -> aec_blocks:height().
+-spec ttl(tx()) -> aetx:tx_ttl().
 ttl(#channel_deposit_tx{ttl = TTL}) ->
     TTL.
 

--- a/apps/aechannel/src/aesc_fsm.erl
+++ b/apps/aechannel/src/aesc_fsm.erl
@@ -1144,8 +1144,9 @@ close_mutual_tx(Account, Nonce, LatestSignedTx,
     LatestTx = aetx_sign:tx(LatestSignedTx),
     IAmt = tx_initiator_amount(LatestTx),
     RAmt = tx_responder_amount(LatestTx),
-    {IAmt1, RAmt1} = pay_close_mutual_fee(maps:get(fee, Opts1), IAmt, RAmt),
-    #{ttl := TTL, fee := Fee} = Opts1,
+    Fee = maps:get(fee, Opts1),
+    TTL = maps:get(ttl, Opts1, 0), %% 0 means no TTL limit
+    {IAmt1, RAmt1} = pay_close_mutual_fee(Fee, IAmt, RAmt),
     aesc_close_mutual_tx:new(#{ channel_id       => ChanId
                               , initiator_amount => IAmt1
                               , responder_amount => RAmt1

--- a/apps/aechannel/src/aesc_offchain_tx.erl
+++ b/apps/aechannel/src/aesc_offchain_tx.erl
@@ -84,7 +84,7 @@ fee(#channel_offchain_tx{}) ->
     %% This tx should never hit the mempool or any block
     ?CHANNEL_OFFCHAIN_TX_FEE.
 
--spec ttl(tx()) -> aec_blocks:height().
+-spec ttl(tx()) -> aetx:tx_ttl().
 ttl(#channel_offchain_tx{}) ->
     %% This tx should never hit the mempool or any block
     0.
@@ -97,7 +97,8 @@ nonce(#channel_offchain_tx{round = N}) ->
 origin(#channel_offchain_tx{initiator = Origin}) ->
     Origin.
 
--spec check(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) -> {ok, aec_trees:trees()} | {error, term()}.
+-spec check(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) ->
+        {ok, aec_trees:trees()} | {error, term()}.
 check(#channel_offchain_tx{
          channel_id         = _ChannelId,
          initiator          = _InitiatorPubKey,
@@ -112,7 +113,8 @@ check(#channel_offchain_tx{
     %% TODO: implement checks relevant to off-chain
     {ok, Trees}.
 
--spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) -> {ok, aec_trees:trees()}.
+-spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) ->
+        {ok, aec_trees:trees()}.
 process(#channel_offchain_tx{}, _Context, _Trees, _Height, _ConsensusVersion) ->
     error(off_chain_tx).
 

--- a/apps/aechannel/src/aesc_settle_tx.erl
+++ b/apps/aechannel/src/aesc_settle_tx.erl
@@ -48,15 +48,14 @@ new(#{channel_id        := ChannelId,
       from              := FromPubKey,
       initiator_amount  := InitiatorAmount,
       responder_amount  := ResponderAmount,
-      ttl               := TTL,
       fee               := Fee,
-      nonce             := Nonce}) ->
+      nonce             := Nonce} = Args) ->
     Tx = #channel_settle_tx{
             channel_id        = ChannelId,
             from              = FromPubKey,
             initiator_amount  = InitiatorAmount,
             responder_amount  = ResponderAmount,
-            ttl               = TTL,
+            ttl               = maps:get(ttl, Args, 0),
             fee               = Fee,
             nonce             = Nonce},
     {ok, aetx:new(?MODULE, Tx)}.
@@ -68,7 +67,7 @@ type() ->
 fee(#channel_settle_tx{fee = Fee}) ->
     Fee.
 
--spec ttl(tx()) -> aec_blocks:height().
+-spec ttl(tx()) -> aetx:tx_ttl().
 ttl(#channel_settle_tx{ttl = TTL}) ->
     TTL.
 

--- a/apps/aechannel/src/aesc_slash_tx.erl
+++ b/apps/aechannel/src/aesc_slash_tx.erl
@@ -47,14 +47,13 @@
 new(#{channel_id := ChannelId,
       from       := FromPubKey,
       payload    := Payload,
-      ttl        := TTL,
       fee        := Fee,
-      nonce      := Nonce}) ->
+      nonce      := Nonce} = Args) ->
     Tx = #channel_slash_tx{
             channel_id = ChannelId,
             from       = FromPubKey,
             payload    = Payload,
-            ttl        = TTL,
+            ttl        = maps:get(ttl, Args, 0),
             fee        = Fee,
             nonce      = Nonce},
     {ok, aetx:new(?MODULE, Tx)}.
@@ -66,7 +65,7 @@ type() ->
 fee(#channel_slash_tx{fee = Fee}) ->
     Fee.
 
--spec ttl(tx()) -> aec_blocks:height().
+-spec ttl(tx()) -> aetx:tx_ttl().
 ttl(#channel_slash_tx{ttl = TTL}) ->
     TTL.
 

--- a/apps/aechannel/src/aesc_withdraw_tx.erl
+++ b/apps/aechannel/src/aesc_withdraw_tx.erl
@@ -48,14 +48,13 @@
 new(#{channel_id := ChannelId,
       to         := ToPubKey,
       amount     := Amount,
-      ttl        := TTL,
       fee        := Fee,
-      nonce      := Nonce}) ->
+      nonce      := Nonce} = Args) ->
     Tx = #channel_withdraw_tx{
             channel_id = ChannelId,
             to         = ToPubKey,
             amount     = Amount,
-            ttl        = TTL,
+            ttl        = maps:get(ttl, Args, 0),
             fee        = Fee,
             nonce      = Nonce},
     {ok, aetx:new(?MODULE, Tx)}.
@@ -67,7 +66,7 @@ type() ->
 fee(#channel_withdraw_tx{fee = Fee}) ->
     Fee.
 
--spec ttl(tx()) -> aec_blocks:height().
+-spec ttl(tx()) -> aetx:tx_ttl().
 ttl(#channel_withdraw_tx{ttl = TTL}) ->
     TTL.
 

--- a/apps/aechannel/test/aesc_fsm_SUITE.erl
+++ b/apps/aechannel/test/aesc_fsm_SUITE.erl
@@ -294,7 +294,6 @@ create_channel_(Cfg, Debug) ->
              lock_period      => 10,
              channel_reserve  => 3,
              minimum_depth    => 3,
-             ttl              => 100,
              client           => self(),
              noise            => [{noise, Proto}],
              timeouts         => #{idle => 20000},

--- a/apps/aechannel/test/aesc_test_utils.erl
+++ b/apps/aechannel/test/aesc_test_utils.erl
@@ -166,7 +166,7 @@ create_tx_spec(InitiatorPubKey, ResponderPubKey, Spec0, State) ->
       responder_amount   => maps:get(responder_amount, Spec),
       channel_reserve    => maps:get(channel_reserve, Spec),
       lock_period        => maps:get(lock_period, Spec),
-      ttl                => maps:get(ttl, Spec),
+      ttl                => maps:get(ttl, Spec, 0),
       fee                => maps:get(fee, Spec),
       nonce              => maps:get(nonce, Spec)}.
 
@@ -175,7 +175,6 @@ create_tx_default_spec(InitiatorPubKey, State) ->
       responder_amount   => 50,
       channel_reserve    => 20,
       lock_period        => 100,
-      ttl                => 100,
       fee                => 3,
       nonce              => try next_nonce(InitiatorPubKey, State) catch _:_ -> 0 end}.
 
@@ -189,14 +188,13 @@ close_mutual_tx_spec(ChannelId, Spec0, State) ->
     #{channel_id        => ChannelId,
       initiator_amount  => maps:get(initiator_amount, Spec),
       responder_amount  => maps:get(responder_amount, Spec),
-      ttl               => maps:get(ttl, Spec),
+      ttl               => maps:get(ttl, Spec, 0),
       fee               => maps:get(fee, Spec),
       nonce             => maps:get(nonce, Spec)}.
 
 close_mutual_tx_default_spec(Initiator, State) ->
     #{initiator_amount => 10,
       responder_amount => 10,
-      ttl              => 100,
       fee              => 3,
       nonce            => try next_nonce(Initiator, State) catch _:_ -> 0 end}.
 
@@ -212,14 +210,13 @@ close_solo_tx_spec(ChannelId, FromPubKey, Payload, Spec0, State) ->
     #{channel_id  => ChannelId,
       from        => FromPubKey,
       payload     => Payload,
-      ttl         => maps:get(ttl, Spec),
+      ttl         => maps:get(ttl, Spec, 0),
       fee         => maps:get(fee, Spec),
       nonce       => maps:get(nonce, Spec)}.
 
 close_solo_tx_default_spec(FromPubKey, State) ->
-    #{ttl     => 100,
-      fee     => 3,
-      nonce   => try next_nonce(FromPubKey, State) catch _:_ -> 0 end}.
+    #{ fee     => 3,
+       nonce   => try next_nonce(FromPubKey, State) catch _:_ -> 0 end}.
 
 %%%===================================================================
 %%% Deposit tx
@@ -233,13 +230,12 @@ deposit_tx_spec(ChannelId, FromPubKey, Spec0, State) ->
     #{channel_id => ChannelId,
       from       => FromPubKey,
       amount     => maps:get(amount, Spec),
-      ttl        => maps:get(ttl, Spec),
+      ttl        => maps:get(ttl, Spec, 0),
       fee        => maps:get(fee, Spec),
       nonce      => maps:get(nonce, Spec)}.
 
 deposit_tx_default_spec(FromPubKey, State) ->
     #{amount => 10,
-      ttl    => 100,
       fee    => 3,
       nonce  => try next_nonce(FromPubKey, State) catch _:_ -> 0 end}.
 
@@ -255,13 +251,12 @@ withdraw_tx_spec(ChannelId, ToPubKey, Spec0, State) ->
     #{channel_id => ChannelId,
       to         => ToPubKey,
       amount     => maps:get(amount, Spec),
-      ttl        => maps:get(ttl, Spec),
+      ttl        => maps:get(ttl, Spec, 0),
       fee        => maps:get(fee, Spec),
       nonce      => maps:get(nonce, Spec)}.
 
 withdraw_tx_spec(ToPubKey, State) ->
     #{amount => 10,
-      ttl    => 100,
       fee    => 3,
       nonce  => try next_nonce(ToPubKey, State) catch _:_ -> 0 end}.
 
@@ -277,14 +272,13 @@ slash_tx_spec(ChannelId, FromPubKey, Payload, Spec0, State) ->
     #{channel_id  => ChannelId,
       from        => FromPubKey,
       payload     => Payload,
-      ttl         => maps:get(ttl, Spec),
+      ttl         => maps:get(ttl, Spec, 0),
       fee         => maps:get(fee, Spec),
       nonce       => maps:get(nonce, Spec)}.
 
 slash_tx_default_spec(FromPubKey, State) ->
-    #{ttl     => 100,
-      fee     => 3,
-      nonce   => try next_nonce(FromPubKey, State) catch _:_ -> 0 end}.
+    #{ fee     => 3,
+       nonce   => try next_nonce(FromPubKey, State) catch _:_ -> 0 end}.
 
 %%%===================================================================
 %%% Settle tx
@@ -299,20 +293,15 @@ settle_tx_spec(ChannelId, FromPubKey, Spec0, State) ->
       from              => FromPubKey,
       initiator_amount  => maps:get(initiator_amount, Spec),
       responder_amount  => maps:get(responder_amount, Spec),
-      ttl               => maps:get(ttl, Spec),
+      ttl               => maps:get(ttl, Spec, 0),
       fee               => maps:get(fee, Spec),
       nonce             => maps:get(nonce, Spec)}.
 
 settle_tx_default_spec(FromPubKey, State) ->
     #{initiator_amount => 10,
       responder_amount => 10,
-      ttl              => 100,
       fee              => 3,
       nonce            => try next_nonce(FromPubKey, State) catch _:_ -> 0 end}.
-
-
-state_tx(ChannelId, Initiator, Responder) ->
-    state_tx(ChannelId, Initiator, Responder, #{}).
 
 state_tx(ChannelId, Initiator, Responder, Spec0) ->
     Spec = maps:merge(state_tx_spec(), Spec0),

--- a/apps/aechannel/test/aesc_txs_SUITE.erl
+++ b/apps/aechannel/test/aesc_txs_SUITE.erl
@@ -952,8 +952,7 @@ settle_negative(Cfg) ->
     %% Test bad from account key
     BadPubKey = <<42:32/unit:8>>,
     TxSpec1 = aesc_test_utils:settle_tx_spec(ChannelId, BadPubKey,
-                                                   #{nonce => 2,
-                                                    ttl => ClosesAt + 1}, S),
+                                                   #{nonce => 2}, S),
     {ok, Tx1} = aesc_settle_tx:new(TxSpec1),
     {error, account_not_found} =
         aetx:check(Tx1, Trees, ClosesAt, ?PROTOCOL_VERSION),
@@ -963,7 +962,6 @@ settle_negative(Cfg) ->
                 ChannelId, PubKey1,
                 #{initiator_amount => 1,
                   responder_amount => ChannelAmount - 1,
-                  ttl    => ClosesAt + 1,
                   fee    => 2}, S),
     {ok, Tx2} = aesc_settle_tx:new(TxSpec2),
     {error, wrong_amt} =
@@ -971,14 +969,13 @@ settle_negative(Cfg) ->
 
     %% Test too high from account nonce
     TxSpec3 = aesc_test_utils:settle_tx_spec(ChannelId, PubKey1,
-                                                   #{nonce => 0, ttl => 1000}, S),
+                                                   #{nonce => 0}, S),
     {ok, Tx3} = aesc_settle_tx:new(TxSpec3),
     {error, account_nonce_too_high} =
         aetx:check(Tx3, Trees, ClosesAt, ?PROTOCOL_VERSION),
 
     %% Test too low TTL
-    TxSpec4 = aesc_test_utils:settle_tx_spec(ChannelId, PubKey1,
-                                                   #{ttl => ClosesAt - 1}, S),
+    TxSpec4 = aesc_test_utils:settle_tx_spec(ChannelId, PubKey1, #{ttl => ClosesAt - 1}, S),
     {ok, Tx4} = aesc_settle_tx:new(TxSpec4),
     {error, ttl_expired} =
         aetx:check(Tx4, Trees, ClosesAt, ?PROTOCOL_VERSION),
@@ -999,7 +996,6 @@ settle_negative(Cfg) ->
 
     TxSpec6 = aesc_test_utils:settle_tx_spec(ChannelId, PubKey1,
                                       #{initiator_amount => ChannelAmount,
-                                        ttl => ClosesAt + 2,
                                         responder_amount => 0}, S5),
     {ok, Tx6} = aesc_close_mutual_tx:new(TxSpec6),
     {error, channel_does_not_exist} =

--- a/apps/aecontract/include/contract_txs.hrl
+++ b/apps/aecontract/include/contract_txs.hrl
@@ -10,7 +10,7 @@
           gas        :: aect_contracts:amount(),
           gas_price  :: aect_contracts:amount(),
           call_data  :: binary(),
-          ttl        :: aec_blocks:height()
+          ttl        :: aetx:tx_ttl()
         }).
 
 -record(contract_call_tx, {
@@ -19,7 +19,7 @@
           contract   :: aec_keys:pubkey(),
           vm_version :: aect_contracts:vm_version(),
           fee        :: integer(),
-          ttl        :: aec_blocks:height(),
+          ttl        :: aetx:tx_ttl(),
           amount     :: aect_contracts:amount(),
           gas        :: aect_contracts:amount(),
           gas_price  :: aect_contracts:amount(),

--- a/apps/aecontract/src/aect_create_tx.erl
+++ b/apps/aecontract/src/aect_create_tx.erl
@@ -93,7 +93,7 @@ call_data(#contract_create_tx{call_data = X}) ->
 fee(#contract_create_tx{fee = Fee}) ->
     Fee.
 
--spec ttl(tx()) -> aec_blocks:height().
+-spec ttl(tx()) -> aetx:tx_ttl().
 ttl(#contract_create_tx{ttl = TTL}) ->
     TTL.
 
@@ -107,8 +107,7 @@ new(#{owner      := OwnerPubKey,
       gas        := Gas,
       gas_price  := GasPrice,
       call_data  := CallData,
-      fee        := Fee,
-      ttl        := TTL}) ->
+      fee        := Fee} = Args) ->
     Tx = #contract_create_tx{owner      = OwnerPubKey,
                              nonce      = Nonce,
                              code       = Code,
@@ -119,7 +118,7 @@ new(#{owner      := OwnerPubKey,
                              gas_price  = GasPrice,
                              call_data  = CallData,
                              fee        = Fee,
-                             ttl        = TTL},
+                             ttl        = maps:get(ttl, Args, 0)},
     {ok, aetx:new(?MODULE, Tx)}.
 
 -spec type() -> atom().
@@ -163,8 +162,8 @@ accounts(#contract_create_tx{owner = OwnerPubKey}) ->
 signers(#contract_create_tx{owner = OwnerPubKey}, _) ->
     {ok, [OwnerPubKey]}.
 
--spec process(tx(), aetx:tx_context(), aec_trees:trees(),
-              aec_blocks:height(), non_neg_integer()) -> {ok, aec_trees:trees()}.
+-spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) ->
+        {ok, aec_trees:trees()}.
 process(#contract_create_tx{owner      = OwnerPubKey,
                             nonce      = Nonce,
 			    vm_version = _VmVersion,

--- a/apps/aecontract/test/aect_test_utils.erl
+++ b/apps/aecontract/test/aect_test_utils.erl
@@ -102,7 +102,7 @@ create_tx(PubKey, Spec0, State) ->
              #contract_create_tx{ owner      = PubKey
                                 , nonce      = maps:get(nonce, Spec)
                                 , fee        = maps:get(fee, Spec)
-                                , ttl        = maps:get(ttl, Spec)
+                                , ttl        = maps:get(ttl, Spec, 0)
                                 , code       = maps:get(code, Spec)
                                 , vm_version = maps:get(vm_version, Spec)
                                 , deposit    = maps:get(deposit, Spec)
@@ -114,7 +114,6 @@ create_tx(PubKey, Spec0, State) ->
 
 create_tx_default_spec(PubKey, State) ->
     #{ fee        => 5
-     , ttl        => 100
      , nonce      => try next_nonce(PubKey, State) catch _:_ -> 0 end
      , code       => <<"NOT PROPER BYTE CODE">>
      , vm_version => 1
@@ -140,7 +139,7 @@ call_tx(PubKey, ContractKey, Spec0, State) ->
                               , contract   = ContractKey
                               , vm_version = maps:get(vm_version, Spec)
                               , fee        = maps:get(fee, Spec)
-                              , ttl        = maps:get(ttl, Spec)
+                              , ttl        = maps:get(ttl, Spec, 0)
                               , amount     = maps:get(amount, Spec)
                               , gas        = maps:get(gas, Spec)
                               , gas_price  = maps:get(gas_price, Spec)
@@ -149,7 +148,6 @@ call_tx(PubKey, ContractKey, Spec0, State) ->
 
 call_tx_default_spec(PubKey, State) ->
     #{ fee         => 5
-     , ttl         => 100
      , nonce       => try next_nonce(PubKey, State) catch _:_ -> 0 end
      , vm_version  => 1
      , amount      => 100

--- a/apps/aecore/src/aec_spend_tx.erl
+++ b/apps/aecore/src/aec_spend_tx.erl
@@ -36,7 +36,7 @@
           recipient = <<>>          :: aec_keys:pubkey(),
           amount    = 0             :: non_neg_integer(),
           fee       = 0             :: non_neg_integer(),
-          ttl       = 0             :: aec_blocks:height(),
+          ttl       = 0             :: aetx:tx_ttl(),
           nonce     = 0             :: non_neg_integer(),
           payload   = <<>>          :: binary()}).
 
@@ -49,21 +49,18 @@ new(#{sender := SenderPubkey,
       recipient := RecipientPubkey,
       amount := Amount,
       fee := Fee,
-      ttl := TTL,
       nonce := Nonce,
-      payload := Payload}) when is_integer(Amount), Amount >= 0,
-                                is_integer(Nonce), Nonce >= 0,
-                                is_integer(Fee), Fee >= 0,
-                                is_integer(TTL), TTL >= 0,
-                                is_binary(SenderPubkey),
-                                is_binary(RecipientPubkey),
-                                is_binary(Payload)
-                                ->
+      payload := Payload} = Args) when is_integer(Amount), Amount >= 0,
+                                       is_integer(Nonce), Nonce >= 0,
+                                       is_integer(Fee), Fee >= 0,
+                                       is_binary(SenderPubkey),
+                                       is_binary(RecipientPubkey),
+                                       is_binary(Payload) ->
     Tx = #spend_tx{sender = SenderPubkey,
                    recipient = RecipientPubkey,
                    amount = Amount,
                    fee = Fee,
-                   ttl = TTL,
+                   ttl = maps:get(ttl, Args, 0),
                    nonce = Nonce,
                    payload = Payload},
     {ok, aetx:new(?MODULE, Tx)}.
@@ -76,7 +73,7 @@ type() ->
 fee(#spend_tx{fee = F}) ->
     F.
 
--spec ttl(tx()) -> aec_blocks:height().
+-spec ttl(tx()) -> aetx:tx_ttl().
 ttl(#spend_tx{ttl = TTL}) ->
     TTL.
 

--- a/apps/aecore/src/aec_vm_chain.erl
+++ b/apps/aecore/src/aec_vm_chain.erl
@@ -312,7 +312,6 @@ call_contract(Target, Gas, Value, CallData, CallStack,
                                     contract   => Target,
                                     vm_version => VmVersion,
                                     fee        => 0,
-                                    ttl        => Height,
                                     amount     => Value,
                                     gas        => Gas,
                                     gas_price  => 0,
@@ -382,7 +381,6 @@ do_spend(Recipient, ContractKey, Amount, Trees, Height) ->
                                       , recipient => Recipient
                                       , amount => Amount
                                       , fee => 0
-                                      , ttl => Height
                                       , nonce => Nonce
                                       , payload => <<>>}),
     case aetx:check_from_contract(SpendTx, Trees, Height, ConsensusVersion) of

--- a/apps/aecore/test/aec_blocks_tests.erl
+++ b/apps/aecore/test/aec_blocks_tests.erl
@@ -108,7 +108,6 @@ validate_test_malformed_txs_root_hash() ->
           #{recipient => <<1:32/unit:8>>,
             amount => 1,
             fee => 1,
-            ttl => 100,
             nonce => 1,
             payload => <<>>}),
 
@@ -116,7 +115,6 @@ validate_test_malformed_txs_root_hash() ->
                                      recipient => <<4242:32/unit:8>>,
                                      amount => 1,
                                      fee => 1,
-                                     ttl => 100,
                                      nonce => 1,
                                      payload => <<>>}),
     BadSignedSpend = aetx_sign:sign(Spend, <<0:64/unit:8>>),
@@ -144,7 +142,6 @@ validate_test_pass_validation() ->
           #{recipient => <<1:32/unit:8>>,
             amount => 1,
             fee => 1,
-            ttl => 100,
             nonce => 1,
             payload => <<>>}),
     Txs = [SignedSpend],

--- a/apps/aecore/test/aec_chain_tests.erl
+++ b/apps/aecore/test/aec_chain_tests.erl
@@ -277,7 +277,6 @@ broken_chain_invalid_transaction() ->
     BogusSpendTx = aec_test_utils:signed_spend_tx(#{recipient => <<>>,
                                                     amount => 0,
                                                     fee => 1,
-                                                    ttl => 100,
                                                     nonce => 10,
                                                     payload => <<"">>}),
     BogusTxs = [BogusSpendTx | Txs],
@@ -899,7 +898,6 @@ make_spend_tx(Sender, SenderNonce, Recipient) ->
                                        recipient => Recipient,
                                        amount => 1,
                                        fee => 1,
-                                       ttl => 100,
                                        nonce => SenderNonce,
                                        payload => <<>>}),
     SpendTx.

--- a/apps/aecore/test/aec_conductor_tests.erl
+++ b/apps/aecore/test/aec_conductor_tests.erl
@@ -386,7 +386,7 @@ test_get_block_candidate() ->
             {ok, Tx} = aec_spend_tx:new(#{sender => MyAccount,
                                           recipient => MyAccount,
                                           amount => 0,
-                                          nonce => X, fee => 1, ttl => 100,
+                                          nonce => X, fee => 1,
                                           payload => <<"">>}),
             {ok, STx} = aec_keys:sign(Tx),
             ok = aec_tx_pool:push(STx, tx_received)

--- a/apps/aecore/test/aec_keys_tests.erl
+++ b/apps/aecore/test/aec_keys_tests.erl
@@ -31,7 +31,6 @@ all_test_() ->
                                                recipient => RecipientPubkey,
                                                amount => 10,
                                                fee => 2,
-                                               ttl => 100,
                                                nonce => 3,
                                                payload => <<"">>}),
                         {ok, SignedTx} = aec_keys:sign(Tx),

--- a/apps/aecore/test/aec_spend_tx_tests.erl
+++ b/apps/aecore/test/aec_spend_tx_tests.erl
@@ -87,7 +87,6 @@ process_test_() ->
                                                  recipient => ?RECIPIENT_PUBKEY,
                                                  amount => 50,
                                                  fee => 10,
-                                                 ttl => 100,
                                                  nonce => 11,
                                                  payload => <<"foo">>}),
               <<"foo">> = aec_spend_tx:payload(aetx:tx(SpendTx)),
@@ -112,7 +111,6 @@ process_test_() ->
                                                  recipient => ?SENDER_PUBKEY,
                                                  amount => 50,
                                                  fee => 10,
-                                                 ttl => 100,
                                                  nonce => 11,
                                                  payload => <<"foo">>}),
               {ok, StateTree0} = aetx:check(SpendTx, StateTree0, 20, ?PROTOCOL_VERSION),
@@ -130,7 +128,6 @@ spend_tx(Data) ->
                     recipient => ?RECIPIENT_PUBKEY,
                     amount => 0,
                     fee => 0,
-                    ttl => 100,
                     nonce => 0},
     aec_spend_tx:new(maps:merge(DefaultData, Data)).
 

--- a/apps/aecore/test/aec_trees_tests.erl
+++ b/apps/aecore/test/aec_trees_tests.erl
@@ -51,7 +51,6 @@ signatures_check_test_() ->
                       #{recipient => <<1:32/unit:8>>,
                         amount => 1,
                         fee => 1,
-                        ttl => 100,
                         nonce => 1,
                         payload => <<>>}),
             SignedTxs = [SignedSpend],
@@ -79,7 +78,6 @@ make_spend_tx(Sender, Recipient) ->
                                        recipient => Recipient,
                                        amount => 1,
                                        fee => 1,
-                                       ttl => 100,
                                        nonce => 1,
                                        payload => <<>>}),
     SpendTx.

--- a/apps/aecore/test/aec_tx_pool_tests.erl
+++ b/apps/aecore/test/aec_tx_pool_tests.erl
@@ -252,7 +252,6 @@ a_signed_tx(Sender, Recipient, Nonce, Fee) ->
                                   recipient => acct(Recipient),
                                   amount => 1,
                                   nonce => Nonce, fee => Fee,
-                                  ttl => 100,
                                   payload => <<"">>}),
     {ok, STx} = sign(Sender, Tx),
     STx.

--- a/apps/aecore/test/aecore_suite_utils.erl
+++ b/apps/aecore/test/aecore_suite_utils.erl
@@ -21,7 +21,7 @@
          mine_blocks/2,
          mine_blocks/3,
          spend/4,         %% (Node, FromPub, ToPub, Amount) -> ok
-         spend/6,         %% (Node, FromPub, ToPub, Amount, Fee, TTL) -> ok
+         spend/5,         %% (Node, FromPub, ToPub, Amount, Fee) -> ok
          forks/0,
          latest_fork_height/0]).
 
@@ -186,15 +186,14 @@ mine_blocks_loop(Blocks, BlocksToMine) ->
     end.
 
 spend(Node, FromPub, ToPub, Amount) ->
-    spend(Node, FromPub, ToPub, Amount, aec_governance:minimum_tx_fee(), 1000).
+    spend(Node, FromPub, ToPub, Amount, aec_governance:minimum_tx_fee()).
 
-spend(Node, FromPub, ToPub, Amount, Fee, TTL) ->
+spend(Node, FromPub, ToPub, Amount, Fee) ->
     {ok, Nonce} = rpc:call(Node, aec_next_nonce, pick_for_account, [FromPub]),
     Params = #{sender => FromPub,
                recipient => ToPub,
                amount => Amount,
                fee => Fee,
-               ttl => TTL,
                nonce => Nonce,
                payload => <<"foo">>},
     {ok, Tx} = rpc:call(Node, aec_spend_tx, new, [Params]),

--- a/apps/aecore/test/aecore_sync_SUITE.erl
+++ b/apps/aecore/test/aecore_sync_SUITE.erl
@@ -248,8 +248,7 @@ tx_first_pays_second_(Config, AmountFun) ->
     ok = new_tx(#{node1  => N1,
                   node2  => N2,
                   amount => AmountFun(Bal1),
-                  fee    => 1,
-                  ttl    => 100}),
+                  fee    => 1}),
     {ok, Pool12} = get_pool(N1),
     [NewTx] = Pool12 -- Pool11,
     true = ensure_new_tx(N2, NewTx).
@@ -511,7 +510,7 @@ get_balance(N) ->
 get_pool(N) ->
     rpc:call(N, aec_tx_pool, peek, [infinity], 5000).
 
-new_tx(#{node1 := N1, node2 := N2, amount := Am, fee := Fee, ttl := TTL} = _M) ->
+new_tx(#{node1 := N1, node2 := N2, amount := Am, fee := Fee} = _M) ->
     PK1 = ok(get_pubkey(N1)),
     PK2 = ok(get_pubkey(N2)),
     Port = rpc:call(N1, aeu_env, user_config_or_env,
@@ -521,7 +520,6 @@ new_tx(#{node1 := N1, node2 := N2, amount := Am, fee := Fee, ttl := TTL} = _M) -
                recipient_pubkey => aec_base58c:encode(account_pubkey, PK2),
                amount => Am,
                fee => Fee,
-               ttl => TTL,
                payload => <<"foo">>},
     %% It's internal API so ext_addr is not included here.
     Cfg = [{int_http, "http://127.0.0.1:" ++ integer_to_list(Port)}],

--- a/apps/aehttp/priv/swagger.json
+++ b/apps/aehttp/priv/swagger.json
@@ -2619,7 +2619,7 @@
     },
     "SpendTx" : {
       "type" : "object",
-      "required" : [ "amount", "fee", "payload", "recipient_pubkey", "ttl" ],
+      "required" : [ "amount", "fee", "payload", "recipient_pubkey" ],
       "properties" : {
         "recipient_pubkey" : {
           "$ref" : "#/definitions/EncodedHash"
@@ -2660,7 +2660,7 @@
     },
     "OracleRegisterTx" : {
       "type" : "object",
-      "required" : [ "fee", "oracle_ttl", "query_fee", "query_format", "response_format", "ttl" ],
+      "required" : [ "fee", "oracle_ttl", "query_fee", "query_format", "response_format" ],
       "properties" : {
         "query_format" : {
           "type" : "string"
@@ -2722,7 +2722,7 @@
     },
     "OracleExtendTx" : {
       "type" : "object",
-      "required" : [ "fee", "oracle_ttl", "ttl" ],
+      "required" : [ "fee", "oracle_ttl" ],
       "properties" : {
         "fee" : {
           "type" : "integer",
@@ -2756,7 +2756,7 @@
     },
     "OracleQueryTx" : {
       "type" : "object",
-      "required" : [ "fee", "oracle_pubkey", "query", "query_fee", "query_ttl", "response_ttl", "ttl" ],
+      "required" : [ "fee", "oracle_pubkey", "query", "query_fee", "query_ttl", "response_ttl" ],
       "properties" : {
         "oracle_pubkey" : {
           "type" : "string"
@@ -2811,7 +2811,7 @@
     },
     "OracleResponseTx" : {
       "type" : "object",
-      "required" : [ "fee", "query_id", "response", "ttl" ],
+      "required" : [ "fee", "query_id", "response" ],
       "properties" : {
         "query_id" : {
           "$ref" : "#/definitions/EncodedHash"
@@ -2922,7 +2922,7 @@
     },
     "NamePreclaimTx" : {
       "type" : "object",
-      "required" : [ "commitment", "fee", "ttl" ],
+      "required" : [ "commitment", "fee" ],
       "properties" : {
         "commitment" : {
           "type" : "string"
@@ -2953,7 +2953,7 @@
     },
     "NameClaimTx" : {
       "type" : "object",
-      "required" : [ "fee", "name", "name_salt", "ttl" ],
+      "required" : [ "fee", "name", "name_salt" ],
       "properties" : {
         "name" : {
           "type" : "string"
@@ -2989,7 +2989,7 @@
     },
     "NameUpdateTx" : {
       "type" : "object",
-      "required" : [ "client_ttl", "fee", "name_hash", "name_ttl", "pointers", "ttl" ],
+      "required" : [ "client_ttl", "fee", "name_hash", "name_ttl", "pointers" ],
       "properties" : {
         "name_hash" : {
           "type" : "string"
@@ -3034,7 +3034,7 @@
     },
     "NameTransferTx" : {
       "type" : "object",
-      "required" : [ "fee", "name_hash", "recipient_pubkey", "ttl" ],
+      "required" : [ "fee", "name_hash", "recipient_pubkey" ],
       "properties" : {
         "name_hash" : {
           "type" : "string"
@@ -3069,7 +3069,7 @@
     },
     "NameRevokeTx" : {
       "type" : "object",
-      "required" : [ "fee", "name_hash", "ttl" ],
+      "required" : [ "fee", "name_hash" ],
       "properties" : {
         "name_hash" : {
           "type" : "string"
@@ -3122,7 +3122,7 @@
     },
     "ChannelCreateTx" : {
       "type" : "object",
-      "required" : [ "channel_reserve", "fee", "initiator", "initiator_amount", "lock_period", "push_amount", "responder", "responder_amount", "ttl" ],
+      "required" : [ "channel_reserve", "fee", "initiator", "initiator_amount", "lock_period", "push_amount", "responder", "responder_amount" ],
       "properties" : {
         "initiator" : {
           "$ref" : "#/definitions/EncodedHash"
@@ -3186,7 +3186,7 @@
     },
     "ChannelDepositTx" : {
       "type" : "object",
-      "required" : [ "amount", "channel_id", "fee", "from", "nonce", "ttl" ],
+      "required" : [ "amount", "channel_id", "fee", "from", "nonce" ],
       "properties" : {
         "channel_id" : {
           "type" : "string"
@@ -3226,7 +3226,7 @@
     },
     "ChannelWithdrawalTx" : {
       "type" : "object",
-      "required" : [ "amount", "channel_id", "fee", "nonce", "to", "ttl" ],
+      "required" : [ "amount", "channel_id", "fee", "nonce", "to" ],
       "properties" : {
         "channel_id" : {
           "type" : "string"
@@ -3266,7 +3266,7 @@
     },
     "ChannelCloseMutualTx" : {
       "type" : "object",
-      "required" : [ "channel_id", "fee", "initiator_amount", "nonce", "responder_amount", "ttl" ],
+      "required" : [ "channel_id", "fee", "initiator_amount", "nonce", "responder_amount" ],
       "properties" : {
         "channel_id" : {
           "type" : "string"
@@ -3308,7 +3308,7 @@
     },
     "ChannelCloseSoloTx" : {
       "type" : "object",
-      "required" : [ "channel_id", "fee", "from", "payload", "ttl" ],
+      "required" : [ "channel_id", "fee", "from", "payload" ],
       "properties" : {
         "channel_id" : {
           "type" : "string"
@@ -3346,7 +3346,7 @@
     },
     "ChannelSlashTx" : {
       "type" : "object",
-      "required" : [ "channel_id", "fee", "from", "payload", "ttl" ],
+      "required" : [ "channel_id", "fee", "from", "payload" ],
       "properties" : {
         "channel_id" : {
           "type" : "string"
@@ -3384,7 +3384,7 @@
     },
     "ChannelSettleTx" : {
       "type" : "object",
-      "required" : [ "channel_id", "fee", "from", "initiator_amount", "nonce", "ttl" ],
+      "required" : [ "channel_id", "fee", "from", "initiator_amount", "nonce" ],
       "properties" : {
         "channel_id" : {
           "type" : "string"
@@ -3913,7 +3913,7 @@
     },
     "ContractCreateData" : {
       "type" : "object",
-      "required" : [ "amount", "call_data", "code", "deposit", "fee", "gas", "gas_price", "owner", "ttl", "vm_version" ],
+      "required" : [ "amount", "call_data", "code", "deposit", "fee", "gas", "gas_price", "owner", "vm_version" ],
       "properties" : {
         "owner" : {
           "type" : "string",
@@ -3984,7 +3984,7 @@
     },
     "ContractCallData" : {
       "type" : "object",
-      "required" : [ "amount", "call_data", "caller", "contract", "fee", "gas", "gas_price", "ttl", "vm_version" ],
+      "required" : [ "amount", "call_data", "caller", "contract", "fee", "gas", "gas_price", "vm_version" ],
       "properties" : {
         "caller" : {
           "type" : "string",
@@ -4049,7 +4049,7 @@
     },
     "ContractCallCompute" : {
       "type" : "object",
-      "required" : [ "amount", "arguments", "caller", "contract", "fee", "function", "gas", "gas_price", "ttl", "vm_version" ],
+      "required" : [ "amount", "arguments", "caller", "contract", "fee", "function", "gas", "gas_price", "vm_version" ],
       "properties" : {
         "caller" : {
           "type" : "string",

--- a/apps/aehttp/src/aehttp_dispatch_ext.erl
+++ b/apps/aehttp/src/aehttp_dispatch_ext.erl
@@ -158,8 +158,8 @@ handle_request('PostTx', #{'Tx' := Tx} = Req, _Context) ->
 handle_request('PostContractCreate', #{'ContractCreateData' := Req}, _Context) ->
     ParseFuns = [parse_map_to_atom_keys(),
                  read_required_params([owner, code, vm_version, deposit,
-                                       amount, gas, gas_price, fee, ttl,
-                                       call_data]),
+                                       amount, gas, gas_price, fee, call_data]),
+                 read_optional_params([{ttl, ttl, '$no_value'}]),
                  base58_decode([{owner, owner, account_pubkey}]),
                  get_nonce(owner),
                  hexstrings_decode([code, call_data]),
@@ -181,8 +181,8 @@ handle_request('PostContractCreate', #{'ContractCreateData' := Req}, _Context) -
 handle_request('PostContractCall', #{'ContractCallData' := Req}, _Context) ->
     ParseFuns = [parse_map_to_atom_keys(),
                  read_required_params([caller, contract, vm_version,
-                                       amount, gas, gas_price, fee, ttl,
-                                       call_data]),
+                                       amount, gas, gas_price, fee, call_data]),
+                 read_optional_params([{ttl, ttl, '$no_value'}]),
                  base58_decode([{caller, caller, account_pubkey},
                                 {contract, contract, contract_pubkey}]),
                  get_nonce(caller),
@@ -195,8 +195,9 @@ handle_request('PostContractCall', #{'ContractCallData' := Req}, _Context) ->
 handle_request('PostContractCallCompute', #{'ContractCallCompute' := Req}, _Context) ->
     ParseFuns = [parse_map_to_atom_keys(),
                  read_required_params([caller, contract, vm_version,
-                                       amount, gas, gas_price, fee, ttl,
+                                       amount, gas, gas_price, fee,
                                        function, arguments]),
+                 read_optional_params([{ttl, ttl, '$no_value'}]),
                  base58_decode([{caller, caller, account_pubkey},
                                 {contract, contract, contract_pubkey}]),
                  get_nonce(caller),
@@ -210,7 +211,8 @@ handle_request('PostOracleRegister', #{'OracleRegisterTx' := Req}, _Context) ->
     ParseFuns = [parse_map_to_atom_keys(),
                  read_required_params([account, {query_format, query_spec},
                                        {response_format, response_spec},
-                                       query_fee, oracle_ttl, fee, ttl]),
+                                       query_fee, oracle_ttl, fee]),
+                 read_optional_params([{ttl, ttl, '$no_value'}]),
                  base58_decode([{account, account, account_pubkey}]),
                  get_nonce(account),
                  ttl_decode(oracle_ttl),
@@ -220,7 +222,8 @@ handle_request('PostOracleRegister', #{'OracleRegisterTx' := Req}, _Context) ->
 
 handle_request('PostOracleExtend', #{'OracleExtendTx' := Req}, _Context) ->
     ParseFuns = [parse_map_to_atom_keys(),
-                 read_required_params([oracle, oracle_ttl, fee, ttl]),
+                 read_required_params([oracle, oracle_ttl, fee]),
+                 read_optional_params([{ttl, ttl, '$no_value'}]),
                  base58_decode([{oracle, oracle, oracle_pubkey}]),
                  get_nonce(oracle),
                  ttl_decode(oracle_ttl),
@@ -231,7 +234,8 @@ handle_request('PostOracleExtend', #{'OracleExtendTx' := Req}, _Context) ->
 handle_request('PostOracleQuery', #{'OracleQueryTx' := Req}, _Context) ->
     ParseFuns = [parse_map_to_atom_keys(),
                  read_required_params([sender, oracle_pubkey, query,
-                                       query_fee, fee, query_ttl, response_ttl, ttl]),
+                                       query_fee, fee, query_ttl, response_ttl]),
+                 read_optional_params([{ttl, ttl, '$no_value'}]),
                  base58_decode([{sender, sender, account_pubkey},
                                {oracle_pubkey, oracle, oracle_pubkey}]),
                  get_nonce(sender),
@@ -244,7 +248,8 @@ handle_request('PostOracleQuery', #{'OracleQueryTx' := Req}, _Context) ->
 
 handle_request('PostOracleResponse', #{'OracleResponseTx' := Req}, _Context) ->
     ParseFuns = [parse_map_to_atom_keys(),
-                 read_required_params([oracle, query_id, response, fee, ttl]),
+                 read_required_params([oracle, query_id, response, fee]),
+                 read_optional_params([{ttl, ttl, '$no_value'}]),
                  base58_decode([{oracle, oracle, oracle_pubkey},
                                {query_id, query_id, oracle_query_id}]),
                  get_nonce(oracle),
@@ -255,7 +260,8 @@ handle_request('PostOracleResponse', #{'OracleResponseTx' := Req}, _Context) ->
 
 handle_request('PostNamePreclaim', #{'NamePreclaimTx' := Req}, _Context) ->
     ParseFuns = [parse_map_to_atom_keys(),
-                 read_required_params([account, commitment, fee, ttl]),
+                 read_required_params([account, commitment, fee]),
+                 read_optional_params([{ttl, ttl, '$no_value'}]),
                  base58_decode([{account, account, account_pubkey},
                                 {commitment, commitment, commitment}]),
                  get_nonce(account),
@@ -265,7 +271,8 @@ handle_request('PostNamePreclaim', #{'NamePreclaimTx' := Req}, _Context) ->
 
 handle_request('PostNameClaim', #{'NameClaimTx' := Req}, _Context) ->
     ParseFuns = [parse_map_to_atom_keys(),
-                 read_required_params([account, name, name_salt, fee, ttl]),
+                 read_required_params([account, name, name_salt, fee]),
+                 read_optional_params([{ttl, ttl, '$no_value'}]),
                  base58_decode([{account, account, account_pubkey},
                                 {name, name, name}]),
                  get_nonce(account),
@@ -277,7 +284,8 @@ handle_request('PostNameClaim', #{'NameClaimTx' := Req}, _Context) ->
 handle_request('PostNameUpdate', #{'NameUpdateTx' := Req}, _Context) ->
     ParseFuns = [parse_map_to_atom_keys(),
                  read_required_params([account, name_hash, name_ttl,
-                                       pointers, client_ttl, fee, ttl]),
+                                       pointers, client_ttl, fee]),
+                 read_optional_params([{ttl, ttl, '$no_value'}]),
                  base58_decode([{account, account, account_pubkey},
                                 {name_hash, name_hash, name}]),
                  nameservice_pointers_decode(pointers),
@@ -288,8 +296,8 @@ handle_request('PostNameUpdate', #{'NameUpdateTx' := Req}, _Context) ->
 
 handle_request('PostNameTransfer', #{'NameTransferTx' := Req}, _Context) ->
     ParseFuns = [parse_map_to_atom_keys(),
-                 read_required_params([account, name_hash, recipient_pubkey,
-                                       fee, ttl]),
+                 read_required_params([account, name_hash, recipient_pubkey, fee]),
+                 read_optional_params([{ttl, ttl, '$no_value'}]),
                  base58_decode([{account, account, account_pubkey},
                                 {recipient_pubkey, recipient_account, account_pubkey},
                                 {name_hash, name_hash, name}]),
@@ -300,7 +308,8 @@ handle_request('PostNameTransfer', #{'NameTransferTx' := Req}, _Context) ->
 
 handle_request('PostNameRevoke', #{'NameRevokeTx' := Req}, _Context) ->
     ParseFuns = [parse_map_to_atom_keys(),
-                 read_required_params([account, name_hash, fee, ttl]),
+                 read_required_params([account, name_hash, fee]),
+                 read_optional_params([{ttl, ttl, '$no_value'}]),
                  base58_decode([{account, account, account_pubkey},
                                 {name_hash, name_hash, name}]),
                  get_nonce(account),
@@ -312,7 +321,9 @@ handle_request('PostSpend', #{'SpendTx' := Req}, _Context) ->
     ParseFuns = [parse_map_to_atom_keys(),
                  read_required_params([sender,
                                        {recipient_pubkey, recipient},
-                                       amount, fee, ttl, payload]),
+                                        amount, fee, payload]),
+                 read_optional_params([{ttl, ttl, '$no_value'}]),
+                 read_optional_params([{ttl, ttl, '$no_value'}]),
                  base58_decode([{sender, sender, account_pubkey},
                                 {recipient, recipient, account_pubkey}]),
                  get_nonce(sender),
@@ -325,7 +336,8 @@ handle_request('PostChannelCreate', #{'ChannelCreateTx' := Req}, _Context) ->
                  read_required_params([initiator, initiator_amount,
                                        responder, responder_amount,
                                        push_amount, channel_reserve,
-                                       lock_period, ttl, fee]),
+                                       lock_period, fee]),
+                 read_optional_params([{ttl, ttl, '$no_value'}]),
                  base58_decode([{initiator, initiator, account_pubkey},
                                 {responder, responder, account_pubkey}]),
                  get_nonce(initiator),
@@ -336,8 +348,8 @@ handle_request('PostChannelCreate', #{'ChannelCreateTx' := Req}, _Context) ->
 handle_request('PostChannelDeposit', #{'ChannelDepositTx' := Req}, _Context) ->
     ParseFuns = [parse_map_to_atom_keys(),
                  read_required_params([channel_id, from,
-                                       amount,
-                                       ttl, fee, nonce]),
+                                       amount, fee, nonce]),
+                 read_optional_params([{ttl, ttl, '$no_value'}]),
                  base58_decode([{channel_id, channel_id, channel},
                                 {from, from, account_pubkey}]),
                  unsigned_tx_response(fun aesc_deposit_tx:new/1)
@@ -347,8 +359,8 @@ handle_request('PostChannelDeposit', #{'ChannelDepositTx' := Req}, _Context) ->
 handle_request('PostChannelWithdrawal', #{'ChannelWithdrawalTx' := Req}, _Context) ->
     ParseFuns = [parse_map_to_atom_keys(),
                  read_required_params([channel_id, to,
-                                       amount,
-                                       ttl, fee, nonce]),
+                                       amount, fee, nonce]),
+                 read_optional_params([{ttl, ttl, '$no_value'}]),
                  base58_decode([{channel_id, channel_id, channel},
                                 {to, to, account_pubkey}]),
                  unsigned_tx_response(fun aesc_withdraw_tx:new/1)
@@ -357,10 +369,9 @@ handle_request('PostChannelWithdrawal', #{'ChannelWithdrawalTx' := Req}, _Contex
 
 handle_request('PostChannelCloseMutual', #{'ChannelCloseMutualTx' := Req}, _Context) ->
     ParseFuns = [parse_map_to_atom_keys(),
-                 read_required_params([channel_id,
-                                       initiator_amount, responder_amount,
-                                       ttl,
-                                       fee, nonce]),
+                 read_required_params([channel_id, initiator_amount,
+                                       responder_amount, fee, nonce]),
+                 read_optional_params([{ttl, ttl, '$no_value'}]),
                  base58_decode([{channel_id, channel_id, channel}]),
                  unsigned_tx_response(fun aesc_close_mutual_tx:new/1)
                 ],
@@ -368,9 +379,8 @@ handle_request('PostChannelCloseMutual', #{'ChannelCloseMutualTx' := Req}, _Cont
 
 handle_request('PostChannelCloseSolo', #{'ChannelCloseSoloTx' := Req}, _Context) ->
     ParseFuns = [parse_map_to_atom_keys(),
-                 read_required_params([channel_id, from,
-                                       payload,
-                                       ttl, fee]),
+                 read_required_params([channel_id, from, payload, fee]),
+                 read_optional_params([{ttl, ttl, '$no_value'}]),
                  base58_decode([{channel_id, channel_id, channel},
                                 {from, from, account_pubkey}]),
                  get_nonce(from),
@@ -380,9 +390,8 @@ handle_request('PostChannelCloseSolo', #{'ChannelCloseSoloTx' := Req}, _Context)
 
 handle_request('PostChannelSlash', #{'ChannelSlashTx' := Req}, _Context) ->
     ParseFuns = [parse_map_to_atom_keys(),
-                 read_required_params([channel_id, from,
-                                       payload,
-                                       ttl, fee]),
+                 read_required_params([channel_id, from, payload, fee]),
+                 read_optional_params([{ttl, ttl, '$no_value'}]),
                  base58_decode([{channel_id, channel_id, channel},
                                 {from, from, account_pubkey}]),
                  get_nonce(from),
@@ -392,9 +401,9 @@ handle_request('PostChannelSlash', #{'ChannelSlashTx' := Req}, _Context) ->
 
 handle_request('PostChannelSettle', #{'ChannelSettleTx' := Req}, _Context) ->
     ParseFuns = [parse_map_to_atom_keys(),
-                 read_required_params([channel_id, from,
-                                       initiator_amount, responder_amount,
-                                       ttl, fee, nonce]),
+                 read_required_params([channel_id, from, initiator_amount,
+                                       responder_amount, fee, nonce]),
+                 read_optional_params([{ttl, ttl, '$no_value'}]),
                  base58_decode([{channel_id, channel_id, channel},
                                 {from, from, account_pubkey}]),
                  unsigned_tx_response(fun aesc_settle_tx:new/1)

--- a/apps/aehttp/src/aehttp_dispatch_ext.erl
+++ b/apps/aehttp/src/aehttp_dispatch_ext.erl
@@ -323,7 +323,6 @@ handle_request('PostSpend', #{'SpendTx' := Req}, _Context) ->
                                        {recipient_pubkey, recipient},
                                         amount, fee, payload]),
                  read_optional_params([{ttl, ttl, '$no_value'}]),
-                 read_optional_params([{ttl, ttl, '$no_value'}]),
                  base58_decode([{sender, sender, account_pubkey},
                                 {recipient, recipient, account_pubkey}]),
                  get_nonce(sender),

--- a/apps/aehttp/src/aehttp_dispatch_int.erl
+++ b/apps/aehttp/src/aehttp_dispatch_int.erl
@@ -20,8 +20,8 @@ handle_request('PostSpendTx', #{'SpendTx' := SpendTxObj}, _Context) ->
     #{<<"recipient_pubkey">> := EncodedRecipientPubkey,
       <<"amount">>           := Amount,
       <<"fee">>              := Fee,
-      <<"ttl">>              := TTL,
       <<"payload">>          := Payload} = SpendTxObj,
+    TTL = maps:get(<<"ttl">>, SpendTxObj, 0),
     case aehttp_int_tx_logic:spend(EncodedRecipientPubkey, Amount, Fee, TTL, Payload) of
         {ok, _} -> {200, [], #{}};
         {error, invalid_key} ->
@@ -37,8 +37,8 @@ handle_request('PostOracleRegisterTx', #{'OracleRegisterTx' := OracleRegisterTxO
       <<"response_format">> := ResponseFormat,
       <<"query_fee">>       := QueryFee,
       <<"oracle_ttl">>      := OracleTTL,
-      <<"fee">>             := Fee,
-      <<"ttl">>             := TTL} = OracleRegisterTxObj,
+      <<"fee">>             := Fee} = OracleRegisterTxObj,
+    TTL = maps:get(<<"ttl">>, OracleRegisterTxObj, 0),
     TTLType = binary_to_existing_atom(maps:get(<<"type">>, OracleTTL), utf8),
     TTLValue = maps:get(<<"value">>, OracleTTL),
     case aehttp_int_tx_logic:oracle_register(QueryFormat, ResponseFormat,
@@ -55,8 +55,8 @@ handle_request('PostOracleRegisterTx', #{'OracleRegisterTx' := OracleRegisterTxO
 
 handle_request('PostOracleExtendTx', #{'OracleExtendTx' := OracleExtendTxObj}, _Context) ->
     #{<<"oracle_ttl">> := OracleTTL,
-      <<"fee">>        := Fee,
-      <<"ttl">>        := TTL} = OracleExtendTxObj,
+      <<"fee">>        := Fee} = OracleExtendTxObj,
+    TTL = maps:get(<<"ttl">>, OracleExtendTxObj, 0),
     TTLType = delta,
     TTLValue = maps:get(<<"value">>, OracleTTL),
     case aehttp_int_tx_logic:oracle_extend(Fee, TTLType, TTLValue, TTL) of
@@ -78,8 +78,8 @@ handle_request('PostOracleQueryTx', #{'OracleQueryTx' := OracleQueryTxObj}, _Con
       <<"response_ttl">>  :=
           #{<<"type">>    := <<"delta">>,
             <<"value">>   := ResponseTTLValue},
-      <<"fee">>           := Fee,
-      <<"ttl">>           := TTL} = OracleQueryTxObj,
+      <<"fee">>           := Fee} = OracleQueryTxObj,
+    TTL = maps:get(<<"ttl">>, OracleQueryTxObj, 0),
     QueryTTLType = binary_to_existing_atom(maps:get(<<"type">>, QueryTTL), utf8),
     QueryTTLValue= maps:get(<<"value">>, QueryTTL),
     case aehttp_int_tx_logic:oracle_query(EncodedOraclePubkey, Query, QueryFee, QueryTTLType,
@@ -99,8 +99,8 @@ handle_request('PostOracleQueryTx', #{'OracleQueryTx' := OracleQueryTxObj}, _Con
 handle_request('PostOracleResponseTx', #{'OracleResponseTx' := OracleResponseTxObj}, _Context) ->
     #{<<"query_id">> := EncodedQueryId,
       <<"response">> := Response,
-      <<"fee">>      := Fee,
-      <<"ttl">>      := TTL} = OracleResponseTxObj,
+      <<"fee">>      := Fee} = OracleResponseTxObj,
+    TTL = maps:get(<<"ttl">>, OracleResponseTxObj, 0),
     case aec_base58c:safe_decode(oracle_query_id, EncodedQueryId) of
         {ok, DecodedQueryId} ->
             case aehttp_int_tx_logic:oracle_response(DecodedQueryId, Response,
@@ -157,9 +157,9 @@ handle_request('GetOracleQuestions', Req, _Context) ->
 
 handle_request('PostNamePreclaimTx', #{'NamePreclaimTx' := NamePreclaimTxObj}, _Context) ->
     #{<<"commitment">> := Commitment,
-      <<"fee">>        := Fee,
-      <<"ttl">>        := TTL} = NamePreclaimTxObj,
-    case aec_base58c:safe_decode(commitment, Commitment) of
+      <<"fee">>        := Fee} = NamePreclaimTxObj,
+    TTL = maps:get(<<"ttl">>, NamePreclaimTxObj, 0),
+     case aec_base58c:safe_decode(commitment, Commitment) of
         {ok, DecodedCommitment} ->
             case aehttp_int_tx_logic:name_preclaim(DecodedCommitment,
                                                    Fee, TTL) of
@@ -177,8 +177,8 @@ handle_request('PostNamePreclaimTx', #{'NamePreclaimTx' := NamePreclaimTxObj}, _
 handle_request('PostNameClaimTx', #{'NameClaimTx' := NameClaimTxObj}, _Context) ->
     #{<<"name">>      := Name,
       <<"name_salt">> := NameSalt,
-      <<"fee">>       := Fee,
-      <<"ttl">>       := TTL} = NameClaimTxObj,
+      <<"fee">>       := Fee} = NameClaimTxObj,
+    TTL = maps:get(<<"ttl">>, NameClaimTxObj, 0),
     case aehttp_int_tx_logic:name_claim(Name, NameSalt, Fee, TTL) of
         {ok, _Tx, NameHash} ->
             {200, [], #{name_hash => aec_base58c:encode(name, NameHash)}};
@@ -196,8 +196,8 @@ handle_request('PostNameUpdateTx', #{'NameUpdateTx' := NameUpdateTxObj}, _Contex
       <<"name_ttl">>   := NameTTL,
       <<"pointers">>   := Pointers,
       <<"client_ttl">> := ClientTTL,
-      <<"fee">>        := Fee,
-      <<"ttl">>        := TTL} = NameUpdateTxObj,
+      <<"fee">>        := Fee} = NameUpdateTxObj,
+    TTL = maps:get(<<"ttl">>, NameUpdateTxObj, 0),
     case aec_base58c:safe_decode(name, NameHash) of
         {ok, DecodedNameHash} ->
             case aehttp_int_tx_logic:name_update(DecodedNameHash, NameTTL,
@@ -216,8 +216,8 @@ handle_request('PostNameUpdateTx', #{'NameUpdateTx' := NameUpdateTxObj}, _Contex
 handle_request('PostNameTransferTx', #{'NameTransferTx' := NameTransferTxObj}, _Context) ->
     #{<<"name_hash">>        := NameHash,
       <<"recipient_pubkey">> := RecipientPubKey,
-      <<"fee">>              := Fee,
-      <<"ttl">>              := TTL} = NameTransferTxObj,
+      <<"fee">>              := Fee} = NameTransferTxObj,
+    TTL = maps:get(<<"ttl">>, NameTransferTxObj, 0),
     case {aec_base58c:safe_decode(name, NameHash),
           aec_base58c:safe_decode(account_pubkey, RecipientPubKey)} of
         {{ok, DecodedNameHash}, {ok, DecodedRecipientPubKey}} ->
@@ -239,8 +239,8 @@ handle_request('PostNameTransferTx', #{'NameTransferTx' := NameTransferTxObj}, _
 
 handle_request('PostNameRevokeTx', #{'NameRevokeTx' := NameRevokeTxObj}, _Context) ->
     #{<<"name_hash">> := NameHash,
-      <<"fee">>       := Fee,
-      <<"ttl">>       := TTL} = NameRevokeTxObj,
+      <<"fee">>       := Fee} = NameRevokeTxObj,
+    TTL = maps:get(<<"ttl">>, NameRevokeTxObj, 0),
     case aec_base58c:safe_decode(name, NameHash) of
         {ok, DecodedNameHash} ->
             case aehttp_int_tx_logic:name_revoke(DecodedNameHash, Fee, TTL) of

--- a/apps/aehttp/src/aehttp_helpers.erl
+++ b/apps/aehttp/src/aehttp_helpers.erl
@@ -330,7 +330,6 @@ ok_response(Fun) ->
 unsigned_tx_response(NewTxFun) when is_function(NewTxFun, 1) ->
     RespFun =
         fun(State) ->
-            lager:debug("ZZZ ~p", [State]),
             {ok, Tx} = NewTxFun(State),
             #{tx => aec_base58c:encode(transaction,
                                        aetx:serialize_to_binary(Tx))

--- a/apps/aehttp/src/sc_ws_handler.erl
+++ b/apps/aehttp/src/sc_ws_handler.erl
@@ -311,7 +311,7 @@ process_fsm(#{type := report,
             {info, _} when is_atom(Event) -> #{event => atom_to_binary(Event, utf8)};
             {on_chain_tx, Tx} ->
                 EncodedTx = aec_base58c:encode(transaction,
-                                               aetx_sign:serialize_to_binary(Tx)), 
+                                               aetx_sign:serialize_to_binary(Tx)),
                 #{tx => EncodedTx};
             {update, NewState} ->
                 Bin = aec_base58c:encode(transaction,
@@ -419,7 +419,7 @@ read_channel_options(Params) ->
          Read(<<"initiator_amount">>, initiator_amount, #{type => integer}),
          Read(<<"responder_amount">>, responder_amount, #{type => integer}),
          Read(<<"channel_reserve">>, channel_reserve, #{type => integer}),
-         Read(<<"ttl">>, ttl, #{type => integer}),
+         Read(<<"ttl">>, ttl, #{type => integer, mandatory => false}),
          Put(noise, [{noise, <<"Noise_NN_25519_ChaChaPoly_BLAKE2b">>}])
         ] ++ lists:map(ReadTimeout, aesc_fsm:timeouts() ++ [awaiting_open,
                                                             initialized])

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -610,7 +610,6 @@ contract_transactions(_Config) ->
                       gas => 30,
                       gas_price => 1,
                       fee => 1,
-                      ttl => 100,
                       call_data => EncodedCallData},
     ValidDecoded = maps:merge(ValidEncoded,
                               #{owner => MinerPubkey,
@@ -638,7 +637,6 @@ contract_transactions(_Config) ->
                              gas => 100,
                              gas_price => 1,
                              fee => 1,
-                             ttl => 100,
                              call_data => EncodedCallData},
 
     ContractCallDecoded = maps:merge(ContractCallEncoded,
@@ -683,7 +681,6 @@ contract_transactions(_Config) ->
                              gas => 100,
                              gas_price => 1,
                              fee => 1,
-                             ttl => 100,
                              function => Function,
                              arguments => Argument},
 
@@ -792,7 +789,6 @@ oracle_transactions(_Config) ->
                    response_format => <<"something else">>,
                    query_fee => 1,
                    fee => 6,
-                   ttl => 100,
                    oracle_ttl => #{type => <<"block">>, value => 2000}},
     RegDecoded = maps:merge(RegEncoded,
                             #{account => MinerPubkey,
@@ -818,7 +814,6 @@ oracle_transactions(_Config) ->
     % oracle_extend_tx positive test
     ExtEncoded = #{oracle => aec_base58c:encode(oracle_pubkey, MinerPubkey),
                    fee => 2,
-                   ttl => 100,
                    oracle_ttl => #{type => <<"delta">>, value => 500}},
     ExtDecoded = maps:merge(ExtEncoded,
                             #{oracle => MinerPubkey,
@@ -833,7 +828,6 @@ oracle_transactions(_Config) ->
                      query => <<"Hejsan Svejsan">>,
                      query_fee => 2,
                      fee => 30,
-                     ttl => 100,
                      query_ttl => #{type => <<"block">>, value => 20},
                      response_ttl => #{type => <<"delta">>, value => 20}},
     QueryDecoded = maps:merge(QueryEncoded,
@@ -863,8 +857,7 @@ oracle_transactions(_Config) ->
                         query_id => aec_base58c:encode(oracle_query_id,
                                                        QueryId),
                         response => <<"Hejsan">>,
-                        fee => 3,
-                        ttl => 100},
+                        fee => 3},
     ResponseDecoded = maps:merge(ResponseEncoded,
                               #{oracle => MinerPubkey,
                                 query_id => QueryId}),
@@ -954,8 +947,7 @@ nameservice_transaction_preclaim(MinerAddress, MinerPubkey) ->
     Commitment = <<"abcd">>,
     Encoded = #{account => MinerAddress,
                 commitment => aec_base58c:encode(commitment, Commitment),
-                fee => 1,
-                ttl => 100},
+                fee => 1},
     Decoded = maps:merge(Encoded,
                         #{account => MinerPubkey,
                           commitment => Commitment}),
@@ -1004,8 +996,7 @@ nameservice_transaction_claim(MinerAddress, MinerPubkey) ->
     Encoded = #{account => MinerAddress,
                 name => aec_base58c:encode(name, Name),
                 name_salt => Salt,
-                fee => 1,
-                ttl => 100},
+                fee => 1},
     Decoded = maps:merge(Encoded,
                         #{account => MinerPubkey,
                           name => Name}),
@@ -1033,8 +1024,7 @@ nameservice_transaction_update(MinerAddress, MinerPubkey) ->
                 name_ttl => 3,
                 client_ttl => 2,
                 pointers => jsx:encode(Pointers),
-                fee => 1,
-                ttl => 100},
+                fee => 1},
     Decoded = maps:merge(Encoded,
                         #{account => MinerPubkey,
                           pointers => Pointers,
@@ -1062,8 +1052,7 @@ nameservice_transaction_transfer(MinerAddress, MinerPubkey) ->
                 name_hash => aec_base58c:encode(name, NameHash),
                 recipient_pubkey => aec_base58c:encode(account_pubkey,
                                                        RandAddress),
-                fee => 1,
-                ttl => 100},
+                fee => 1},
     Decoded = maps:merge(Encoded,
                         #{account => MinerPubkey,
                           recipient_account => RandAddress,
@@ -1081,8 +1070,7 @@ nameservice_transaction_revoke(MinerAddress, MinerPubkey) ->
     NameHash = <<"name">>,
     Encoded = #{account => MinerAddress,
                 name_hash => aec_base58c:encode(name, NameHash),
-                fee => 1,
-                ttl => 100},
+                fee => 1},
     Decoded = maps:merge(Encoded,
                         #{account => MinerPubkey,
                           name_hash => NameHash}),
@@ -1132,7 +1120,6 @@ state_channels_create(MinerPubkey, ResponderPubkey) ->
                 responder_amount => 3,
                 push_amount => 5, channel_reserve => 5,
                 lock_period => 20,
-                ttl => 100,
                 fee => 1},
     Decoded = maps:merge(Encoded,
                         #{initiator => MinerPubkey,
@@ -1150,7 +1137,6 @@ state_channels_deposit(ChannelId, MinerPubkey) ->
     Encoded = #{channel_id => aec_base58c:encode(channel, ChannelId),
                 from => MinerAddress,
                 amount => 2,
-                ttl => 100,
                 fee => 1},
     Decoded = maps:merge(Encoded,
                         #{channel_id => ChannelId,
@@ -1170,7 +1156,6 @@ state_channels_withdrawal(ChannelId, MinerPubkey) ->
     MinerAddress = aec_base58c:encode(account_pubkey, MinerPubkey),
     Encoded = #{channel_id => aec_base58c:encode(channel, ChannelId),
                 to => MinerAddress,
-                ttl => 100,
                 amount => 2,
                 fee => 1},
     Decoded = maps:merge(Encoded,
@@ -1190,7 +1175,6 @@ state_channels_close_mutual(ChannelId, InitiatorPubkey) ->
     Encoded = #{channel_id => aec_base58c:encode(channel, ChannelId),
                 initiator_amount => 4,
                 responder_amount => 3,
-                ttl => 100,
                 fee => 1},
     Decoded = maps:merge(Encoded,
                         #{channel_id => ChannelId}),
@@ -1208,7 +1192,6 @@ state_channels_close_solo(ChannelId, MinerPubkey) ->
     Encoded = #{channel_id => aec_base58c:encode(channel, ChannelId),
                 from => aec_base58c:encode(account_pubkey, MinerPubkey),
                 payload => <<"hejsan svejsan">>, %%TODO proper payload
-                ttl => 100,
                 fee => 1},
     Decoded = maps:merge(Encoded,
                         #{from => MinerPubkey,
@@ -1223,7 +1206,6 @@ state_channels_slash(ChannelId, MinerPubkey) ->
     Encoded = #{channel_id => aec_base58c:encode(channel, ChannelId),
                 from => aec_base58c:encode(account_pubkey, MinerPubkey),
                 payload => <<"hejsan svejsan">>, %%TODO proper payload
-                ttl => 100,
                 fee => 1},
     Decoded = maps:merge(Encoded,
                         #{from => MinerPubkey,
@@ -1239,7 +1221,6 @@ state_channels_settle(ChannelId, MinerPubkey) ->
                 from => aec_base58c:encode(account_pubkey, MinerPubkey),
                 initiator_amount => 4,
                 responder_amount => 3,
-                ttl => 100,
                 fee => 1},
     Decoded = maps:merge(Encoded,
                         #{from => MinerPubkey,
@@ -1266,7 +1247,7 @@ spend_transaction(_Config) ->
                                                        RandAddress),
                 amount => 2,
                 fee => 1,
-                ttl => 100,
+                ttl => 43,
                 payload => <<"hejsan svejsan">>},
     Decoded = maps:merge(Encoded,
                         #{sender => MinerPubkey,
@@ -1293,7 +1274,6 @@ unknown_atom_in_spend_tx(_Config) ->
                                                        RandAddress),
                 amount => 2,
                 fee => 1,
-                ttl => 100,
                 %% this tests relies on this being an atom unknown to the VM
                 %% if someone adds this atom in particular, please modify the
                 %% binary below accordingly
@@ -1374,7 +1354,6 @@ get_transaction(_Config) ->
                                                        RandAddress),
                 amount => 2,
                 fee => 1,
-                ttl => 100,
                 payload => <<"foo">>},
     {ok, 200, #{<<"tx">> := EncodedSpendTx}} = get_spend(Encoded),
     {ok, SpendTxBin} = aec_base58c:safe_decode(transaction, EncodedSpendTx),
@@ -1544,7 +1523,6 @@ post_correct_tx(_Config) ->
             recipient => random_hash(),
             amount => Amount,
             fee => Fee,
-            ttl => 100,
             nonce => Nonce,
             payload => <<"foo">>}),
     {ok, SignedTx} = rpc(aec_keys, sign, [SpendTx]),
@@ -1564,7 +1542,6 @@ post_broken_tx(_Config) ->
             recipient => random_hash(),
             amount => Amount,
             fee => Fee,
-            ttl => 100,
             nonce => Nonce,
             payload => <<"foo">>}),
     {ok, SignedTx} = rpc(aec_keys, sign, [SpendTx]),
@@ -1592,7 +1569,6 @@ post_broken_base58_tx(_Config) ->
                     recipient => random_hash(),
                     amount => Amount,
                     fee => Fee,
-                    ttl => 100,
                     nonce => Nonce,
                     payload => <<"foo">>}),
             {ok, SignedTx} = rpc(aec_keys, sign, [SpendTx]),
@@ -2574,7 +2550,6 @@ naming_system_manage_name(_Config) ->
                                 #{recipient_pubkey => Name,
                                   amount           => 77,
                                   fee              => 50,
-                                  ttl              => 100,
                                   payload          => <<"foo">>}),
     aecore_suite_utils:mine_blocks(aecore_suite_utils:node_name(?NODE), 1),
     {ok, []} = rpc(aec_tx_pool, peek, [infinity]),
@@ -2755,7 +2730,6 @@ register_oracle(ChainHeight, PubKey, PrivKey, Nonce, QueryFee, TTL) ->
                                         response_spec => <<"TODO">>,
                                         query_fee     => QueryFee,
                                         oracle_ttl    => TTL,
-                                        ttl           => 1000,
                                         fee           => 4 + TTLFee}),
     SignedTx = aetx_sign:sign(RegTx, PrivKey),
     SendTx = aec_base58c:encode(transaction, aetx_sign:serialize_to_binary(SignedTx)),
@@ -2770,7 +2744,6 @@ query_oracle(ChainHeight, PubKey, PrivKey, Oracle, Nonce, Query, TTL, QueryFee) 
                                        query_fee     => QueryFee,
                                        query_ttl     => TTL,
                                        response_ttl  => {delta, 10},
-                                       ttl           => 1000,
                                        fee           => QueryFee + 2 + TTLFee }),
     SignedTx = aetx_sign:sign(QueryTx, PrivKey),
     SendTx = aec_base58c:encode(transaction, aetx_sign:serialize_to_binary(SignedTx)),
@@ -2914,7 +2887,6 @@ ws_tx_on_chain(_Config) ->
            response_format => <<"the response spec">>,
            query_fee => 4,
            oracle_ttl => #{ type => delta, value => 500 },
-           ttl => 100,
            fee => 5 },
     #{<<"result">> := <<"ok">>,
       <<"tx_hash">> := TxHash } = ws_do_request(ConnPid, oracle, register, RegisterData),
@@ -2962,7 +2934,6 @@ ws_oracles(_Config) ->
            response_ttl => #{ type => delta, value => 10 },
            query => <<"How are you doing?">>,
            query_fee => 4,
-           ttl => 100,
            fee => 7 },
     #{<<"result">> := <<"ok">>,
       <<"query_id">> := QId } = ws_do_request(ConnPid, oracle, query, QueryData),
@@ -2980,7 +2951,6 @@ ws_oracles(_Config) ->
     ResponseData = #{ type => 'OracleResponseTxObject',
                       query_id => QId,
                       response => <<"I am fine, thank you!">>,
-                      ttl => 100,
                       fee => 3 },
     #{<<"result">> := <<"ok">>,
       <<"query_id">> := QId } = ws_do_request(ConnPid, oracle, response, ResponseData),
@@ -2994,7 +2964,6 @@ ws_oracles(_Config) ->
         #{ type => 'OracleExtendTxObject',
            oracle => OId,
            oracle_ttl => #{ type => delta, value => 50 },
-           ttl => 100,
            fee => 2 },
     #{<<"result">> := <<"ok">>,
       <<"tx_hash">> := ExtendTxHash,
@@ -3515,8 +3484,7 @@ channel_options(IPubkey, RPubkey, IAmt, RAmt, Other) ->
                   push_amount => 10,
                   initiator_amount => IAmt,
                   responder_amount => RAmt,
-                  channel_reserve => 2,
-                  ttl => 1000
+                  channel_reserve => 2
                 }, Other).
 
 %% changing of another account's balance is checked in pending_transactions test
@@ -3782,23 +3750,21 @@ get_tx(TxHash, TxEncoding) ->
     http_request(Host, get, "tx/" ++ binary_to_list(TxHash), Params).
 
 post_spend_tx(Recipient, Amount, Fee) ->
-    post_spend_tx(Recipient, Amount, Fee, <<"foo">>, 100).
+    post_spend_tx(Recipient, Amount, Fee, <<"foo">>).
 
-post_spend_tx(Recipient, Amount, Fee, Payload, TTL) ->
+post_spend_tx(Recipient, Amount, Fee, Payload) ->
     Host = internal_address(),
     http_request(Host, post, "spend-tx",
                  #{recipient_pubkey => aec_base58c:encode(
                                          account_pubkey, Recipient),
                    amount => Amount,
                    fee => Fee,
-                   ttl => TTL,
                    payload => Payload}).
 
 post_name_preclaim_tx(Commitment, Fee) ->
     Host = internal_address(),
     http_request(Host, post, "name-preclaim-tx",
                  #{commitment => aec_base58c:encode(commitment, Commitment),
-                   ttl        => 100,
                    fee        => Fee}).
 
 post_name_claim_tx(Name, NameSalt, Fee) ->
@@ -3806,7 +3772,6 @@ post_name_claim_tx(Name, NameSalt, Fee) ->
     http_request(Host, post, "name-claim-tx",
                  #{name      => Name,
                    name_salt => NameSalt,
-                   ttl       => 100,
                    fee       => Fee}).
 
 post_name_update_tx(NameHash, NameTTL, Pointers, ClientTTL, Fee) ->
@@ -3816,7 +3781,6 @@ post_name_update_tx(NameHash, NameTTL, Pointers, ClientTTL, Fee) ->
                    client_ttl => ClientTTL,
                    pointers   => Pointers,
                    name_ttl   => NameTTL,
-                   ttl        => 100,
                    fee        => Fee}).
 
 post_name_transfer_tx(NameHash, RecipientPubKey, Fee) ->
@@ -3824,14 +3788,12 @@ post_name_transfer_tx(NameHash, RecipientPubKey, Fee) ->
     http_request(Host, post, "name-transfer-tx",
                  #{name_hash        => aec_base58c:encode(name, NameHash),
                    recipient_pubkey => aec_base58c:encode(account_pubkey, RecipientPubKey),
-                   ttl              => 100,
                    fee              => Fee}).
 
 post_name_revoke_tx(NameHash, Fee) ->
     Host = internal_address(),
     http_request(Host, post, "name-revoke-tx",
                  #{name_hash => aec_base58c:encode(name, NameHash),
-                   ttl       => 100,
                    fee       => Fee}).
 
 get_commitment_hash(Name, Salt) ->

--- a/apps/aens/include/ns_txs.hrl
+++ b/apps/aens/include/ns_txs.hrl
@@ -10,7 +10,7 @@
           nonce      :: integer(),
           commitment :: binary(),
           fee        :: integer(),
-          ttl        :: aec_blocks:height()
+          ttl        :: aetx:tx_ttl()
          }).
 
 -record(ns_claim_tx, {
@@ -19,7 +19,7 @@
           name      :: binary(),
           name_salt :: integer(),
           fee       :: integer(),
-          ttl       :: aec_blocks:height()
+          ttl       :: aetx:tx_ttl()
          }).
 
 -record(ns_update_tx, {
@@ -30,7 +30,7 @@
           pointers   :: [{binary(),binary()}],
           client_ttl :: integer(),
           fee        :: integer(),
-          ttl        :: aec_blocks:height()
+          ttl        :: aetx:tx_ttl()
          }).
 
 -record(ns_transfer_tx, {
@@ -39,7 +39,7 @@
           name_hash         :: binary(),
           recipient_account :: aec_keys:pubkey(),
           fee               :: integer(),
-          ttl               :: aec_blocks:height()
+          ttl               :: aetx:tx_ttl()
          }).
 
 -record(ns_revoke_tx, {
@@ -47,5 +47,5 @@
           nonce     :: integer(),
           name_hash :: binary(),
           fee       :: integer(),
-          ttl       :: aec_blocks:height()
+          ttl       :: aetx:tx_ttl()
          }).

--- a/apps/aens/src/aens_claim_tx.erl
+++ b/apps/aens/src/aens_claim_tx.erl
@@ -52,14 +52,13 @@ new(#{account   := AccountPubKey,
       nonce     := Nonce,
       name      := Name,
       name_salt := NameSalt,
-      fee       := Fee,
-      ttl       := TTL}) ->
+      fee       := Fee} = Args) ->
     Tx = #ns_claim_tx{account   = AccountPubKey,
                       nonce     = Nonce,
                       name      = Name,
                       name_salt = NameSalt,
                       fee       = Fee,
-                      ttl       = TTL},
+                      ttl       = maps:get(ttl, Args, 0)},
     {ok, aetx:new(?MODULE, Tx)}.
 
 -spec type() -> atom().
@@ -70,7 +69,7 @@ type() ->
 fee(#ns_claim_tx{fee = Fee}) ->
     Fee.
 
--spec ttl(tx()) -> aec_blocks:height().
+-spec ttl(tx()) -> aetx:tx_ttl().
 ttl(#ns_claim_tx{ttl = TTL}) ->
     TTL.
 
@@ -82,7 +81,8 @@ nonce(#ns_claim_tx{nonce = Nonce}) ->
 origin(#ns_claim_tx{account = AccountPubKey}) ->
     AccountPubKey.
 
--spec check(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) -> {ok, aec_trees:trees()} | {error, term()}.
+-spec check(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) ->
+        {ok, aec_trees:trees()} | {error, term()}.
 check(#ns_claim_tx{account = AccountPubKey, nonce = Nonce,
                    fee = Fee, name = Name, name_salt = NameSalt}, _Context, Trees, Height, _ConsensusVersion) ->
     case aens_utils:to_ascii(Name) of
@@ -105,7 +105,8 @@ check(#ns_claim_tx{account = AccountPubKey, nonce = Nonce,
             {error, Reason}
     end.
 
--spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) -> {ok, aec_trees:trees()}.
+-spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) ->
+        {ok, aec_trees:trees()}.
 process(#ns_claim_tx{account = AccountPubKey, nonce = Nonce, fee = Fee,
                      name = PlainName, name_salt = NameSalt} = ClaimTx, _Context, Trees0, Height, _ConsensusVersion) ->
     AccountsTree0 = aec_trees:accounts(Trees0),

--- a/apps/aens/src/aens_preclaim_tx.erl
+++ b/apps/aens/src/aens_preclaim_tx.erl
@@ -51,13 +51,12 @@
 new(#{account    := AccountPubKey,
       nonce      := Nonce,
       commitment := Commitment,
-      fee        := Fee,
-      ttl        := TTL}) ->
+      fee        := Fee} = Args) ->
     Tx = #ns_preclaim_tx{account    = AccountPubKey,
                          nonce      = Nonce,
                          commitment = Commitment,
                          fee        = Fee,
-                         ttl        = TTL},
+                         ttl        = maps:get(ttl, Args, 0)},
     {ok, aetx:new(?MODULE, Tx)}.
 
 -spec type() -> atom().
@@ -68,7 +67,7 @@ type() ->
 fee(#ns_preclaim_tx{fee = Fee}) ->
     Fee.
 
--spec ttl(tx()) -> aec_blocks:height().
+-spec ttl(tx()) -> aetx:tx_ttl().
 ttl(#ns_preclaim_tx{ttl = TTL}) ->
     TTL.
 
@@ -80,7 +79,8 @@ nonce(#ns_preclaim_tx{nonce = Nonce}) ->
 origin(#ns_preclaim_tx{account = AccountPubKey}) ->
     AccountPubKey.
 
--spec check(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) -> {ok, aec_trees:trees()} | {error, term()}.
+-spec check(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) ->
+        {ok, aec_trees:trees()} | {error, term()}.
 check(#ns_preclaim_tx{account = AccountPubKey, nonce = Nonce,
                       fee = Fee, commitment = Commitment}, _Context, Trees, _Height, _ConsensusVersion) ->
     Checks =
@@ -92,7 +92,8 @@ check(#ns_preclaim_tx{account = AccountPubKey, nonce = Nonce,
         {error, Reason} -> {error, Reason}
     end.
 
--spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) -> {ok, aec_trees:trees()}.
+-spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) ->
+        {ok, aec_trees:trees()}.
 process(#ns_preclaim_tx{account = AccountPubKey, fee = Fee,
                         nonce = Nonce} = PreclaimTx, _Context, Trees0, Height, _ConsensusVersion) ->
     AccountsTree0 = aec_trees:accounts(Trees0),

--- a/apps/aens/src/aens_revoke_tx.erl
+++ b/apps/aens/src/aens_revoke_tx.erl
@@ -46,13 +46,12 @@
 new(#{account   := AccountPubKey,
       nonce     := Nonce,
       name_hash := NameHash,
-      fee       := Fee,
-      ttl       := TTL}) ->
+      fee       := Fee} = Args) ->
     Tx = #ns_revoke_tx{account   = AccountPubKey,
                        nonce     = Nonce,
                        name_hash = NameHash,
                        fee       = Fee,
-                       ttl       = TTL},
+                       ttl       = maps:get(ttl, Args, 0)},
     {ok, aetx:new(?MODULE, Tx)}.
 
 -spec type() -> atom().
@@ -63,7 +62,7 @@ type() ->
 fee(#ns_revoke_tx{fee = Fee}) ->
     Fee.
 
--spec ttl(tx()) -> aec_blocks:height().
+-spec ttl(tx()) -> aetx:tx_ttl().
 ttl(#ns_revoke_tx{ttl = TTL}) ->
     TTL.
 
@@ -75,7 +74,8 @@ nonce(#ns_revoke_tx{nonce = Nonce}) ->
 origin(#ns_revoke_tx{account = AccountPubKey}) ->
     AccountPubKey.
 
--spec check(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) -> {ok, aec_trees:trees()} | {error, term()}.
+-spec check(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) ->
+        {ok, aec_trees:trees()} | {error, term()}.
 check(#ns_revoke_tx{account = AccountPubKey, nonce = Nonce,
                     fee = Fee, name_hash = NameHash}, _Context, Trees, _Height, _ConsensusVersion) ->
     Checks =
@@ -87,7 +87,8 @@ check(#ns_revoke_tx{account = AccountPubKey, nonce = Nonce,
         {error, Reason} -> {error, Reason}
     end.
 
--spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) -> {ok, aec_trees:trees()}.
+-spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) ->
+        {ok, aec_trees:trees()}.
 process(#ns_revoke_tx{account = AccountPubKey, fee = Fee,
                       name_hash = NameHash, nonce = Nonce}, _Context, Trees0, Height, _ConsensusVersion) ->
     AccountsTree0 = aec_trees:accounts(Trees0),

--- a/apps/aens/src/aens_transfer_tx.erl
+++ b/apps/aens/src/aens_transfer_tx.erl
@@ -51,14 +51,13 @@ new(#{account           := AccountPubKey,
       nonce             := Nonce,
       name_hash         := NameHash,
       recipient_account := RecipientAccountPubKey,
-      fee               := Fee,
-      ttl               := TTL}) ->
+      fee               := Fee} = Args) ->
     Tx = #ns_transfer_tx{account           = AccountPubKey,
                          nonce             = Nonce,
                          name_hash         = NameHash,
                          recipient_account = RecipientAccountPubKey,
                          fee               = Fee,
-                         ttl               = TTL},
+                         ttl               = maps:get(ttl, Args, 0)},
     {ok, aetx:new(?MODULE, Tx)}.
 
 -spec type() -> atom().
@@ -69,7 +68,7 @@ type() ->
 fee(#ns_transfer_tx{fee = Fee}) ->
     Fee.
 
--spec ttl(tx()) -> aec_blocks:height().
+-spec ttl(tx()) -> aetx:tx_ttl().
 ttl(#ns_transfer_tx{ttl = TTL}) ->
     TTL.
 
@@ -81,7 +80,8 @@ nonce(#ns_transfer_tx{nonce = Nonce}) ->
 origin(#ns_transfer_tx{account = AccountPubKey}) ->
     AccountPubKey.
 
--spec check(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) -> {ok, aec_trees:trees()} | {error, term()}.
+-spec check(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) ->
+        {ok, aec_trees:trees()} | {error, term()}.
 check(#ns_transfer_tx{account = AccountPubKey, nonce = Nonce,
                       fee = Fee, name_hash = NameHash}, _Context, Trees, _Height, _ConsensusVersion) ->
     Checks =
@@ -93,9 +93,11 @@ check(#ns_transfer_tx{account = AccountPubKey, nonce = Nonce,
         {error, Reason} -> {error, Reason}
     end.
 
--spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) -> {ok, aec_trees:trees()}.
+-spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) ->
+        {ok, aec_trees:trees()}.
 process(#ns_transfer_tx{account = AccountPubKey, fee = Fee,
-                        name_hash = NameHash, nonce = Nonce} = TransferTx, _Context, Trees0, _Height, _ConsensusVersion) ->
+                        name_hash = NameHash, nonce = Nonce} = TransferTx,
+        _Context, Trees0, _Height, _ConsensusVersion) ->
     AccountsTree0 = aec_trees:accounts(Trees0),
     NamesTree0 = aec_trees:ns(Trees0),
 

--- a/apps/aens/src/aens_update_tx.erl
+++ b/apps/aens/src/aens_update_tx.erl
@@ -55,8 +55,7 @@ new(#{account    := AccountPubKey,
       name_ttl   := NameTTL,
       pointers   := Pointers,
       client_ttl := ClientTTL,
-      fee        := Fee,
-      ttl        := TTL}) ->
+      fee        := Fee} = Args) ->
     Tx = #ns_update_tx{account    = AccountPubKey,
                        nonce      = Nonce,
                        name_hash  = NameHash,
@@ -64,7 +63,7 @@ new(#{account    := AccountPubKey,
                        pointers   = Pointers,
                        client_ttl = ClientTTL,
                        fee        = Fee,
-                       ttl        = TTL},
+                       ttl        = maps:get(ttl, Args, 0)},
     {ok, aetx:new(?MODULE, Tx)}.
 
 -spec type() -> atom().
@@ -75,7 +74,7 @@ type() ->
 fee(#ns_update_tx{fee = Fee}) ->
     Fee.
 
--spec ttl(tx()) -> aec_blocks:height().
+-spec ttl(tx()) -> aetx:tx_ttl().
 ttl(#ns_update_tx{ttl = TTL}) ->
     TTL.
 

--- a/apps/aens/test/aens_test_utils.erl
+++ b/apps/aens/test/aens_test_utils.erl
@@ -119,12 +119,11 @@ preclaim_tx_spec(PubKey, Commitment, Spec0, State) ->
       nonce      => maps:get(nonce, Spec),
       commitment => Commitment,
       fee        => maps:get(fee, Spec),
-      ttl        => maps:get(ttl, Spec)}.
+      ttl        => maps:get(ttl, Spec, 0)}.
 
 preclaim_tx_default_spec(PubKey, State) ->
     #{nonce => try next_nonce(PubKey, State) catch _:_ -> 0 end,
-      fee   => 3,
-      ttl   => 100}.
+      fee   => 3}.
 
 %%%===================================================================
 %%% Claim tx
@@ -140,12 +139,11 @@ claim_tx_spec(PubKey, Name, NameSalt, Spec0, State) ->
       name      => Name,
       name_salt => NameSalt,
       fee       => maps:get(fee, Spec),
-      ttl       => maps:get(ttl, Spec)}.
+      ttl       => maps:get(ttl, Spec, 0)}.
 
 claim_tx_default_spec(PubKey, State) ->
     #{nonce => try next_nonce(PubKey, State) catch _:_ -> 0 end,
-      fee   => 3,
-      ttl   => 100}.
+      fee   => 3}.
 
 %%%===================================================================
 %%% Update tx
@@ -163,15 +161,14 @@ update_tx_spec(PubKey, NameHash, Spec0, State) ->
       pointers   => maps:get(pointers, Spec),
       client_ttl => maps:get(client_ttl, Spec),
       fee        => maps:get(fee, Spec),
-      ttl        => maps:get(ttl, Spec)}.
+      ttl        => maps:get(ttl, Spec, 0)}.
 
 update_tx_default_spec(PubKey, State) ->
     #{nonce      => try next_nonce(PubKey, State) catch _:_ -> 0 end,
       name_ttl   => 20000,
       pointers   => [{<<"key">>, <<"val">>}],
       client_ttl => 60000,
-      fee        => 3,
-      ttl        => 100}.
+      fee        => 3}.
 
 %%%===================================================================
 %%% Transfer tx
@@ -187,12 +184,11 @@ transfer_tx_spec(PubKey, NameHash, RecipientAccount, Spec0, State) ->
       name_hash         => NameHash,
       recipient_account => RecipientAccount,
       fee               => maps:get(fee, Spec),
-      ttl               => maps:get(ttl, Spec)}.
+      ttl               => maps:get(ttl, Spec, 0)}.
 
 transfer_tx_default_spec(PubKey, State) ->
     #{nonce => try next_nonce(PubKey, State) catch _:_ -> 0 end,
-      fee   => 3,
-      ttl   => 100}.
+      fee   => 3}.
 
 %%%===================================================================
 %%% Revoke tx
@@ -207,9 +203,8 @@ revoke_tx_spec(PubKey, NameHash, Spec0, State) ->
       nonce     => maps:get(nonce, Spec),
       name_hash => NameHash,
       fee       => maps:get(fee, Spec),
-      ttl       => maps:get(ttl, Spec)}.
+      ttl       => maps:get(ttl, Spec, 0)}.
 
 revoke_tx_default_spec(PubKey, State) ->
     #{nonce => try next_nonce(PubKey, State) catch _:_ -> 0 end,
-      fee   => 3,
-      ttl   => 100}.
+      fee   => 3}.

--- a/apps/aeoracle/include/oracle_txs.hrl
+++ b/apps/aeoracle/include/oracle_txs.hrl
@@ -11,7 +11,7 @@
           query_fee                                   :: integer(),
           oracle_ttl                                  :: aeo_oracles:ttl(),
           fee                                         :: integer(),
-          ttl                                         :: aec_blocks:height()
+          ttl                                         :: aetx:tx_ttl()
           }).
 
 -record(oracle_extend_tx, {
@@ -19,7 +19,7 @@
           nonce      :: integer(),
           oracle_ttl :: aeo_oracles:relative_ttl(),
           fee        :: integer(),
-          ttl        :: aec_blocks:height()
+          ttl        :: aetx:tx_ttl()
           }).
 
 -record(oracle_query_tx, {
@@ -31,7 +31,7 @@
           query_ttl    :: aeo_oracles:ttl(),
           response_ttl :: aeo_oracles:relative_ttl(),
           fee          :: integer(),
-          ttl          :: aec_blocks:height()
+          ttl          :: aetx:tx_ttl()
           }).
 
 -record(oracle_response_tx, {
@@ -40,5 +40,5 @@
           query_id :: aeo_query:id(),
           response :: aeo_oracles:response(),
           fee      :: integer(),
-          ttl      :: aec_blocks:height()
+          ttl      :: aetx:tx_ttl()
           }).

--- a/apps/aeoracle/src/aeo_extend_tx.erl
+++ b/apps/aeoracle/src/aeo_extend_tx.erl
@@ -51,7 +51,7 @@ oracle_ttl(#oracle_extend_tx{oracle_ttl = OTTL}) ->
 fee(#oracle_extend_tx{fee = Fee}) ->
     Fee.
 
--spec ttl(tx()) -> aec_blocks:height().
+-spec ttl(tx()) -> aetx:tx_ttl().
 ttl(#oracle_extend_tx{ttl = TTL}) ->
     TTL.
 
@@ -59,13 +59,12 @@ ttl(#oracle_extend_tx{ttl = TTL}) ->
 new(#{oracle     := OraclePK,
       nonce      := Nonce,
       oracle_ttl := OracleTTL,
-      fee        := Fee,
-      ttl        := TTL}) ->
+      fee        := Fee} = Args) ->
     Tx = #oracle_extend_tx{oracle     = OraclePK,
                            nonce      = Nonce,
                            oracle_ttl = OracleTTL,
                            fee        = Fee,
-                           ttl        = TTL},
+                           ttl        = maps:get(ttl, Args, 0)},
     {ok, aetx:new(?MODULE, Tx)}.
 
 -spec type() -> atom().

--- a/apps/aeoracle/src/aeo_query_tx.erl
+++ b/apps/aeoracle/src/aeo_query_tx.erl
@@ -76,8 +76,7 @@ new(#{sender        := SenderPubKey,
       query_fee     := QueryFee,
       query_ttl     := QueryTTL,
       response_ttl  := ResponseTTL,
-      fee           := Fee,
-      ttl           := TTL}) ->
+      fee           := Fee} = Args) ->
     Tx = #oracle_query_tx{sender        = SenderPubKey,
                           nonce         = Nonce,
                           oracle        = Oracle,
@@ -86,7 +85,7 @@ new(#{sender        := SenderPubKey,
                           query_ttl     = QueryTTL,
                           response_ttl  = ResponseTTL,
                           fee           = Fee,
-                          ttl           = TTL},
+                          ttl           = maps:get(ttl, Args, 0)},
     {ok, aetx:new(?MODULE, Tx)}.
 
 -spec type() -> atom().
@@ -97,7 +96,7 @@ type() ->
 fee(#oracle_query_tx{fee = F}) ->
     F.
 
--spec ttl(tx()) -> aec_blocks:height().
+-spec ttl(tx()) -> aetx:tx_ttl().
 ttl(#oracle_query_tx{ttl = TTL}) ->
     TTL.
 

--- a/apps/aeoracle/src/aeo_register_tx.erl
+++ b/apps/aeoracle/src/aeo_register_tx.erl
@@ -66,7 +66,7 @@ oracle_ttl(#oracle_register_tx{oracle_ttl = TTL}) ->
 fee(#oracle_register_tx{fee = Fee}) ->
     Fee.
 
--spec ttl(tx()) -> aec_blocks:height().
+-spec ttl(tx()) -> aetx:tx_ttl().
 ttl(#oracle_register_tx{ttl = TTL}) ->
     TTL.
 
@@ -77,8 +77,7 @@ new(#{account       := AccountPubKey,
       response_spec := ResponseSpec,
       query_fee     := QueryFee,
       oracle_ttl    := OracleTTL,
-      fee           := Fee,
-      ttl           := TTL}) ->
+      fee           := Fee} = Args) ->
     Tx = #oracle_register_tx{account       = AccountPubKey,
                              nonce         = Nonce,
                              query_spec    = QuerySpec,
@@ -86,7 +85,7 @@ new(#{account       := AccountPubKey,
                              query_fee     = QueryFee,
                              oracle_ttl    = OracleTTL,
                              fee           = Fee,
-                             ttl           = TTL},
+                             ttl           = maps:get(ttl, Args, 0)},
     {ok, aetx:new(?MODULE, Tx)}.
 
 -spec type() -> atom().

--- a/apps/aeoracle/src/aeo_response_tx.erl
+++ b/apps/aeoracle/src/aeo_response_tx.erl
@@ -58,14 +58,13 @@ new(#{oracle   := Oracle,
       nonce    := Nonce,
       query_id := QId,
       response := Response,
-      fee      := Fee,
-      ttl      := TTL}) ->
+      fee      := Fee} = Args) ->
     Tx = #oracle_response_tx{oracle   = Oracle,
                              nonce    = Nonce,
                              query_id = QId,
                              response = Response,
                              fee      = Fee,
-                             ttl      = TTL},
+                             ttl      = maps:get(ttl, Args, 0)},
     {ok, aetx:new(?MODULE, Tx)}.
 
 -spec type() -> atom().
@@ -76,7 +75,7 @@ type() ->
 fee(#oracle_response_tx{fee = F}) ->
     F.
 
--spec ttl(tx()) -> aec_blocks:height().
+-spec ttl(tx()) -> aetx:tx_ttl().
 ttl(#oracle_response_tx{ttl = TTL}) ->
     TTL.
 

--- a/apps/aeoracle/test/aeo_test_utils.erl
+++ b/apps/aeoracle/test/aeo_test_utils.erl
@@ -77,14 +77,13 @@ register_tx(PubKey, Spec0, State) ->
                                 , nonce      = maps:get(nonce, Spec)
                                 , oracle_ttl = maps:get(oracle_ttl, Spec)
                                 , fee        = maps:get(fee, Spec)
-                                , ttl        = maps:get(ttl, Spec)
+                                , ttl        = maps:get(ttl, Spec, 0)
                                 , query_fee  = maps:get(query_fee, Spec)
                                 }).
 
 register_tx_default_spec(PubKey, State) ->
     #{ oracle_ttl => {delta, maps:get(oracle, ttl_defaults())}
      , fee        => 5
-     , ttl        => 100
      , nonce      => try next_nonce(PubKey, State) catch _:_ -> 0 end
      , query_fee  => 5
      }.
@@ -103,13 +102,12 @@ extend_tx(PubKey, Spec0, State) ->
                               , nonce      = maps:get(nonce, Spec)
                               , oracle_ttl = maps:get(oracle_ttl, Spec)
                               , fee        = maps:get(fee, Spec)
-                              , ttl        = maps:get(ttl, Spec)
+                              , ttl        = maps:get(ttl, Spec, 0)
                               }).
 
 extend_tx_default_spec(PubKey, State) ->
     #{ oracle_ttl => {delta, maps:get(extend, ttl_defaults())}
      , fee        => 5
-     , ttl        => 100
      , nonce      => try next_nonce(PubKey, State) catch _:_ -> 0 end
      }.
 
@@ -131,7 +129,7 @@ query_tx(PubKey, OracleKey, Spec0, State) ->
                              , query_ttl = maps:get(query_ttl, Spec)
                              , response_ttl = maps:get(response_ttl, Spec)
                              , fee = maps:get(fee, Spec)
-                             , ttl = maps:get(ttl, Spec)
+                             , ttl = maps:get(ttl, Spec, 0)
                              }).
 
 query_tx_default_spec(PubKey, State) ->
@@ -140,7 +138,6 @@ query_tx_default_spec(PubKey, State) ->
      , query_ttl    => {delta, maps:get(query, ttl_defaults())}
      , response_ttl => {delta, maps:get(response, ttl_defaults())}
      , fee          => 5
-     , ttl          => 100
      , nonce        => try next_nonce(PubKey, State) catch _:_ -> 0 end
      }.
 
@@ -159,13 +156,12 @@ response_tx(PubKey, ID, Response, Spec0, State) ->
                                 , query_id = ID
                                 , response = Response
                                 , fee      = maps:get(fee, Spec)
-                                , ttl      = maps:get(ttl, Spec)
+                                , ttl      = maps:get(ttl, Spec, 0)
                                 }).
 
 response_tx_default_spec(PubKey, State) ->
     #{ nonce    => try next_nonce(PubKey, State) catch _:_ -> 0 end
      , fee      => 3
-     , ttl      => 100
      }.
 
 

--- a/apps/aeoracle/test/aeoracle_SUITE.erl
+++ b/apps/aeoracle/test/aeoracle_SUITE.erl
@@ -94,8 +94,8 @@ register_oracle_negative(_Cfg) ->
     {error, too_low_fee} = aetx:check(RTx4, Trees, CurrHeight, ?PROTOCOL_VERSION),
 
     %% Test too low TTL
-    RTx5 = aeo_test_utils:register_tx(PubKey, #{ttl => 0}, S1),
-    {error, ttl_expired} = aetx:check(RTx5, Trees, CurrHeight, ?PROTOCOL_VERSION),
+    RTx5 = aeo_test_utils:register_tx(PubKey, #{ttl => 1}, S1),
+    {error, ttl_expired} = aetx:check(RTx5, Trees, 2, ?PROTOCOL_VERSION),
     ok.
 
 register_oracle(_Cfg) ->

--- a/apps/aetx/src/aetx.erl
+++ b/apps/aetx/src/aetx.erl
@@ -28,8 +28,6 @@
 -export([tx/1]).
 -endif.
 
--define(MAXINT, 16#FFFFffffFFFFffff).
-
 %% -- Types ------------------------------------------------------------------
 -record(aetx, { type :: tx_type()
               , cb   :: module()
@@ -85,10 +83,9 @@
 %% logic is different.
 
 -type tx_ttl() :: 0 | aec_blocks:height().
-%% A transaction TTL is either an absolute block height, or the
-%% transaction does not have a TTL. The latter is represented as 0
-%% internally to get a small serialization. `aetx:ttl/1' returns MAXINT
-%% (= 0xFFFFFFFFFFFFFFFF) in this case.
+%% A transaction TTL is either an absolute block height, or the transaction
+%% does not have a TTL. The latter is represented as 0 to get a small
+%% serialization. `aetx:ttl/1' returns `max_ttl' in this case.
 
 -export_type([ tx/0
              , tx_instance/0
@@ -178,13 +175,13 @@ accounts(#aetx{ cb = CB, tx = Tx }) ->
 signers(#aetx{ cb = CB, tx = Tx }, Trees) ->
     CB:signers(Tx, Trees).
 
-%% Internally we let 0 represent no TTL/infinity in order to keep the
-%% serialization as short as possible. Since there are no transactions in the
-%% genesis block there is little risk for confusion.
--spec ttl(Tx :: tx()) -> non_neg_integer().
+%% We let 0 represent no TTL/infinity in order to keep the serialization as
+%% short as possible. Since there are no transactions in the genesis block
+%% there is little risk for confusion.
+-spec ttl(Tx :: tx()) -> max_ttl | aec_blocks:height().
 ttl(#aetx{ cb = CB, tx = Tx }) ->
     case CB:ttl(Tx) of
-        0 -> ?MAXINT;
+        0 -> max_ttl;
         N -> N
     end.
 

--- a/apps/aetx/src/aetx.erl
+++ b/apps/aetx/src/aetx.erl
@@ -28,6 +28,8 @@
 -export([tx/1]).
 -endif.
 
+-define(MAXINT, 16#FFFFffffFFFFffff).
+
 %% -- Types ------------------------------------------------------------------
 -record(aetx, { type :: tx_type()
               , cb   :: module()
@@ -77,14 +79,22 @@
                      | aesc_settle_tx:tx()
                      | aesc_offchain_tx:tx().
 
-%% @doc Where does this transaction come from? Is it a top level transaction or was it created by
-%%      smart contract. In the latter case the fee logic is different.
 -type tx_context() :: aetx_transaction | aetx_contract.
+%% Where does this transaction come from? Is it a top level transaction
+%% or was it created by a smart contract. In the latter case the fee
+%% logic is different.
+
+-type tx_ttl() :: 0 | aec_blocks:height().
+%% A transaction TTL is either an absolute block height, or the
+%% transaction does not have a TTL. The latter is represented as 0
+%% internally to get a small serialization. `aetx:ttl/1' returns MAXINT
+%% (= 0xFFFFFFFFFFFFFFFF) in this case.
 
 -export_type([ tx/0
              , tx_instance/0
              , tx_type/0
-             , tx_context/0 ]).
+             , tx_context/0
+             , tx_ttl/0 ]).
 
 %% -- Behaviour definition ---------------------------------------------------
 
@@ -151,7 +161,7 @@ tx_type(TxType) when is_atom(TxType) ->
 fee(#aetx{ cb = CB, tx = Tx }) ->
     CB:fee(Tx).
 
--spec nonce(Tx :: tx()) -> Nonce :: non_neg_integer() | undefined.
+-spec nonce(Tx :: tx()) -> Nonce :: non_neg_integer().
 nonce(#aetx{ cb = CB, tx = Tx }) ->
     CB:nonce(Tx).
 
@@ -168,11 +178,21 @@ accounts(#aetx{ cb = CB, tx = Tx }) ->
 signers(#aetx{ cb = CB, tx = Tx }, Trees) ->
     CB:signers(Tx, Trees).
 
+%% Internally we let 0 represent no TTL/infinity in order to keep the
+%% serialization as short as possible. Since there are no transactions in the
+%% genesis block there is little risk for confusion.
+-spec ttl(Tx :: tx()) -> non_neg_integer().
+ttl(#aetx{ cb = CB, tx = Tx }) ->
+    case CB:ttl(Tx) of
+        0 -> ?MAXINT;
+        N -> N
+    end.
+
 -spec check(Tx :: tx(), Trees :: aec_trees:trees(), Height :: non_neg_integer(),
             ConsensusVersion :: non_neg_integer()) ->
     {ok, NewTrees :: aec_trees:trees()} | {error, Reason :: term()}.
-check(#aetx{ cb = CB, tx = Tx }, Trees, Height, ConsensusVersion) ->
-    case {CB:fee(Tx) >= aec_governance:minimum_tx_fee(), CB:ttl(Tx) >= Height} of
+check(AeTx = #aetx{ cb = CB, tx = Tx }, Trees, Height, ConsensusVersion) ->
+    case {CB:fee(Tx) >= aec_governance:minimum_tx_fee(), ttl(AeTx) >= Height} of
         {true, true} ->
             CB:check(Tx, aetx_transaction, Trees, Height, ConsensusVersion);
         {false, _} ->
@@ -202,8 +222,12 @@ process_from_contract(#aetx{ cb = CB, tx = Tx }, Trees, Height, ConsensusVersion
 
 -spec serialize_for_client(Tx :: tx()) -> map().
 serialize_for_client(#aetx{ cb = CB, type = Type, tx = Tx }) ->
-    Res = CB:for_client(Tx),
-    Res#{ <<"type">> => tx_type(Type) }.
+    Res0 = CB:for_client(Tx),
+    Res1 = Res0#{ <<"type">> => tx_type(Type) },
+    case maps:get(<<"ttl">>, Res1, 0) of
+        0 -> maps:remove(<<"ttl">>, Res1);
+        _ -> Res1
+    end.
 
 -spec serialize_to_binary(Tx :: tx()) -> term().
 serialize_to_binary(#aetx{ cb = CB, type = Type, tx = Tx }) ->

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -2224,7 +2224,6 @@ definitions:
     - recipient_pubkey
     - amount
     - fee
-    - ttl
     - payload
   OracleRegisterTx:
     type: object
@@ -2255,7 +2254,6 @@ definitions:
     - query_fee
     - fee
     - oracle_ttl
-    - ttl
   OracleRegisterResponse:
     type: object
     properties:
@@ -2282,7 +2280,6 @@ definitions:
     required:
     - fee
     - oracle_ttl
-    - ttl
   OracleQueryTx:
     type: object
     properties:
@@ -2316,7 +2313,6 @@ definitions:
     - query_ttl
     - response_ttl
     - fee
-    - ttl
   OracleResponseTx:
     type: object
     properties:
@@ -2340,7 +2336,6 @@ definitions:
     - query_id
     - response
     - fee
-    - ttl
   OracleQueryResponse:
     type: object
     properties:
@@ -2399,7 +2394,6 @@ definitions:
     required:
     - commitment
     - fee
-    - ttl
   NameClaimTx:
     type: object
     properties:
@@ -2423,7 +2417,6 @@ definitions:
     - name
     - name_salt
     - fee
-    - ttl
   NameUpdateTx:
     type: object
     properties:
@@ -2453,7 +2446,6 @@ definitions:
     - name_ttl
     - client_ttl
     - pointers
-    - ttl
     - fee
   NameTransferTx:
     type: object
@@ -2477,7 +2469,6 @@ definitions:
     - name_hash
     - recipient_pubkey
     - fee
-    - ttl
   NameRevokeTx:
     type: object
     properties:
@@ -2497,7 +2488,6 @@ definitions:
     required:
     - name_hash
     - fee
-    - ttl
   NameCommitmentHash:
     type: object
     properties:
@@ -2555,7 +2545,6 @@ definitions:
     - push_amount
     - channel_reserve
     - lock_period
-    - ttl
     - fee
   ChannelDepositTx:
     type: object
@@ -2584,7 +2573,6 @@ definitions:
     - channel_id
     - from
     - amount
-    - ttl
     - fee
     - nonce
   ChannelWithdrawalTx:
@@ -2614,7 +2602,6 @@ definitions:
     - channel_id
     - to
     - amount
-    - ttl
     - fee
     - nonce
   ChannelCloseMutualTx:
@@ -2646,7 +2633,6 @@ definitions:
     - channel_id
     - initiator_amount
     - responder_amount
-    - ttl
     - fee
     - nonce
   ChannelCloseSoloTx:
@@ -2674,7 +2660,6 @@ definitions:
     - channel_id
     - from
     - payload
-    - ttl
     - fee
   ChannelSlashTx:
     type: object
@@ -2701,7 +2686,6 @@ definitions:
     - channel_id
     - from
     - payload
-    - ttl
     - fee
   ChannelSettleTx:
     type: object
@@ -2735,7 +2719,6 @@ definitions:
     - from
     - initiator_amount
     - participant_amount
-    - ttl
     - fee
     - nonce
   PubKey:
@@ -3061,7 +3044,6 @@ definitions:
     - gas
     - gas_price
     - fee
-    - ttl
     - call_data
   ContractCallData:
     type: object
@@ -3108,7 +3090,6 @@ definitions:
     - contract
     - vm_version
     - fee
-    - ttl
     - amount
     - gas
     - gas_price
@@ -3161,7 +3142,6 @@ definitions:
     - contract
     - vm_version
     - fee
-    - ttl
     - amount
     - gas
     - gas_price

--- a/docs/release-notes/RELEASE-NOTES-0.16.0.md
+++ b/docs/release-notes/RELEASE-NOTES-0.16.0.md
@@ -2,7 +2,7 @@
 
 [This release][this-release] is focused on TODOFILLMEIN.
 It:
-* Transaction TTL is now optional (giving no TTL means the transaction is valid "forever").
+* Makes the transaction TTL optional (giving no TTL means the transaction is valid "forever").
 * TODO Improves the stability of the testnet.
 
 [this-release]: https://github.com/aeternity/epoch/releases/tag/v0.16.0

--- a/docs/release-notes/RELEASE-NOTES-0.16.0.md
+++ b/docs/release-notes/RELEASE-NOTES-0.16.0.md
@@ -2,6 +2,7 @@
 
 [This release][this-release] is focused on TODOFILLMEIN.
 It:
+* Transaction TTL is now optional (giving no TTL means the transaction is valid "forever").
 * TODO Improves the stability of the testnet.
 
 [this-release]: https://github.com/aeternity/epoch/releases/tag/v0.16.0


### PR DESCRIPTION
Internally represent no-ttl/infinity with 0 to keep serialisation short.