### PR TITLE
Contract PoI tests

### DIFF
--- a/apps/aecontract/src/aect_contracts.erl
+++ b/apps/aecontract/src/aect_contracts.erl
@@ -30,7 +30,6 @@
           %% Setters
         , set_pubkey/2
         , set_owner/2
-        , set_vm_version/2
         , set_code/2
         , set_state/2
         , set_log/2
@@ -38,6 +37,9 @@
         , set_referers/2
         , set_deposit/2
         ]).
+
+%% For testing only.
+-export([set_vm_version/2]).
 
 -ifdef(TEST).
 -export([internal_set_state/2]).
@@ -255,7 +257,7 @@ set_code(X, C) ->
 
 -spec set_state(store(), contract()) -> contract().
 set_state(X, C) ->
-    internal_set_state(assert_field(store, X), C).
+    internal_set_state(assert_field(store, X, C), C).
 
 internal_set_state(X, C) ->
     C#contract{store = X}.
@@ -292,31 +294,23 @@ assert_fields(C) ->
            , {referers,   referers(C)}
            , {deposit,    C#contract.deposit}
            ],
-    List1 = [try assert_field(X, Y), [] catch _:X -> X end
+    List1 = [try assert_field(X, Y, C), [] catch _:X -> X end
              || {X, Y} <- List],
     case lists:flatten(List1) of
         [] -> C;
         Other -> error({missing, Other})
     end.
 
+assert_field(store = FieldKey, FieldValue, C) ->
+    assert_field_store(FieldKey, FieldValue, C#contract.vm_version);
+assert_field(FieldKey, FieldValue, _) ->
+    assert_field(FieldKey, FieldValue).
+
 assert_field(pubkey, <<_:?PUB_SIZE/binary>> = X)         -> X;
 assert_field(owner,  <<_:?PUB_SIZE/binary>> = X)         -> X;
 assert_field(vm_version, X) when is_integer(X), X > 0,
                                                 X < 6    -> X;
 assert_field(code, X)       when is_binary(X)            -> X;
-assert_field(store = Field, X) when is_map(X) ->
-    try
-        F = fun(K, V, unused) ->
-                    assert_field(store_k, K),
-                    assert_field(store_v, V),
-                    unused
-            end,
-        %% map iterator would limit memory usage though it is available from OTP 21.
-        maps:fold(F, unused, X),
-        X
-    catch _:_ -> error({illegal, Field, X}) end;
-assert_field(store_k, X) when is_binary(X), byte_size(X) > 0 -> X;
-assert_field(store_v, X)    when is_binary(X)            -> X;
 assert_field(log, X)        when is_binary(X)            -> X;
 assert_field(active, X)     when X =:= true; X =:= false -> X;
 assert_field(referers = Field, X) ->
@@ -325,3 +319,20 @@ assert_field(referers = Field, X) ->
 assert_field(referer, <<_:?PUB_SIZE/binary>> = X)        -> X;
 assert_field(deposit, X)    when is_integer(X), X >= 0   -> X;
 assert_field(Field, X) -> error({illegal, Field, X}).
+
+assert_field_store(store = Field, X, VmVersion) when is_map(X) ->
+    try
+        F = fun(K, V, unused) ->
+                    assert_field_store(store_k, K, VmVersion),
+                    assert_field_store(store_v, V, VmVersion),
+                    unused
+            end,
+        %% map iterator would limit memory usage though it is available from OTP 21.
+        maps:fold(F, unused, X),
+        X
+    catch _:_ -> error({illegal, Field, X}) end;
+assert_field_store(store_k = Field, X, VmVersion) when is_binary(X),
+                                               byte_size(X) > 0 ->
+    try true = aevm_eeevm_store:is_valid_key(VmVersion, X)
+    catch _:_ -> error({illegal, Field, X}) end;
+assert_field_store(store_v, X,_VmVersion) when is_binary(X) -> X.

--- a/apps/aecontract/src/aect_state_tree.erl
+++ b/apps/aecontract/src/aect_state_tree.erl
@@ -186,6 +186,11 @@ add_store_keys_poi(Id, {PrefixedKey, _Val, Iter}, PrefixSize, Poi, CtTree) ->
 -spec verify_poi(aect_contracts:id(), aect_contracts:contract(), aec_poi:poi()) ->
                         'ok' | {'error', term()}.
 verify_poi(Id, Contract, Poi) ->
+    %% Hardcode expectation on specified contract object key being
+    %% equal to key in internal representation of contract.  The key
+    %% is not part of the contract serialization so this shall never
+    %% happen.
+    Id = aect_contracts:id(Contract),
     case aec_poi:verify(Id, aect_contracts:serialize(Contract), Poi) of
         {error, _} = E -> E; %% More fine grained error reason than lookup.
         ok ->

--- a/apps/aecontract/test/aecontract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_SUITE.erl
@@ -320,7 +320,8 @@ call_contract_(ContractCallTxGasPrice) ->
 %%%===================================================================
 
 make_contract(PubKey, Code, S) ->
-    Tx = aect_test_utils:create_tx(PubKey, #{ code => Code }, S),
+    Tx = aect_test_utils:create_tx(PubKey, #{ vm_version => 2,
+                                              code => Code }, S),
     {contract_create_tx, CTx} = aetx:specialize_type(Tx),
     aect_contracts:new(CTx).
 

--- a/apps/aecontract/test/aect_contracts_tests.erl
+++ b/apps/aecontract/test/aect_contracts_tests.erl
@@ -49,16 +49,16 @@ basic_setters() ->
 state_setter() ->
     C = aect_contracts:new(create_tx()),
     ?assertEqual(#{}, state(set_state(#{}, C))),
-    ?assertEqual(#{<<"k">> => <<"v">>},
-                 state(set_state(#{<<"k">> => <<"v">>}, C))),
-    ?assertEqual(#{<<"k1">> => <<"v2">>,
-                   <<"k2">> => <<"v1">>},
-                 state(set_state(#{<<"k1">> => <<"v2">>,
-                                   <<"k2">> => <<"v1">>}, C))),
+    ?assertEqual(#{<<1>> => <<"v">>},
+                 state(set_state(#{<<1>> => <<"v">>}, C))),
+    ?assertEqual(#{<<1>> => <<"v2">>,
+                   <<2>> => <<"v1">>},
+                 state(set_state(#{<<1>> => <<"v2">>,
+                                   <<2>> => <<"v1">>}, C))),
     ?assertError({illegal, _, _}, set_state(#{<<>> => <<"v">>}, C)),
-    ?assertEqual(#{<<"k">> => <<>>}, state(set_state(#{<<"k">> => <<>>}, C))),
+    ?assertEqual(#{<<1>> => <<>>}, state(set_state(#{<<1>> => <<>>}, C))),
     ?assertError({illegal, _, _}, set_state(#{<<1:4>> => <<"v">>}, C)),
-    ?assertError({illegal, _, _}, set_state(#{<<"k">> => <<1:4>>}, C)),
+    ?assertError({illegal, _, _}, set_state(#{<<1>> => <<1:4>>}, C)),
     ok.
 
 
@@ -69,7 +69,7 @@ create_tx(Override) ->
     Map = #{ owner      => <<4711:32/unit:8>>
            , nonce      => 42
            , code       => <<"THIS IS NOT ACTUALLY PROPER BYTE CODE">>
-           , vm_version => 1
+           , vm_version => 2
            , fee        => 10
            , ttl        => 100
            , deposit    => 100

--- a/apps/aecore/src/aec_accounts_trees.erl
+++ b/apps/aecore/src/aec_accounts_trees.erl
@@ -86,6 +86,11 @@ add_poi(Pubkey, Tree, Poi) ->
 -spec verify_poi(aec_keys:pubkey(), aec_accounts:account(), aec_poi:poi()) ->
                         'ok' | {'error', term()}.
 verify_poi(AccountKey, Account, Poi) ->
+    %% Hardcode expectation on specified account object key being
+    %% equal to key in internal representation of account.  The key is
+    %% not part of the account serialization so this shall never
+    %% happen.
+    AccountKey = aec_accounts:pubkey(Account),
     aec_poi:verify(AccountKey, aec_accounts:serialize(Account), Poi).
 
 -spec lookup_poi(aec_keys:pubkey(), aec_poi:poi()) ->

--- a/apps/aecore/test/aec_trees_tests.erl
+++ b/apps/aecore/test/aec_trees_tests.erl
@@ -8,6 +8,8 @@
 
 -include("blocks.hrl").
 
+-include_lib("apps/aecontract/src/aecontract.hrl").
+
 -define(TEST_MODULE, aec_trees).
 -define(MINER_PUBKEY, <<42:?MINER_PUB_BYTES/unit:8>>).
 
@@ -168,8 +170,8 @@ poi_test_() ->
       {"Broken serialized PoI fails verification",
        fun() ->
                OwnerPubkey = <<123:?MINER_PUB_BYTES/unit:8>>,
-               Contract = aect_contracts:set_state(#{<<"k1">> => <<"v1">>,
-                                                     <<"k2">> => <<"v2">>},
+               Contract = aect_contracts:set_state(#{<<1>> => <<"v1">>,
+                                                     <<2>> => <<"v2">>},
                                                    make_contract(OwnerPubkey)),
                ContractId = aect_contracts:id(Contract),
 
@@ -385,7 +387,7 @@ poi_test_() ->
        fun() ->
                OwnerPubkey = <<123:?MINER_PUB_BYTES/unit:8>>,
                Contract0 = make_contract(OwnerPubkey),
-               Contract1 = aect_contracts:set_state(#{<<"k">> => <<"v">>},
+               Contract1 = aect_contracts:set_state(#{<<2>> => <<"v">>},
                                                     Contract0),
 
                check_poi_for_one_contract(
@@ -405,7 +407,7 @@ poi_test_() ->
                  fun(C) -> %% Change contract function.
                          ?assertEqual(#{}, %% Assumption for simplicity.
                                       aect_contracts:state(C)),
-                         aect_contracts:set_state(#{<<"k">> => <<"v">>}, C)
+                         aect_contracts:set_state(#{<<1>> => <<"v">>}, C)
                  end)
        end},
       {"PoI for one contract with store that becomes without store",
@@ -413,10 +415,10 @@ poi_test_() ->
                OwnerPubkey = <<123:?MINER_PUB_BYTES/unit:8>>,
 
                check_poi_for_one_contract(
-                 aect_contracts:set_state(#{<<"k">> => <<"v">>},
+                 aect_contracts:set_state(#{<<1>> => <<"v">>},
                                           make_contract(OwnerPubkey)),
                  fun(C) -> %% Change contract function.
-                         ?assertEqual(#{<<"k">> => <<"v">>}, %% Assumption for simplicity.
+                         ?assertEqual(#{<<1>> => <<"v">>}, %% Assumption for simplicity.
                                       aect_contracts:state(C)),
                          aect_contracts:set_state(#{}, C)
                  end)
@@ -425,7 +427,7 @@ poi_test_() ->
        fun() ->
                Contracts =
                    [aect_contracts:set_state(
-                      #{<<"k", X>> => <<"v", X>>}, %% Distinct key per contract.
+                      #{<<1, X>> => <<"v", X>>}, %% Distinct key per contract.
                       make_contract(<<X:?MINER_PUB_BYTES/unit:8>>))
                     || X <- [1, 2, 3]],
                [check_poi_for_a_contract_among_others(
@@ -435,8 +437,22 @@ poi_test_() ->
        end},
       {"Serialized contract PoI with empty contract store key fails verification",
        fun() ->
-               check_poi_for_contract_with_invalid_store_with_binary_keys(
-                 #{<<>> => <<"v">>})
+               [check_poi_for_contract_with_invalid_store_with_binary_keys(
+                  V, #{<<>> => <<"v">>}) || V <- vm_versions()]
+       end},
+      {"Serialized Solidity contract PoI with invalid contract store key fails verification",
+       fun() ->
+               IllegalKeys =
+                   [<<0, (binary:encode_unsigned(K))/binary>>
+                        || K <- lists:seq(0, 3)],
+               [check_poi_for_contract_with_invalid_store_with_binary_keys(
+                  ?AEVM_01_Solidity_01, #{K => <<"v">>}) || K <- IllegalKeys]
+       end},
+      {"Serialized Sophia contract PoI with invalid contract store key fails verification",
+       fun() ->
+               IllegalKeys = [<<1>>, <<2>>, <<16>>],
+               [check_poi_for_contract_with_invalid_store_with_binary_keys(
+                  ?AEVM_01_Sophia_01,  #{K => <<"v">>}) || K <- IllegalKeys]
        end}
     ].
 
@@ -571,11 +587,12 @@ check_poi_for_an_object_among_others(SubTree,
 
     ok.
 
-check_poi_for_contract_with_invalid_store_with_binary_keys(InvalidStore) ->
+check_poi_for_contract_with_invalid_store_with_binary_keys(
+  VmVersion, InvalidStore) ->
     OwnerPubkey = <<123:?MINER_PUB_BYTES/unit:8>>,
 
     %% Generate contract invalid because of an invalid contract store key.
-    ValidContract = make_contract(OwnerPubkey),
+    ValidContract = make_contract(OwnerPubkey, VmVersion),
     InvalidContract = aect_contracts:internal_set_state(InvalidStore,
                                                         ValidContract),
     ContractId = aect_contracts:id(InvalidContract),
@@ -632,16 +649,19 @@ poi_fields_update_with(FieldKey, Fun, PoiFields) ->
       PoiFields).
 
 make_contract(Owner) ->
-    {contract_create_tx, CTx} = aetx:specialize_type(ct_create_tx(Owner)),
+    make_contract(Owner, ?AEVM_01_Solidity_01).
+
+make_contract(Owner, VmVersion) ->
+    {contract_create_tx, CTx} = aetx:specialize_type(ct_create_tx(Owner, VmVersion)),
     aect_contracts:new(CTx).
 
-ct_create_tx(Sender) ->
+ct_create_tx(Sender, VmVersion) ->
     Spec =
         #{ fee        => 5
          , owner      => Sender
          , nonce      => 0
          , code       => <<"NOT PROPER BYTE CODE">>
-         , vm_version => 1
+         , vm_version => VmVersion
          , deposit    => 10
          , amount     => 200
          , gas        => 10
@@ -651,3 +671,8 @@ ct_create_tx(Sender) ->
          },
     {ok, Tx} = aect_create_tx:new(Spec),
     Tx.
+
+vm_versions() ->
+    [ ?AEVM_01_Sophia_01
+    , ?AEVM_01_Solidity_01
+    ].

--- a/apps/aecore/test/aec_trees_tests.erl
+++ b/apps/aecore/test/aec_trees_tests.erl
@@ -181,7 +181,7 @@ poi_test_() ->
                {ok, Poi11} = ?TEST_MODULE:add_poi(contracts, ContractId, Trees1, Poi1),
                Poi11Fields = aec_trees:internal_serialize_poi_fields(Poi11),
 
-               SerializePoiFromFieldsF =
+               PoiFromFieldsF =
                    fun(Fields) ->
                            aec_trees:deserialize_poi(
                              aec_trees:internal_serialize_poi_from_fields(Fields))
@@ -190,7 +190,7 @@ poi_test_() ->
                %% The identified PoI fields lead to PoI that proves object.
                ?assertEqual(ok,
                             aec_trees:verify_poi(contracts, ContractId, Contract,
-                                                 SerializePoiFromFieldsF(Poi11Fields))),
+                                                 PoiFromFieldsF(Poi11Fields))),
 
                %% Check that removing a node from PoI makes object inclusion not proved.
                [{_, Poi11ProofKVs = [_,_|_]}] = %% Hardcoded expectation on test data: at least 2 nodes so able to remove 1 leaving at least a node.
@@ -198,7 +198,7 @@ poi_test_() ->
                lists:foreach(
                  fun(KV) ->
                          BrokenSerializedPoi =
-                             SerializePoiFromFieldsF(
+                             PoiFromFieldsF(
                                poi_fields_update_with(
                                  contracts,
                                  fun([{H, ProofKVs = [_,_|_]}]) ->

--- a/apps/aeutils/test/aeu_mp_trees_tests.erl
+++ b/apps/aeutils/test/aeu_mp_trees_tests.erl
@@ -353,8 +353,8 @@ test_bogus_proofs([],_T) ->
 alter_one_hash_value(DB) ->
     Dict = aeu_mp_trees_db:get_cache(DB),
     Size = dict:size(Dict),
-    Pos  = rand:uniform(Size - 1),
-    {Hash, Node} = lists:nth(Pos + 1, dict:to_list(Dict)),
+    Pos  = rand:uniform(Size),
+    {Hash, Node} = lists:nth(Pos, dict:to_list(Dict)),
     NewNode =
         case Node of
             [X, Y] ->

--- a/apps/aeutils/test/aeu_mp_trees_tests.erl
+++ b/apps/aeutils/test/aeu_mp_trees_tests.erl
@@ -400,7 +400,7 @@ delete_vals([], T) ->
     T.
 
 random_hexstring(N) when N >= 1 ->
-    << <<(rand:uniform(15)):4>> || _ <- lists:seq(1, N) >>.
+    << <<(rand:uniform(16) - 1):4>> || _ <- lists:seq(1, N) >>.
 
 new_dict_db() ->
     aeu_mp_trees_db:new(dict_db_spec()).


### PR DESCRIPTION
Delivers https://www.pivotaltracker.com/story/show/158719808 (not ~PT-158520766~).
* It does not test contract store non-binary (nibble) keys - [tracked separately](https://www.pivotaltracker.com/n/projects/2159793/stories/158689478)
* It does not test contract store values - [tracked separately](https://www.pivotaltracker.com/n/projects/2159793/stories/158630078)

This is follow-up PR for https://github.com/aeternity/epoch/pull/1280 that had not covered test case for "verification of PoI with a contract with an empty (hence invalid) key".

There is no amendment of release notes as this change is not user-visible.

TODO:
* [x] Ensure Python UAT tests and system tests pass
  * [Auxiliary CI workflow](https://circleci.com/workflow-run/040ceee3-3d01-4b3e-ba26-94666771366c) on 0f2aae2 that is equivalent to 66daa87a

Open questions:
* [x] Shall `aeu_mp_trees:iterator_from` semantics be amended to include item it starts from? It seems not in line with `gb_trees:next(gb_trees:iterator_from(...)).`(Please refer to commit messages for details.)
  * Answer: [not now](https://www.pivotaltracker.com/story/show/158520766/comments/191232366).