### PR TITLE
[RFC] User API for retrieving contract call object for contract create init

### DIFF
--- a/apps/aehttp/src/aehttp_helpers.erl
+++ b/apps/aehttp/src/aehttp_helpers.erl
@@ -194,7 +194,7 @@ get_contract_call_object_from_tx(TxKey, CallKey) ->
                                     {ok, maps:put(CallKey, CallObject, State)}
                             end;
                         {_, _} ->
-                            {error, {400, [], #{<<"reason">> => <<"Tx is not a call">>}}}
+                            {error, {400, [], #{<<"reason">> => <<"Tx is not a create or call">>}}}
                     end
             end
     end.

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -617,10 +617,30 @@ contract_transactions(_Config) ->
     {ok, ContractPubKey} = aec_base58c:safe_decode(contract_pubkey, EncodedContractPubKey),
     ContractCreateTxHash = sign_and_post_tx(MinerAddress, EncodedUnsignedContractCreateTx),
 
+    %% Try to get the contract init call object while in mempool
+    {ok, 400, #{<<"reason">> := <<"Tx not mined">>}} =
+        get_contract_call_object(ContractCreateTxHash),
+
     % mine a block
     aecore_suite_utils:mine_blocks(aecore_suite_utils:node_name(?NODE), 2),
     ?assert(tx_in_chain(ContractCreateTxHash)),
 
+    %% Get the contract init call object
+    {ok, 200, InitCallObject} = get_contract_call_object(ContractCreateTxHash),
+    ?assertEqual(MinerAddress, maps:get(<<"caller_address">>, InitCallObject)),
+    ?assertEqual(get_tx_nonce(ContractCreateTxHash), maps:get(<<"caller_nonce">>, InitCallObject)),
+    ?assertEqual(aec_base58c:encode(contract_pubkey, ContractPubKey),
+        maps:get(<<"contract_address">>, InitCallObject)),
+    ?assertEqual(maps:get(gas_price, ValidDecoded), maps:get(<<"gas_price">>, InitCallObject)),
+    ?assertMatch({Used, Limit} when
+        is_integer(Used) andalso
+            is_integer(Limit) andalso
+            Limit > 0 andalso
+            Used =< Limit,
+        {maps:get(<<"gas_used">>, InitCallObject), maps:get(gas, ValidDecoded)}
+    ),
+    ?assertEqual(<<"ok">>, maps:get(<<"return_type">>, InitCallObject)),
+    ?assertMatch(_, maps:get(<<"return_value">>, InitCallObject)),
 
     Function = <<"main">>,
     Argument = <<"42">>,
@@ -781,9 +801,11 @@ contract_transactions(_Config) ->
     {ok, 400, #{<<"reason">> := <<"Failed to compute call_data, reason: bad argument">>}} =
         get_contract_call_compute(maps:put(arguments, <<"garbadge">>,
                                            ComputeCCallEncoded)),
+
     %% Call objects
+    {ok, 200, #{<<"tx_hash">> := SpendTxHash}} = post_spend_tx(MinerAddress, 1, 1),
     {ok, 400, #{<<"reason">> := <<"Tx is not a call">>}} =
-        get_contract_call_object(ContractCreateTxHash),
+        get_contract_call_object(SpendTxHash),
 
     ok.
 

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -662,6 +662,7 @@ contract_transactions(_Config) ->
     %% Get the call object
     {ok, 200, CallObject} = get_contract_call_object(ContractCallTxHash),
     ?assertEqual(MinerAddress, maps:get(<<"caller_address">>, CallObject, <<>>)),
+    ?assertEqual(get_tx_nonce(ContractCallTxHash), maps:get(<<"caller_nonce">>, CallObject)),
     ?assertEqual(aec_base58c:encode(contract_pubkey, ContractPubKey),
                  maps:get(<<"contract_address">>, CallObject, <<>>)),
     ?assertEqual(maps:get(gas_price, ContractCallDecoded), maps:get(<<"gas_price">>, CallObject)),
@@ -672,6 +673,7 @@ contract_transactions(_Config) ->
       Used =< Limit,
       {maps:get(<<"gas_used">>, CallObject), maps:get(gas, ContractCallDecoded)}
       ),
+    ?assertEqual(<<"ok">>, maps:get(<<"return_type">>, CallObject)),
 
     %% Test to call the contract without a transaction.
     {ok, 200, #{<<"out">> := DirectCallResult}} =
@@ -3594,6 +3596,10 @@ get_tx(TxHash, TxEncoding) ->
     Params = tx_encoding_param(TxEncoding),
     Host = external_address(),
     http_request(Host, get, "tx/" ++ binary_to_list(TxHash), Params).
+
+get_tx_nonce(TxHash) ->
+    {ok, 200, Tx} = get_tx(TxHash, json),
+    maps:get(<<"nonce">>, maps:get(<<"tx">>, maps:get(<<"transaction">>, Tx))).
 
 post_spend_tx(Recipient, Amount, Fee) ->
     post_spend_tx(Recipient, Amount, Fee, <<"foo">>).

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -203,7 +203,7 @@ paths:
         - external
         - transactions
       operationId: GetContractCallFromTx
-      description: 'Get the call result for a contract_call transaction'
+      description: 'Get the call result for a contract_create or contract_call transaction'
       produces:
         - application/json
       parameters:

--- a/docs/release-notes/RELEASE-NOTES-0.16.0.md
+++ b/docs/release-notes/RELEASE-NOTES-0.16.0.md
@@ -16,6 +16,7 @@ It:
 * Ensures that the create contract function calls the init function for Sophia ABI contracts. This impacts consensus.
 * Rewards miner with gas used for execution of contracts, i.e. the execution of the initial call in any contract create transaction and the execution of any contract call transaction. This impacts consensus.
 * Enhances mempool to consider reward miner might get by processing contract-related transactions. This impacts the persisted DB.
+* Enables retrieving the contract call object produced by the execution of the initialization call in a contract create transaction.
 
 [this-release]: https://github.com/aeternity/epoch/releases/tag/v0.16.0
 


### PR DESCRIPTION
I open this PR for getting feedback on how [the user API for fetching the call object resulting from the execution of the initialization function in the contract create tx](https://www.pivotaltracker.com/story/show/158152982) will look like. The main point is that I plan to overload this on the existing path for fetching the call object for a contract call tx - see swagger.yaml file.

This PR is not meant to be merged yet.

TODO:
* [ ] Code
* [ ] Test coverage for contract create init failure
* [ ] Ensure Python UAT tests do not break