### PR TITLE
Enhance mempool to consider gas fees to miner

### DIFF
--- a/apps/aecore/src/aec_governance.erl
+++ b/apps/aecore/src/aec_governance.erl
@@ -8,6 +8,7 @@
          block_mine_reward/0,
          max_txs_in_block/0,
          minimum_tx_fee/0,
+         minimum_gas_price/0,
          name_preclaim_expiration/0,
          name_claim_burned_fee/0,
          name_claim_max_expiration/0,
@@ -65,6 +66,9 @@ max_txs_in_block() ->
 
 minimum_tx_fee() ->
     1.
+
+minimum_gas_price() ->
+    0.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Naming system variables

--- a/apps/aecore/src/aec_tx_pool.erl
+++ b/apps/aecore/src/aec_tx_pool.erl
@@ -198,8 +198,7 @@ int_get_candidate(N, Mempool, {_Fee, Account, Nonce, _} = Key, BlockHash, Acc) -
 -spec pool_db_key(aetx_sign:signed_tx()) -> pool_db_key().
 pool_db_key(SignedTx) ->
     Tx = aetx_sign:tx(SignedTx),
-    %% INFO: Sort by fee
-    %%       TODO: sort by fee, then by origin, then by nonce
+    %% INFO: Sort by fee, then by origin, then by nonce
 
     %% INFO: * given that nonce is an index of transactions for a user,
     %%         the following key is unique for a transaction

--- a/apps/aetx/src/aetx.erl
+++ b/apps/aetx/src/aetx.erl
@@ -9,6 +9,7 @@
         , check_from_contract/4
         , deserialize_from_binary/1
         , fee/1
+        , lookup_gas_price/1
         , is_tx_type/1
         , new/2
         , nonce/1
@@ -103,6 +104,9 @@
 -callback fee(Tx :: tx_instance()) ->
     Fee :: integer().
 
+-callback gas_price(Tx :: tx_instance()) ->
+    GasPrice :: aect_contracts:amount().
+
 -callback ttl(Tx :: tx_instance()) ->
     TTL :: aec_blocks:height().
 
@@ -137,6 +141,8 @@
 -callback for_client(Tx :: tx_instance()) ->
     map().
 
+-optional_callbacks([gas_price/1]).
+
 %% -- ADT Implementation -----------------------------------------------------
 
 -spec new(CallbackModule :: module(),  Tx :: tx_instance()) ->
@@ -154,6 +160,15 @@ tx_type(TxType) when is_atom(TxType) ->
 -spec fee(Tx :: tx()) -> Fee :: integer().
 fee(#aetx{ cb = CB, tx = Tx }) ->
     CB:fee(Tx).
+
+-spec lookup_gas_price(Tx :: tx()) -> none | {value, GasPrice} when
+      GasPrice :: aect_contracts:amount().
+lookup_gas_price(#aetx{ cb = aect_create_tx, tx = Tx }) ->
+    {value, aect_create_tx:gas_price(Tx)};
+lookup_gas_price(#aetx{ cb = aect_call_tx, tx = Tx }) ->
+    {value, aect_call_tx:gas_price(Tx)};
+lookup_gas_price(#aetx{}) ->
+    none.
 
 -spec nonce(Tx :: tx()) -> Nonce :: non_neg_integer().
 nonce(#aetx{ cb = CB, tx = Tx }) ->

--- a/deployment/ansible/deploy.yml
+++ b/deployment/ansible/deploy.yml
@@ -56,7 +56,7 @@
           port: 3114
       chain:
         persist: true
-        db_path: "./db64"
+        db_path: "./db65"
       keypair:
         dir: "keys"
         password: "{{ vault_keys_password|default('secret') }}"

--- a/docs/release-notes/RELEASE-NOTES-0.16.0.md
+++ b/docs/release-notes/RELEASE-NOTES-0.16.0.md
@@ -15,6 +15,7 @@ It:
 * Makes the owner of the contract create transaction lose the gas - in addition to the fee - if the init fails. This impacts consensus.
 * Ensures that the create contract function calls the init function for Sophia ABI contracts. This impacts consensus.
 * Rewards miner with gas used for execution of contracts, i.e. the execution of the initial call in any contract create transaction and the execution of any contract call transaction. This impacts consensus.
+* Enhances mempool to consider reward miner might get by processing contract-related transactions. This impacts the persisted DB.
 
 [this-release]: https://github.com/aeternity/epoch/releases/tag/v0.16.0
 


### PR DESCRIPTION
Delivers https://www.pivotaltracker.com/story/show/154664693

Follows from #1232 

TODO:
* [x] Check minimum gas price before adding tx to mempool
* [x] Enhance mempool to consider reward miner might get by processing contract-related transaction
  * [x] Tests
  * [x] Code
* [x] Ensure Python UAT tests pass
  * [CI job passed](https://circleci.com/gh/lucafavatella/epoch/4178) on f2a46806 equivalent to 7e6a954f
* [x] Ensure system tests pass
  *  [CI job passed](https://circleci.com/gh/lucafavatella/epoch/4174) on f2a46806 equivalent to 7e6a954f 
  * (System tests had [passed](https://circleci.com/gh/aeternity/epoch/16911) on master 5a138412 )