### PR TITLE
Make conductor start_mining api friendly for multiple calls

### DIFF
--- a/apps/aecore/src/aec_conductor.erl
+++ b/apps/aecore/src/aec_conductor.erl
@@ -208,6 +208,9 @@ handle_call(stop_mining,_From, State = #state{ consensus = Cons }) ->
     State1 = kill_all_workers(State),
     {reply, ok, State1#state{mining_state = 'stopped',
                              key_block_candidate = undefined}};
+handle_call(start_mining,_From, #state{mining_state = 'running'} = State) ->
+    epoch_mining:info("Mining running"),
+    {reply, ok, State};
 handle_call(start_mining,_From, State) ->
     epoch_mining:info("Mining started"),
     State1 = start_mining(State#state{mining_state = 'running', consensus = #consensus{leader = false}}),
@@ -789,7 +792,7 @@ create_key_block_candidate(#state{top_block_hash = TopHash} = State) ->
 
 handle_key_block_candidate_reply({{ok, KeyBlockCandidate}, TopHash},
                                  #state{top_block_hash = TopHash} = State) ->
-    epoch_mining:info("Created key block candidate"
+    epoch_mining:info("Created key block candidate "
                       "Its target is ~p (= difficulty ~p).",
                       [aec_blocks:target(KeyBlockCandidate),
                        aec_blocks:difficulty(KeyBlockCandidate)]),


### PR DESCRIPTION
Close PT-158762778

API was designed to be called by supervisor only once per conductor process lifetime.
Not it actually matches on state.

`aecore_suite_utils` is still imperfect for getting chain ready for tests (it is possible to shut down mining too early in case of multiple mining requests).