### PR TITLE
Pt 158520766 contract poi tests

### DIFF
--- a/apps/aechannel/test/aesc_test_utils.erl
+++ b/apps/aechannel/test/aesc_test_utils.erl
@@ -388,8 +388,8 @@ proof_of_inclusion(Participants) ->
     Trees = aec_test_utils:create_state_tree_with_accounts(Accounts, no_backend),
     lists:foldl(
         fun({Pubkey, _}, AccumPoI) ->
-            {ok, _, AccumPoI1} = aec_trees:add_poi(accounts, Pubkey,
-                                                    Trees, AccumPoI),
+            {ok, AccumPoI1} = aec_trees:add_poi(accounts, Pubkey,
+                                                Trees, AccumPoI),
             AccumPoI1
         end,
         aec_trees:new_poi(Trees),

--- a/apps/aecontract/src/aect_contracts.erl
+++ b/apps/aecontract/src/aect_contracts.erl
@@ -135,7 +135,7 @@ serialize(#contract{owner = OwnerId, referers = RefererIds} = C) ->
       , {deposit, deposit(C)}
       ]).
 
--spec deserialize(aec_keys:pubkey(), serialized()) -> contract().
+-spec deserialize(id(), serialized()) -> contract().
 deserialize(Pubkey, Bin) ->
     [ {owner, OwnerId}
     , {vm_version, VmVersion}
@@ -189,7 +189,7 @@ serialize_for_poi(#contract{owner = OwnerId, referers = RefererIds} = C) ->
       , {store,  lists:sort(maps:to_list(state(C)))}
       ]).
 
--spec deserialize_from_poi(aec_keys:pubkey(), serialized()) -> contract().
+-spec deserialize_from_poi(id(), serialized()) -> contract().
 deserialize_from_poi(Pubkey, Bin) ->
     [ {owner, OwnerId}
     , {vm_version, VmVersion}
@@ -231,7 +231,7 @@ poi_serialization_template(?CONTRACT_VSN) ->
     ].
 
 
--spec compute_contract_pubkey(aec_keys:pubkey(), non_neg_integer()) -> aec_keys:pubkey().
+-spec compute_contract_pubkey(aec_keys:pubkey(), non_neg_integer()) -> id().
 compute_contract_pubkey(<<_:?PUB_SIZE/binary>> = Owner, Nonce) when Nonce >= 0  ->
     NonceBin = binary:encode_unsigned(Nonce),
     aec_hash:hash(pubkey, <<Owner/binary, NonceBin/binary>>).
@@ -240,7 +240,7 @@ compute_contract_pubkey(<<_:?PUB_SIZE/binary>> = Owner, Nonce) when Nonce >= 0  
 %%% Getters
 
 %% The address of the contract account.
--spec pubkey(contract()) -> aec_keys:pubkey().
+-spec pubkey(contract()) -> id().
 pubkey(C) -> aec_id:specialize(C#contract.id, contract).
 
 %% The owner of the contract is (initially) the account that created it.
@@ -268,7 +268,7 @@ log(C) -> C#contract.log.
 active(C) -> C#contract.active.
 
 %% A list of other contracts referring to this contract.
--spec referers(contract()) -> [aec_keys:pubkey()].
+-spec referers(contract()) -> [id()].
 referers(C) -> [aec_id:specialize(X, contract) || X <- C#contract.referers].
 
 %% The amount deposited at contract creation.
@@ -278,7 +278,7 @@ deposit(C) -> C#contract.deposit.
 %%%===================================================================
 %%% Setters
 
--spec set_pubkey(aec_keys:pubkey(), contract()) -> contract().
+-spec set_pubkey(id(), contract()) -> contract().
 set_pubkey(X, C) ->
     C#contract{id = aec_id:create(contract, assert_field(pubkey, X))}.
 
@@ -306,7 +306,7 @@ set_log(X, C) ->
 set_active(X, C) ->
     C#contract{active = assert_field(active, X)}.
 
--spec set_referers([aec_keys:pubkey()], contract()) -> contract().
+-spec set_referers([id()], contract()) -> contract().
 set_referers(X, C) ->
     C#contract{referers = [aec_id:create(contract, Y)
                            || Y <- assert_field(referers, X)]}.

