### PR TITLE
Prevent unsanitized height from peer to cause deletion of txs in pool

### DIFF
--- a/apps/aecore/src/aec_tx_pool.erl
+++ b/apps/aecore/src/aec_tx_pool.erl
@@ -478,8 +478,7 @@ pool_db_put(#state{ db = Db, gc_db = GCDb, gc_height = GCHeight }, Key, Tx, Even
 
 pool_db_raw_put(Db, GCDb, GCHeight, Key, Tx, TxHash) ->
     ets:insert(Db, {Key, Tx}),
-    enter_tx_gc(GCDb, TxHash, GCHeight + tx_ttl()),
-    ok.
+    enter_tx_gc(GCDb, TxHash, GCHeight + tx_ttl()).
 
 check_tx_ttl(STx, _Hash) ->
     Tx = aetx_sign:tx(STx),

--- a/apps/aecore/src/aec_tx_pool.erl
+++ b/apps/aecore/src/aec_tx_pool.erl
@@ -292,8 +292,9 @@ adjust_gc_height(GCDb, TxHash, Diff) ->
     adjust_gc_height(GCDb, ets:next(GCDb, TxHash), Diff).
 
 do_gc(State) ->
-    State1 = do_update_sync_top(State, top_height()),
-    do_gc(State1, State1#state.gc_height).
+    Height = top_height(),
+    State1 = do_update_sync_top(State, Height),
+    do_gc(State1, Height).
 
 do_gc(State = #state{ gc_db = GCDb }, Height) ->
     GCTxs = ets:foldl(fun({TxHash, ExpireBy}, Acc) ->

--- a/docs/release-notes/RELEASE-NOTES-0.18.0.md
+++ b/docs/release-notes/RELEASE-NOTES-0.18.0.md
@@ -4,6 +4,8 @@
 It:
 * Introduces new configuration parameter - `beneficiary`, that is an encoded form of account pubkey, that will receive rewards from mining on a node. This parameter is to be set in [User provided configuration](https://github.com/aeternity/epoch/wiki/User-provided-configuration) and is mandatory to start a node.
 * Adds new field - `beneficiary` - to block. This impacts consensus.
+* Improves the stability of the garbage collection of transactions in the mempool.
+
 [this-release]: https://github.com/aeternity/epoch/releases/tag/v0.18.0
 
 This release introduces backward incompatible changes in the chain format:


### PR DESCRIPTION
~This PR is a draft patch proposed by @hanssv - I packaged it as a PR while I understand better its impact.~

Delivers https://www.pivotaltracker.com/n/projects/2124891/stories/158915027
* This PR does not prevent peer to delay GC, though that is considered smaller issue and tracked as https://www.pivotaltracker.com/story/show/158939771