### PR TITLE
Mitigate net split sysmte test failures

### DIFF
--- a/system_test/aest_sync_SUITE.erl
+++ b/system_test/aest_sync_SUITE.erl
@@ -447,7 +447,7 @@ add_spend_tx(Node, #{ pubkey := SendPubKey, privkey := SendSecKey }, Nonce) ->
 %% network partitions, and that the network is partitiioned when the chain
 %% is already shared.
 net_split_recovery(Cfg) ->
-    Length = 10,
+    Length = 20,
 
     setup_nodes([?NET1_NODE1, ?NET1_NODE2, ?NET2_NODE1, ?NET2_NODE2], Cfg),
     Nodes = [net1_node1, net1_node2, net2_node1, net2_node2],


### PR DESCRIPTION
I was able to reproduce the issue https://circleci.com/gh/aeternity/epoch/21990 locally roughly one time out of 7.
From what I could see, it seems that the test fails when a node tries to connect to another node and it fails (probably because of startup time) and then the nodes mine the 10 blocks faster than the reconnection delay. When changing the number of blocks to mine from 10 to 20, the test run 50 times without any failure (and then I stopped, it never failed for me locally).