### PR TITLE
Adapt system test creating spend tx to recent aec_id changes

### DIFF
--- a/system_test/aest_sync_SUITE.erl
+++ b/system_test/aest_sync_SUITE.erl
@@ -428,8 +428,8 @@ add_spend_txs(Node, SenderAcct, N, NonceStart) ->
 
 add_spend_tx(Node, #{ pubkey := SendPubKey, privkey := SendSecKey }, Nonce) ->
     #{ public := RecvPubKey, secret := RecvSecKey } = enacl:sign_keypair(),
-    Params = #{ sender => SendPubKey
-              , recipient => RecvPubKey
+    Params = #{ sender => aec_id:create(account, SendPubKey)
+              , recipient => aec_id:create(account, RecvPubKey)
               , amount => 10000
               , fee => 100
               , ttl => 10000000


### PR DESCRIPTION
Delivers https://www.pivotaltracker.com/story/show/159034444
Follows https://github.com/aeternity/epoch/pull/1332

TODO:
* [x] Check system test sync suite passes (no error for "aec_spend_tx,new")
  * [Auxiliary CI workflow](https://circleci.com/gh/lucafavatella/epoch/4308) on b4a538b equivalent to e205c152 UPDATE: No error for aec_spend_tx,new"