### PR TITLE
PT-158827776 Add second batch of the new HTTP API endpoints

### DIFF
--- a/apps/aechannel/src/aesc_channels.erl
+++ b/apps/aechannel/src/aesc_channels.erl
@@ -228,15 +228,15 @@ serialization_template(?CHANNEL_VSN) ->
 
 -spec serialize_for_client(channel()) -> map().
 serialize_for_client(#channel{} = Ch) ->
-    #{<<"id">>               => id(Ch),
-      <<"initiator">>        => initiator(Ch),
-      <<"responder">>        => responder(Ch),
+    #{<<"id">>               => aec_base58c:encode(channel, id(Ch)),
+      <<"initiator">>        => aec_base58c:encode(account_pubkey, initiator(Ch)),
+      <<"responder">>        => aec_base58c:encode(account_pubkey, responder(Ch)),
       <<"total_amount">>     => total_amount(Ch),
       <<"initiator_amount">> => initiator_amount(Ch),
       <<"responder_amount">> => responder_amount(Ch),
       <<"channel_reserve">>  => channel_reserve(Ch),
-      <<"delegates">>        => delegates(Ch),
-      <<"state_hash">>       => state_hash(Ch),
+      <<"delegates">>        => [aec_base58c:encode(account_pubkey, D) || D <- delegates(Ch)],
+      <<"state_hash">>       => aec_base58c:encode(block_state_hash, state_hash(Ch)),
       <<"round">>            => round(Ch),
       <<"lock_period">>      => lock_period(Ch),
       <<"closes_at">>        => closes_at(Ch)}.

--- a/apps/aechannel/src/aesc_channels.erl
+++ b/apps/aechannel/src/aesc_channels.erl
@@ -16,6 +16,7 @@
          peers/1,
          delegates/1,
          serialize/1,
+         serialize_for_client/1,
          close_solo/3,
          close_solo/4,
          snapshot_solo/2,
@@ -225,6 +226,21 @@ serialization_template(?CHANNEL_VSN) ->
     , {closes_at        , int}
     ].
 
+-spec serialize_for_client(channel()) -> map().
+serialize_for_client(#channel{} = Ch) ->
+    #{<<"id">>               => id(Ch),
+      <<"initiator">>        => initiator(Ch),
+      <<"responder">>        => responder(Ch),
+      <<"total_amount">>     => total_amount(Ch),
+      <<"initiator_amount">> => initiator_amount(Ch),
+      <<"responder_amount">> => responder_amount(Ch),
+      <<"channel_reserve">>  => channel_reserve(Ch),
+      <<"delegates">>        => delegates(Ch),
+      <<"state_hash">>       => state_hash(Ch),
+      <<"round">>            => round(Ch),
+      <<"lock_period">>      => lock_period(Ch),
+      <<"closes_at">>        => closes_at(Ch)}.
+
 -spec withdraw(channel(), amount(), seq_number(), binary()) -> channel().
 withdraw(#channel{total_amount = TotalAmount} = Ch, Amount, Round, StateHash) ->
     Ch#channel{total_amount = TotalAmount - Amount,
@@ -289,4 +305,4 @@ fetch_amount_from_poi(PoI, Pubkey) ->
     {ok, Account} = aec_trees:lookup_poi(accounts, Pubkey, PoI),
     aec_accounts:balance(Account).
 
-    
+

--- a/apps/aechannel/test/aesc_fsm_SUITE.erl
+++ b/apps/aechannel/test/aesc_fsm_SUITE.erl
@@ -32,6 +32,11 @@
         , multiple_channels/1
         ]).
 
+%% exports for aehttp_integration_SUITE
+-export([
+          create_channel_on_port/1
+        ]).
+
 -include_lib("common_test/include/ct.hrl").
 
 -define(TIMEOUT, 10000).
@@ -492,6 +497,13 @@ ch_loop(I, R, Parent) ->
             ch_loop(I1, R1, Parent);
         die -> ok
     end.
+
+create_channel_on_port(Port) ->
+    Node = dev1,
+    I = prep_initiator(Node),
+    R = prep_responder(I, Node),
+    Cfg = [{port, Port}, {initiator, I}, {responder, R}, ?SLOGAN],
+    create_channel_(Cfg, get_debug(Cfg)).
 
 create_channel_(Cfg) ->
     create_channel_(Cfg, get_debug(Cfg)).

--- a/apps/aecontract/src/aect_contracts.erl
+++ b/apps/aecontract/src/aect_contracts.erl
@@ -14,6 +14,7 @@
         , new/1
         , new/5 %% For use without transaction
         , serialize/1
+        , serialize_for_client/1
         , compute_contract_pubkey/2
         , compute_contract_store_id/1
         , is_legal_state_fun/1
@@ -137,6 +138,17 @@ serialize(#contract{owner = OwnerId, referers = RefererIds} = C) ->
       , {referers, RefererIds}
       , {deposit, deposit(C)}
       ]).
+
+-spec serialize_for_client(contract()) -> map().
+serialize_for_client(#contract{} = C) ->
+    #{ <<"id">> => aec_base58c:encode(contract_pubkey, id(C))
+     , <<"owner">> => aec_base58c:encode(account_pubkey, owner(C))
+     , <<"vm_version">> => vm_version(C)
+     , <<"log">> => log(C)
+     , <<"active">> => active(C)
+     , <<"referers">> => [ aec_base58c:encode(contract_pubkey, Ref) || Ref <- referers(C) ]
+     , <<"deposit">> => deposit(C)
+     }.
 
 -spec deserialize(id(), serialized()) -> contract().
 deserialize(Pubkey, Bin) ->

--- a/apps/aecore/src/aec_base58c.erl
+++ b/apps/aecore/src/aec_base58c.erl
@@ -1,6 +1,7 @@
 -module(aec_base58c).
 
--export([encode/2,
+-export([encode/1,
+         encode/2,
          decode/1,
          safe_decode/2,
          byte_size_for_type/1]).
@@ -27,6 +28,10 @@
 
 -type payload() :: binary().
 -type encoded() :: binary().
+
+-spec encode(payload()) -> encoded().
+encode(Payload) ->
+    base58_check(Payload).
 
 -spec encode(known_type(), payload() | aec_id:id()) -> encoded().
 encode(id_hash, Payload) ->

--- a/apps/aecore/src/aec_chain.erl
+++ b/apps/aecore/src/aec_chain.erl
@@ -52,8 +52,10 @@
         ]).
 
 %%% Oracles API
--export([ get_open_oracle_queries/3
-        , get_oracles/2
+-export([ get_oracles/2
+        , get_oracle/1
+        , get_oracle_queries/4
+        , get_oracle_query/2
         ]).
 
 %%% Contracts API
@@ -113,26 +115,52 @@ all_accounts_balances_at_hash(Hash) when is_binary(Hash) ->
 %%% Oracles
 %%%===================================================================
 
--spec get_open_oracle_queries(aec_keys:pubkey(), binary() | '$first', non_neg_integer()) ->
-                                     {'ok', list()} |
-                                     {'error', 'no_state_trees'}.
-get_open_oracle_queries(Oracle, From, Max) ->
-    case get_top_state() of
-        {ok, Trees} ->
-            OT = aec_trees:oracles(Trees),
-            {ok, aeo_state_tree:get_open_oracle_queries(Oracle, From, Max, OT)};
-        error -> {error, no_state_trees}
-    end.
-
 -spec get_oracles(binary() | '$first', non_neg_integer()) ->
-                         {'ok', list()} |
-                         {'error', 'no_state_trees'}.
+    {ok, [aeo_oracles:oracle()]} | {error, no_state_trees}.
 get_oracles(From, Max) ->
     case get_top_state() of
         {ok, Trees} ->
             {ok, aeo_state_tree:get_oracles(From, Max, aec_trees:oracles(Trees))};
         error ->
             {error, no_state_trees}
+    end.
+
+-spec get_oracle(aec_keys:pubkey()) ->
+    {ok, aeo_oracles:oracle()} | {error, not_found} | {error, no_state_trees}.
+get_oracle(Pubkey) ->
+    case get_top_state() of
+        {ok, Trees} -> get_oracle(Pubkey, aec_trees:oracles(Trees));
+        error -> {error, no_state_trees}
+    end.
+
+-spec get_oracle_queries(aec_keys:pubkey(), binary() | '$first', open | closed | all, non_neg_integer()) ->
+    {ok, [aeo_query:query()]} | {error, no_state_trees}.
+get_oracle_queries(Oracle, From, QueryType, Max) ->
+    case get_top_state() of
+        {ok, Trees} ->
+            OT = aec_trees:oracles(Trees),
+            {ok, aeo_state_tree:get_oracle_queries(Oracle, From, QueryType, Max, OT)};
+        error -> {error, no_state_trees}
+    end.
+
+-spec get_oracle_query(aec_keys:pubkey(), aeo_query:id()) ->
+    {ok, aeo_query:query()} | {error, not_found} | {error, no_state_trees}.
+get_oracle_query(Pubkey, Id) ->
+    case get_top_state() of
+        {ok, Trees} -> get_oracle_query(Pubkey, Id, aec_trees:oracles(Trees));
+        error -> {error, no_state_trees}
+    end.
+
+get_oracle(Pubkey, Trees) ->
+    case aeo_state_tree:lookup_oracle(Pubkey, Trees) of
+        {value, Oracle} -> {ok, Oracle};
+        none -> {error, not_found}
+    end.
+
+get_oracle_query(Pubkey, Id, Trees) ->
+    case aeo_state_tree:lookup_query(Pubkey, Id, Trees) of
+        {value, Query} -> {ok, Query};
+        none -> {error, not_found}
     end.
 
 %%%===================================================================

--- a/apps/aehttp/priv/swagger.json
+++ b/apps/aehttp/priv/swagger.json
@@ -837,6 +837,41 @@
         }
       }
     },
+    "/names/{name}" : {
+      "get" : {
+        "tags" : [ "external", "name_service" ],
+        "description" : "Get name entry from naming system",
+        "operationId" : "GetNameEntryByName",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "name",
+          "in" : "path",
+          "description" : "The name key of the name entry",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/NameEntry"
+            }
+          },
+          "400" : {
+            "description" : "Invalid name",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Name not found",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
     "/header-by-hash" : {
       "get" : {
         "tags" : [ "external", "gossip" ],

--- a/apps/aehttp/priv/swagger.json
+++ b/apps/aehttp/priv/swagger.json
@@ -606,6 +606,138 @@
         }
       }
     },
