### PR TITLE
158591718 compact state db representation

### DIFF
--- a/apps/aechannel/src/aesc_state_tree.erl
+++ b/apps/aechannel/src/aesc_state_tree.erl
@@ -14,6 +14,7 @@
          enter/2,
          get/2,
          lookup/2,
+         new_with_backend/1,
          root_hash/1]).
 
 %%%===================================================================
@@ -48,6 +49,10 @@ empty() ->
 -spec empty_with_backend() -> tree().
 empty_with_backend() ->
     aeu_mtrees:empty_with_backend(aec_db_backends:channels_backend()).
+
+-spec new_with_backend(aeu_mtrees:root_hash() | 'empty') -> tree().
+new_with_backend(Hash) ->
+    aeu_mtrees:new_with_backend(Hash, aec_db_backends:channels_backend()).
 
 -spec enter(channel(), tree()) -> tree().
 enter(Channel, Tree) ->

--- a/apps/aecontract/src/aect_call_state_tree.erl
+++ b/apps/aecontract/src/aect_call_state_tree.erl
@@ -14,6 +14,7 @@
         , get_call/3
         , insert_call/2
         , lookup_call/3
+        , new_with_backend/1
         , iterator/1
         , prune/2
         , root_hash/1]).
@@ -46,7 +47,11 @@ empty() ->
 
 -spec empty_with_backend() -> tree().
 empty_with_backend() ->
-    CtTree = aeu_mtrees:empty_with_backend(aec_db_backends:calls_backend()),
+    new_with_backend(empty).
+
+-spec new_with_backend(aeu_mtrees:root_hash() | 'empty') -> tree().
+new_with_backend(Hash) ->
+    CtTree = aeu_mtrees:new_with_backend(Hash, aec_db_backends:calls_backend()),
     #call_tree{calls = CtTree}.
 
 %% A new block always starts with an empty calls tree.

--- a/apps/aecontract/src/aect_state_tree.erl
+++ b/apps/aecontract/src/aect_state_tree.erl
@@ -15,6 +15,7 @@
         , insert_contract/2
         , enter_contract/2
         , lookup_contract/2
+        , new_with_backend/1
         , root_hash/1]).
 
 %% API - Proof of inclusion
@@ -48,6 +49,11 @@ empty() ->
 -spec empty_with_backend() -> tree().
 empty_with_backend() ->
     CtTree = aeu_mtrees:empty_with_backend(aec_db_backends:contracts_backend()),
+    #contract_tree{contracts = CtTree}.
+
+-spec new_with_backend(aeu_mtrees:root_hash() | 'empty') -> tree().
+new_with_backend(Hash) ->
+    CtTree = aeu_mtrees:new_with_backend(Hash, aec_db_backends:contracts_backend()),
     #contract_tree{contracts = CtTree}.
 
 %% -- Contracts --

--- a/apps/aecore/src/aec_accounts_trees.erl
+++ b/apps/aecore/src/aec_accounts_trees.erl
@@ -10,6 +10,7 @@
          empty_with_backend/0,
          get/2,
          lookup/2,
+         new_with_backend/1,
          enter/2]).
 
 %% API - Merkle tree
@@ -42,6 +43,10 @@ empty() ->
 -spec empty_with_backend() -> tree().
 empty_with_backend() ->
     aeu_mtrees:empty_with_backend(aec_db_backends:accounts_backend()).
+
+-spec new_with_backend(aeu_mtrees:root_hash() | 'empty') -> tree().
+new_with_backend(Hash) ->
+    aeu_mtrees:new_with_backend(Hash, aec_db_backends:accounts_backend()).
 
 -spec get(aec_keys:pubkey(), tree()) -> aec_accounts:account().
 get(Pubkey, Tree) ->

--- a/apps/aecore/src/aec_chain_state.erl
+++ b/apps/aecore/src/aec_chain_state.erl
@@ -498,8 +498,7 @@ db_find_nodes_at_height(Height) when is_integer(Height) ->
     end.
 
 db_put_state(Hash, Trees, Difficulty, ForkId) when is_binary(Hash) ->
-    Trees1 = aec_trees:commit_to_db(Trees),
-    ok = aec_db:write_block_state(Hash, Trees1, Difficulty, ForkId).
+    ok = aec_db:write_block_state(Hash, Trees, Difficulty, ForkId).
 
 db_find_state(Hash) when is_binary(Hash) ->
     case aec_db:find_block_state_and_data(Hash) of

--- a/apps/aecore/src/aec_object_serialization.erl
+++ b/apps/aecore/src/aec_object_serialization.erl
@@ -66,6 +66,7 @@ tag(channel_settle_tx) -> 56;
 tag(channel_offchain_tx) -> 57;
 tag(channel) -> 58;
 tag(trees_poi) -> 60;
+tag(trees_db) -> 61;
 tag(block) -> 100.
 
 rev_tag(10) -> account;
@@ -98,4 +99,5 @@ rev_tag(56) -> channel_settle_tx;
 rev_tag(57) -> channel_offchain_tx;
 rev_tag(58) -> channel;
 rev_tag(60) -> trees_poi;
+rev_tag(61) -> trees_db;
 rev_tag(100) -> block.

--- a/apps/aens/src/aens_state_tree.erl
+++ b/apps/aens/src/aens_state_tree.erl
@@ -9,6 +9,7 @@
 
 %% API
 -export([commit_to_db/1,
+         cache_root_hash/1,
          delete_commitment/2,
          delete_name/2,
          empty/0,
@@ -19,6 +20,7 @@
          prune/2,
          lookup_commitment/2,
          lookup_name/2,
+         new_with_backend/2,
          root_hash/1]).
 
 %% Export for test
