### PR TITLE
Give gas fees to miner (no mempool changes yet)

### DIFF
--- a/apps/aecontract/src/aect_call_tx.erl
+++ b/apps/aecontract/src/aect_call_tx.erl
@@ -155,7 +155,8 @@ process(#contract_call_tx{nonce = Nonce,
     Call0 = aect_call:new(caller(CallTx),
 			  nonce(CallTx),
 			  contract(CallTx),
-			  Height),
+			  Height,
+                          aect_call_tx:gas_price(CallTx)),
 
     %% Run the contract code. Also computes the amount of gas left and updates
     %% the call object.

--- a/apps/aecontract/src/aect_call_tx.erl
+++ b/apps/aecontract/src/aect_call_tx.erl
@@ -40,6 +40,8 @@
 -define(CONTRACT_CALL_TX_TYPE, contract_call_tx).
 -define(CONTRACT_CALL_TX_FEE, 2).
 
+-define(is_non_neg_integer(X), (is_integer(X) andalso (X >= 0))).
+
 -record(contract_call_tx, {
           caller     :: aec_id:id(),
           nonce      :: integer(),
@@ -116,7 +118,8 @@ check(#contract_call_tx{nonce = Nonce,
                         fee = Fee, amount = Value,
                         gas = GasLimit, gas_price = GasPrice,
                         call_stack = CallStack
-                       } = CallTx, Context, Trees, Height, _ConsensusVersion) ->
+                       } = CallTx, Context, Trees, Height, _ConsensusVersion
+     ) when ?is_non_neg_integer(GasPrice) ->
     CallerPubKey = caller(CallTx),
     Checks =
         case Context of

--- a/apps/aecontract/src/aect_create_tx.erl
+++ b/apps/aecontract/src/aect_create_tx.erl
@@ -206,7 +206,7 @@ process(#contract_create_tx{nonce      = Nonce,
               Nonce, Context, Height, Trees1, ConsensusVersion),
 
     %% Create the init call.
-    Call0 = aect_call:new(OwnerPubKey, Nonce, ContractPubKey, Height),
+    Call0 = aect_call:new(OwnerPubKey, Nonce, ContractPubKey, Height, GasPrice),
     %% Execute init calQl to get the contract state and return value
     {CallRes, Trees3} =
         run_contract(CreateTx, Call0, Height, Trees2, Contract, ContractPubKey),

--- a/apps/aecontract/src/aect_create_tx.erl
+++ b/apps/aecontract/src/aect_create_tx.erl
@@ -43,6 +43,8 @@
 %% Should this be in a header file somewhere?
 -define(PUB_SIZE, 32).
 
+-define(is_non_neg_integer(X), (is_integer(X) andalso (X >= 0))).
+
 -record(contract_create_tx, {
           owner      :: aec_id:id(),
           nonce      :: non_neg_integer(),
@@ -156,7 +158,8 @@ check(#contract_create_tx{nonce = Nonce,
                           gas        = Gas,
                           gas_price  = GasPrice,
                           deposit    = Deposit,
-                          fee = Fee} = Tx, _Context, Trees, _Height, _ConsensusVersion) ->
+                          fee = Fee} = Tx, _Context, Trees, _Height, _ConsensusVersion
+     ) when ?is_non_neg_integer(GasPrice) ->
     OwnerPubKey = owner(Tx),
     TotalAmount = Fee + Amount + Deposit + Gas * GasPrice,
     Checks =