+    "/oracles/{pubkey}" : {
+      "get" : {
+        "tags" : [ "external", "gossip" ],
+        "description" : "Get an oracle by public key",
+        "operationId" : "GetOracleByPubkey",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "pubkey",
+          "in" : "path",
+          "description" : "The public key of the oracle",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/RegisteredOracle"
+            }
+          },
+          "400" : {
+            "description" : "Invalid public key",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Oracle not found",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/oracles/{pubkey}/queries" : {
+      "get" : {
+        "tags" : [ "external", "gossip" ],
+        "description" : "Get oracle queries by public key",
+        "operationId" : "GetOracleQueriesByPubkey",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "pubkey",
+          "in" : "path",
+          "description" : "The public key of the oracle",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "from",
+          "in" : "query",
+          "description" : "Last query id in previous page",
+          "required" : false,
+          "type" : "string"
+        }, {
+          "name" : "limit",
+          "in" : "query",
+          "description" : "Max number of oracle queries",
+          "required" : false,
+          "type" : "integer",
+          "maximum" : 1000,
+          "minimum" : 1
+        }, {
+          "name" : "type",
+          "in" : "query",
+          "description" : "The type of a query: open, closed or all",
+          "required" : false,
+          "type" : "string",
+          "enum" : [ "open", "closed", "all" ]
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/OracleQueries"
+            }
+          },
+          "400" : {
+            "description" : "Invalid public key",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Oracle not found",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/oracles/{pubkey}/queries/{query-id}" : {
+      "get" : {
+        "tags" : [ "external", "gossip" ],
+        "description" : "Get an oracle query by public key and query ID",
+        "operationId" : "GetOracleQueryByPubkeyAndQueryId",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "pubkey",
+          "in" : "path",
+          "description" : "The public key of the oracle",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "query-id",
+          "in" : "path",
+          "description" : "The ID of the query",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/OracleQuery"
+            }
+          },
+          "400" : {
+            "description" : "Invalid public key or query ID",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Oracle query not found",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
     "/header-by-hash" : {
       "get" : {
         "tags" : [ "external", "gossip" ],
@@ -3108,16 +3240,152 @@
         "$ref" : "#/definitions/Tx"
       }
     },
+    "RegisteredOracle" : {
+      "type" : "object",
+      "properties" : {
+        "id" : {
+          "type" : "string"
+        },
+        "query_format" : {
+          "type" : "string"
+        },
+        "response_format" : {
+          "type" : "string"
+        },
+        "query_fee" : {
+          "type" : "integer"
+        },
+        "expires" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      },
+      "example" : {
+        "expires" : 6,
+        "response_format" : "response_format",
+        "id" : "id",
+        "query_fee" : 0,
+        "query_format" : "query_format"
+      }
+    },
     "RegisteredOracles" : {
       "type" : "array",
       "items" : {
-        "$ref" : "#/definitions/RegisteredOracles_inner"
+        "$ref" : "#/definitions/RegisteredOracle"
+      }
+    },
+    "OracleQuery" : {
+      "type" : "object",
+      "properties" : {
+        "id" : {
+          "type" : "string"
+        },
+        "sender" : {
+          "type" : "string"
+        },
+        "sender_nonce" : {
+          "type" : "integer",
+          "format" : "int64",
+          "minimum" : 0
+        },
+        "oracle_id" : {
+          "type" : "string"
+        },
+        "query" : {
+          "type" : "string"
+        },
+        "response" : {
+          "type" : "string"
+        },
+        "expires" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "response_ttl" : {
+          "$ref" : "#/definitions/TTL"
+        },
+        "fee" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      },
+      "example" : {
+        "expires" : 6,
+        "oracle_id" : "oracle_id",
+        "response_ttl" : {
+          "type" : "delta",
+          "value" : 1
+        },
+        "sender" : "sender",
+        "response" : "response",
+        "query" : "query",
+        "fee" : 5,
+        "sender_nonce" : 0,
+        "id" : "id"
+      }
+    },
+    "OracleQuestion" : {
+      "type" : "object",
+      "properties" : {
+        "query_id" : {
+          "type" : "string"
+        },
+        "query" : {
+          "type" : "string"
+        },
+        "query_fee" : {
+          "type" : "integer"
+        },
+        "expires_at" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      }
+    },
+    "OracleQueries" : {
+      "type" : "object",
+      "properties" : {
+        "oracle_queries" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/OracleQuery"
+          }
+        }
+      },
+      "example" : {
+        "oracle_queries" : [ {
+          "expires" : 6,
+          "oracle_id" : "oracle_id",
+          "response_ttl" : {
+            "type" : "delta",
+            "value" : 1
+          },
+          "sender" : "sender",
+          "response" : "response",
+          "query" : "query",
+          "fee" : 5,
+          "sender_nonce" : 0,
+          "id" : "id"
+        }, {
+          "expires" : 6,
+          "oracle_id" : "oracle_id",
+          "response_ttl" : {
+            "type" : "delta",
+            "value" : 1
+          },
+          "sender" : "sender",
+          "response" : "response",
+          "query" : "query",
+          "fee" : 5,
+          "sender_nonce" : 0,
+          "id" : "id"
+        } ]
       }
     },
     "OracleQuestions" : {
       "type" : "array",
       "items" : {
-        "$ref" : "#/definitions/OracleQuestions_inner"
+        "$ref" : "#/definitions/OracleQuestion"
       }
     },
     "SpendTx" : {
@@ -3204,13 +3472,13 @@
       },
       "example" : {
         "response_format" : "response_format",
-        "fee" : 5,
+        "fee" : 1,
         "oracle_ttl" : {
           "type" : "delta",
           "value" : 1
         },
         "query_fee" : 0,
-        "nonce" : 1,
+        "nonce" : 6,
         "ttl" : 5,
         "query_format" : "query_format",
         "account" : { }
@@ -4878,43 +5146,6 @@
       },
       "example" : {
         "pubkey" : { }
-      }
-    },
-    "RegisteredOracles_inner" : {
-      "properties" : {
-        "address" : {
-          "type" : "string"
-        },
-        "query_format" : {
-          "type" : "string"
-        },
-        "response_format" : {
-          "type" : "string"
-        },
-        "query_fee" : {
-          "type" : "integer"
-        },
-        "expires_at" : {
-          "type" : "integer",
-          "format" : "int64"
-        }
-      }
-    },
-    "OracleQuestions_inner" : {
-      "properties" : {
-        "query_id" : {
-          "type" : "string"
-        },
-        "query" : {
-          "type" : "string"
-        },
-        "query_fee" : {
-          "type" : "integer"
-        },
-        "expires_at" : {
-          "type" : "integer",
-          "format" : "int64"
-        }
       }
     }
   },

--- a/apps/aehttp/priv/swagger.json
+++ b/apps/aehttp/priv/swagger.json
@@ -449,6 +449,76 @@
         }
       }
     },
+    "/accounts/{pubkey}" : {
+      "get" : {
+        "tags" : [ "external", "gossip" ],
+        "description" : "Get an account by public key",
+        "operationId" : "GetAccountByPubkey",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "pubkey",
+          "in" : "path",
+          "description" : "The public key of the account",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/Account"
+            }
+          },
+          "400" : {
+            "description" : "Invalid public key",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Account not found",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/accounts/{pubkey}/transactions/pending" : {
+      "get" : {
+        "tags" : [ "external", "gossip" ],
+        "description" : "Get pending account transactions by public key",
+        "operationId" : "GetPendingAccountTransactionsByPubkey",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "pubkey",
+          "in" : "path",
+          "description" : "The public key of the account",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/JSONTxs"
+            }
+          },
+          "400" : {
+            "description" : "Invalid public key",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Account not found",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
     "/header-by-hash" : {
       "get" : {
         "tags" : [ "external", "gossip" ],
@@ -2900,6 +2970,32 @@
           }
         }
       } ]
+    },
+    "Account" : {
+      "type" : "object",
+      "properties" : {
+        "pubkey" : {
+          "type" : "string",
+          "description" : "Public key"
+        },
+        "balance" : {
+          "type" : "integer",
+          "format" : "int64",
+          "description" : "Balance",
+          "minimum" : 0
+        },
+        "nonce" : {
+          "type" : "integer",
+          "format" : "int64",
+          "description" : "Nonce",
+          "minimum" : 0
+        }
+      },
+      "example" : {
+        "balance" : 0,
+        "nonce" : 0,
+        "pubkey" : "pubkey"
+      }
     },
     "Balance" : {
       "type" : "object",

--- a/apps/aehttp/priv/swagger.json
+++ b/apps/aehttp/priv/swagger.json
@@ -872,6 +872,41 @@
         }
       }
     },
+    "/channels/{pubkey}" : {
+      "get" : {
+        "tags" : [ "external", "gossip" ],
+        "description" : "Get channel by public key",
+        "operationId" : "GetChannelByPubkey",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "pubkey",
+          "in" : "path",
+          "description" : "The pubkey of the channel",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/Channel"
+            }
+          },
+          "400" : {
+            "description" : "Invalid public key",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Channel not found",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
     "/header-by-hash" : {
       "get" : {
         "tags" : [ "external", "gossip" ],
@@ -4031,6 +4066,77 @@
       },
       "example" : {
         "name_hash" : "name_hash"
+      }
+    },
+    "Channel" : {
+      "type" : "object",
+      "properties" : {
+        "id" : {
+          "$ref" : "#/definitions/EncodedHash"
+        },
+        "initiator" : {
+          "$ref" : "#/definitions/EncodedHash"
+        },
+        "responder" : {
+          "$ref" : "#/definitions/EncodedHash"
+        },
+        "total_amount" : {
+          "type" : "integer",
+          "format" : "int64",
+          "minimum" : 0
+        },
+        "initiator_amount" : {
+          "type" : "integer",
+          "format" : "int64",
+          "minimum" : 0
+        },
+        "responder_amount" : {
+          "type" : "integer",
+          "format" : "int64",
+          "minimum" : 0
+        },
+        "channel_reserve" : {
+          "type" : "integer",
+          "format" : "int64",
+          "minimum" : 0
+        },
+        "delegates" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/EncodedHash"
+          }
+        },
+        "state_hash" : {
+          "$ref" : "#/definitions/EncodedHash"
+        },
+        "round" : {
+          "type" : "integer",
+          "format" : "int64",
+          "minimum" : 0
+        },
+        "lock_period" : {
+          "type" : "integer",
+          "format" : "int64",
+          "minimum" : 0
+        },
+        "closes_at" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      },
+      "example" : {
+        "responder_amount" : 0,
+        "initiator_amount" : 0,
+        "round" : 0,
+        "total_amount" : 0,
+        "state_hash" : null,
+        "initiator" : null,
+        "responder" : null,
+        "id" : { },
+        "delegates" : [ null, null ],
+        "closes_at" : 7,
+        "lock_period" : 0,
+        "channel_reserve" : 0
       }
     },
     "ChannelCreateTx" : {

--- a/apps/aehttp/priv/swagger.json
+++ b/apps/aehttp/priv/swagger.json
@@ -519,6 +519,93 @@
         }
       }
     },
+    "/transactions/{hash}" : {
+      "get" : {
+        "tags" : [ "external", "transactions" ],
+        "description" : "Get a transaction by hash",
+        "operationId" : "GetTransactionByHash",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "hash",
+          "in" : "path",
+          "description" : "The hash of the transaction",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/SignedTxJSON"
+            }
+          },
+          "400" : {
+            "description" : "Invalid hash",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Transaction not found",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/transactions/{hash}/info" : {
+      "get" : {
+        "tags" : [ "external", "transactions" ],
+        "description" : "Get a transaction info by hash",
+        "operationId" : "GetTransactionInfoByHash",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "hash",
+          "in" : "path",
+          "description" : "The hash of the transaction",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/ContractCallObject"
+            }
+          },
+          "400" : {
+            "description" : "Invalid hash",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Transaction not found",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/transactions" : {
+      "get" : {
+        "tags" : [ "external", "transactions" ],
+        "description" : "Get transactions in the mempool",
+        "operationId" : "GetTxs",
+        "produces" : [ "application/json" ],
+        "parameters" : [ ],
+        "responses" : {
+          "200" : {
+            "description" : "Successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/Transactions"
+            }
+          }
+        }
+      }
+    },
     "/header-by-hash" : {
       "get" : {
         "tags" : [ "external", "gossip" ],
@@ -1447,23 +1534,6 @@
             "description" : "Contract not found",
             "schema" : {
               "$ref" : "#/definitions/Error"
-            }
-          }
-        }
-      }
-    },
-    "/transactions" : {
-      "get" : {
-        "tags" : [ "external", "transactions" ],
-        "description" : "Get transactions in the mempool",
-        "operationId" : "GetTxs",
-        "produces" : [ "application/json" ],
-        "parameters" : [ ],
-        "responses" : {
-          "200" : {
-            "description" : "Successful operation",
-            "schema" : {
-              "$ref" : "#/definitions/Transactions"
             }
           }
         }

--- a/apps/aehttp/priv/swagger.json
+++ b/apps/aehttp/priv/swagger.json
@@ -907,6 +907,23 @@
         }
       }
     },
