### PR TITLE
Encode signature and key_hash

### DIFF
--- a/apps/aecore/src/aec_blocks.erl
+++ b/apps/aecore/src/aec_blocks.erl
@@ -106,7 +106,7 @@ set_signature(Block, Signature) ->
 key_hash(Block) ->
     Block#block.key_hash.
 
--spec signature(block()) -> binary().
+-spec signature(block()) -> binary() | undefined.
 signature(Block) ->
     Block#block.signature.
 


### PR DESCRIPTION
PT: [Encode/decode signatures in blocks](https://www.pivotaltracker.com/story/show/158723043)
There is a workaround for encoding microblocks with a missing signature. This is to be removed as soon as the get pending block endpoint is refactored to be returning only key blocks