--- a/apps/aecontract/src/aect_contracts.erl
+++ b/apps/aecontract/src/aect_contracts.erl
@@ -77,7 +77,7 @@
 -define(HASH_SIZE, 32).
 -define(CONTRACT_TYPE, contract).
 -define(CONTRACT_VSN, 1).
--define(STORE_PREFIX, 16). %% To collect storage trees in one subtree.
+-define(STORE_PREFIX, <<16:8/integer-unsigned-unit:1>>). %% To collect storage trees in one subtree.
 
 %%%===================================================================
 %%% API
@@ -92,7 +92,7 @@ store_id(C) ->
     CId = pubkey(C),
     %% The STORE_PREFIX is used to name the storage tree and keep
     %% all storage nodes in one subtree under the contract tree.
-    << CId/binary, ?STORE_PREFIX>>.
+    << CId/binary, ?STORE_PREFIX/binary>>.
 
 -spec new(aect_create_tx:tx()) -> contract().
 new(RTx) ->

--- a/apps/aecontract/src/aect_contracts.erl
+++ b/apps/aecontract/src/aect_contracts.erl
@@ -62,6 +62,7 @@
 -opaque contract() :: #contract{}.
 
 -type id() :: aec_keys:pubkey().
+-type store_id() :: binary().
 -type serialized() :: binary().
 -type vm_version() :: byte().
 
@@ -87,7 +88,7 @@
 id(C) ->
   pubkey(C).
 
--spec store_id(contract()) -> id().
+-spec store_id(contract()) -> store_id().
 store_id(C) ->
     CId = pubkey(C),
     %% The STORE_PREFIX is used to name the storage tree and keep