+    "/peers/pubkey" : {
+      "get" : {
+        "tags" : [ "external", "gossip" ],
+        "description" : "Get peer public key",
+        "operationId" : "GetPeerPubkey",
+        "produces" : [ "application/json" ],
+        "parameters" : [ ],
+        "responses" : {
+          "200" : {
+            "description" : "Successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/inline_response_200_3"
+            }
+          }
+        }
+      }
+    },
     "/header-by-hash" : {
       "get" : {
         "tags" : [ "external", "gossip" ],
@@ -2734,7 +2751,7 @@
           "200" : {
             "description" : "The count of transactions in the block",
             "schema" : {
-              "$ref" : "#/definitions/inline_response_200_3"
+              "$ref" : "#/definitions/inline_response_200_4"
             }
           },
           "400" : {
@@ -2781,7 +2798,7 @@
           "200" : {
             "description" : "The count of transactions in the block",
             "schema" : {
-              "$ref" : "#/definitions/inline_response_200_3"
+              "$ref" : "#/definitions/inline_response_200_4"
             }
           },
           "404" : {
@@ -2816,7 +2833,7 @@
           "200" : {
             "description" : "The count of transactions in the genesis block",
             "schema" : {
-              "$ref" : "#/definitions/inline_response_200_3"
+              "$ref" : "#/definitions/inline_response_200_4"
             }
           }
         }
@@ -2845,7 +2862,7 @@
           "200" : {
             "description" : "The count of transactions in the latest block",
             "schema" : {
-              "$ref" : "#/definitions/inline_response_200_3"
+              "$ref" : "#/definitions/inline_response_200_4"
             }
           }
         }
@@ -2874,7 +2891,7 @@
           "200" : {
             "description" : "The count of transactions in the pending block",
             "schema" : {
-              "$ref" : "#/definitions/inline_response_200_3"
+              "$ref" : "#/definitions/inline_response_200_4"
             }
           },
           "404" : {
@@ -3149,7 +3166,7 @@
           "200" : {
             "description" : "Node's peer public key",
             "schema" : {
-              "$ref" : "#/definitions/inline_response_200_4"
+              "$ref" : "#/definitions/inline_response_200_5"
             }
           },
           "404" : {
@@ -5429,6 +5446,16 @@
     },
     "inline_response_200_3" : {
       "properties" : {
+        "pubkey" : {
+          "type" : "string"
+        }
+      },
+      "example" : {
+        "pubkey" : "pubkey"
+      }
+    },
+    "inline_response_200_4" : {
+      "properties" : {
         "count" : {
           "type" : "integer",
           "description" : "Count"
@@ -5438,7 +5465,7 @@
         "count" : 0
       }
     },
-    "inline_response_200_4" : {
+    "inline_response_200_5" : {
       "properties" : {
         "pubkey" : {
           "$ref" : "#/definitions/EncodedHash"

--- a/apps/aehttp/priv/swagger.json
+++ b/apps/aehttp/priv/swagger.json
@@ -606,6 +606,105 @@
         }
       }
     },
+    "/contracts/{pubkey}" : {
+      "get" : {
+        "tags" : [ "external", "transactions" ],
+        "description" : "Get a contract by pubkey",
+        "operationId" : "GetContract",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "pubkey",
+          "in" : "path",
+          "description" : "The pubkey of the contract",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/ContractObject"
+            }
+          },
+          "400" : {
+            "description" : "Invalid pubkey",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Contract not found"
+          }
+        }
+      }
+    },
+    "/contracts/{pubkey}/code" : {
+      "get" : {
+        "tags" : [ "external", "transactions" ],
+        "description" : "Get contract code by pubkey",
+        "operationId" : "GetContractCode",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "pubkey",
+          "in" : "path",
+          "description" : "The pubkey of the contract",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Contract code",
+            "schema" : {
+              "$ref" : "#/definitions/ByteCode"
+            }
+          },
+          "400" : {
+            "description" : "Invalid pubkey",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Contract not found",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/contracts/{pubkey}/store" : {
+      "get" : {
+        "tags" : [ "external", "transactions" ],
+        "description" : "Get contract store by pubkey",
+        "operationId" : "GetContractStore",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "pubkey",
+          "in" : "path",
+          "description" : "The pubkey of the contract",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Contract Store",
+            "schema" : {
+              "$ref" : "#/definitions/ContractStore"
+            }
+          },
+          "400" : {
+            "description" : "Invalid pubkey",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Contract not found"
+          }
+        }
+      }
+    },
     "/oracles/{pubkey}" : {
       "get" : {
         "tags" : [ "external", "gossip" ],
@@ -4687,6 +4786,66 @@
         }
       }
     },
+    "ContractObject" : {
+      "type" : "object",
+      "properties" : {
+        "id" : {
+          "$ref" : "#/definitions/EncodedHash"
+        },
+        "owner" : {
+          "$ref" : "#/definitions/EncodedHash"
+        },
+        "vm_version" : {
+          "type" : "integer",
+          "minimum" : 0,
+          "maximum" : 255
+        },
+        "log" : {
+          "type" : "string"
+        },
+        "active" : {
+          "type" : "boolean"
+        },
+        "referers" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/EncodedHash"
+          }
+        },
+        "deposit" : {
+          "type" : "integer"
+        }
+      },
+      "example" : {
+        "owner" : null,
+        "vm_version" : 20,
+        "log" : "log",
+        "referers" : [ null, null ],
+        "active" : true,
+        "deposit" : 6,
+        "id" : { }
+      }
+    },
+    "ContractStore" : {
+      "type" : "object",
+      "properties" : {
+        "store" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ContractStore_store"
+          }
+        }
+      },
+      "example" : {
+        "store" : [ {
+          "value" : "value",
+          "key" : "key"
+        }, {
+          "value" : "value",
+          "key" : "key"
+        } ]
+      }
+    },
     "Contract" : {
       "type" : "object",
       "properties" : {
@@ -5146,6 +5305,20 @@
       },
       "example" : {
         "pubkey" : { }
+      }
+    },
+    "ContractStore_store" : {
+      "properties" : {
+        "key" : {
+          "type" : "string"
+        },
+        "value" : {
+          "type" : "string"
+        }
+      },
+      "example" : {
+        "value" : "value",
+        "key" : "key"
       }
     }
   },

--- a/apps/aehttp/priv/swagger.json
+++ b/apps/aehttp/priv/swagger.json
@@ -589,18 +589,33 @@
         }
       }
     },
