### PR TITLE
alternative way of setting release version from file

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -49,7 +49,7 @@
 {plugins, [{swagger_endpoints, {git, "https://github.com/aeternity/swagger_endpoints", {tag, "0.2.1"}}}, {pc, "1.6.0"}]}.
 {swagger_endpoints, [{src, "config/swagger.yaml"}, {dst, "apps/aeutils/src/endpoints.erl"}]}.
 
-{relx, [{release, { epoch, "version value comes from VERSION" },
+{relx, [{release, { epoch, {cmd, "cat VERSION | tr -d '[:space:]'"}},
          % sasl is required for the command `epoch versions` to work,
          % it is disabled in `sys.config` though.
          [runtime_tools, sasl, lager, setup, sext, rocksdb, mnesia_rocksdb, gproc,

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,8 +1,0 @@
-Relx0 = lists:keyfind(relx, 1, CONFIG),
-{relx, [{release, {epoch, _}, Opts} | T]} = Relx0,
-{ok, VersionBin} = file:read_file(<<"VERSION">>),
-Version = string:trim(binary_to_list(VersionBin)),
-%% the release should be in front
-Relx = {relx, [{release, {epoch, Version}, Opts}] ++ T},
-lists:keyreplace(relx, 1, CONFIG, Relx).
-


### PR DESCRIPTION
Was just looking around and noticed the use of a `rebar.config.script` for this instead of relx's `cmd` option. I should probably make a better way in relx to do this that doesn't require the `tr -d ...`, but yea, just thought I'd mention it.