--- a/apps/aecontract/src/aect_state_tree.erl
+++ b/apps/aecontract/src/aect_state_tree.erl
@@ -165,7 +165,7 @@ add_poi(Id, #contract_tree{contracts = CtTree}, Poi) ->
     end.
 
 add_store_to_poi(Id, CtTree, Poi) ->
-    Iterator = aeu_mtrees:iterator_from(Id, CtTree),
+    Iterator = aeu_mtrees:iterator_from(Id, CtTree, [{with_prefix, Id}]),
     Next = aeu_mtrees:iterator_next(Iterator),
     Size = byte_size(Id),
     case add_store_keys_poi(Id, Next, Size, Poi, CtTree) of
@@ -177,16 +177,12 @@ add_store_to_poi(Id, CtTree, Poi) ->
 add_store_keys_poi(_, '$end_of_table', _, Poi, _) ->
     Poi;
 add_store_keys_poi(Id, {PrefixedKey, _Val, Iter}, PrefixSize, Poi, CtTree) ->
-    case PrefixedKey of
-        <<Id:PrefixSize/binary, _Key/binary>> = KeyId ->
-            case aec_poi:add_poi(KeyId, CtTree, Poi) of
-                {ok, Poi1} ->
-                    Next = aeu_mtrees:iterator_next(Iter),
-                    add_store_keys_poi(Id, Next, PrefixSize, Poi1, CtTree);
-                {error, _} = E -> E
-            end;
-        _ ->
-            Poi
+    KeyId = <<Id:PrefixSize/binary, _Key/binary>> = PrefixedKey,
+    case aec_poi:add_poi(KeyId, CtTree, Poi) of
+        {ok, Poi1} ->
+            Next = aeu_mtrees:iterator_next(Iter),
+            add_store_keys_poi(Id, Next, PrefixSize, Poi1, CtTree);
+        {error, _} = E -> E
     end.
 
 

--- a/apps/aecontract/src/aect_state_tree.erl
+++ b/apps/aecontract/src/aect_state_tree.erl
@@ -232,6 +232,8 @@ add_store_from_poi(Contract, Poi) ->
         {error, _} = E -> E
     end.
 
+add_store_from_poi(_, {error, bad_proof} = E, _, _, _) ->
+    E;
 add_store_from_poi(_, '$end_of_table', _, Store,_Poi) ->
     Store;
 add_store_from_poi(Id, {PrefixedKey, Val, Iter}, PrefixSize, Store, Poi) ->

--- a/apps/aecontract/src/aect_state_tree.erl
+++ b/apps/aecontract/src/aect_state_tree.erl
@@ -118,7 +118,7 @@ get_contract(Id, #contract_tree{ contracts = CtTree }) ->
 
 add_store(Contract, CtTree) ->
     Id = aect_contracts:store_id(Contract),
-    Iterator = aeu_mtrees:iterator_from(Id, CtTree),
+    Iterator = aeu_mtrees:iterator_from(Id, CtTree, [{with_prefix, Id}]),
     Next = aeu_mtrees:iterator_next(Iterator),
     Size = byte_size(Id),
     Store = find_store_keys(Id, Next, Size, #{}),
@@ -127,14 +127,10 @@ add_store(Contract, CtTree) ->
 find_store_keys(_, '$end_of_table', _, Store) ->
     Store;
 find_store_keys(Id, {PrefixedKey, Val, Iter}, PrefixSize, Store) ->
-    case PrefixedKey of
-        <<Id:PrefixSize/binary, Key/binary>> ->
-            Store1 = Store#{ Key => Val},
-            Next = aeu_mtrees:iterator_next(Iter),
-            find_store_keys(Id, Next, PrefixSize, Store1);
-        _ ->
-            Store
-    end.
+    <<Id:PrefixSize/binary, Key/binary>> = PrefixedKey,
+    Store1 = Store#{ Key => Val},
+    Next = aeu_mtrees:iterator_next(Iter),
+    find_store_keys(Id, Next, PrefixSize, Store1).
 
 
 -spec lookup_contract(aect_contracts:id(), tree()) -> {value, aect_contracts:contract()} | none.

--- a/apps/aecontract/test/aect_contracts_tests.erl
+++ b/apps/aecontract/test/aect_contracts_tests.erl
@@ -55,6 +55,10 @@ state_setter() ->
                    <<"k2">> => <<"v1">>},
                  state(set_state(#{<<"k1">> => <<"v2">>,
                                    <<"k2">> => <<"v1">>}, C))),