-    "/transactions" : {
-      "get" : {
+    "/ng-transactions" : {
+      "post" : {
         "tags" : [ "external", "transactions" ],
-        "description" : "Get transactions in the mempool",
-        "operationId" : "GetTxs",
+        "description" : "Post a new transaction",
+        "operationId" : "PostTransaction",
+        "consumes" : [ "application/json" ],
         "produces" : [ "application/json" ],
-        "parameters" : [ ],
+        "parameters" : [ {
+          "in" : "body",
+          "name" : "body",
+          "description" : "The new transaction",
+          "required" : true,
+          "schema" : {
+            "$ref" : "#/definitions/Tx"
+          }
+        } ],
         "responses" : {
           "200" : {
             "description" : "Successful operation",
             "schema" : {
-              "$ref" : "#/definitions/Transactions"
+              "$ref" : "#/definitions/PostTxResponse"
+            }
+          },
+          "400" : {
+            "description" : "Invalid transaction",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
             }
           }
         }
@@ -1869,6 +1884,23 @@
             "description" : "Contract not found",
             "schema" : {
               "$ref" : "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/transactions" : {
+      "get" : {
+        "tags" : [ "external", "transactions" ],
+        "description" : "Get transactions in the mempool",
+        "operationId" : "GetTxs",
+        "produces" : [ "application/json" ],
+        "parameters" : [ ],
+        "responses" : {
+          "200" : {
+            "description" : "Successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/Transactions"
             }
           }
         }

--- a/apps/aehttp/priv/swagger.json
+++ b/apps/aehttp/priv/swagger.json
@@ -924,6 +924,23 @@
         }
       }
     },
+    "/status" : {
+      "get" : {
+        "tags" : [ "external", "gossip" ],
+        "description" : "Get the status of a node",
+        "operationId" : "GetStatus",
+        "produces" : [ "application/json" ],
+        "parameters" : [ ],
+        "responses" : {
+          "200" : {
+            "description" : "Successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/Status"
+            }
+          }
+        }
+      }
+    },
     "/header-by-hash" : {
       "get" : {
         "tags" : [ "external", "gossip" ],
@@ -4669,6 +4686,88 @@
       },
       "example" : {
         "height" : 0
+      }
+    },
+    "Status" : {
+      "type" : "object",
+      "properties" : {
+        "genesis-key-block-hash" : {
+          "$ref" : "#/definitions/EncodedHash"
+        },
+        "solutions" : {
+          "type" : "integer",
+          "format" : "int64",
+          "minimum" : 0
+        },
+        "difficulty" : {
+          "type" : "number",
+          "format" : "int64"
+        },
+        "syncing" : {
+          "type" : "boolean"
+        },
+        "listening" : {
+          "type" : "boolean"
+        },
+        "protocols" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/Protocol"
+          }
+        },
+        "node-version" : {
+          "type" : "string"
+        },
+        "node-revision" : {
+          "type" : "string"
+        },
+        "peer-count" : {
+          "type" : "integer",
+          "format" : "int64",
+          "minimum" : 0
+        },
+        "pending-transactions-count" : {
+          "type" : "integer",
+          "format" : "int64",
+          "minimum" : 0
+        }
+      },
+      "example" : {
+        "difficulty" : 6.02745618307040320615897144307382404804229736328125,
+        "listening" : true,
+        "syncing" : true,
+        "node-version" : "node-version",
+        "solutions" : 0,
+        "node-revision" : "node-revision",
+        "peer-count" : 0,
+        "protocols" : [ {
+          "protocol_version" : 1,
+          "effective_at_height" : 0
+        }, {
+          "protocol_version" : 1,
+          "effective_at_height" : 0
+        } ],
+        "pending-transactions-count" : 0,
+        "genesis-key-block-hash" : { }
+      }
+    },
+    "Protocol" : {
+      "type" : "object",
+      "properties" : {
+        "protocol_version" : {
+          "type" : "integer",
+          "format" : "int64",
+          "minimum" : 1
+        },
+        "effective_at_height" : {
+          "type" : "integer",
+          "format" : "int64",
+          "minimum" : 0
+        }
+      },
+      "example" : {
+        "protocol_version" : 1,
+        "effective_at_height" : 0
       }
     },
     "SingleTxObject" : {

--- a/apps/aehttp/src/aehttp_dispatch_ext.erl
+++ b/apps/aehttp/src/aehttp_dispatch_ext.erl
@@ -236,8 +236,7 @@ handle_request('PostTransaction', #{'Tx' := Tx}, _Context) ->
         {error, _} ->
             {400, [], #{reason => <<"Invalid base58Check encoding">>}};
         {ok, SignedTx} ->
-            %% TODO: lager debug log?
-            aec_tx_pool:push(SignedTx),
+            ok = aec_tx_pool:push(SignedTx), %% TODO Add proper error handling
             Hash = aetx_sign:hash(SignedTx),
             {200, [], #{<<"tx_hash">> => aec_base58c:encode(tx_hash, Hash)}}
     end;

--- a/apps/aehttp/src/aehttp_dispatch_ext.erl
+++ b/apps/aehttp/src/aehttp_dispatch_ext.erl
@@ -242,6 +242,44 @@ handle_request('PostTransaction', #{'Tx' := Tx}, _Context) ->
             {200, [], #{<<"tx_hash">> => aec_base58c:encode(tx_hash, Hash)}}
     end;
 
+handle_request('GetContract', Req, _Context) ->
+    case aec_base58c:safe_decode(contract_pubkey, maps:get(pubkey, Req)) of
+        {error, _} -> {400, [], #{reason => <<"Invalid public key">>}};
+        {ok, PubKey} ->
+            case aec_chain:get_contract(PubKey) of
+                {error, _} -> {404, [], #{reason => <<"Contract not found">>}};
+                {ok, Contract} ->
+                    Response = aect_contracts:serialize_for_client(Contract),
+                    {200, [], Response}
+            end
+    end;
+
+handle_request('GetContractCode', Req, _Context) ->
+    case aec_base58c:safe_decode(contract_pubkey, maps:get(pubkey, Req)) of
+        {error, _} -> {400, [], #{reason => <<"Invalid public key">>}};
+        {ok, PubKey} ->
+            case aec_chain:get_contract(PubKey) of
+                {error, _} -> {404, [], #{reason => <<"Contract not found">>}};
+                {ok, Contract} ->
+                    Code = aect_contracts:code(Contract),
+                    {200, [], #{ <<"bytecode">> => aeu_hex:hexstring_encode(Code) }}
+            end
+    end;
+
+handle_request('GetContractStore', Req, _Context) ->
+    case aec_base58c:safe_decode(contract_pubkey, maps:get(pubkey, Req)) of
+        {error, _} -> {400, [], #{reason => <<"Invalid public key">>}};
+        {ok, PubKey} ->
+            case aec_chain:get_contract(PubKey) of
+                {error, _} -> {404, [], #{reason => <<"Contract not found">>}};
+                {ok, Contract} ->
+                    Response = [ #{<<"key">> => aeu_hex:hexstring_encode(K),
+                                   <<"value">> => aeu_hex:hexstring_encode(V)}
+                               || {K, V} <- maps:to_list(aect_contracts:state(Contract)) ],
+                    {200, [], #{ <<"store">> => Response }}
+            end
+    end;
+
 handle_request('GetOracleByPubkey', Params, _Context) ->
     case aec_base58c:safe_decode(oracle_pubkey, maps:get(pubkey, Params)) of
         {ok, Pubkey} ->

--- a/apps/aehttp/src/aehttp_dispatch_ext.erl
+++ b/apps/aehttp/src/aehttp_dispatch_ext.erl
@@ -374,6 +374,10 @@ handle_request('GetChannelByPubkey', Params, _Context) ->
             {400, [], #{reason => <<"Invalid public key">>}}
     end;
 
+handle_request('GetPeerPubkey', _Params, _Context) ->
+    {ok, Pubkey} = aec_keys:peer_pubkey(),
+    {200, [], #{pubkey => aec_base58c:encode(peer_pubkey, Pubkey)}};
+
 handle_request('GetBlockGenesis', Req, _Context) ->
     get_block(fun aehttp_logic:get_block_genesis/0, Req, json);
 

--- a/apps/aehttp/src/aehttp_dispatch_ext.erl
+++ b/apps/aehttp/src/aehttp_dispatch_ext.erl
@@ -361,6 +361,19 @@ handle_request('GetNameEntryByName', Params, _Context) ->
             {400, [], #{reason => <<"Name validation failed with a reason: ", ReasonBin/binary>>}}
     end;
 
+handle_request('GetChannelByPubkey', Params, _Context) ->
+    case aec_base58c:safe_decode(channel, maps:get(pubkey, Params)) of
+        {ok, Pubkey} ->
+            case aec_chain:get_channel(Pubkey) of
+                {ok, Channel} ->
+                    {200, [], aesc_channels:serialize_for_client(Channel)};
+                {error, _} ->
+                    {404, [], #{reason => <<"Channel not found">>}}
+            end;
+        {error, _} ->
+            {400, [], #{reason => <<"Invalid public key">>}}
+    end;
+
 handle_request('GetBlockGenesis', Req, _Context) ->
     get_block(fun aehttp_logic:get_block_genesis/0, Req, json);
 

--- a/apps/aehttp/src/aehttp_dispatch_ext.erl
+++ b/apps/aehttp/src/aehttp_dispatch_ext.erl
@@ -166,6 +166,39 @@ handle_request('GetGenerationByHeight', Params, _Context) ->
         {ok, Hash} -> get_generation(Hash)
     end;
 
+handle_request('GetAccountByPubkey', Params, _Context) ->
+    case aec_base58c:safe_decode(account_pubkey, maps:get(pubkey, Params)) of
+        {ok, Pubkey} ->
+            case aehttp_logic:get_account(Pubkey) of
+                {ok, Account} ->
+                    {200, [],
+                     #{pubkey => aec_base58c:encode(account_pubkey, Pubkey),
+                       balance => aec_accounts:balance(Account),
+                       nonce => aec_accounts:nonce(Account)}};
+                {error, _} ->
+                    {404, [], #{reason => <<"Account not found">>}}
+            end;
+        {error, _} ->
+            {400, [], #{reason => <<"Invalid public key">>}}
+    end;
+
+handle_request('GetPendingAccountTransactionsByPubkey', Params, _Context) ->
+    case aec_base58c:safe_decode(account_pubkey, maps:get(pubkey, Params)) of
+        {ok, Pubkey} ->
+            case aec_chain:get_account(Pubkey) of
+                {value, _} ->
+                    {ok, Txs0} = aec_tx_pool:peek(infinity, Pubkey),
+                    Txs = [aetx_sign:serialize_for_client_pending(json, T) || T <- Txs0],
+                    JsonTxs = #{data_schema => <<"JSONTx">>,
+                                transactions => Txs},
+                    {200, [], JsonTxs};
+                _ ->
+                    {404, [], #{reason => <<"Account not found">>}}
+            end;
+        {error, _} ->
+            {400, [], #{reason => <<"Invalid public key">>}}
+    end;
+
 handle_request('GetBlockGenesis', Req, _Context) ->
     get_block(fun aehttp_logic:get_block_genesis/0, Req, json);
 
@@ -766,3 +799,4 @@ get_generation(Hash) ->
             },
             {200, [], Struct}
     end.
+

--- a/apps/aehttp/src/aehttp_int_tx_logic.erl
+++ b/apps/aehttp/src/aehttp_int_tx_logic.erl
@@ -136,7 +136,7 @@ get_oracles(From, Max) ->
     {ok, FmtOracles}.
 
 get_oracle_questions(OracleId, From, Max) ->
-    {ok, Queries} = aec_chain:get_open_oracle_queries(OracleId, From, Max),
+    {ok, Queries} = aec_chain:get_oracle_queries(OracleId, From, open, Max),
     FmtQueries =
         lists:map(
             fun(Q) -> #{<<"query_id">> => aeo_query:id(Q),

--- a/apps/aehttp/src/aehttp_logic.erl
+++ b/apps/aehttp/src/aehttp_logic.erl
@@ -18,7 +18,8 @@
         , get_top_blocks_time_summary/1
         ]).
 
--export([ get_account_balance/1
+-export([ get_account/1
+        , get_account_balance/1
         , get_account_balance_at_hash/2
         , get_all_accounts_balances/0
         ]).
@@ -138,6 +139,13 @@ get_block_range_by_hash(HashFrom, HashTo) ->
 
 get_block_range_by_height(HeightFrom, HeightTo) ->
     aec_chain:get_block_range_by_height(HeightFrom, HeightTo).
+
+-spec get_account(binary()) -> {ok, map()} | {error, account_not_found}.
+get_account(Pubkey) ->
+    case aec_chain:get_account(Pubkey) of
+        {value, Account} -> {ok, Account};
+        none -> {error, account_not_found}
+    end.
 
 -spec get_account_balance(binary()) -> {ok, integer()}
                                      | {error, account_not_found}.

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -57,6 +57,12 @@
      get_generation_by_height/1
     ]).
 
+-export(
+   [
+    get_account_by_pubkey/1,
+    get_pending_account_transactions_by_pubkey/1
+   ]).
+
 %% test case exports
 %% external endpoints
 -export(
@@ -250,6 +256,7 @@ groups() ->
        {group, on_genesis_block},
        {group, on_key_block},
        {group, on_micro_block},
+       {group, account},
        {group, off_chain_endpoints},
        {group, external_endpoints},
        {group, internal_endpoints},
@@ -293,6 +300,29 @@ groups() ->
        get_generation_current,
        get_generation_by_hash,
        get_generation_by_height
+      ]},
+     {account, [sequence],
+      [
+       {group, nonexistent},
+       {group, with_balance}
+      ]},
+     { nonexistent, [sequence],
+      [
+       {group, get_account_info}
+      ]},
+     {with_balance, [sequence],
+      [
+       {group, get_account_info},
+       {group, with_pending_txs}
+      ]},
+     {with_pending_txs, [],
+      [
+       {group, get_account_info}
+      ]},
+     {get_account_info, [sequence],
+      [
+       get_account_by_pubkey,
+       get_pending_account_transactions_by_pubkey
       ]},
      {off_chain_endpoints, [],
       [
@@ -554,6 +584,26 @@ init_per_group(with_pending_key_block, Config) ->
     ok = rpc(aec_conductor, start_mining, []),
     ok = wait_for_key_block_candidate(),
     [{expected_mine_rate, MineRate}, {pending_key_block, true} | Config];
+init_per_group(account, Config) ->
+    {ok, Node} = init_node(Config),
+    [{node, Node} | Config];
+init_per_group(nonexistent, Config) ->
+    {ok, Pubkey} = rpc(aec_keys, pubkey, []),
+    [{account_pubkey, aec_base58c:encode(account_pubkey, Pubkey)},
+     {account_state, nonexistent} | Config];
+init_per_group(with_balance, Config) ->
+    Node = ?config(node, Config),
+    {ok, Pubkey} = rpc(aec_keys, pubkey, []),
+    aecore_suite_utils:mine_key_blocks(Node, aecore_suite_utils:latest_fork_height()),
+    {ok, [_KeyBlock0]} = aecore_suite_utils:mine_key_blocks(Node, 1),
+    [{account_pubkey, aec_base58c:encode(account_pubkey, Pubkey)},
+     {account_state, with_balance} | Config];
+init_per_group(with_pending_txs, Config) ->
+    Node = ?config(node, Config),
+    {ok, Pubkey} = rpc(aec_keys, pubkey, []),
+    {ok, Tx} = aecore_suite_utils:spend(Node, Pubkey, Pubkey, 1),
+    {ok, [Tx]} = rpc:call(Node, aec_tx_pool, peek, [infinity]),
+    [{pending_txs, [Tx]} | Config];
 init_per_group(channel_websocket, Config) ->
     aecore_suite_utils:start_node(?NODE, Config),
     aecore_suite_utils:connect(aecore_suite_utils:node_name(?NODE)),
@@ -584,6 +634,8 @@ init_per_group(channel_websocket, Config) ->
     [{participants, Participants} | Config];
 init_per_group(get_block_info, Config) ->
     Config;
+init_per_group(get_account_info, Config) ->
+    Config;
 init_per_group(_Group, Config) ->
     {ok, Node} = init_node(Config),
     BlocksToMine = aecore_suite_utils:latest_fork_height(),
@@ -595,6 +647,14 @@ end_per_group(all, _Config) ->
 end_per_group(with_pending_key_block, _Config) ->
     ok = rpc(aec_conductor, stop_mining, []);
 end_per_group(get_block_info, _Config) ->
+    ok;
+end_per_group(nonexistent, _Config) ->
+    ok;
+end_per_group(with_balance, _Config) ->
+    ok;
+end_per_group(with_pending_txs, _Config) ->
+    ok;
+end_per_group(get_account_info, _Config) ->
     ok;
 end_per_group(_Group, Config) ->
     ok = stop_node(Config).
@@ -1075,6 +1135,50 @@ get_generation_by_hash_sut(Hash) ->
 get_generation_by_height_sut(Height) ->
     Host = external_address(),
     http_request(Host, get, "generations/height/" ++ integer_to_list(Height), []).
+
+%% /accounts/*
+
+get_account_by_pubkey(Config) ->
+    get_account_by_pubkey(?config(account_state, Config), Config).
+
+get_account_by_pubkey(nonexistent, Config) ->
+    AccountPubkey = ?config(account_pubkey, Config),
+    {ok, 404, Error} = get_accounts_by_pubkey_sut(AccountPubkey),
+    ?assertEqual(<<"Account not found">>, maps:get(<<"reason">>, Error)),
+    ok;
+get_account_by_pubkey(with_balance, Config) ->
+    AccountPubkey = ?config(account_pubkey, Config),
+    {ok, 200, Account} = get_accounts_by_pubkey_sut(AccountPubkey),
+    ?assertEqual(AccountPubkey, maps:get(<<"pubkey">>, Account)),
+    ?assert(maps:get(<<"balance">>, Account) > 0),
+    %% TODO: check nonce?
+    ok.
+
+get_pending_account_transactions_by_pubkey(Config) ->
+    AccountState = ?config(account_state, Config),
+    PendingTxs = {pending_txs, proplists:get_value(pending_txs, Config, [])},
+    get_pending_account_transactions_by_pubkey(PendingTxs, AccountState, Config).
+
+get_pending_account_transactions_by_pubkey(_PendingTxs, nonexistent, Config) ->
+    AccountPubkey = ?config(account_pubkey, Config),
+    {ok, 404, Error} = get_accounts_transactions_pending_by_pubkey_sut(AccountPubkey),
+    ?assertEqual(<<"Account not found">>, maps:get(<<"reason">>, Error)),
+    ok;
+get_pending_account_transactions_by_pubkey({pending_txs, PendingTxs}, with_balance, Config) ->
+    AccountPubkey = ?config(account_pubkey, Config),
+    {ok, 200, Txs} = get_accounts_transactions_pending_by_pubkey_sut(AccountPubkey),
+    %% TODO: check txs hashes
+    ?assertEqual(length(PendingTxs), length(maps:get(<<"transactions">>, Txs))),
+    ok.
+
+get_accounts_by_pubkey_sut(Pubkey) ->
+    Host = external_address(),
+    http_request(Host, get, "accounts/" ++ http_uri:encode(Pubkey), []).
+
+get_accounts_transactions_pending_by_pubkey_sut(Pubkey) ->
+    Host = external_address(),
+    Pubkey1 = binary_to_list(Pubkey),
+    http_request(Host, get, "accounts/" ++ http_uri:encode(Pubkey1) ++ "/transactions/pending", []).
 
 %% enpoints
 

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -338,7 +338,7 @@ groups() ->
       ]},
      {chain_with_pending_key_block, [],
       [
-       {group, block_info}
+       get_pending_key_block
       ]},
      {block_info, [sequence],
       [

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -79,6 +79,11 @@
     get_name_entry_by_name/1
    ]).
 
+-export(
+   [
+    get_peer_pubkey/1
+   ]).
+
 %% off chain endpoints
 -export(
    [test_decode_sophia_data/1,
@@ -289,6 +294,7 @@ groups() ->
        %% /names/*
        {group, name_endpoints},
        %% TODO: /channels/*
+       {group, peer_endpoints},
 
        {group, off_chain_endpoints},
        {group, external_endpoints},
@@ -441,6 +447,13 @@ groups() ->
       [
        %% TODO
       ]},
+     %% TODO: /channels/*
+
+     %% /peers/*
+    {peer_endpoints, [],
+     [
+      get_peer_pubkey
+     ]},
 
      {off_chain_endpoints, [],
       [
@@ -660,7 +673,9 @@ init_per_group(Group, Config) when
       Group =:= transaction_endpoints;
       %%Group =:= contract_endpoint;
       Group =:= oracle_endpoints;
-      Group =:= name_endpoints ->
+      Group =:= name_endpoints;
+      %%Group =:= channel_endpoints;
+      Group =:= peer_endpoints ->
     start_node(Group, Config);
 %% block_endpoints
 init_per_group(on_genesis_block = Group, Config) ->
@@ -1724,6 +1739,18 @@ get_names_entry_by_name_sut(Name) ->
     Host = external_address(),
     Name1 = binary_to_list(Name),
     http_request(Host, get, "names/" ++ http_uri:encode(Name1), []).
+
+%% /channels/*
+
+%% /peers/*
+
+get_peer_pubkey(_Config) ->
+    {ok, 200, _PeerPubkey} = get_peers_pubkey_sut(),
+    ok.
+
+get_peers_pubkey_sut() ->
+    Host = external_address(),
+    http_request(Host, get, "peers/pubkey", []).
 
 prepare_tx(TxType, Args) ->
     %assert_required_tx_fields(TxType, Args),

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -56,7 +56,13 @@
    [
     get_transaction_by_hash/1,
     get_transaction_info_by_hash/1,
-    post_spend_tx/1
+    post_spend_tx/1,
+    post_contract_and_call_tx/1
+   ]).
+
+-export(
+   [
+    get_contract/1
    ]).
 
 -export(
@@ -271,7 +277,8 @@ groups() ->
        {group, account_endpoints},
        %% /transactions/*
        {group, transaction_endpoints},
-       %% TODO: /contracts/*
+       %% /contracts/*
+       {group, contract_endpoints},
        %% /oracles/*
        {group, oracle_endpoints},
 
@@ -360,7 +367,8 @@ groups() ->
        {group, nonexistent_tx},    %% standalone
        {group, tx_is_pending},     %% standalone
        {group, tx_is_on_chain},    %% standalone
-       {group, post_tx_to_mempool} %% standalone
+       {group, post_tx_to_mempool},%% standalone
+       {group, contract_txs}
       ]},
      {nonexistent_tx, [],
       [
@@ -383,7 +391,15 @@ groups() ->
        get_transaction_by_hash,
        get_transaction_info_by_hash
       ]},
-     %% TODO: /contracts/*
+     {contract_txs, [sequence],
+      [
+       post_contract_and_call_tx
+      ]},
+     %% /contracts/*
+     {contract_endpoints, [sequence],
+      [
+       get_contract
+      ]},
 
      %% /oracles/*
      {oracle_endpoints, [sequence],
@@ -1408,6 +1424,64 @@ post_spend_tx(Config) ->
     ok = post_tx(TxHash, Tx),
     ok.
 
+post_contract_and_call_tx(_Config) ->
+    {ok, 200, #{<<"pub_key">> := MinerAddress}} = get_miner_pub_key(),
+    SophiaCode = <<"contract Identity = function main (x:int) = x">>,
+    {ok, 200, #{<<"bytecode">> := Code}} = get_contract_bytecode(SophiaCode),
+
+    {ok, EncodedInitCallData} = aect_sophia:encode_call_data(Code, <<"init">>, <<"()">>),
+    ValidEncoded = #{ owner => MinerAddress,
+                      code => Code,
+                      vm_version => 1,
+                      deposit => 2,
+                      amount => 1,
+                      gas => 300,
+                      gas_price => 1,
+                      fee => 1,
+                      call_data => EncodedInitCallData},
+
+    %% prepare a contract_create_tx and post it
+    {ok, 200, #{<<"tx">> := EncodedUnsignedContractCreateTx,
+                <<"contract_address">> := EncodedContractPubKey}} =
+        get_contract_create(ValidEncoded),
+    %%%% {ok, ContractPubKey} = aec_base58c:safe_decode(contract_pubkey, EncodedContractPubKey),
+    ContractCreateTxHash = sign_and_post_tx(EncodedUnsignedContractCreateTx),
+
+    ?assertMatch({ok, 200, _}, get_transactions_by_hash_sut(ContractCreateTxHash)),
+    ?assertEqual({ok, 400, #{<<"reason">> => <<"Tx not mined">>}}, get_transactions_info_by_hash_sut(ContractCreateTxHash)),
+
+    % mine
+    Fun1 = fun() -> tx_in_chain(ContractCreateTxHash) end,
+    aecore_suite_utils:mine_blocks_until(aecore_suite_utils:node_name(?NODE), Fun1, 10),
+    ?assert(tx_in_chain(ContractCreateTxHash)),
+
+    ?assertMatch({ok, 200, _}, get_transactions_by_hash_sut(ContractCreateTxHash)),
+    ?assertMatch({ok, 200, _}, get_transactions_info_by_hash_sut(ContractCreateTxHash)),
+
+    {ok, EncodedCallData} = aect_sophia:encode_call_data(Code, <<"main">>, <<"42">>),
+    ContractCallEncoded = #{ caller => MinerAddress,
+                             contract => EncodedContractPubKey,
+                             vm_version => 1,
+                             amount => 1,
+                             gas => 1000,
+                             gas_price => 1,
+                             fee => 1,
+                             call_data => EncodedCallData},
+    {ok, 200, #{<<"tx">> := EncodedUnsignedContractCallTx}} = get_contract_call(ContractCallEncoded),
+    ContractCallTxHash = sign_and_post_tx(EncodedUnsignedContractCallTx),
+
+    ?assertMatch({ok, 200, _}, get_transactions_by_hash_sut(ContractCallTxHash)),
+    ?assertEqual({ok, 400, #{<<"reason">> => <<"Tx not mined">>}}, get_transactions_info_by_hash_sut(ContractCallTxHash)),
+
+    % mine
+    Fun2 = fun() -> tx_in_chain(ContractCallTxHash) end,
+    aecore_suite_utils:mine_blocks_until(aecore_suite_utils:node_name(?NODE), Fun2, 10),
+    ?assert(tx_in_chain(ContractCallTxHash)),
+
+    ?assertMatch({ok, 200, _}, get_transactions_by_hash_sut(ContractCallTxHash)),
+    ?assertMatch({ok, 200, _}, get_transactions_info_by_hash_sut(ContractCallTxHash)),
+    ok.
+
 get_transactions_by_hash_sut(Hash) ->
     Host = external_address(),
     http_request(Host, get, "transactions/" ++ http_uri:encode(Hash), []).
@@ -1415,13 +1489,90 @@ get_transactions_by_hash_sut(Hash) ->
 get_transactions_info_by_hash_sut(Hash) ->
     Host = external_address(),
     Hash1 = http_uri:encode(Hash),
-    http_request(Host, get, "transactions/" ++ Hash1, []).
+    http_request(Host, get, "transactions/" ++ binary_to_list(Hash1) ++ "/info", []).
 
 post_transactions_sut(Tx) ->
     Host = external_address(),
     http_request(Host, post, "transactions", #{tx => Tx}).
 
 %% /contracts/*
+
+get_contract(_Config) ->
+    aecore_suite_utils:mine_key_blocks(aecore_suite_utils:node_name(?NODE), 1),
+
+    {ok, 200, _} = get_balance_at_top(),
+    {ok, 200, #{<<"pub_key">> := MinerAddress}} = get_miner_pub_key(),
+    {ok, MinerPubkey} = aec_base58c:safe_decode(account_pubkey, MinerAddress),
+    SophiaCode = <<"contract Identity = function main (x:int) = x">>,
+    {ok, 200, #{<<"bytecode">> := Code}} = get_contract_bytecode(SophiaCode),
+
+    % contract_create_tx positive test
+    InitFunction = <<"init">>,
+    InitArgument = <<"()">>,
+    {ok, EncodedInitCallData} =
+        aect_sophia:encode_call_data(Code,
+                                     InitFunction,
+                                     InitArgument),
+
+    ContractInitBalance = 1,
+    ValidEncoded = #{ owner => MinerAddress,
+                      code => Code,
+                      vm_version => 1,
+                      deposit => 2,
+                      amount => ContractInitBalance,
+                      gas => 300,
+                      gas_price => 1,
+                      fee => 1,
+                      call_data => EncodedInitCallData},
+
+    ValidDecoded = maps:merge(ValidEncoded,
+                              #{owner => aec_id:create(account, MinerPubkey),
+                                code => aeu_hex:hexstring_decode(Code),
+                                call_data => aeu_hex:hexstring_decode(EncodedInitCallData)}),
+
+    unsigned_tx_positive_test(ValidDecoded, ValidEncoded, fun get_contract_create/1,
+                               fun aect_create_tx:new/1, MinerPubkey),
+
+    %% prepare a contract_create_tx and post it
+    {ok, 200, #{<<"tx">> := EncodedUnsignedContractCreateTx,
+                <<"contract_address">> := EncodedContractPubKey}} = get_contract_create(ValidEncoded),
+    ContractCreateTxHash = sign_and_post_tx(EncodedUnsignedContractCreateTx),
+
+    %% Try to get the contract init call object while in mempool
+    {ok, 400, #{<<"reason">> := <<"Tx not mined">>}} = get_contract_call_object(ContractCreateTxHash),
+
+    {ok, 404, #{<<"reason">> := <<"Proof for contract not found">>}} = get_contract_poi(EncodedContractPubKey),
+    ?assertEqual({ok, 404, #{<<"reason">> => <<"Account not found">>}}, get_balance_at_top(EncodedContractPubKey)),
+
+    % mine a block
+    Fun1 = fun() -> tx_in_chain(ContractCreateTxHash) end,
+    aecore_suite_utils:mine_blocks_until(aecore_suite_utils:node_name(?NODE), Fun1, 10),
+    ?assert(tx_in_chain(ContractCreateTxHash)),
+
+    {ok, 200, #{<<"return_value">> := ReturnValue}} = get_contract_call_object(ContractCreateTxHash),
+
+    ?assertMatch({ok, 200, #{
+            <<"id">> := EncodedContractPubKey, <<"owner">> := MinerAddress,
+            <<"active">> := true, <<"deposit">> := 2, <<"vm_version">> := 1,
+            <<"referers">> := [], <<"log">> := <<>>
+        }}, get_contract_sut(EncodedContractPubKey)),
+    ?assertEqual({ok, 200, #{<<"bytecode">> => Code}}, get_contract_code_sut(EncodedContractPubKey)),
+    ?assertMatch({ok, 200, #{<<"store">> := [
+        #{<<"key">> := <<"0x00">>, <<"value">> := ReturnValue}
+        ]}}, get_contract_store_sut(EncodedContractPubKey)),
+    ok.
+
+get_contract_sut(PubKey) ->
+    Host = external_address(),
+    http_request(Host, get, "contracts/" ++ binary_to_list(PubKey), []).
+
+get_contract_code_sut(PubKey) ->
+    Host = external_address(),
+    http_request(Host, get, "contracts/" ++ binary_to_list(PubKey) ++ "/code", []).
+
+get_contract_store_sut(PubKey) ->
+    Host = external_address(),
+    http_request(Host, get, "contracts/" ++ binary_to_list(PubKey) ++ "/store", []).
 
 %% /oracles/*
 

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -1552,7 +1552,7 @@ get_transactions_info_by_hash_sut(Hash) ->
 
 post_transactions_sut(Tx) ->
     Host = external_address(),
-    http_request(Host, post, "transactions", #{tx => Tx}).
+    http_request(Host, post, "ng-transactions", #{tx => Tx}).
 
 %% /contracts/*
 
@@ -4927,7 +4927,7 @@ get_block_by_hash(Hash, TxObjects) ->
 
 get_transactions() ->
     Host = external_address(),
-    http_request(Host, get, "transactions-obsolete", []).
+    http_request(Host, get, "transactions", []).
 
 get_transactions(EncodedPubKey) ->
     Host = external_address(),

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -1507,7 +1507,7 @@ post_contract_and_call_tx(_Config) ->
     ContractCreateTxHash = sign_and_post_tx(EncodedUnsignedContractCreateTx),
 
     ?assertMatch({ok, 200, _}, get_transactions_by_hash_sut(ContractCreateTxHash)),
-    ?assertEqual({ok, 400, #{<<"reason">> => <<"Tx not mined">>}}, get_transactions_info_by_hash_sut(ContractCreateTxHash)),
+    ?assertEqual({ok, 404, #{<<"reason">> => <<"Tx not mined">>}}, get_transactions_info_by_hash_sut(ContractCreateTxHash)),
 
     % mine
     Fun1 = fun() -> tx_in_chain(ContractCreateTxHash) end,
@@ -1530,7 +1530,7 @@ post_contract_and_call_tx(_Config) ->
     ContractCallTxHash = sign_and_post_tx(EncodedUnsignedContractCallTx),
 
     ?assertMatch({ok, 200, _}, get_transactions_by_hash_sut(ContractCallTxHash)),
-    ?assertEqual({ok, 400, #{<<"reason">> => <<"Tx not mined">>}}, get_transactions_info_by_hash_sut(ContractCallTxHash)),
+    ?assertEqual({ok, 404, #{<<"reason">> => <<"Tx not mined">>}}, get_transactions_info_by_hash_sut(ContractCallTxHash)),
 
     % mine
     Fun2 = fun() -> tx_in_chain(ContractCallTxHash) end,
@@ -1598,7 +1598,7 @@ get_contract(_Config) ->
     ContractCreateTxHash = sign_and_post_tx(EncodedUnsignedContractCreateTx),
 
     %% Try to get the contract init call object while in mempool
-    {ok, 400, #{<<"reason">> := <<"Tx not mined">>}} = get_contract_call_object(ContractCreateTxHash),
+    {ok, 404, #{<<"reason">> := <<"Tx not mined">>}} = get_contract_call_object(ContractCreateTxHash),
 
     {ok, 404, #{<<"reason">> := <<"Proof for contract not found">>}} = get_contract_poi(EncodedContractPubKey),
     ?assertEqual({ok, 404, #{<<"reason">> => <<"Account not found">>}}, get_balance_at_top(EncodedContractPubKey)),

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -1723,7 +1723,7 @@ post_oracle_response(Config) ->
     {ok, 200, Resp1} = get_oracles_query_by_pubkey_and_query_id(OraclePubkey, QueryId),
     ?assertEqual(QueryId, maps:get(<<"query_id">>, Resp1)),
     ?assertEqual(OraclePubkey, maps:get(<<"oracle_id">>, Resp1)),
-    ?assertEqual(Response, maps:get(<<"response">>, Resp1)),
+    ?assertEqual(aec_base58c:encode(Response), maps:get(<<"response">>, Resp1)),
     ok.
 
 get_oracles_by_pubkey_sut(Pubkey) ->

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -84,6 +84,11 @@
     get_peer_pubkey/1
    ]).
 
+-export(
+   [
+    get_status/1
+   ]).
+
 %% off chain endpoints
 -export(
    [test_decode_sophia_data/1,
@@ -294,7 +299,10 @@ groups() ->
        %% /names/*
        {group, name_endpoints},
        %% TODO: /channels/*
+       %% /peers/*
        {group, peer_endpoints},
+       %% /status/*
+       {group, status_endpoints},
 
        {group, off_chain_endpoints},
        {group, external_endpoints},
@@ -450,10 +458,16 @@ groups() ->
      %% TODO: /channels/*
 
      %% /peers/*
-    {peer_endpoints, [],
-     [
-      get_peer_pubkey
-     ]},
+     {peer_endpoints, [],
+      [
+       get_peer_pubkey
+      ]},
+
+     %% /status/*
+     {status_endpoints, [],
+      [
+       get_status
+      ]},
 
      {off_chain_endpoints, [],
       [
@@ -675,7 +689,8 @@ init_per_group(Group, Config) when
       Group =:= oracle_endpoints;
       Group =:= name_endpoints;
       %%Group =:= channel_endpoints;
-      Group =:= peer_endpoints ->
+      Group =:= peer_endpoints;
+      Group =:= status_endpoints ->
     start_node(Group, Config);
 %% block_endpoints
 init_per_group(on_genesis_block = Group, Config) ->
@@ -1751,6 +1766,27 @@ get_peer_pubkey(_Config) ->
 get_peers_pubkey_sut() ->
     Host = external_address(),
     http_request(Host, get, "peers/pubkey", []).
+
+%% /status/*
+
+get_status(_Config) ->
+    {ok, 200, #{
+       <<"genesis-key-block-hash">>     := _,
+       <<"solutions">>                  := _,
+       <<"difficulty">>                 := _,
+       <<"syncing">>                    := _,
+       <<"listening">>                  := _,
+       <<"protocols">>                  := _,
+       <<"node-version">>               := _,
+       <<"node-revision">>              := _,
+       <<"peer-count">>                 := _,
+       <<"pending-transactions-count">> := _
+      }} = get_status_sut(),
+    ok.
+
+get_status_sut() ->
+    Host = external_address(),
+    http_request(Host, get, "status", []).
 
 prepare_tx(TxType, Args) ->
     %assert_required_tx_fields(TxType, Args),

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -288,6 +288,7 @@ groups() ->
        {group, oracle_endpoints},
        %% /names/*
        {group, name_endpoints},
+       %% TODO: /channels/*
 
        {group, off_chain_endpoints},
        {group, external_endpoints},

--- a/apps/aeoracle/src/aeo_oracles.erl
+++ b/apps/aeoracle/src/aeo_oracles.erl
@@ -17,6 +17,7 @@
         , query_format/1
         , response_format/1
         , serialize/1
+        , serialize_for_client/1
         , set_expires/2
         , set_owner/2
         , set_query_fee/2
@@ -127,6 +128,13 @@ serialization_template(?ORACLE_VSN) ->
     , {expires, int}
     ].
 
+-spec serialize_for_client(oracle()) -> map().
+serialize_for_client(#oracle{} = O) ->
+    #{ <<"id">>              => aec_base58c:encode(oracle_pubkey, owner(O))
+     , <<"query_format">>    => query_format(O)
+     , <<"response_format">> => response_format(O)
+     , <<"query_fee">>       => query_fee(O)
+     , <<"expires">>         => expires(O)}.
 
 %%%===================================================================
 %%% Getters

--- a/apps/aeoracle/src/aeo_query.erl
+++ b/apps/aeoracle/src/aeo_query.erl
@@ -14,6 +14,7 @@
         , fee/1
         , id/1
         , id/3
+        , is_open/1
         , is_closed/1
         , new/4
         , oracle_address/1
@@ -23,6 +24,7 @@
         , sender_address/1
         , sender_nonce/1
         , serialize/1
+        , serialize_for_client/1
         , set_expires/2
         , set_fee/2
         , set_oracle_address/2
@@ -44,8 +46,10 @@
 -type oracle_response() :: 'undefined' | aeo_oracles:response().
 -type relative_ttl()    :: aeo_oracles:relative_ttl().
 
+               %% TODO: consider renaming sender_address to sender
 -record(query, { sender_address :: aec_keys:pubkey()
                , sender_nonce   :: integer()
+               %% TODO: consider renaming oracle_address to id/oracle_id/oracle
                , oracle_address :: aec_keys:pubkey()
                , query          :: oracle_query()
                , response       :: oracle_response()
@@ -71,13 +75,12 @@
 %%% API
 %%%===================================================================
 
--spec new(aeo_query_tx:tx(), aec_keys:pubkey(),
-          aec_keys:pubkey(), aec_blocks:height()) -> query().
-new(QTx, SenderPubkey, OraclePubKey, BlockHeight) ->
+-spec new(aeo_query_tx:tx(), aec_keys:pubkey(), aec_keys:pubkey(), aec_blocks:height()) -> query().
+new(QTx, SenderPubkey, OraclePubkey, BlockHeight) ->
     Expires = aeo_utils:ttl_expiry(BlockHeight, aeo_query_tx:query_ttl(QTx)),
     I = #query{ sender_address = SenderPubkey
               , sender_nonce   = aeo_query_tx:nonce(QTx)
-              , oracle_address = OraclePubKey
+              , oracle_address = OraclePubkey
               , query          = aeo_query_tx:query(QTx)
               , response       = undefined
               , expires        = Expires
@@ -98,6 +101,10 @@ id(SenderAddress, Nonce, OracleAddress) ->
             Nonce:?NONCE_SIZE,
             OracleAddress:?PUB_SIZE/binary>>,
     aec_hash:hash(pubkey, Bin).
+
+-spec is_open(query()) -> boolean().
+is_open(#query{response = undefined}) -> true;
+is_open(#query{}) -> false.
 
 -spec is_closed(query()) -> boolean().
 %% @doc An query is closed if it is already answered.
@@ -172,6 +179,26 @@ serialization_template(?ORACLE_QUERY_VSN) ->
     , {response_ttl   , int}
     , {fee            , int}
     ].
+
+-spec serialize_for_client(query()) -> map().
+serialize_for_client(#query{} = I) ->
+    {delta, ResponseTtlValue} = response_ttl(I),
+    Response = case response(I) of
+                   undefined -> <<>>;
+                   R -> R
+               end,
+    #{ <<"query_id">>     => aec_base58c:encode(oracle_query_id, id(I))
+     , <<"sender">>       => aec_base58c:encode(account_pubkey, sender_address(I))
+     , <<"sender_nonce">> => sender_nonce(I)
+     , <<"oracle_id">>    => aec_base58c:encode(oracle_pubkey, oracle_address(I))
+     , <<"query">>        => query(I)
+     , <<"response">>     => Response
+     , <<"expires">>      => expires(I)
+     , <<"response_ttl">> => #{ <<"type">>  => <<"delta">>
+                              , <<"value">> => ResponseTtlValue
+                              }
+     , <<"fee">>          => fee(I)
+     }.
 
 %%%===================================================================
 %%% Getters

--- a/apps/aeoracle/src/aeo_query.erl
+++ b/apps/aeoracle/src/aeo_query.erl
@@ -191,8 +191,8 @@ serialize_for_client(#query{} = I) ->
      , <<"sender">>       => aec_base58c:encode(account_pubkey, sender_address(I))
      , <<"sender_nonce">> => sender_nonce(I)
      , <<"oracle_id">>    => aec_base58c:encode(oracle_pubkey, oracle_address(I))
-     , <<"query">>        => query(I)
-     , <<"response">>     => Response
+     , <<"query">>        => aec_base58c:encode(query(I))
+     , <<"response">>     => aec_base58c:encode(Response)
      , <<"expires">>      => expires(I)
      , <<"response_ttl">> => #{ <<"type">>  => <<"delta">>
                               , <<"value">> => ResponseTtlValue

--- a/apps/aeoracle/src/aeo_query_tx.erl
+++ b/apps/aeoracle/src/aeo_query_tx.erl
@@ -281,9 +281,9 @@ for_client(#oracle_query_tx{nonce         = Nonce,
 
 %% -- Local functions  -------------------------------------------------------
 
-check_query(Q, SenderPubKey, OraclePubKey, Trees, Height) ->
+check_query(Q, SenderPubkey, OraclePubkey, Trees, Height) ->
     Oracles  = aec_trees:oracles(Trees),
-    I        = aeo_query:new(Q, SenderPubKey, OraclePubKey, Height),
+    I        = aeo_query:new(Q, SenderPubkey, OraclePubkey, Height),
     OracleId = aeo_query:oracle_address(I),
     Id       = aeo_query:id(I),
     case aeo_state_tree:lookup_query(OracleId, Id, Oracles) of

--- a/apps/aeoracle/src/aeo_state_tree.erl
+++ b/apps/aeoracle/src/aeo_state_tree.erl
@@ -337,10 +337,10 @@ find_oracle_queries(Iterator, QueryType, N, Acc) when N > 0 ->
             end;
         %% Either end_of_table or next Oracle
         _Other ->
-            Acc
+            lists:reverse(Acc)
     end;
 find_oracle_queries(_Iterator, _QueryType, 0, Acc) ->
-    Acc.
+    lists:reverse(Acc).
 
 find_oracles(FromOracleId, Max, #oracle_tree{otree = T}) ->
     %% Only allow paths that match the size of an OracleId - Queries have

--- a/apps/aeoracle/src/aeo_state_tree.erl
+++ b/apps/aeoracle/src/aeo_state_tree.erl
@@ -13,7 +13,7 @@
         , get_query/3
         , get_oracle/2
         , get_oracle_query_ids/2
-        , get_open_oracle_queries/4
+        , get_oracle_queries/5
         , get_oracles/3
         , empty/0
         , empty_with_backend/0
@@ -140,12 +140,10 @@ get_oracle(Id, Tree) ->
 get_oracle_query_ids(Id, Tree) ->
     find_oracle_query_ids(Id, Tree).
 
--spec get_open_oracle_queries(aeo_oracles:id(),
-                              binary() | '$first',
-                              non_neg_integer(),
-                              tree()) -> list(query()).
-get_open_oracle_queries(OracleId, From, Max, Tree) ->
-    find_open_oracle_queries(OracleId, From, Max, Tree).
+-spec get_oracle_queries(aeo_oracles:id(), binary() | '$first', open | closed | all,
+                         non_neg_integer(), tree()) -> list(query()).
+get_oracle_queries(OracleId, From, QueryType, Max, Tree) ->
+    find_oracle_queries(OracleId, From, QueryType, Max, Tree).
 
 -spec get_oracles(binary() | '$first', non_neg_integer(), tree()) -> list(oracle()).
 get_oracles(From, Max, Tree) ->
@@ -313,25 +311,36 @@ find_oracle_query_tree_ids(OracleId, Tree) ->
 find_oracle_query_ids(OracleId, Tree) ->
     find_oracle_query_ids(OracleId, Tree, id).
 
-find_open_oracle_queries(OracleId, FromQueryId, Max, #oracle_tree{otree = T}) ->
+find_oracle_queries(OracleId, FromQueryId, QueryType, Max, #oracle_tree{otree = T}) ->
     IteratorKey = case FromQueryId of
                       '$first' -> OracleId;
                       _        -> <<OracleId/binary, FromQueryId/binary>>
                   end,
     Iterator = aeu_mtrees:iterator_from(IteratorKey, T),
-    find_open_oracle_queries(Iterator, Max).
+    find_oracle_queries(Iterator, QueryType, Max, []).
 
-find_open_oracle_queries(_Iterator, 0) -> [];
-find_open_oracle_queries(Iterator, N) ->
+find_oracle_queries(Iterator, QueryType, N, Acc) when N > 0 ->
     case aeu_mtrees:iterator_next(Iterator) of
         {Key, Value, NextIterator} when byte_size(Key) > ?PUB_SIZE ->
             Query = aeo_query:deserialize(Value),
-            case aeo_query:is_closed(Query) of
-                false -> [Query | find_open_oracle_queries(NextIterator, N-1)];
-                true  -> find_open_oracle_queries(NextIterator, N)
+            case {QueryType, aeo_query:is_open(Query)} of
+                {open, true} ->
+                    find_oracle_queries(NextIterator, QueryType, N - 1, [Query | Acc]);
+                {open, false} ->
+                    find_oracle_queries(NextIterator, QueryType, N, Acc);
+                {closed, true} ->
+                    find_oracle_queries(NextIterator, QueryType, N, Acc);
+                {closed, false} ->
+                    find_oracle_queries(NextIterator, QueryType, N - 1, [Query | Acc]);
+                {all, _} ->
+                    find_oracle_queries(NextIterator, QueryType, N - 1, [Query | Acc])
             end;
-        _Other -> [] %% Either end_of_table or next Oracle
-    end.
+        %% Either end_of_table or next Oracle
+        _Other ->
+            Acc
+    end;
+find_oracle_queries(_Iterator, _QueryType, 0, Acc) ->
+    Acc.
 
 find_oracles(FromOracleId, Max, #oracle_tree{otree = T}) ->
     %% Only allow paths that match the size of an OracleId - Queries have

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -460,6 +460,92 @@ paths:
           schema:
             $ref: '#/definitions/Error'
       security:
+  /transactions/{hash}:
+    get:
+      tags:
+        - external
+        - transactions
+      operationId: GetTransactionByHash
+      description: 'Get a transaction by hash'
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: hash
+          description: 'The hash of the transaction'
+          required: true
+          type: string
+      responses:
+        '200':
+          description: 'Successful operation'
+          schema:
+            $ref: '#/definitions/SignedTxJSON'
+        '400':
+          description: 'Invalid hash'
+          schema:
+            $ref: '#/definitions/Error'
+        '404':
+          description: 'Transaction not found'
+          schema:
+            $ref: '#/definitions/Error'
+      security:
+  /transactions/{hash}/info:
+    get:
+      tags:
+        - external
+        - transactions
+      operationId: GetTransactionInfoByHash
+      description: 'Get a transaction info by hash'
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: hash
+          description: 'The hash of the transaction'
+          required: true
+          type: string
+      responses:
+        '200':
+          description: 'Successful operation'
+          schema:
+            $ref: '#/definitions/ContractCallObject'
+        '400':
+          description: 'Invalid hash'
+          schema:
+            $ref: '#/definitions/Error'
+        '404':
+          description: 'Transaction not found'
+          schema:
+            $ref: '#/definitions/Error'
+      security:
+  /transactions:
+    post:
+      tags:
+        - external
+        - transactions
+      operationId: PostTransaction
+      description: 'Post a new transaction'
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: 'The new transaction'
+          required: true
+          schema:
+            $ref: '#/definitions/Tx'
+      responses:
+        '200':
+          description: 'Successful operation'
+          schema:
+            $ref: '#/definitions/PostTxResponse'
+        '400':
+          description: 'Invalid transaction'
+          schema:
+            $ref: '#/definitions/Error'
+      security:
   /header-by-hash:
     get:
       tags:
@@ -3633,7 +3719,7 @@ definitions:
     type: object
     properties:
       tx_hash:
-        description: Hash of a signed transaction
+        description: 'Hash of a signed transaction'
         $ref: '#/definitions/EncodedHash'
     required:
     - tx_hash

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -546,6 +546,86 @@ paths:
           schema:
             $ref: '#/definitions/Error'
       security:
+  /contracts/{pubkey}:
+    get:
+      tags:
+        - external
+        - transactions
+      operationId: GetContract
+      description: 'Get a contract by pubkey'
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: pubkey
+          description: 'The pubkey of the contract'
+          required: true
+          type: string
+      responses:
+        '200':
+          description: 'Successful operation'
+          schema:
+            $ref: '#/definitions/ContractObject'
+        '400':
+          description: 'Invalid pubkey'
+          schema:
+            $ref: '#/definitions/Error'
+        '404':
+          description: 'Contract not found'
+  /contracts/{pubkey}/code:
+    get:
+      tags:
+        - external
+        - transactions
+      operationId: GetContractCode
+      description: 'Get contract code by pubkey'
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: pubkey
+          description: 'The pubkey of the contract'
+          required: true
+          type: string
+      responses:
+        '200':
+          description: 'Contract code'
+          schema:
+            $ref: '#/definitions/ByteCode'
+        '400':
+          description: 'Invalid pubkey'
+          schema:
+            $ref: '#/definitions/Error'
+        '404':
+          description: 'Contract not found'
+          schema:
+            $ref: '#/definitions/Error'
+  /contracts/{pubkey}/store:
+    get:
+      tags:
+        - external
+        - transactions
+      operationId: GetContractStore
+      description: 'Get contract store by pubkey'
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: pubkey
+          description: 'The pubkey of the contract'
+          required: true
+          type: string
+      responses:
+        '200':
+          description: 'Contract Store'
+          schema:
+            $ref: '#/definitions/ContractStore'
+        '400':
+          description: 'Invalid pubkey'
+          schema:
+            $ref: '#/definitions/Error'
+        '404':
+          description: 'Contract not found'
   /oracles/{pubkey}:
     get:
       tags:
@@ -3631,6 +3711,39 @@ definitions:
     properties:
       reason:
         type: string
+  ContractObject:
+    type: object
+    properties:
+      id:
+        $ref: '#/definitions/EncodedHash'
+      owner:
+        $ref: '#/definitions/EncodedHash'
+      vm_version:
+        type: integer
+        minimum: 0
+        maximum: 255
+      log:
+        type: string
+      active:
+        type: boolean
+      referers:
+        type: array
+        items:
+          $ref: '#/definitions/EncodedHash'
+      deposit:
+        type: integer
+  ContractStore:
+    type: object
+    properties:
+      store:
+        type: array
+        items:
+          type: object
+          properties:
+            key:
+              type: string
+            value:
+              type: string
   Contract:
     type: object
     properties:

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -546,6 +546,116 @@ paths:
           schema:
             $ref: '#/definitions/Error'
       security:
+  /oracles/{pubkey}:
+    get:
+      tags:
+        - external
+        - gossip
+      operationId: GetOracleByPubkey
+      description: 'Get an oracle by public key'
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: pubkey
+          description: 'The public key of the oracle'
+          required: true
+          type: string
+      responses:
+        '200':
+          description: 'Successful operation'
+          schema:
+            $ref: '#/definitions/RegisteredOracle'
+        '400':
+          description: 'Invalid public key'
+          schema:
+            $ref: '#/definitions/Error'
+        '404':
+          description: 'Oracle not found'
+          schema:
+            $ref: '#/definitions/Error'
+      security:
+  /oracles/{pubkey}/queries:
+    get:
+      tags:
+        - external
+        - gossip
+      operationId: GetOracleQueriesByPubkey
+      description: 'Get oracle queries by public key'
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: pubkey
+          description: 'The public key of the oracle'
+          required: true
+          type: string
+        - in: query
+          name: from
+          description: 'Last query id in previous page'
+          required: false
+          type: string
+        - in: query
+          name: limit
+          description: 'Max number of oracle queries'
+          required: false
+          type: integer
+          minimum: 1
+          maximum: 1000
+        - in: query
+          name: type
+          description: 'The type of a query: open, closed or all'
+          required: false
+          type: string
+          enum: [open, closed, all]
+      responses:
+        '200':
+          description: 'Successful operation'
+          schema:
+            $ref: '#/definitions/OracleQueries'
+        '400':
+          description: 'Invalid public key'
+          schema:
+            $ref: '#/definitions/Error'
+        '404':
+          description: 'Oracle not found'
+          schema:
+            $ref: '#/definitions/Error'
+      security:
+  /oracles/{pubkey}/queries/{query-id}:
+    get:
+      tags:
+        - external
+        - gossip
+      operationId: GetOracleQueryByPubkeyAndQueryId
+      description: 'Get an oracle query by public key and query ID'
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: pubkey
+          description: 'The public key of the oracle'
+          required: true
+          type: string
+        - in: path
+          name: query-id
+          description: 'The ID of the query'
+          required: true
+          type: string
+      responses:
+        '200':
+          description: 'Successful operation'
+          schema:
+            $ref: '#/definitions/OracleQuery'
+        '400':
+          description: 'Invalid public key or query ID'
+          schema:
+            $ref: '#/definitions/Error'
+        '404':
+          description: 'Oracle query not found'
+          schema:
+            $ref: '#/definitions/Error'
+      security:
   /header-by-hash:
     get:
       tags:
@@ -2619,36 +2729,72 @@ definitions:
     type: array
     items:
       $ref: '#/definitions/Tx'
+  RegisteredOracle:
+    type: object
+    properties:
+      id:
+        type: string
+      query_format:
+        type: string
+      response_format:
+        type: string
+      query_fee:
+        type: integer
+      expires:
+        type: integer
+        format: int64
   RegisteredOracles:
     type: array
     items:
-      type: object
-      properties:
-        address:
-          type: string
-        query_format:
-          type: string
-        response_format:
-          type: string
-        query_fee:
-          type: integer
-        expires_at:
-          type: integer
-          format: int64
+      $ref: '#/definitions/RegisteredOracle'
+  OracleQuery:
+    type: object
+    properties:
+      id:
+        type: string
+      sender:
+        type: string
+      sender_nonce:
+        type: integer
+        format: int64
+        minimum: 0
+      oracle_id:
+        type: string
+      query:
+        type: string
+      response:
+        type: string
+      expires:
+        type: integer
+        format: int64
+      response_ttl:
+        $ref: '#/definitions/TTL'
+      fee:
+        type: integer
+        format: int64
+  OracleQuestion:
+    type: object
+    properties:
+      query_id:
+        type: string
+      query:
+        type: string
+      query_fee:
+        type: integer
+      expires_at:
+        type: integer
+        format: int64
+  OracleQueries:
+    type: object
+    properties:
+      oracle_queries:
+        type: array
+        items:
+          $ref: '#/definitions/OracleQuery'
   OracleQuestions:
     type: array
     items:
-      type: object
-      properties:
-        query_id:
-          type: string
-        query:
-          type: string
-        query_fee:
-          type: integer
-        expires_at:
-          type: integer
-          format: int64
+      $ref: '#/definitions/OracleQuestion'
   SpendTx:
     type: object
     properties:

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -736,6 +736,36 @@ paths:
           schema:
             $ref: '#/definitions/Error'
       security:
+  /names/{name}:
+    get:
+      tags:
+        - external
+        - name_service
+      operationId: GetNameEntryByName
+      description: 'Get name entry from naming system'
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: name
+          description: 'The name key of the name entry'
+          required: true
+          type: string
+      responses:
+        '200':
+          description: 'Successful operation'
+          schema:
+            $ref: '#/definitions/NameEntry'
+        '400':
+          description: 'Invalid name'
+          schema:
+            $ref: '#/definitions/Error'
+        '404':
+          description: 'Name not found'
+          schema:
+            $ref: '#/definitions/Error'
+      security:
+
   /header-by-hash:
     get:
       tags:

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -765,6 +765,35 @@ paths:
           schema:
             $ref: '#/definitions/Error'
       security:
+  /channels/{pubkey}:
+    get:
+      tags:
+        - external
+        - gossip
+      operationId: GetChannelByPubkey
+      description: 'Get channel by public key'
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: pubkey
+          description: 'The pubkey of the channel'
+          required: true
+          type: string
+      responses:
+        '200':
+          description: 'Successful operation'
+          schema:
+            $ref: '#/definitions/Channel'
+        '400':
+          description: 'Invalid public key'
+          schema:
+            $ref: '#/definitions/Error'
+        '404':
+          description: 'Channel not found'
+          schema:
+            $ref: '#/definitions/Error'
+      security:
 
   /header-by-hash:
     get:
@@ -3210,6 +3239,48 @@ definitions:
     properties:
       name_hash:
         type: string
+  Channel:
+    type: object
+    properties:
+      id:
+        $ref: '#/definitions/EncodedHash'
+      initiator:
+        $ref: '#/definitions/EncodedHash'
+      responder:
+        $ref: '#/definitions/EncodedHash'
+      total_amount:
+        type: integer
+        format: int64
+        minimum: 0
+      initiator_amount:
+        type: integer
+        format: int64
+        minimum: 0
+      responder_amount:
+        type: integer
+        format: int64
+        minimum: 0
+      channel_reserve:
+        type: integer
+        format: int64
+        minimum: 0
+      delegates:
+        type: array
+        items:
+          $ref: '#/definitions/EncodedHash'
+      state_hash:
+        $ref: '#/definitions/EncodedHash'
+      round:
+        type: integer
+        format: int64
+        minimum: 0
+      lock_period:
+        type: integer
+        format: int64
+        minimum: 0
+      closes_at:
+        type: integer
+        format: int64
   ChannelCreateTx:
     type: object
     properties:

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -813,6 +813,22 @@ paths:
               pubkey:
                 type: string
       security:
+  /status:
+    get:
+      tags:
+        - external
+        - gossip
+      operationId: GetStatus
+      description: 'Get the status of a node'
+      produces:
+        - application/json
+      parameters:
+      responses:
+        '200':
+          description: 'Successful operation'
+          schema:
+            $ref: '#/definitions/Status'
+      security:
 
   /header-by-hash:
     get:
@@ -3666,7 +3682,49 @@ definitions:
         description: 'Blocks''s height'
     required:
     - height
-
+  Status:
+    type: object
+    properties:
+      genesis-key-block-hash:
+        $ref: '#/definitions/EncodedHash'
+      solutions:
+        type: integer
+        format: int64
+        minimum: 0
+      difficulty:
+        type: number
+        format: int64
+      syncing:
+        type: boolean
+      listening:
+        type: boolean
+      protocols:
+        type: array
+        items:
+          $ref: '#/definitions/Protocol'
+      node-version:
+        type: string
+      node-revision:
+        type: string
+      peer-count:
+        type: integer
+        format: int64
+        minimum: 0
+      pending-transactions-count:
+        type: integer
+        format: int64
+        minimum: 0
+  Protocol:
+    type: object
+    properties:
+      protocol_version:
+        type: integer
+        format: int64
+        minimum: 1
+      effective_at_height:
+        type: integer
+        format: int64
+        minimum: 0
   SingleTxObject:
     type: object
     discriminator: data_schema

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -794,6 +794,25 @@ paths:
           schema:
             $ref: '#/definitions/Error'
       security:
+  /peers/pubkey:
+    get:
+      tags:
+        - external
+        - gossip
+      operationId: GetPeerPubkey
+      description: 'Get peer public key'
+      produces:
+        - application/json
+      parameters:
+      responses:
+        '200':
+          description: 'Successful operation'
+          schema:
+            type: object
+            properties:
+              pubkey:
+                type: string
+      security:
 
   /header-by-hash:
     get:

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -402,6 +402,64 @@ paths:
           schema:
             $ref: '#/definitions/Error'
       security:
+  /accounts/{pubkey}:
+    get:
+      tags:
+        - external
+        - gossip
+      operationId: GetAccountByPubkey
+      description: 'Get an account by public key'
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: pubkey
+          description: 'The public key of the account'
+          required: true
+          type: string
+      responses:
+        '200':
+          description: 'Successful operation'
+          schema:
+            $ref: '#/definitions/Account'
+        '400':
+          description: 'Invalid public key'
+          schema:
+            $ref: '#/definitions/Error'
+        '404':
+          description: 'Account not found'
+          schema:
+            $ref: '#/definitions/Error'
+      security:
+  /accounts/{pubkey}/transactions/pending:
+    get:
+      tags:
+        - external
+        - gossip
+      operationId: GetPendingAccountTransactionsByPubkey
+      description: 'Get pending account transactions by public key'
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: pubkey
+          description: 'The public key of the account'
+          required: true
+          type: string
+      responses:
+        '200':
+          description: 'Successful operation'
+          schema:
+            $ref: '#/definitions/JSONTxs'
+        '400':
+          description: 'Invalid public key'
+          schema:
+            $ref: '#/definitions/Error'
+        '404':
+          description: 'Account not found'
+          schema:
+            $ref: '#/definitions/Error'
+      security:
   /header-by-hash:
     get:
       tags:
@@ -2438,6 +2496,22 @@ definitions:
             type: array
             items:
               $ref: '#/definitions/SignedTxJSON'
+  Account:
+    type: object
+    properties:
+      pubkey:
+        type: string
+        description: 'Public key'
+      balance:
+        type: integer
+        description: 'Balance'
+        format: int64
+        minimum: 0
+      nonce:
+        type: integer
+        description: 'Nonce'
+        format: int64
+        minimum: 0
   Balance:
     type: object
     properties:

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -518,7 +518,7 @@ paths:
           schema:
             $ref: '#/definitions/Error'
       security:
-  /transactions:
+  /ng-transactions:
     post:
       tags:
         - external


### PR DESCRIPTION
In this PR we're adding another batch of new endpoints. Following PRs are going to remove and clean up obsolete endpoints. 

TODO: 

- [x] docker smoke test #1363 d5a55f2f2d49b56909e04aa08ada0716232977f6
- [x] `aehttp_integration_SUITE ==> all.internal_endpoints.list_oracle_queries`
- [x] `aehttp_integration_SUITE ==> *.get_pending_key_block` 

TODO covered in following PRs:

- [ ] Improve test coverage for contracts, channels, names
- [ ] rename `/ng-transactions` to `/transactions`
- [ ] consult `/status` return with eapps 
- [ ] update release notes 
- [ ] update protocol repo 