--- a/apps/aecontract/test/aect_call_tests.erl
+++ b/apps/aecontract/test/aect_call_tests.erl
@@ -11,10 +11,11 @@
 
 -import(aect_call, [ deserialize/1
                    , return_value/1
+                   , gas_price/1
                    , gas_used/1
                    , height/1
                    , id/1
-                   , new/4
+                   , new/5
                    , contract_address/1
                    , caller_address/1
                    , caller_nonce/1
@@ -46,6 +47,7 @@ basic_getters() ->
     ?assert(is_integer(caller_nonce(I))),
     ?assert(is_integer(height(I))),
     ?assert(is_binary(return_value(I))),
+    ?assert(is_integer(gas_price(I))),
     ?assert(is_integer(gas_used(I))),
     ok.
 
@@ -69,7 +71,8 @@ new_call(Tx, Height) ->
     Caller = aect_call_tx:caller(Tx),
     Nonce  = aect_call_tx:nonce(Tx),
     Address = aect_call_tx:contract(Tx),
-    new(Caller, Nonce, Address, Height).
+    GasPrice = aect_call_tx:gas_price(Tx),
+    new(Caller, Nonce, Address, Height, GasPrice).
 
 call_tx() ->
     call_tx(#{}).

--- a/apps/aecore/src/aec_trees.erl
+++ b/apps/aecore/src/aec_trees.erl
@@ -262,12 +262,12 @@ apply_txs_on_state_trees([SignedTx | Rest], FilteredSignedTxs, Trees0, Height, C
 
 -spec grant_fee_to_miner(aec_keys:pubkey(), trees(), non_neg_integer()) ->
                                 trees().
-grant_fee_to_miner(MinerPubkey, Trees0, TotalFee) ->
+grant_fee_to_miner(MinerPubkey, Trees0, Fee) ->
     Trees1 = ensure_account(MinerPubkey, Trees0),
     AccountsTrees1 = accounts(Trees1),
 
     {value, Account1} = aec_accounts_trees:lookup(MinerPubkey, AccountsTrees1),
-    {ok, Account} = aec_accounts:earn(Account1, TotalFee),
+    {ok, Account} = aec_accounts:earn(Account1, Fee),
 
     AccountsTrees = aec_accounts_trees:enter(Account, AccountsTrees1),
     set_accounts(Trees1, AccountsTrees).

--- a/apps/aehttp/priv/swagger.json
+++ b/apps/aehttp/priv/swagger.json
@@ -3704,7 +3704,7 @@
     },
     "ContractCallObject" : {
       "type" : "object",
-      "required" : [ "caller_address", "caller_nonce", "contract_address", "gas_used", "height", "return_type", "return_value" ],
+      "required" : [ "caller_address", "caller_nonce", "contract_address", "gas_price", "gas_used", "height", "return_type", "return_value" ],
       "properties" : {
         "caller_address" : {
           "$ref" : "#/definitions/EncodedHash"
@@ -3717,6 +3717,9 @@
         },
         "contract_address" : {
           "$ref" : "#/definitions/EncodedHash"
+        },
+        "gas_price" : {
+          "type" : "integer"
         },
         "gas_used" : {
           "type" : "integer"
@@ -3731,10 +3734,11 @@
         }
       },
       "example" : {
+        "gas_price" : 1,
         "return_type" : "return_type",
         "caller_address" : { },
         "return_value" : "return_value",
-        "gas_used" : 1,
+        "gas_used" : 5,
         "caller_nonce" : 0,
         "contract_address" : null,
         "height" : 6

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -665,6 +665,14 @@ contract_transactions(_Config) ->
     ?assertEqual(MinerAddress, maps:get(<<"caller_address">>, CallObject, <<>>)),
     ?assertEqual(aec_base58c:encode(contract_pubkey, ContractPubKey),
                  maps:get(<<"contract_address">>, CallObject, <<>>)),
+    ?assertEqual(maps:get(gas_price, ContractCallDecoded), maps:get(<<"gas_price">>, CallObject)),
+    ?assertMatch({Used, Limit} when
+      is_integer(Used) andalso
+      is_integer(Limit) andalso
+      Limit > 0 andalso
+      Used =< Limit,
+      {maps:get(<<"gas_used">>, CallObject), maps:get(gas, ContractCallDecoded)}
+      ),
 
     %% Test to call the contract without a transaction.
     {ok, 200, #{<<"out">> := DirectCallResult}} =

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -2867,6 +2867,8 @@ definitions:
         type: integer
       contract_address:
         $ref: '#/definitions/EncodedHash'
+      gas_price:
+        type: integer
       gas_used:
         type: integer
       return_value:
@@ -2880,6 +2882,7 @@ definitions:
       - caller_nonce
       - height
       - contract_address
+      - gas_price
       - gas_used
       - return_value
       - return_type

--- a/deployment/ansible/deploy.yml
+++ b/deployment/ansible/deploy.yml
@@ -56,7 +56,7 @@
           port: 3114
       chain:
         persist: true
-        db_path: "./db63"
+        db_path: "./db64"
       keypair:
         dir: "keys"
         password: "{{ vault_keys_password|default('secret') }}"

--- a/docs/release-notes/RELEASE-NOTES-0.16.0.md
+++ b/docs/release-notes/RELEASE-NOTES-0.16.0.md
@@ -11,7 +11,8 @@ It:
 * Makes the system more resistant against mistakes by checking sizes of identifiers as a side effect of introducing the typed identifiers.
 * Creates contract call object in calls state tree even if contract create transaction init fails. This impacts consensus.
 * Makes the owner of the contract create transaction lose the gas - in addition to the fee - if the init fails. This impacts consensus.
-* Ensure that the create contract function calls the init function for Sophia ABI contracts. This impacts consensus.
+* Ensures that the create contract function calls the init function for Sophia ABI contracts. This impacts consensus.
+* Rewards miner with gas used for execution of contracts, i.e. the execution of the initial call in any contract create transaction and the execution of any contract call transaction. This impacts consensus.
 
 [this-release]: https://github.com/aeternity/epoch/releases/tag/v0.16.0
 


### PR DESCRIPTION
Corresponding spec PR: https://github.com/aeternity/protocol/pull/112
Please also review https://github.com/aeternity/protocol/pull/116

Supersedes #1230

TODO:
* [x] Rebase on master once #1238 merged
* [x] Rebase on master once #1239 merged (at least for release notes and DB folder)
* [x] Ensure gas price check (price in call object equal to price in tx, gas fee credited to miner) added in all unit tests updated in master
* [x] Ensure contract create tx and contract call tx process only non-negative gas price
* [x] Bump consensus

----

What is missing for delivering https://www.pivotaltracker.com/story/show/154664693 :
* Enhance mempool to consider reward miner might get by processing contract-related transaction.
* Check minimum gas price before adding tx to mempool.

I plan to add none of the above in this PR in order to keep PRs small and avoid too many rebases.
