### PR TITLE
Adjust ping interval and fail instead of crash end_per_testcase

### DIFF
--- a/system_test/aest_commands_SUITE.erl
+++ b/system_test/aest_commands_SUITE.erl
@@ -45,10 +45,7 @@ init_per_testcase(_TC, Config) ->
     aest_nodes:ct_setup(Config).
 
 end_per_testcase(_TC, Config) ->
-    try aest_nodes:ct_cleanup(Config)
-    catch _:Reason ->
-        {fail, Reason}
-    end.
+    aest_nodes:ct_cleanup(Config).
 
 %=== TEST CASES ================================================================
 

--- a/system_test/aest_commands_SUITE.erl
+++ b/system_test/aest_commands_SUITE.erl
@@ -45,8 +45,10 @@ init_per_testcase(_TC, Config) ->
     aest_nodes:ct_setup(Config).
 
 end_per_testcase(_TC, Config) ->
-    aest_nodes:ct_cleanup(Config).
-
+    try aest_nodes:ct_cleanup(Config)
+    catch _:Reason ->
+        {fail, Reason}
+    end.
 
 %=== TEST CASES ================================================================
 

--- a/system_test/aest_perf_SUITE.erl
+++ b/system_test/aest_perf_SUITE.erl
@@ -84,8 +84,9 @@ init_per_group(long_chain, InitCfg) ->
     Ref = aest_nodes:export(n1, Tag, Cfg),
     [kill_node(N, Cfg) || N <- Nodes],
 
-    %% catch may be removed when errors are fixed
-    catch aest_nodes:ct_cleanup(Cfg),
+    %% Match "ok =" when we want to find errors in this stage
+    %% ok = 
+    aest_nodes:ct_cleanup(Cfg),
  
     [{height, Height}, {source, Ref}|Cfg].
 
@@ -94,10 +95,7 @@ end_per_group(long_chain, _Cfg) -> ok.
 init_per_testcase(_TC, Cfg) -> aest_nodes:ct_setup(Cfg).
 
 end_per_testcase(_TC, Cfg) ->
-  try aest_nodes:ct_cleanup(Cfg)
-  catch _:Reason ->
-      {fail, Reason}
-  end.
+  aest_nodes:ct_cleanup(Cfg).
 
 end_per_suite(_Cfg) -> ok.
 

--- a/system_test/aest_perf_SUITE.erl
+++ b/system_test/aest_perf_SUITE.erl
@@ -83,14 +83,21 @@ init_per_group(long_chain, InitCfg) ->
     Tag = io_lib:format("local-h~b", [Height]),
     Ref = aest_nodes:export(n1, Tag, Cfg),
     [kill_node(N, Cfg) || N <- Nodes],
-    aest_nodes:ct_cleanup(Cfg),
+
+    %% catch may be removed when errors are fixed
+    catch aest_nodes:ct_cleanup(Cfg),
+ 
     [{height, Height}, {source, Ref}|Cfg].
 
 end_per_group(long_chain, _Cfg) -> ok.
 
 init_per_testcase(_TC, Cfg) -> aest_nodes:ct_setup(Cfg).
 
-end_per_testcase(_TC, Cfg) -> aest_nodes:ct_cleanup(Cfg).
+end_per_testcase(_TC, Cfg) ->
+  try aest_nodes:ct_cleanup(Cfg)
+  catch _:Reason ->
+      {fail, Reason}
+  end.
 
 end_per_suite(_Cfg) -> ok.
 

--- a/system_test/aest_perf_SUITE_data/epoch.yaml.mustache
+++ b/system_test/aest_perf_SUITE_data/epoch.yaml.mustache
@@ -7,6 +7,7 @@ peers: {{^peers}}[]{{/peers}}
 
 sync:
     port: {{services.sync.port}}
+    ping_interval: 5000
 
 http:
     external:

--- a/system_test/aest_sync_SUITE.erl
+++ b/system_test/aest_sync_SUITE.erl
@@ -121,10 +121,7 @@ init_per_testcase(_TC, Config) ->
     aest_nodes:ct_setup(Config).
 
 end_per_testcase(_TC, Config) ->
-    try aest_nodes:ct_cleanup(Config)
-    catch _:Reason ->
-        {fail, Reason}
-    end.
+    aest_nodes:ct_cleanup(Config).
 
 end_per_suite(_Config) -> ok.
 

--- a/system_test/aest_sync_SUITE.erl
+++ b/system_test/aest_sync_SUITE.erl
@@ -121,7 +121,10 @@ init_per_testcase(_TC, Config) ->
     aest_nodes:ct_setup(Config).
 
 end_per_testcase(_TC, Config) ->
-    aest_nodes:ct_cleanup(Config).
+    try aest_nodes:ct_cleanup(Config)
+    catch _:Reason ->
+        {fail, Reason}
+    end.
 
 end_per_suite(_Config) -> ok.
 

--- a/system_test/aest_sync_SUITE_data/epoch.yaml.mustache
+++ b/system_test/aest_sync_SUITE_data/epoch.yaml.mustache
@@ -7,6 +7,7 @@ peers: {{^peers}}[]{{/peers}}
 
 sync:
     port: {{services.sync.port}}
+    ping_interval: 5000
 
 http:
     external:

--- a/system_test/helpers/aest_nodes.erl
+++ b/system_test/helpers/aest_nodes.erl
@@ -453,7 +453,8 @@ validate_logs(Cfg) ->
     maps:fold(fun(NodeName, LogPath, Result) ->
         Result1 = check_crash_log(NodeName, LogPath, Cfg, Result),
         Result2 = check_log_for_errors(NodeName, LogPath, "epoch.log", Cfg, Result1),
-        check_log_for_errors(NodeName, LogPath, "epoch_sync.log", Cfg, Result2)
+        Result3 = check_log_for_errors(NodeName, LogPath, "epoch_sync.log", Cfg, Result2),
+                  check_log_for_errors(NodeName, LogPath, "epoch_mining.log", Cfg, Result3)
     end, ok, Logs).
 
 check_crash_log(NodeName, LogPath, Cfg, Result) ->

--- a/system_test/helpers/aest_nodes.erl
+++ b/system_test/helpers/aest_nodes.erl
@@ -161,7 +161,9 @@ ct_cleanup(Ctx) ->
     call(Pid, stop),
     wait_for_exit(Pid, ?CALL_TIMEOUT),
     case Result of
-        {error, Reason} -> erlang:error(Reason);
+        {error, Reason} ->
+            %% returning fail will cause common test to see it as test failure 
+            {fail, Reason};
         ok -> ok
     end.
 


### PR DESCRIPTION
The system tests were not very realistic, because mining speed and ping interval are related, but only mining speed was decreased a lot in system test, without taking case of ping interval.

By looking for errors in mining.log the system test fails on present master, because there are errors that need to be fixed in block generation!

[finishes PT-158819238] 