@@ -72,6 +74,13 @@ empty() ->
 empty_with_backend() ->
     MTree = aeu_mtrees:empty_with_backend(aec_db_backends:ns_backend()),
     Cache = aeu_mtrees:empty_with_backend(aec_db_backends:ns_cache_backend()),
+    #ns_tree{mtree = MTree, cache = Cache}.
+
+-spec new_with_backend(aeu_mtrees:root_hash() | 'empty',
+                       aeu_mtrees:root_hash() | 'empty') -> tree().
+new_with_backend(RootHash, CacheRootHash) ->
+    MTree = aeu_mtrees:new_with_backend(RootHash, aec_db_backends:ns_backend()),
+    Cache = aeu_mtrees:new_with_backend(CacheRootHash, aec_db_backends:ns_cache_backend()),
     #ns_tree{mtree = MTree, cache = Cache}.
 
 -spec prune(block_height(), tree()) -> tree().
@@ -129,6 +138,10 @@ lookup_name(Id, Tree) ->
 
 -spec root_hash(tree()) -> {ok, aeu_mtrees:root_hash()} | {error, empty}.
 root_hash(#ns_tree{mtree = MTree}) ->
+    aeu_mtrees:root_hash(MTree).
+
+-spec cache_root_hash(tree()) -> {ok, aeu_mtrees:root_hash()} | {error, empty}.
+cache_root_hash(#ns_tree{cache = MTree}) ->
     aeu_mtrees:root_hash(MTree).
 
 -spec commit_to_db(tree()) -> tree().

--- a/apps/aeoracle/src/aeo_state_tree.erl
+++ b/apps/aeoracle/src/aeo_state_tree.erl
@@ -8,7 +8,8 @@
 -module(aeo_state_tree).
 
 %% API
--export([ commit_to_db/1
+-export([ cache_root_hash/1
+        , commit_to_db/1
         , get_query/3
         , get_oracle/2
         , get_oracle_query_ids/2
@@ -22,6 +23,7 @@
         , insert_oracle/2
         , lookup_query/3
         , lookup_oracle/2
+        , new_with_backend/2
         , prune/2
         , root_hash/1
         ]).
@@ -80,6 +82,15 @@ empty() ->
 empty_with_backend() ->
     OTree  = aeu_mtrees:empty_with_backend(aec_db_backends:oracles_backend()),
     Cache  = aeu_mtrees:empty_with_backend(aec_db_backends:oracles_cache_backend()),
+    #oracle_tree{ otree  = OTree
+                , cache  = Cache
+                }.
+
+-spec new_with_backend(aeu_mtrees:root_hash() | 'empty',
+                       aeu_mtrees:root_hash() | 'empty') -> tree().
+new_with_backend(RootHash, CacheRootHash) ->
+    OTree  = aeu_mtrees:new_with_backend(RootHash, aec_db_backends:oracles_backend()),
+    Cache  = aeu_mtrees:new_with_backend(CacheRootHash, aec_db_backends:oracles_cache_backend()),
     #oracle_tree{ otree  = OTree
                 , cache  = Cache
                 }.
@@ -150,6 +161,10 @@ lookup_oracle(Id, Tree) ->
 -spec root_hash(tree()) -> {ok, aeu_mtrees:root_hash()} | {error, empty}.
 root_hash(#oracle_tree{otree = OTree}) ->
     aeu_mtrees:root_hash(OTree).
+
+-spec cache_root_hash(tree()) -> {ok, aeu_mtrees:root_hash()} | {error, empty}.
+cache_root_hash(#oracle_tree{cache = CTree}) ->
+    aeu_mtrees:root_hash(CTree).
 
 -ifdef(TEST).
 -spec oracle_list(tree()) -> list(oracle()).

--- a/apps/aeutils/src/aeu_mtrees.erl
+++ b/apps/aeutils/src/aeu_mtrees.erl
@@ -23,6 +23,7 @@
          iterator_from/3,
          iterator_next/1,
          lookup/2,
+         new_with_backend/2,
          enter/3,
          to_list/1]).
 
@@ -85,6 +86,12 @@ empty() ->
 -spec empty_with_backend(aeu_mp_trees_db:db()) -> mtree().
 empty_with_backend(DB) ->
     aeu_mp_trees:new(DB).
+
+-spec new_with_backend(root_hash() | 'empty', aeu_mp_trees_db:db()) -> mtree().
+new_with_backend(empty, DB) ->
+    empty_with_backend(DB);
+new_with_backend(<<_:256>> = Hash, DB) ->
+    aeu_mp_trees:new(Hash, DB).
 
 delete(Key, Tree) when ?IS_KEY(Key) ->
     aeu_mp_trees:delete(Key, Tree).

--- a/deployment/ansible/deploy.yml
+++ b/deployment/ansible/deploy.yml
@@ -58,7 +58,7 @@
           port: 3114
       chain:
         persist: true
-        db_path: "./db65"
+        db_path: "./db66"
       keypair:
         dir: "keys"
         password: "{{ vault_keys_password|default('secret') }}"

--- a/docs/release-notes/RELEASE-NOTES-0.17.0.md
+++ b/docs/release-notes/RELEASE-NOTES-0.17.0.md
@@ -2,6 +2,7 @@
 
 [This release][this-release] is focused on TODOFILLMEIN.
 It:
+* Stores the chain state in the database in a more compact way. This affects the persisted chain.
 * Does this.
 
 [this-release]: https://github.com/aeternity/epoch/releases/tag/v0.17.0


### PR DESCRIPTION
Make a more compact representation for the state trees of a block. This becomes more important for NG, but it is good for the current system as well.

I add nothing new in Protocol for this, since it is a node local change, and is not visible in the communication protocol.

https://www.pivotaltracker.com/n/projects/2124891/stories/158591718