### PR TITLE
PT-158797515: Use base address 0 for decode-data endpoint

### DIFF
--- a/apps/aecontract/src/aect_sophia.erl
+++ b/apps/aecontract/src/aect_sophia.erl
@@ -109,7 +109,7 @@ encode_call_data(Contract, Function, Argument) ->
 decode_data(Type, Data) ->
     case get_type(Type) of
         {ok, SophiaType} ->
-            try aeso_data:from_binary(32, SophiaType,
+            try aeso_data:from_binary(0, SophiaType,
                                       aeu_hex:hexstring_decode(Data)) of
                 {ok, Term} ->
                     try prepare_for_json(SophiaType, Term) of


### PR DESCRIPTION
This makes it possible to use it to decode return values from contract
calls. It previously used base address 32.

[PT-158797515](https://www.pivotaltracker.com/story/show/158797515)