### PR TITLE
Add endpoints for nonce and pending transactions

### DIFF
--- a/apps/aehttp/priv/swagger.json
+++ b/apps/aehttp/priv/swagger.json
@@ -1536,6 +1536,76 @@
         }
       }
     },
+    "/account/{account_pubkey}/nonce" : {
+      "get" : {
+        "tags" : [ "external", "chain" ],
+        "description" : "Get accounts's last used nonce on chain",
+        "operationId" : "GetAccountNonce",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "account_pubkey",
+          "in" : "path",
+          "description" : "Account pubkey to show nonce for",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/Nonce"
+            }
+          },
+          "400" : {
+            "description" : "Invalid account_pubkey provided",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Account not found",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/account/{account_pubkey}/pending_transactions" : {
+      "get" : {
+        "tags" : [ "external", "transactions" ],
+        "description" : "Get accounts's pending transactions from the mempool",
+        "operationId" : "GetAccountPendingTransactions",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "account_pubkey",
+          "in" : "path",
+          "description" : "Account pubkey to search for in mempool",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/Transactions"
+            }
+          },
+          "400" : {
+            "description" : "Invalid account_pubkey provided",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Account not found",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
     "/balances" : {
       "get" : {
         "tags" : [ "external", "debug" ],
@@ -2513,6 +2583,18 @@
       },
       "example" : {
         "balance" : 0
+      }
+    },
+    "Nonce" : {
+      "type" : "object",
+      "properties" : {
+        "nonce" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      },
+      "example" : {
+        "nonce" : 0
       }
     },
     "Tx" : {

--- a/apps/aehttp/src/aehttp_dispatch_ext.erl
+++ b/apps/aehttp/src/aehttp_dispatch_ext.erl
@@ -447,6 +447,16 @@ handle_request('GetAccountBalance', Req, _Context) ->
             {400, [], #{reason => <<"Invalid account hash">>}}
     end;
 
+handle_request('GetAccountPendingTransactions', Req, _Context) ->
+    case aec_base58c:safe_decode(account_pubkey, maps:get('account_pubkey', Req)) of
+        {ok, AccountPubkey} ->
+            {ok, Txs0} = aec_tx_pool:peek(infinity, AccountPubkey),
+            Txs = [aehttp_api_parser:encode(tx, T) || T <- Txs0],
+            {200, [], Txs};
+        _ ->
+            {400, [], #{reason => <<"Invalid account hash">>}}
+    end;
+
 handle_request('GetAccountNonce', Req, _Context) ->
     case aec_base58c:safe_decode(account_pubkey, maps:get('account_pubkey', Req)) of
         {ok, AccountPubkey} ->

--- a/apps/aehttp/src/aehttp_dispatch_ext.erl
+++ b/apps/aehttp/src/aehttp_dispatch_ext.erl
@@ -447,6 +447,19 @@ handle_request('GetAccountBalance', Req, _Context) ->
             {400, [], #{reason => <<"Invalid account hash">>}}
     end;
 
+handle_request('GetAccountNonce', Req, _Context) ->
+    case aec_base58c:safe_decode(account_pubkey, maps:get('account_pubkey', Req)) of
+        {ok, AccountPubkey} ->
+            case aec_chain:get_account(AccountPubkey) of
+                {value, Account} ->
+                    {200, [], #{nonce => aec_accounts:nonce(Account)}};
+                _ ->
+                    {404, [], #{reason => <<"Account not found">>}}
+            end;
+        _ ->
+            {400, [], #{reason => <<"Invalid account hash">>}}
+    end;
+
 handle_request('GetCommitmentHash', Req, _Context) ->
     Name         = maps:get('name', Req),
     Salt         = maps:get('salt', Req),

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -1602,6 +1602,9 @@ all_accounts_balances(_Config) ->
         ReceiversAccounts),
 
     {ok, MinerPubKey} = rpc(aec_keys, pubkey, []),
+    {ok, 200, Txs} =  get_transactions(aec_base58c:encode(account_pubkey, MinerPubKey)),
+    ?assertEqual(Receivers, length(Txs)),
+
     % mine a block to include the txs
     {ok, [Block]} = aecore_suite_utils:mine_blocks(aecore_suite_utils:node_name(?NODE), 1),
     {ok, 200, #{<<"accounts_balances">> := BalancesMap}} = get_all_accounts_balances(),
@@ -3597,6 +3600,11 @@ get_header_by_hash(Hash) ->
 get_transactions() ->
     Host = external_address(),
     http_request(Host, get, "transactions", []).
+
+get_transactions(EncodedPubKey) ->
+    Host = external_address(),
+    http_request(Host, get, "account/" ++ binary_to_list(EncodedPubKey) ++ "/pending_transactions", []).
+
 
 get_tx(TxHash, TxEncoding) ->
     Params = tx_encoding_param(TxEncoding),

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -1601,10 +1601,11 @@ all_accounts_balances(_Config) ->
         end,
         ReceiversAccounts),
 
+    {ok, MinerPubKey} = rpc(aec_keys, pubkey, []),
     % mine a block to include the txs
     {ok, [Block]} = aecore_suite_utils:mine_blocks(aecore_suite_utils:node_name(?NODE), 1),
     {ok, 200, #{<<"accounts_balances">> := BalancesMap}} = get_all_accounts_balances(),
-    {ok, MinerPubKey} = rpc(aec_keys, pubkey, []),
+    {ok, 200, #{<<"nonce">> := Receivers}} = get_account_nonce(aec_base58c:encode(account_pubkey, MinerPubKey)),
     {ok, MinerBal} = rpc(aec_mining, get_miner_account_balance, []),
     ExpectedBalances = [{MinerPubKey, MinerBal} | GenesisAccounts] ++  ReceiversAccounts,
 
@@ -3668,6 +3669,10 @@ get_balance(EncodedPubKey, Params) ->
     Host = external_address(),
     http_request(Host, get, "account/" ++ binary_to_list(EncodedPubKey) ++ "/balance",
                  Params).
+
+get_account_nonce(EncodedPubKey) ->
+    Host = external_address(),
+    http_request(Host, get, "account/" ++ binary_to_list(EncodedPubKey) ++ "/nonce", []).
 
 post_block(Block) ->
     post_block_map(aehttp_api_parser:encode(block, Block)).

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -1281,6 +1281,34 @@ paths:
           description: Block or account not found
           schema:
             $ref: '#/definitions/Error'
+  /account/{account_pubkey}/nonce:
+    get:
+      tags:
+        - external
+        - chain
+      operationId: GetAccountNonce
+      description: 'Get accounts''s last used nonce on chain'
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: account_pubkey
+          description: 'Account pubkey to show nonce for'
+          required: true
+          type: string
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            $ref: '#/definitions/Nonce'
+        '400':
+          description: Invalid account_pubkey provided
+          schema:
+            $ref: '#/definitions/Error'
+        '404':
+          description: Account not found
+          schema:
+            $ref: '#/definitions/Error'
 
 ## CAUTION: debug endpoints, implementation may be inefficient
   /balances:
@@ -2098,6 +2126,12 @@ definitions:
     type: object
     properties:
       balance:
+        type: integer
+        format: int64
+  Nonce:
+    type: object
+    properties:
+      nonce:
         type: integer
         format: int64
   Tx:

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -1310,6 +1310,35 @@ paths:
           schema:
             $ref: '#/definitions/Error'
 
+  /account/{account_pubkey}/pending_transactions:
+    get:
+      tags:
+        - external
+        - transactions
+      operationId: GetAccountPendingTransactions
+      description: 'Get accounts''s pending transactions from the mempool'
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: account_pubkey
+          description: 'Account pubkey to search for in mempool'
+          required: true
+          type: string
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            $ref: '#/definitions/Transactions'
+        '400':
+          description: Invalid account_pubkey provided
+          schema:
+            $ref: '#/definitions/Error'
+        '404':
+          description: Account not found
+          schema:
+            $ref: '#/definitions/Error'
+
 ## CAUTION: debug endpoints, implementation may be inefficient
   /balances:
     get:


### PR DESCRIPTION
Introduce 2 endpoints for
1) returing account's nonce that is on-chain
2) returning all transaction in mempool originating from a certain account

This is to be used to initialize a wallet app. 

Finishes: PT-158222460 