### PR TITLE
Fix a bug in channel's FSM: deposit and withdrawal txs

### DIFF
--- a/docs/release-notes/RELEASE-NOTES-0.19.0.md
+++ b/docs/release-notes/RELEASE-NOTES-0.19.0.md
@@ -4,7 +4,8 @@
 It:
 * Removes `key_hash` field from micro blocks. This impacts consensus.
 * Fixes a bug when a trusted peer changes its IP, it was crashing instead of just ignoring the change.
-* Does this.
+* Fine tunes deposit and withdrawal channel transactions being produced for the user.
+  This does not impact channels' protocol
 
 [this-release]: https://github.com/aeternity/epoch/releases/tag/v0.19.0
 


### PR DESCRIPTION
[FSM balances of deposit/withdrawal](https://www.pivotaltracker.com/story/show/159215557)

FSM used to produce `channel_deposit_tx` and `channel_withdraw_tx` with erronous `state_hash`
It used to be the current root hash of the channel state tree without the changes being applied (while it should include the change being applied as well). Basically the resulted state hash was correct, disregarding the deposit/withdrawal, so it was correct for the wrong balances. This results in posting an incorrect state hash on-chain.

In order to expose the bug, I needed to peek inside the FSM state. Provided an `aesc_fsm:get_state/1` for this.