### PR TITLE
Try making aec_peers_tests more reliable.

### DIFF
--- a/apps/aecore/test/aec_peers_tests.erl
+++ b/apps/aecore/test/aec_peers_tests.erl
@@ -144,9 +144,9 @@ test_single_trusted_peer() ->
     ?assertEqual(0, aec_peers:count(unverified)),
     ?assertEqual(0, aec_peers:count(standby)),
 
-    Peer = peer(PubKey, "aeternity.com", 4000),
+    Peer = peer(PubKey, "10.1.0.1", 4000),
     aec_peers:add_trusted(Peer),
-    {ok, Conn} = ?assertCalled(connect, [#{ r_pubkey := PubKey }], {ok, _}, 100),
+    {ok, Conn} = ?assertCalled(connect, [#{ r_pubkey := PubKey }], {ok, _}, 200),
 
     ?assertMatch([], aec_peers:connected_peers()),
     ?assertMatch([#{ pubkey := PubKey }], aec_peers:get_random(all)),
@@ -180,7 +180,7 @@ test_single_normal_peer() ->
     Source = {192, 168, 0, 1},
     PubKey = <<"ef42d46eace742cd">>,
     Id = aec_peers:peer_id(PubKey),
-    Peer = peer(PubKey, <<"aeternity.com">>, 4000),
+    Peer = peer(PubKey, <<"10.1.0.1">>, 4000),
 
     aec_peers:add_peers(Source, Peer),
 
@@ -190,7 +190,7 @@ test_single_normal_peer() ->
     ?assertMatch([Peer], aec_peers:available_peers(unverified)),
     ?assertEqual(1, aec_peers:count(available)),
 
-    {ok, Conn} = ?assertCalled(connect, [#{ r_pubkey := PubKey }], {ok, _}, 150),
+    {ok, Conn} = ?assertCalled(connect, [#{ r_pubkey := PubKey }], {ok, _}, 200),
 
     ?assertMatch([], aec_peers:connected_peers()),
     ?assertMatch([#{ pubkey := PubKey }], aec_peers:get_random(all)),
@@ -228,15 +228,15 @@ test_multiple_trusted_peers() ->
     Id3 = aec_peers:peer_id(PubKey3),
 
     Peers = [
-        peer(PubKey1, <<"aeternity.com">>, 4000),
-        peer(PubKey2, "google.com", 4000),
-        peer(PubKey3, "192.168.0.1", 4000)
+        peer(PubKey1, <<"10.1.0.1">>, 4000),
+        peer(PubKey2, "10.2.0.1", 4000),
+        peer(PubKey3, "10.3.0.1", 4000)
     ],
 
     aec_peers:add_trusted(Peers),
     {ok, Conn1} = ?assertCalled(connect, [#{ r_pubkey := PubKey1 }], {ok, _}, 500),
-    {ok, Conn2} = ?assertCalled(connect, [#{ r_pubkey := PubKey2 }], {ok, _}, 100),
-    {ok, Conn3} = ?assertCalled(connect, [#{ r_pubkey := PubKey3 }], {ok, _}, 100),
+    {ok, Conn2} = ?assertCalled(connect, [#{ r_pubkey := PubKey2 }], {ok, _}, 200),
+    {ok, Conn3} = ?assertCalled(connect, [#{ r_pubkey := PubKey3 }], {ok, _}, 200),
 
     ?assertMatch([], aec_peers:connected_peers()),
     ?assertEqual(lists:sort(Peers), lists:sort(aec_peers:get_random(all))),
@@ -282,9 +282,9 @@ test_multiple_normal_peers() ->
     Id3 = aec_peers:peer_id(PubKey3),
 
     Peers = [
-        peer(PubKey1, <<"aeternity.com">>, 4000),
-        peer(PubKey2, "google.com", 4000),
-        peer(PubKey3, "192.168.0.1", 4000)
+        peer(PubKey1, <<"10.1.0.1">>, 4000),
+        peer(PubKey2, "10.2.0.1", 4000),
+        peer(PubKey3, "10.3.0.1", 4000)
     ],
 
     aec_peers:add_peers(Source, Peers),
@@ -292,11 +292,11 @@ test_multiple_normal_peers() ->
     %% and the third one after 2 seconds; but there is no way of knowing the
     %% order they will get connect to.
     A = erlang:system_time(millisecond),
-    {ok, Conn1} = ?assertCalled(connect, [#{ r_pubkey := PubKey1 }], {ok, _}, 3150),
-    {ok, Conn2} = ?assertCalled(connect, [#{ r_pubkey := PubKey2 }], {ok, _}, 3150),
-    {ok, Conn3} = ?assertCalled(connect, [#{ r_pubkey := PubKey3 }], {ok, _}, 3150),
+    {ok, Conn1} = ?assertCalled(connect, [#{ r_pubkey := PubKey1 }], {ok, _}, 3500),
+    {ok, Conn2} = ?assertCalled(connect, [#{ r_pubkey := PubKey2 }], {ok, _}, 3500),
+    {ok, Conn3} = ?assertCalled(connect, [#{ r_pubkey := PubKey3 }], {ok, _}, 3500),
     B = erlang:system_time(millisecond),
-    ?assert((B - A) =< 3150),
+    ?assertEqual({(B - A), true}, {(B - A), ((B - A) =< 3500)}),
 
     ok = conn_peer_connected(Conn1),
     ok = conn_peer_connected(Conn2),
@@ -349,33 +349,33 @@ test_invalid_hostname() ->
     ?assertEqual(0, aec_peers:count(standby)),
 
     % First retry
-    ?assertMessage({getaddr, "aeternity.com"}, 300),
+    ?assertMessage({getaddr, "aeternity.com"}, 400),
     ?assertMatch(1, aec_peers:count(hostnames)),
 
     aec_peers:add_trusted(Peer2),
-    ?assertMessage({getaddr, "aeternity.com"}, 50),
+    ?assertMessage({getaddr, "aeternity.com"}, 100),
 
     % Second retry
-    ?assertMessage({getaddr, "aeternity.com"}, 300),
+    ?assertMessage({getaddr, "aeternity.com"}, 400),
     ?assertMatch(1, aec_peers:count(hostnames)),
 
     % Third retry
-    ?assertMessage({getaddr, "aeternity.com"}, 400),
+    ?assertMessage({getaddr, "aeternity.com"}, 500),
     ?assertMatch(1, aec_peers:count(hostnames)),
 
     % Trusted peers keep retrying forever, but normal peers are removed.
-    ?assertMessage({getaddr, "aeternity.com"}, 400),
+    ?assertMessage({getaddr, "aeternity.com"}, 500),
     ?assertMatch(1, aec_peers:count(hostnames)),
 
-    ?assertMessage({getaddr, "aeternity.com"}, 400),
+    ?assertMessage({getaddr, "aeternity.com"}, 500),
     ?assertMatch(1, aec_peers:count(hostnames)),
 
     % Make the hostname resolvable again
     mock_getaddr({ok, {192, 168, 0, 10}}),
 
     % Only the trusted peer is added, the other one was removed.
-    ?assertMessage({getaddr, "aeternity.com"}, 400),
-    {ok, Conn1} = ?assertCalled(connect, [#{ r_pubkey := PubKey2 }], {ok, _}, 100),
+    ?assertMessage({getaddr, "aeternity.com"}, 500),
+    {ok, Conn1} = ?assertCalled(connect, [#{ r_pubkey := PubKey2 }], {ok, _}, 200),
 
     ?assertMatch(0, aec_peers:count(hostnames)),
     ?assertEqual(1, aec_peers:count(connections)),
@@ -390,11 +390,11 @@ test_invalid_hostname() ->
 
     % Delete peer2 and add back both.
     aec_peers:del_peer(Peer2),
-    ?assertCalled(disconnect, [Conn1], ok, 50),
+    ?assertCalled(disconnect, [Conn1], ok, 100),
     aec_peers:add_peers(Source, Peer1),
-    ?assertMessage({getaddr, "aeternity.com"}, 50),
+    ?assertMessage({getaddr, "aeternity.com"}, 100),
     aec_peers:add_trusted(Peer2),
-    ?assertMessage({getaddr, "aeternity.com"}, 50),
+    ?assertMessage({getaddr, "aeternity.com"}, 100),
 
     ?assertMatch(1, aec_peers:count(hostnames)),
     ?assertEqual(0, aec_peers:count(connections)),
@@ -406,14 +406,14 @@ test_invalid_hostname() ->
     ?assertEqual(0, aec_peers:count(standby)),
 
     % First retry
-    ?assertMessage({getaddr, "aeternity.com"}, 150),
+    ?assertMessage({getaddr, "aeternity.com"}, 200),
 
     mock_getaddr({ok, {192, 168, 0, 10}}),
 
     % Both peers hould get added and get connected to.
     ?assertMessage({getaddr, "aeternity.com"}, 350),
-    ?assertCalled(connect, [#{ r_pubkey := PubKey2 }], {ok, _}, 100),
-    ?assertCalled(connect, [#{ r_pubkey := PubKey1 }], {ok, _}, 1050),
+    ?assertCalled(connect, [#{ r_pubkey := PubKey2 }], {ok, _}, 200),
+    ?assertCalled(connect, [#{ r_pubkey := PubKey1 }], {ok, _}, 1200),
 
     ok.
 
@@ -423,22 +423,22 @@ test_address_group_selection() ->
     Source = {192, 168, 0, 1},
     PubKey1 = <<"ef42d46eace742cd">>,
     Id1 = aec_peers:peer_id(PubKey1),
-    Peer1 = peer(PubKey1, "192.168.0.1", 4000),
+    Peer1 = peer(PubKey1, "10.1.0.1", 4000),
     PubKey2 = <<"854a8e1f93f94b95">>,
     Id2 = aec_peers:peer_id(PubKey2),
-    Peer2 = peer(PubKey2, "192.168.0.2", 4000),
+    Peer2 = peer(PubKey2, "10.1.0.2", 4000),
     PubKey3 = <<"eb56e9292dda481c">>,
     Id3 = aec_peers:peer_id(PubKey3),
-    Peer3 = peer(PubKey3, "193.168.0.1", 4000),
+    Peer3 = peer(PubKey3, "10.2.0.1", 4000),
     PubKey4 = <<"9d9e1c43de304d81">>,
     Id4 = aec_peers:peer_id(PubKey4),
-    Peer4 = peer(PubKey4, "193.168.0.2", 4000),
+    Peer4 = peer(PubKey4, "10.2.0.1", 4000),
     PubKey5 = <<"75640b5ffaac4048">>,
     Id5 = aec_peers:peer_id(PubKey5),
-    Peer5 = peer(PubKey5, "194.168.0.1", 4000),
+    Peer5 = peer(PubKey5, "10.3.0.1", 4000),
 
     aec_peers:add_peers(Source, Peer1),
-    {ok, Conn1} = ?assertCalled(connect, [#{ r_pubkey := PubKey1 }], {ok, _}, 150),
+    {ok, Conn1} = ?assertCalled(connect, [#{ r_pubkey := PubKey1 }], {ok, _}, 200),
     ok = conn_peer_connected(Conn1),
 
     aec_peers:add_peers(Source, Peer2),
@@ -452,7 +452,7 @@ test_address_group_selection() ->
     ?assertMatch({error, _}, aec_peers:get_connection(Id2)),
 
     aec_peers:add_peers(Source, Peer3),
-    {ok, Conn3} = ?assertCalled(connect, [#{ r_pubkey := PubKey3 }], {ok, _}, 1100),
+    {ok, Conn3} = ?assertCalled(connect, [#{ r_pubkey := PubKey3 }], {ok, _}, 1200),
     ok = conn_peer_connected(Conn3),
 
     ?assertEqual(lists:sort([Peer1, Peer3]),
@@ -476,7 +476,7 @@ test_address_group_selection() ->
     ?assertMatch({error, _}, aec_peers:get_connection(Id4)),
 
     aec_peers:add_peers(Source, Peer5),
-    {ok, Conn5} = ?assertCalled(connect, [#{ r_pubkey := PubKey5 }], {ok, _}, 2100),
+    {ok, Conn5} = ?assertCalled(connect, [#{ r_pubkey := PubKey5 }], {ok, _}, 2200),
     ok = conn_peer_connected(Conn5),
 
     ?assertEqual(lists:sort([Peer1, Peer3, Peer5]),
@@ -504,24 +504,24 @@ test_selection_without_address_group() ->
     Source = {192, 168, 0, 1},
     PubKey1 = <<"ef42d46eace742cd">>,
     Id1 = aec_peers:peer_id(PubKey1),
-    Peer1 = peer(PubKey1, "192.168.0.1", 4000),
+    Peer1 = peer(PubKey1, "10.1.0.1", 4000),
     PubKey2 = <<"854a8e1f93f94b95">>,
     Id2 = aec_peers:peer_id(PubKey2),
-    Peer2 = peer(PubKey2, "192.168.0.2", 4000),
+    Peer2 = peer(PubKey2, "10.1.0.2", 4000),
     PubKey3 = <<"eb56e9292dda481c">>,
     Id3 = aec_peers:peer_id(PubKey3),
-    Peer3 = peer(PubKey3, "192.168.0.3", 4000),
+    Peer3 = peer(PubKey3, "10.1.0.3", 4000),
 
     aec_peers:add_peers(Source, Peer1),
-    {ok, Conn1} = ?assertCalled(connect, [#{ r_pubkey := PubKey1 }], {ok, _}, 150),
+    {ok, Conn1} = ?assertCalled(connect, [#{ r_pubkey := PubKey1 }], {ok, _}, 200),
     ok = conn_peer_connected(Conn1),
 
     aec_peers:add_peers(Source, Peer2),
-    {ok, Conn2} = ?assertCalled(connect, [#{ r_pubkey := PubKey2 }], {ok, _}, 1100),
+    {ok, Conn2} = ?assertCalled(connect, [#{ r_pubkey := PubKey2 }], {ok, _}, 1200),
     ok = conn_peer_connected(Conn2),
 
     aec_peers:add_peers(Source, Peer3),
-    {ok, Conn3} = ?assertCalled(connect, [#{ r_pubkey := PubKey3 }], {ok, _}, 2100),
+    {ok, Conn3} = ?assertCalled(connect, [#{ r_pubkey := PubKey3 }], {ok, _}, 2200),
     ok = conn_peer_connected(Conn3),
 
     ?assertEqual(lists:sort([Peer1, Peer2, Peer3]),
@@ -539,10 +539,10 @@ test_connection_closed() ->
     Source = {192, 168, 0, 1},
     PubKey = <<"ef42d46eace742cd">>,
     Id = aec_peers:peer_id(PubKey),
-    Peer = peer(PubKey, "aeternity.com", 4000),
+    Peer = peer(PubKey, "10.1.0.1", 4000),
 
     aec_peers:add_peers(Source, Peer),
-    {ok, Conn1} = ?assertCalled(connect, [#{ r_pubkey := PubKey }], {ok, _}, 150),
+    {ok, Conn1} = ?assertCalled(connect, [#{ r_pubkey := PubKey }], {ok, _}, 200),
     ok = conn_peer_connected(Conn1),
 
     ?assertMatch([Peer], aec_peers:connected_peers()),
@@ -561,7 +561,7 @@ test_connection_closed() ->
     ?assertEqual(0, aec_peers:count(standby)),
 
     % Check it is reconnects
-    {ok, Conn2} = ?assertCalled(connect, [#{ r_pubkey := PubKey }], {ok, _}, 1100),
+    {ok, Conn2} = ?assertCalled(connect, [#{ r_pubkey := PubKey }], {ok, _}, 1200),
     ok = conn_peer_connected(Conn2),
 
     ?assertMatch([Peer], aec_peers:connected_peers()),
@@ -583,10 +583,10 @@ test_connection_failure() ->
     Source = {192, 168, 0, 1},
     PubKey = <<"ef42d46eace742cd">>,
     Id = aec_peers:peer_id(PubKey),
-    Peer = peer(PubKey, "aeternity.com", 4000),
+    Peer = peer(PubKey, "10.1.0.1", 4000),
 
     aec_peers:add_peers(Source, Peer),
-    {ok, Conn1} = ?assertCalled(connect, [#{ r_pubkey := PubKey }], {ok, _}, 150),
+    {ok, Conn1} = ?assertCalled(connect, [#{ r_pubkey := PubKey }], {ok, _}, 200),
     ok = conn_connection_failed(Conn1),
 
     ?assertMatch([], aec_peers:connected_peers()),
@@ -599,7 +599,7 @@ test_connection_failure() ->
     ?assertEqual(1, aec_peers:count(standby)),
 
     % Check it is retried after 200 milliseconds
-    {ok, Conn2} = ?assertCalled(connect, [#{ r_pubkey := PubKey }], {ok, _}, 250),
+    {ok, Conn2} = ?assertCalled(connect, [#{ r_pubkey := PubKey }], {ok, _}, 300),
     ok = conn_peer_connected(Conn2),
 
     ?assertMatch([Peer], aec_peers:connected_peers()),
@@ -621,10 +621,10 @@ test_connection_down() ->
     Source = {192, 168, 0, 1},
     PubKey = <<"ef42d46eace742cd">>,
     Id = aec_peers:peer_id(PubKey),
-    Peer = peer(PubKey, "aeternity.com", 4000),
+    Peer = peer(PubKey, "10.1.0.1", 4000),
 
     aec_peers:add_peers(Source, Peer),
-    {ok, Conn1} = ?assertCalled(connect, [#{ r_pubkey := PubKey }], {ok, _}, 150),
+    {ok, Conn1} = ?assertCalled(connect, [#{ r_pubkey := PubKey }], {ok, _}, 200),
     conn_kill(Conn1),
 
     ?assertMatch([], aec_peers:connected_peers()),
@@ -637,7 +637,7 @@ test_connection_down() ->
     ?assertEqual(1, aec_peers:count(standby)),
 
     % Check first retry.
-    {ok, Conn2} = ?assertCalled(connect, [#{ r_pubkey := PubKey }], {ok, _}, 350),
+    {ok, Conn2} = ?assertCalled(connect, [#{ r_pubkey := PubKey }], {ok, _}, 400),
     ok = conn_peer_connected(Conn2),
     conn_kill(Conn2),
 
@@ -651,7 +651,7 @@ test_connection_down() ->
     ?assertEqual(1, aec_peers:count(standby)),
 
     % Check second retry.
-    {ok, Conn3} = ?assertCalled(connect, [#{ r_pubkey := PubKey }], {ok, _}, 450),
+    {ok, Conn3} = ?assertCalled(connect, [#{ r_pubkey := PubKey }], {ok, _}, 500),
     ok = conn_peer_connected(Conn3),
     conn_kill(Conn3),
 
@@ -665,12 +665,12 @@ test_connection_down() ->
     ?assertEqual(1, aec_peers:count(standby)),
 
     % Check last retry.
-    {ok, Conn4} = ?assertCalled(connect, [#{ r_pubkey := PubKey }], {ok, _}, 450),
+    {ok, Conn4} = ?assertCalled(connect, [#{ r_pubkey := PubKey }], {ok, _}, 500),
     ok = conn_peer_connected(Conn4),
     conn_kill(Conn4),
 
     % Peer is downgraded to the unverified pool, and retried.
-    {ok, Conn5} = ?assertCalled(connect, [#{ r_pubkey := PubKey }], {ok, _}, 150),
+    {ok, Conn5} = ?assertCalled(connect, [#{ r_pubkey := PubKey }], {ok, _}, 200),
 
     ?assertMatch([], aec_peers:connected_peers()),
     ?assertMatch([Peer], aec_peers:get_random(all)),
@@ -686,10 +686,10 @@ test_connection_down() ->
 
     conn_kill(Conn5),
 
-    {ok, Conn6} = ?assertCalled(connect, [#{ r_pubkey := PubKey }], {ok, _}, 350),
+    {ok, Conn6} = ?assertCalled(connect, [#{ r_pubkey := PubKey }], {ok, _}, 400),
     conn_kill(Conn6),
 
-    {ok, Conn7} = ?assertCalled(connect, [#{ r_pubkey := PubKey }], {ok, _}, 450),
+    {ok, Conn7} = ?assertCalled(connect, [#{ r_pubkey := PubKey }], {ok, _}, 500),
     conn_kill(Conn7),
 
     ?assertMatch([], aec_peers:connected_peers()),
@@ -703,7 +703,7 @@ test_connection_down() ->
 
     % Last retry of unverified peer, should be removed.
 
-    {ok, Conn8} = ?assertCalled(connect, [#{ r_pubkey := PubKey }], {ok, _}, 450),
+    {ok, Conn8} = ?assertCalled(connect, [#{ r_pubkey := PubKey }], {ok, _}, 500),
     conn_kill(Conn8),
 
     ?assertMatch([], aec_peers:connected_peers()),
@@ -719,7 +719,7 @@ test_connection_down() ->
 test_inbound_connections() ->
     test_mgr_set_recipient(self()),
 
-    Peers = [ peer(I, "aeternity.com", I) || I <- lists:seq(1, 10) ],
+    Peers = [ peer(I, "10.1.0.1", I) || I <- lists:seq(1, 10) ],
 
     lists:foldl(fun(Peer, Acc) ->
         {ok, Conn} = test_mgr_start_inbound(Peer),
@@ -743,7 +743,7 @@ test_inbound_connections() ->
     ?assertNotCalled(connect, _, 1000),
 
     % Check the inbound connection limit.
-    Peer11 = peer(11, "aeternity.com", 11),
+    Peer11 = peer(11, "10.1.0.1", 11),
     {ok, Conn11a} = test_mgr_start_inbound(Peer11),
     ?assertEqual(temporary, conn_peer_accepted(Conn11a)),
     ?assertEqual(11, aec_peers:count(connections)),
@@ -754,7 +754,7 @@ test_inbound_connections() ->
 
     % The extra inbound that was closed is used for outbound.
     #{ pubkey := PubKey11} = Peer11,
-    {ok, Conn11b} = ?assertCalled(connect, [#{ r_pubkey := PubKey11 }], {ok, _}, 1000),
+    {ok, Conn11b} = ?assertCalled(connect, [#{ r_pubkey := PubKey11 }], {ok, _}, 1100),
     conn_peer_connected(Conn11b),
 
     ?assertEqual(11, aec_peers:count(connections)),
@@ -773,22 +773,22 @@ test_outbound_connections() ->
     test_mgr_set_recipient(self()),
 
     Source = {192, 168, 0, 1},
-    Peer1 = peer(1, "192.168.0.1", 1),
+    Peer1 = peer(1, "10.1.0.1", 1),
     #{ pubkey := PubKey1 } = Peer1,
-    Peer2 = peer(2, "192.168.0.2", 2),
+    Peer2 = peer(2, "10.1.0.2", 2),
     #{ pubkey := PubKey2 } = Peer2,
-    Peer3 = peer(3, "193.168.0.1", 3),
+    Peer3 = peer(3, "10.2.0.1", 3),
     #{ pubkey := PubKey3 } = Peer3,
-    Peer4 = peer(4, "194.168.0.1", 4),
-    Peer5 = peer(5, "195.168.0.1", 5),
+    Peer4 = peer(4, "10.3.0.1", 4),
+    Peer5 = peer(5, "10.4.0.1", 5),
     Peers = [Peer1, Peer2, Peer3],
 
     ok = aec_peers:add_trusted(Peers),
-    {ok, Conn1} = ?assertCalled(connect, [#{ r_pubkey := PubKey1 }], {ok, _}, 1000),
+    {ok, Conn1} = ?assertCalled(connect, [#{ r_pubkey := PubKey1 }], {ok, _}, 1100),
     ok = conn_peer_connected(Conn1),
-    {ok, Conn2} = ?assertCalled(connect, [#{ r_pubkey := PubKey2 }], {ok, _}, 1000),
+    {ok, Conn2} = ?assertCalled(connect, [#{ r_pubkey := PubKey2 }], {ok, _}, 1100),
     ok = conn_peer_connected(Conn2),
-    {ok, Conn3} = ?assertCalled(connect, [#{ r_pubkey := PubKey3 }], {ok, _}, 1000),
+    {ok, Conn3} = ?assertCalled(connect, [#{ r_pubkey := PubKey3 }], {ok, _}, 1100),
     ok = conn_peer_connected(Conn3),
 
     ok = aec_peers:add_trusted(Peers),
@@ -818,14 +818,14 @@ test_ping() ->
     Source = {192, 168, 0, 1},
     PubKey = <<"ef42d46eace742cd">>,
     Id = aec_peers:peer_id(PubKey),
-    Peer = peer(PubKey, "192.168.0.1", 4000),
+    Peer = peer(PubKey, "10.1.0.1", 4000),
 
     ok = aec_peers:add_peers(Source, Peer),
-    {ok, Conn} = ?assertCalled(connect, [#{ r_pubkey := PubKey }], {ok, _}, 150),
+    {ok, Conn} = ?assertCalled(connect, [#{ r_pubkey := PubKey }], {ok, _}, 200),
     ok = conn_peer_connected(Conn),
 
     % Check we are sheduling a ping right away.
-    ?assertCalled(schedule_ping, [Id], ok, 100),
+    ?assertCalled(schedule_ping, [Id], ok, 200),
     ok = conn_log_ping(Conn, ok),
 
     % Check we continue pinging
@@ -842,15 +842,15 @@ test_connection_conflict() ->
     test_mgr_set_recipient(self()),
 
     Source = {192, 168, 0, 1},
-    Peer1 = peer(1, "192.168.0.1", 4000),
+    Peer1 = peer(1, "10.1.0.1", 4000),
     #{ pubkey := PubKey1 } = Peer1,
     Id1 = aec_peers:peer_id(PubKey1),
-    Peer2 = peer(9, "192.168.0.2", 4000),
+    Peer2 = peer(9, "10.1.0.2", 4000),
     #{ pubkey := PubKey2 } = Peer2,
     Id2 = aec_peers:peer_id(PubKey2),
 
     ok = aec_peers:add_peers(Source, Peer1),
-    {ok, Conn1} = ?assertCalled(connect, [#{ r_pubkey := PubKey1 }], {ok, _}, 150),
+    {ok, Conn1} = ?assertCalled(connect, [#{ r_pubkey := PubKey1 }], {ok, _}, 200),
     ok = conn_peer_connected(Conn1),
 
     ?assertEqual(1, aec_peers:count(connections)),
@@ -875,7 +875,7 @@ test_connection_conflict() ->
     ?assertEqual(0, aec_peers:count(peers)),
 
     ok = aec_peers:add_peers(Source, Peer2),
-    {ok, Conn3} = ?assertCalled(connect, [#{ r_pubkey := PubKey2 }], {ok, _}, 1100),
+    {ok, Conn3} = ?assertCalled(connect, [#{ r_pubkey := PubKey2 }], {ok, _}, 1200),
     ok = conn_peer_connected(Conn3),
 
     ?assertEqual(1, aec_peers:count(connections)),
@@ -898,7 +898,7 @@ test_connection_conflict() ->
     % Check that an outbound connection not yet connected is canceled.
 
     ok = aec_peers:add_peers(Source, Peer1),
-    {ok, Conn5} = ?assertCalled(connect, [#{ r_pubkey := PubKey1 }], {ok, _}, 1100),
+    {ok, Conn5} = ?assertCalled(connect, [#{ r_pubkey := PubKey1 }], {ok, _}, 1200),
 
     {ok, Conn6} = test_mgr_start_inbound(Peer1),
     ?assertEqual(permanent, conn_peer_accepted(Conn6)),
@@ -914,16 +914,16 @@ test_blocking() ->
     test_mgr_set_recipient(self()),
 
     Source = {192, 168, 0, 1},
-    Peer1 = peer(1, "192.168.0.1", 1),
+    Peer1 = peer(1, "10.1.0.1", 1),
     Id1 = aec_peers:peer_id(Peer1),
     #{ pubkey := PubKey1 } = Peer1,
-    Peer2 = peer(2, "192.168.0.2", 2),
+    Peer2 = peer(2, "10.1.0.2", 2),
     #{ pubkey := PubKey2 } = Peer2,
     Id2 = aec_peers:peer_id(Peer2),
-    Peer3 = peer(3, "192.168.0.3", 3),
+    Peer3 = peer(3, "10.1.0.3", 3),
     #{ pubkey := PubKey3 } = Peer3,
     Id3 = aec_peers:peer_id(Peer3),
-    Peer4 = peer(4, "192.168.0.4", 4),
+    Peer4 = peer(4, "10.1.0.4", 4),
     Id4 = aec_peers:peer_id(Peer4),
 
     A = erlang:system_time(millisecond),
@@ -944,7 +944,7 @@ test_blocking() ->
     ?assertEqual(0, aec_peers:count(connections)),
 
     ok = aec_peers:add_peers(Source, Peer2),
-    {ok, Conn2} = ?assertCalled(connect, [#{ r_pubkey := PubKey2 }], {ok, _}, 1100),
+    {ok, Conn2} = ?assertCalled(connect, [#{ r_pubkey := PubKey2 }], {ok, _}, 1200),
     ?assertEqual(1, aec_peers:count(peers)),
     ?assertEqual(1, aec_peers:count(connections)),
 
@@ -958,7 +958,7 @@ test_blocking() ->
     ?assertEqual(0, aec_peers:count(connections)),
 
     ok = aec_peers:add_peers(Source, Peer3),
-    {ok, Conn3} = ?assertCalled(connect, [#{ r_pubkey := PubKey3 }], {ok, _}, 1100),
+    {ok, Conn3} = ?assertCalled(connect, [#{ r_pubkey := PubKey3 }], {ok, _}, 1200),
     ok = conn_peer_connected(Conn3),
     ?assertEqual(1, aec_peers:count(peers)),
     ?assertEqual(1, aec_peers:count(connections)),
@@ -992,7 +992,7 @@ test_blocking() ->
                  lists:sort(aec_peers:blocked_peers())),
 
     ok = aec_peers:add_peers(Source, Peer2),
-    {ok, Conn5} = ?assertCalled(connect, [#{ r_pubkey := PubKey2 }], {ok, _}, 1100),
+    {ok, Conn5} = ?assertCalled(connect, [#{ r_pubkey := PubKey2 }], {ok, _}, 1200),
     ok = conn_peer_connected(Conn5),
     ?assertEqual(1, aec_peers:count(peers)),
     ?assertEqual(1, aec_peers:count(connections)),
@@ -1005,7 +1005,7 @@ test_blocking() ->
 
     B = erlang:system_time(millisecond),
 
-    timer:sleep(2100 - (B - A)),
+    timer:sleep(2200 - (B - A)),
 
     ?assertNot(aec_peers:is_blocked(Id1)),
     ?assertNot(aec_peers:is_blocked(Id2)),
@@ -1041,7 +1041,7 @@ test_blocking() ->
     ?assertEqual(0, aec_peers:count(peers)),
     timer:sleep(1100),
     aec_peers:add_peers(Source, Peer1),
-    {ok, Conn9} = ?assertCalled(connect, [#{ r_pubkey := PubKey1 }], {ok, _}, 1100),
+    {ok, Conn9} = ?assertCalled(connect, [#{ r_pubkey := PubKey1 }], {ok, _}, 1200),
     ok = conn_peer_connected(Conn9),
     ?assertEqual(1, aec_peers:count(peers)),
     ?assertEqual(1, aec_peers:count(connections)),
@@ -1049,7 +1049,7 @@ test_blocking() ->
     % Check trusted peers cannot be blocked.
 
     aec_peers:add_trusted(Peer2),
-    {ok, Conn10} = ?assertCalled(connect, [#{ r_pubkey := PubKey2 }], {ok, _}, 1100),
+    {ok, Conn10} = ?assertCalled(connect, [#{ r_pubkey := PubKey2 }], {ok, _}, 1200),
     ok = conn_peer_connected(Conn10),
     ?assertEqual(2, aec_peers:count(peers)),
     ?assertEqual(2, aec_peers:count(connections)),

--- a/apps/aecore/test/aec_peers_tests.erl
+++ b/apps/aecore/test/aec_peers_tests.erl
@@ -296,7 +296,8 @@ test_multiple_normal_peers() ->
     {ok, Conn2} = ?assertCalled(connect, [#{ r_pubkey := PubKey2 }], {ok, _}, 3500),
     {ok, Conn3} = ?assertCalled(connect, [#{ r_pubkey := PubKey3 }], {ok, _}, 3500),
     B = erlang:system_time(millisecond),
-    ?assertEqual({(B - A), true}, {(B - A), ((B - A) =< 3500)}),
+    Delta = B - A,
+    ?assertEqual({Delta, true}, {Delta, (Delta =< 3500)}),
 
     ok = conn_peer_connected(Conn1),
     ok = conn_peer_connected(Conn2),


### PR DESCRIPTION
 * relaxed a bit all timeouts.
 * Removed all name resolution.
 * Made the assert that failed an equality containing the tested value
to have more information in case the test fails again.