+    ?assertError({illegal, _, _}, set_state(#{<<>> => <<"v">>}, C)),
+    ?assertEqual(#{<<"k">> => <<>>}, state(set_state(#{<<"k">> => <<>>}, C))),
+    ?assertError({illegal, _, _}, set_state(#{<<1:4>> => <<"v">>}, C)),
+    ?assertError({illegal, _, _}, set_state(#{<<"k">> => <<1:4>>}, C)),
     ok.
 
 

--- a/apps/aecontract/test/aect_contracts_tests.erl
+++ b/apps/aecontract/test/aect_contracts_tests.erl
@@ -14,14 +14,17 @@
                         , new/2
                         , owner/1
                         , pubkey/1
+                        , state/1
                         , serialize/1
                         , set_owner/2
+                        , set_state/2
                         ]).
 
 basic_test_() ->
     [ {"Serialization test", fun basic_serialize/0}
     , {"Access test", fun basic_getters/0}
     , {"Update test", fun basic_setters/0}
+    , {"Update state test", fun state_setter/0}
     ].
 
 basic_serialize() ->
@@ -41,6 +44,17 @@ basic_setters() ->
     C = aect_contracts:new(create_tx()),
     ?assertError({illegal, _, _}, set_owner(<<4711:64/unit:8>>, C)),
     _ = set_owner(<<42:32/unit:8>>, C),
+    ok.
+
+state_setter() ->
+    C = aect_contracts:new(create_tx()),
+    ?assertEqual(#{}, state(set_state(#{}, C))),
+    ?assertEqual(#{<<"k">> => <<"v">>},
+                 state(set_state(#{<<"k">> => <<"v">>}, C))),
+    ?assertEqual(#{<<"k1">> => <<"v2">>,
+                   <<"k2">> => <<"v1">>},
+                 state(set_state(#{<<"k1">> => <<"v2">>,
+                                   <<"k2">> => <<"v1">>}, C))),
     ok.
 
 

--- a/apps/aecore/src/aec_accounts_trees.erl
+++ b/apps/aecore/src/aec_accounts_trees.erl
@@ -78,15 +78,15 @@ root_hash(Tree) ->
     aeu_mtrees:root_hash(Tree).
 
 -spec add_poi(aec_keys:pubkey(), tree(), aec_poi:poi()) ->
-                     {'ok', binary(), aec_poi:poi()}
+                     {'ok', aec_poi:poi()}
                          | {'error', 'not_present' | 'wrong_root_hash'}.
 add_poi(Pubkey, Tree, Poi) ->
     aec_poi:add_poi(Pubkey, Tree, Poi).
 
--spec verify_poi(aec_keys:pubkey(), binary(), aec_poi:poi()) ->
+-spec verify_poi(aec_keys:pubkey(), aec_accounts:account(), aec_poi:poi()) ->
                         'ok' | {'error', term()}.
-verify_poi(AccountKey, SerializedAccount, Poi) ->
-    aec_poi:verify(AccountKey, SerializedAccount, Poi).
+verify_poi(AccountKey, Account, Poi) ->
+    aec_poi:verify(AccountKey, aec_accounts:serialize(Account), Poi).
 
 -spec lookup_poi(aec_keys:pubkey(), aec_poi:poi()) ->
                         {'ok', aec_accounts:account()} | {'error', not_found}.

--- a/apps/aecore/src/aec_poi.erl
+++ b/apps/aecore/src/aec_poi.erl
@@ -58,7 +58,7 @@ root_hash(#aec_poi{root_hash = Hash}) ->
     Hash.
 
 -spec add_poi(key(), aeu_mtrees:mtree(), poi()) ->
-                     {'ok', value(), poi()}
+                     {'ok', poi()}
                    | {'error', 'not_present' | 'wrong_root_hash'}.
 add_poi(Key, Tree, #aec_poi{root_hash = RootHash} = Poi) ->
     case aeu_mtrees:root_hash(Tree) of
@@ -66,9 +66,8 @@ add_poi(Key, Tree, #aec_poi{root_hash = RootHash} = Poi) ->
             Proof = Poi#aec_poi.proof,
             case aeu_mtrees:lookup_with_proof(Key, Tree, Proof) of
                 none -> {error, not_present};
-                {value_and_proof, Value, NewProof} ->
+                {value_and_proof, _Value, NewProof} ->
                     { ok
-                    , Value
                     , Poi#aec_poi{ proof = NewProof}
                     }
             end;

--- a/apps/aecore/src/aec_trees.erl
+++ b/apps/aecore/src/aec_trees.erl
@@ -49,6 +49,12 @@
          verify_poi/4
         ]).
 
+-ifdef(TEST).
+-export([internal_serialize_poi_fields/1,
+         internal_serialize_poi_from_fields/1
+        ]).
+-endif.
+
 -record(trees, {
           accounts  :: aec_accounts_trees:tree(),
           calls     :: aect_call_state_tree:tree(),
@@ -472,21 +478,26 @@ new_part_poi(<<_:?STATE_HASH_BYTES/unit:8>> = Hash) ->
 
 -define(POI_VSN, 1).
 
-internal_serialize_poi(#poi{ accounts  = Accounts
-                           , calls     = Calls
-                           , channels  = Channels
-                           , contracts = Contracts
-                           , ns        = Ns
-                           , oracles   = Oracles
-                           }) ->
+internal_serialize_poi(Poi) ->
+    Fields = internal_serialize_poi_fields(Poi),
+    internal_serialize_poi_from_fields(Fields).
 
-    Fields = [ {accounts  , poi_serialization_format(Accounts)}
-             , {calls     , poi_serialization_format(Calls)}
-             , {channels  , poi_serialization_format(Channels)}
-             , {contracts , poi_serialization_format(Contracts)}
-             , {ns        , poi_serialization_format(Ns)}
-             , {oracles   , poi_serialization_format(Oracles)}
-             ],
+internal_serialize_poi_fields(#poi{ accounts  = Accounts
+                                  , calls     = Calls
+                                  , channels  = Channels
+                                  , contracts = Contracts
+                                  , ns        = Ns
+                                  , oracles   = Oracles
+                                  }) ->
+    [ {accounts  , poi_serialization_format(Accounts)}
+    , {calls     , poi_serialization_format(Calls)}
+    , {channels  , poi_serialization_format(Channels)}
+    , {contracts , poi_serialization_format(Contracts)}
+    , {ns        , poi_serialization_format(Ns)}
+    , {oracles   , poi_serialization_format(Oracles)}
+    ].
+
+internal_serialize_poi_from_fields(Fields) ->
     aec_object_serialization:serialize(trees_poi,
                                        ?POI_VSN,
                                        internal_serialize_poi_template(?POI_VSN),

--- a/apps/aecore/src/aec_trees.erl
+++ b/apps/aecore/src/aec_trees.erl
@@ -109,7 +109,7 @@ new_without_backend() ->
 new_poi(Trees) ->
     internal_new_poi(Trees).
 
--spec add_poi(tree_type(), aec_keys:pubkey(), trees(), poi()) -> {'ok', binary(), poi()}
+-spec add_poi(tree_type(), aec_keys:pubkey(), trees(), poi()) -> {'ok', poi()}
                                                       | {'error', term()}.
 add_poi(accounts, PubKey, Trees, #poi{} = Poi) ->
     internal_add_accounts_poi(PubKey, accounts(Trees), Poi);
@@ -139,12 +139,14 @@ serialize_poi(#poi{} = Poi) ->
 deserialize_poi(Bin) when is_binary(Bin) ->
     internal_deserialize_poi(Bin).
 
--spec verify_poi(tree_type(), aec_keys:pubkey(), binary(), poi()) -> 'ok'
-                                                          | {'error', term()}.
-verify_poi(accounts, PubKey, SerializedAccount, #poi{} = Poi) ->
-    internal_verify_accounts_poi(PubKey, SerializedAccount, Poi);
-verify_poi(contracts, PubKey, SerializedContract, #poi{} = Poi) ->
-    internal_verify_contracts_poi(PubKey, SerializedContract, Poi);
+-spec verify_poi(tree_type(), aec_keys:pubkey(), Object, poi()) ->
+                        'ok' | {'error', term()} when
+      Object :: aec_accounts:account()
+              | aect_contracts:contract().
+verify_poi(accounts, PubKey, Account, #poi{} = Poi) ->
+    internal_verify_accounts_poi(PubKey, Account, Poi);
+verify_poi(contracts, PubKey, Contract, #poi{} = Poi) ->
+    internal_verify_contracts_poi(PubKey, Contract, Poi);
 verify_poi(Type,_PubKey,_Account, #poi{} =_Poi) ->
     error({nyi, Type}).
 
@@ -422,8 +424,8 @@ internal_add_accounts_poi(_Pubkey,_Trees, #poi{accounts = empty}) ->
     {error, not_present};
 internal_add_accounts_poi(Pubkey, Trees, #poi{accounts = {poi, APoi}} = Poi) ->
     case aec_accounts_trees:add_poi(Pubkey, Trees, APoi) of
-        {ok, SerializedAccount, NewAPoi} ->
-            {ok, SerializedAccount, Poi#poi{accounts = {poi, NewAPoi}}};
+        {ok, NewAPoi} ->
+            {ok, Poi#poi{accounts = {poi, NewAPoi}}};
         {error, _} = E -> E
     end.
 
@@ -431,8 +433,8 @@ internal_add_contracts_poi(_ContractPubKey, _Trees, #poi{contracts = empty}) ->
     {error, not_present};
 internal_add_contracts_poi(ContractPubKey, Trees, #poi{contracts = {poi, CPoi}} = Poi) ->
     case aect_state_tree:add_poi(ContractPubKey, Trees, CPoi) of
-        {ok, SerializedContract, NewAPoi} ->
-            {ok, SerializedContract, Poi#poi{contracts = {poi, NewAPoi}}};
+        {ok, NewAPoi} ->
+            {ok, Poi#poi{contracts = {poi, NewAPoi}}};
         {error, _} = E -> E
     end.
 

--- a/apps/aecore/src/aec_trees.erl
+++ b/apps/aecore/src/aec_trees.erl
@@ -118,8 +118,10 @@ add_poi(contracts, Id, Trees, #poi{} = Poi) ->
 add_poi(Type,_PubKey,_Trees, #poi{} =_Poi) ->
     error({nyi, Type}).
 
--spec lookup_poi(tree_type(), aec_keys:pubkey(), poi()) -> {'ok', aec_accounts:account()}
-                                                         | {'error', 'not_found'}.
+-spec lookup_poi(tree_type(), aec_keys:pubkey(), poi()) ->
+                        {'ok', Object} | {'error', 'not_found'} when
+      Object :: aec_accounts:account()
+              | aect_contracts:contract().
 lookup_poi(accounts, PubKey, #poi{} = Poi) ->
     internal_lookup_accounts_poi(PubKey, Poi);
 lookup_poi(contracts, PubKey, #poi{} = Poi) ->

--- a/apps/aecore/test/aec_trees_tests.erl
+++ b/apps/aecore/test/aec_trees_tests.erl
@@ -83,18 +83,29 @@ make_spend_tx(Sender, Recipient) ->
     SpendTx.
 
 poi_test_() ->
-    [ {"POI for one account",
+    [ {"PoI constructed from empty state trees enables computation of state trees root hash",
        fun() ->
-               AccountPubkey = <<123:?MINER_PUB_BYTES/unit:8>>,
-
-               %% POI from an empty tree cannot be constructed.
                Trees0 = aec_test_utils:create_state_tree(),
                Poi0 = ?TEST_MODULE:new_poi(Trees0),
                ?assertEqual(?TEST_MODULE:hash(Trees0),
-                            ?TEST_MODULE:poi_hash(Poi0)),
+                            ?TEST_MODULE:poi_hash(Poi0))
+       end},
+      {"Non-empty PoI cannot be constructed from empty state trees",
+       fun() ->
+               AccountPubkey = <<123:?MINER_PUB_BYTES/unit:8>>,
+
+               Trees0 = aec_test_utils:create_state_tree(),
+               Poi0 = ?TEST_MODULE:new_poi(Trees0),
+
                ?assertEqual({error, not_present},
                             ?TEST_MODULE:add_poi(accounts, AccountPubkey,
-                                                 Trees0, Poi0)),
+                                                 Trees0, Poi0))
+       end},
+      {"POI for one account",
+       fun() ->
+               AccountPubkey = <<123:?MINER_PUB_BYTES/unit:8>>,
+
+               Trees0 = aec_test_utils:create_state_tree(),
 
                %% Add the account to the tree, and see that
                %% we can construct a POI for the correct account.

--- a/apps/aecore/test/aec_trees_tests.erl
+++ b/apps/aecore/test/aec_trees_tests.erl
@@ -115,7 +115,7 @@ poi_test_() ->
                ?assertEqual(aec_accounts:deserialize(AccountPubkey, SerializedAccount),
                             Account),
 
-               %% Ensure that we can verify the presens of the
+               %% Ensure that we can verify the presence of the
                %% account in the POI.
                ?assertEqual(ok,
                             aec_trees:verify_poi(accounts, AccountPubkey,

--- a/apps/aehttp/src/aehttp_helpers.erl
+++ b/apps/aehttp/src/aehttp_helpers.erl
@@ -539,7 +539,7 @@ get_poi(Subtree, KeyName, PutKey) when Subtree =:= accounts
         {ok, Trees} = aec_chain:get_top_state(),
         EmptyPoI = aec_trees:new_poi(Trees),
         case aec_trees:add_poi(Subtree, PubKey, Trees, EmptyPoI) of
-            {ok, _EncodedObj, PoI} ->
+            {ok, PoI} ->
                 {ok, maps:put(PutKey, PoI, State)};
             {error, _} ->
                 Msg = "Proof for " ++ atom_to_list(Subtree) ++ " not found",

--- a/apps/aeutils/test/aeu_rlp_tests.erl
+++ b/apps/aeutils/test/aeu_rlp_tests.erl
@@ -24,6 +24,11 @@ rlp_another_one_byte_test() ->
     B = aeu_rlp:encode(B),
     B = aeu_rlp:decode(B).
 
+rlp_zero_bytes_test() ->
+    B = <<>>,
+    S = ?BYTE_ARRAY_OFFSET + 0,
+    <<S, B/binary>> = aeu_rlp:encode(B).
+
 rlp_two_bytes_test() ->
     B = <<128>>,
     S = ?BYTE_ARRAY_OFFSET + 1,
@@ -51,6 +56,13 @@ rlp_tagged_size_two_bytes_bytes_test() ->
     X = list_to_binary(lists:duplicate(L, 42)),
     S = byte_size(X),
     E = <<Tag, S:SizeSize/unit:8, X/binary>> = aeu_rlp:encode(X),
+    X = aeu_rlp:decode(E).
+
+rlp_zero_bytes_list_test() ->
+    L = 0,
+    Tag = ?LIST_OFFSET + L,
+    X = [],
+    E = <<Tag>> = aeu_rlp:encode(X),
     X = aeu_rlp:decode(E).
 
 rlp_one_byte_list_test() ->


### PR DESCRIPTION
Corresponding spec PR: https://github.com/aeternity/protocol/pull/128

TODO:
* [ ] Re-target on master once PR #1275 merged
* [x] Stricter prefix iterator testing
* [ ] ... see https://www.pivotaltracker.com/story/show/158520766
  * [x] Test broken POI
    * Tested by removal of one of the contract-related nodes in the PoI
  * [x] Test a POI where some of the contract state is missing
    * See test case "PoI for one contract without store that becomes with store"
  * [x] Test a POI where there is an extra contract state key/value
    * See test case "PoI for one contract with store that becomes without store"
  * [ ] Test corner cases with empty keys etc.
    * Done though I plan to address case "verification of PoI with a contract with an empty (hence invalid) key" in a follow-up PR.
* [x] Clarify whether empty key can be in contract store

Maybe TODO:
* [x] Stricter assertion on contract state set e.g. both key and value are binaries
* [ ] Clarify whether empty value can be in contract store
  * Tracked as https://www.pivotaltracker.com/story/show/158630078
* [ ] Clarify how [`lookup` third argument](https://github.com/aeternity/epoch/blob/v0.16.0/apps/aeutils/src/aeu_mp_trees.erl#L177) works in PoI verification so to understand whether the value can be removed from the verify function.