### PR TITLE
Ensure state cache evicts data after channel closes

### DIFF
--- a/apps/aechannel/src/aechannel.app.src
+++ b/apps/aechannel/src/aechannel.app.src
@@ -12,7 +12,8 @@
    ]},
   {mod,{aesc_app,[]}},
   {env,[
-        {'$aec_db_create_tables', {aesc_db, create_tables}}
+         {'$aec_db_create_tables', {aesc_db, create_tables}}
+       , {'$aec_db_check_tables' , {aesc_db, check_tables}}
        ]},
   {modules, []},
   {maintainers, []},

--- a/apps/aechannel/src/aechannel.app.src
+++ b/apps/aechannel/src/aechannel.app.src
@@ -10,6 +10,7 @@
     aetx,
     sext
    ]},
+  {mod,{aesc_app,[]}},
   {env,[]},
   {modules, []},
   {maintainers, []},

--- a/apps/aechannel/src/aechannel.app.src
+++ b/apps/aechannel/src/aechannel.app.src
@@ -11,7 +11,9 @@
     sext
    ]},
   {mod,{aesc_app,[]}},
-  {env,[]},
+  {env,[
+        {'$aec_db_create_tables', {aesc_db, create_tables}}
+       ]},
   {modules, []},
   {maintainers, []},
   {licenses, []},

--- a/apps/aechannel/src/aesc_app.erl
+++ b/apps/aechannel/src/aesc_app.erl
@@ -1,0 +1,21 @@
+-module(aesc_app).
+-behavior(application).
+
+-export([
+          start/2
+        , start_phase/3
+        , prep_stop/1
+        , stop/1
+        ]).
+
+start(_StartType, _StartArgs) ->
+    aesc_sup:start_link().
+
+start_phase(_Phase, _StartType, _PhaseArgs) ->
+    ok.
+
+prep_stop(_State) ->
+    ok.
+
+stop(_State) ->
+    ok.

--- a/apps/aechannel/src/aesc_codec.hrl
+++ b/apps/aechannel/src/aesc_codec.hrl
@@ -3,6 +3,7 @@
 -define(CH_OPEN      , channel_open).
 -define(CH_ACCEPT    , channel_accept).
 -define(CH_REESTABL  , channel_reestablish).
+-define(CH_REEST_ACK , channel_reest_ack).
 -define(FND_CREATED  , funding_created).
 -define(FND_SIGNED   , funding_signed).
 -define(FND_LOCKED   , funding_locked).
@@ -18,6 +19,8 @@
 -define(WDRAW_LOCKED , withdraw_locked).
 -define(WDRAW_ERR    , withdraw_error).
 -define(ERROR        , error).
+-define(LEAVE        , leave).
+-define(LEAVE_ACK    , leave_ack).
 -define(SHUTDOWN     , shutdown).
 -define(SHUTDOWN_ACK , shutdown_ack).
 -define(INBAND_MSG   , inband_msg).
@@ -25,20 +28,23 @@
 -define(ID_CH_OPEN      , 1).
 -define(ID_CH_ACCEPT    , 2).
 -define(ID_CH_REESTABL  , 3).
--define(ID_FND_CREATED  , 4).
--define(ID_FND_SIGNED   , 5).
--define(ID_FND_LOCKED   , 6).
--define(ID_UPDATE       , 7).
--define(ID_UPDATE_ACK   , 8).
--define(ID_UPDATE_ERR   , 9).
--define(ID_DEP_CREATED  , 10).
--define(ID_DEP_SIGNED   , 11).
--define(ID_DEP_LOCKED   , 12).
--define(ID_DEP_ERR      , 13).
--define(ID_WDRAW_CREATED, 14).
--define(ID_WDRAW_SIGNED , 15).
--define(ID_WDRAW_LOCKED , 16).
--define(ID_WDRAW_ERR    , 17).
+-define(ID_CH_REEST_ACK , 4).
+-define(ID_FND_CREATED  , 5).
+-define(ID_FND_SIGNED   , 6).
+-define(ID_FND_LOCKED   , 7).
+-define(ID_UPDATE       , 8).
+-define(ID_UPDATE_ACK   , 9).
+-define(ID_UPDATE_ERR   , 10).
+-define(ID_DEP_CREATED  , 11).
+-define(ID_DEP_SIGNED   , 12).
+-define(ID_DEP_LOCKED   , 13).
+-define(ID_DEP_ERR      , 14).
+-define(ID_WDRAW_CREATED, 15).
+-define(ID_WDRAW_SIGNED , 16).
+-define(ID_WDRAW_LOCKED , 17).
+-define(ID_WDRAW_ERR    , 18).
+-define(ID_LEAVE        , 94).
+-define(ID_LEAVE_ACK    , 95).
 -define(ID_INBAND_MSG   , 96).
 -define(ID_ERROR        , 97).
 -define(ID_SHUTDOWN     , 98).

--- a/apps/aechannel/src/aesc_db.erl
+++ b/apps/aechannel/src/aesc_db.erl
@@ -1,0 +1,11 @@
+-module(aesc_db).
+-export([create_tables/1]).    %% (Mode) -> ok
+
+
+create_tables(Mode) ->
+    Specs = lists:flatten([M:table_specs(Mode) || M <- modules()]),
+    [{atomic, ok} = mnesia:create_table(Tab, Spec)
+     || {Tab, Spec} <- Specs].
+
+modules() ->
+    [aesc_state_cache].

--- a/apps/aechannel/src/aesc_db.erl
+++ b/apps/aechannel/src/aesc_db.erl
@@ -1,11 +1,18 @@
 -module(aesc_db).
--export([create_tables/1]).    %% (Mode) -> ok
-
+-export([ create_tables/1    %% (Mode) -> ok
+        , check_tables/1     %% (Acc)  -> Acc1
+        ]).
 
 create_tables(Mode) ->
     Specs = lists:flatten([M:table_specs(Mode) || M <- modules()]),
     [{atomic, ok} = mnesia:create_table(Tab, Spec)
      || {Tab, Spec} <- Specs].
+
+check_tables(Acc) ->
+    lists:foldl(
+      fun(M, Acc1) ->
+              M:check_tables(Acc1)
+      end, Acc, modules()).
 
 modules() ->
     [aesc_state_cache].

--- a/apps/aechannel/src/aesc_fsm.erl
+++ b/apps/aechannel/src/aesc_fsm.erl
@@ -2013,15 +2013,12 @@ default_minimum_depth(responder) -> ?MINIMUM_DEPTH.
 
 start_min_depth_watcher(Type, SignedTx,
                         #data{watcher = Watcher0,
-                              opts = #{initiator     := Initiator,
-                                       responder     := Responder,
-                                       minimum_depth := MinDepth}} = D) ->
+                              opts = #{minimum_depth := MinDepth}} = D) ->
     Tx = aetx_sign:tx(SignedTx),
     TxHash = aetx_sign:hash(SignedTx),
     evt({tx_hash, TxHash}),
     Nonce = aetx:nonce(Tx),
     evt({nonce, Nonce}),
-    %% {OnChainId, D1} = on_chain_id(D, Initiator, Nonce, Responder),
     {OnChainId, D1} = on_chain_id(D, Tx),
     case {Type, Watcher0} of
         {funding, undefined} ->

--- a/apps/aechannel/src/aesc_fsm.erl
+++ b/apps/aechannel/src/aesc_fsm.erl
@@ -15,6 +15,11 @@
          inband_msg/3,
          get_state/1]).
 
+%% Inspection and configuration functions
+-export([get_history/1,    %% (fsm()) -> [Event]
+         change_config/3   %% (fsm(), key(), value()) -> ok | {error,_}
+        ]).
+
 %% Used by noise session
 -export([message/2]).
 
@@ -36,6 +41,7 @@
          reestablish_init/3,
          accepted/3,
          awaiting_open/3,
+         awaiting_reestablish/3,
          awaiting_signature/3,
          awaiting_locked/3,
          awaiting_initial_state/3,
@@ -71,6 +77,13 @@
 -define(WATCH_DEP, deposit).
 -define(WATCH_WDRAW, withdraw).
 
+-define(KEEP, 10).
+-record(w, { n = 0         :: non_neg_integer()
+           , keep = ?KEEP  :: non_neg_integer()
+           , a = []        :: list()
+           , b = []        :: list()
+           }).
+
 -record(data, { role                   :: role()
               , channel_status         :: undefined | open
               , cur_statem_state       :: undefined | atom()
@@ -84,12 +97,16 @@
               , watcher                :: undefined | pid()
               , latest = undefined     :: undefined | any()
               , last_reported_update   :: undefined | non_neg_integer()
+              , log = #w{}             :: #w{}
               }).
 
 -define(TRANSITION_STATE(S),  S=:=awaiting_signature
                             ; S=:=awaiting_open
                             ; S=:=awaiting_locked
                             ; S=:=awaiting_update_ack
+                            ; S=:=awaiting_leave_ack
+                            ; S=:=awaiting_deposit_update
+                            ; S=:=awaiting_withdraw_update
                             ; S=:=closing ).
 
 callback_mode() -> [state_functions, state_enter].
@@ -160,7 +177,8 @@ message(Fsm, {T, _} = Msg) when T =:= ?CH_OPEN
                               ; T =:= ?LEAVE_ACK
                               ; T =:= ?SHUTDOWN
                               ; T =:= ?SHUTDOWN_ACK
-                              ; T =:= ?CH_REESTABL ->
+                              ; T =:= ?CH_REESTABL
+                              ; T =:= ?CH_REEST_ACK ->
     lager:debug("message(~p, ~p)", [Fsm, Msg]),
     gen_statem:cast(Fsm, Msg).
 
@@ -207,6 +225,7 @@ timer_for_state(St, #data{opts = #{timeouts := TOs}} = D) ->
 
 timer_subst(open                    ) -> idle;
 timer_subst(awaiting_open           ) -> idle;
+timer_subst(awaiting_reestablish    ) -> idle;
 timer_subst(reestablish_init        ) -> accept;
 timer_subst(awaiting_signature      ) -> sign;
 timer_subst(awaiting_locked         ) -> funding_lock;
@@ -214,6 +233,7 @@ timer_subst(awaiting_initial_state  ) -> accept;
 timer_subst(awaiting_update_ack     ) -> accept;
 timer_subst(awaiting_deposit_update ) -> accept;
 timer_subst(awaiting_withdraw_update) -> accept;
+timer_subst(awaiting_leave_ack      ) -> accept;
 timer_subst(accepted                ) -> funding_create;
 timer_subst(half_signed             ) -> funding_sign;
 timer_subst(signed                  ) -> funding_lock;
@@ -240,20 +260,24 @@ timeouts() ->
 %%
 %% ======================================================================
 
+%% NOTE: we currently double-book Role in both the #data{} record and
+%% the Opts map. This is a bit annoying, but simplifies the pattern-matching
+%% in this module (the #data{} part); also, the aesc_offchain_state module
+%% needs Role for the cache interaction. Future refactoring can resolve this
+%% slight code smell.
+
 initiate(Host, Port, #{} = Opts0) ->
     lager:debug("initiate(~p, ~p, ~p)", [Host, Port, Opts0]),
     Opts = maps:merge(#{client => self()}, Opts0),
-    start_link(#{role => initiator
-               , host => Host
-               , port => Port
-               , opts => Opts}).
+    start_link(#{ host => Host
+                , port => Port
+                , opts => Opts#{role => initiator} }).
 
 respond(Port, #{} = Opts0) ->
     lager:debug("respond(~p, ~p)", [Port, Opts0]),
     Opts = maps:merge(#{client => self()}, Opts0),
-    start_link(#{role => responder
-               , port => Port
-               , opts => Opts}).
+    start_link(#{ port => Port
+                , opts => Opts#{role => responder} }).
 
 upd_transfer(_Fsm, _From, _To, Amount) when Amount < 0 ->
     {error, negative_amount};
@@ -295,18 +319,38 @@ client_died(Fsm) ->
 start_link(#{} = Arg) ->
     gen_statem:start_link(?MODULE, Arg, ?GEN_STATEM_OPTS).
 
+%% ======================================================================
+
+%% Fetch the list of recent fsm events (sliding window)
+get_history(Fsm) ->
+    lager:debug("get_history(~p)", [Fsm]),
+    gen_statem:call(Fsm, get_history).
+
+change_config(Fsm, Key, Value) ->
+    case check_change_config(Key, Value) of
+        {ok, Key1, Val1} ->
+            gen_statem:call(Fsm, {change_config, Key1, Val1});
+        {error, _} = Error ->
+            Error
+    end.
+
+check_change_config(log_keep, Keep) when is_integer(Keep), Keep >= 0 ->
+    {ok, log_keep, Keep};
+check_change_config(_, _) ->
+    {error, invalid_config}.
 
 %% ======================================================================
 %% FSM initialization
 
-init(#{role := Role} = Arg) ->
-    #{client := Client} = Opts0 = maps:get(opts, Arg, #{}),
+init(#{opts := Opts0} = Arg) ->
+    #{role := Role, client := Client} = Opts0,
     DefMinDepth = default_minimum_depth(Role),
     Opts = check_opts(
              [
               fun(O) -> check_minimum_depth_opt(DefMinDepth, Role, O) end,
               fun check_timeout_opt/1,
-              fun check_rpt_opt/1
+              fun check_rpt_opt/1,
+              fun check_log_opt/1
              ], Opts0),
     Session = start_session(Arg, Opts),
     {ok, State} = aesc_offchain_state:new(Opts),
@@ -314,21 +358,30 @@ init(#{role := Role} = Arg) ->
                  client  = Client,
                  session = Session,
                  opts    = Opts,
-                 state   = State},
+                 state   = State,
+                 log     = #w{keep = maps:get(log_keep, Opts)}},
     lager:debug("Session started, Data = ~p", [Data]),
     %% TODO: Amend the fsm above to include this step. We have transport-level
     %% connectivity, but not yet agreement on the channel parameters. We will next send
     %% a channel_open() message and await a channel_accept().
-    case {Role, Opts} of
-        {initiator, #{ existing_channel_id := _ }} ->
-            {ok, reestablish_init, send_reestablish_msg(Data),
-             [timer_for_state(reestablish_init, Data)]};
-        {initiator, _} ->
-            {ok, initialized, send_open_msg(Data),
-                        [timer_for_state(initialized, Data)]};
-        {responder, _} ->
-            {ok, awaiting_open, Data,
-                        [timer_for_state(awaiting_open, Data)]}
+    Reestablish = maps:is_key(existing_channel_id, Opts),
+    case Role of
+        initiator ->
+            if Reestablish ->
+                    {ok, reestablish_init, send_reestablish_msg(Data),
+                     [timer_for_state(reestablish_init, Data)]};
+               true ->
+                    {ok, initialized, send_open_msg(Data),
+                     [timer_for_state(initialized, Data)]}
+            end;
+        responder ->
+            if Reestablish ->
+                    {ok, awaiting_reestablish, Data,
+                     [timer_for_state(awaiting_reestablish, Data)]};
+               true ->
+                    {ok, awaiting_open, Data,
+                     [timer_for_state(awaiting_open, Data)]}
+            end
     end.
 
 check_opts([H|T], Opts) ->
@@ -375,12 +428,24 @@ check_rpt_opt(Opts) ->
     lager:debug("Report opts = ~p", [ROpts]),
     Opts#{report => maps:merge(default_report_flags(), ROpts)}.
 
+check_log_opt(Opts) ->
+    case maps:find(log_keep, Opts) of
+        {ok, Keep} when is_integer(Keep), Keep >= 0 ->
+            Opts;
+        {ok, Invalid} ->
+            lager:error("Invalid 'log_keep' option: ~p", [Invalid]),
+            Opts#{log_keep => ?KEEP};
+        error ->
+            Opts#{log_keep => ?KEEP}
+    end.
+
+
 %% As per CHANNELS.md, the responder is regarded as the one typically
 %% providing the service, and the initiator connects.
-start_session(#{role := responder, port := Port}, Opts) ->
+start_session(#{port := Port}, #{role := responder} = Opts) ->
     NoiseOpts = maps:get(noise, Opts, []),
     ok(aesc_session_noise:accept(Port, NoiseOpts));
-start_session(#{role := initiator, host := Host, port := Port}, Opts) ->
+start_session(#{host := Host, port := Port}, #{role := initiator} = Opts) ->
     NoiseOpts = maps:get(noise, Opts, []),
     ok(aesc_session_noise:connect(Host, Port, NoiseOpts)).
 
@@ -420,7 +485,19 @@ awaiting_open(cast, {?CH_OPEN, Msg}, #data{role = responder} = D) ->
         {error, _} = Error ->
             close(Error, D)
     end;
-awaiting_open(cast, {?CH_REESTABL, Msg}, #data{role = responder} = D) ->
+awaiting_open(timeout, awaiting_open = T, D) ->
+    close({timeout, T}, D);
+awaiting_open(cast, {?DISCONNECT, _Msg}, D) ->
+    close(disconnect, D);
+awaiting_open(cast, {_, _} = Msg, D) ->
+    lager:debug("Wrong msg in awaiting_open: ~p", [Msg]),
+    %% should send an error msg
+    close(protocol_error, D);
+awaiting_open({call, From}, Req, D) ->
+    handle_call(awaiting_open, Req, From, D).
+
+awaiting_reestablish(enter, _OldSt, _D) -> keep_state_and_data;
+awaiting_reestablish(cast, {?CH_REESTABL, Msg}, #data{role = responder} = D) ->
     case check_reestablish_msg(Msg, D) of
         {ok, D1} ->
             report(info, channel_reestablished, D1),
@@ -429,12 +506,14 @@ awaiting_open(cast, {?CH_REESTABL, Msg}, #data{role = responder} = D) ->
         {error, _} = Error ->
             close(Error, D)
     end;
-awaiting_open(timeout, awaiting_open = T, D) ->
+awaiting_reestablish(timeout, awaiting_reestablish = T, D) ->
     close({timeout, T}, D);
-awaiting_open(cast, {?DISCONNECT, _Msg}, D) ->
+awaiting_reestablish(cast, {?DISCONNECT, _Msg}, D) ->
     close(disconnect, D);
-awaiting_open({call, From}, Req, D) ->
-    handle_call(awaiting_open, Req, From, D).
+awaiting_reestablish(cast, {_, _} = Msg, D) ->
+    lager:debug("Wrong msg in awaiting_reestablish: ~p", [Msg]),
+    %% should send and error msg
+    close(protocol_error, D).
 
 initialized(enter, _OldSt, _D) -> keep_state_and_data;
 initialized(cast, {?CH_ACCEPT, Msg}, #data{role = initiator} = D) ->
@@ -443,8 +522,7 @@ initialized(cast, {?CH_ACCEPT, Msg}, #data{role = initiator} = D) ->
             gproc_register(D1),
             report(info, channel_accept, D1),
             {ok, CTx} = create_tx_for_signing(D1),
-            ok = request_signing(create_tx, CTx, D1),
-            D2 = D1#data{latest = {sign, create_tx, CTx}},
+            D2 = request_signing(create_tx, CTx, D1),
             next_state(awaiting_signature, D2);
         {error, _} = Error ->
             close(Error, D)
@@ -473,70 +551,82 @@ reestablish_init({call, From}, Req, D) ->
     handle_call(reestablish_init, Req, From, D).
 
 awaiting_signature(enter, _OldSt, _D) -> keep_state_and_data;
-awaiting_signature(cast, {?SIGNED, create_tx, Tx},
+awaiting_signature(cast, {?SIGNED, create_tx, Tx} = Msg,
                    #data{role = initiator, latest = {sign, create_tx, _CTx}} = D) ->
     next_state(half_signed,
-               send_funding_created_msg(Tx, D#data{latest = undefined}));
-awaiting_signature(cast, {?SIGNED, deposit_tx, Tx},
+               send_funding_created_msg(
+                 Tx, log(rcv, ?SIGNED, Msg, D#data{latest = undefined})));
+awaiting_signature(cast, {?SIGNED, deposit_tx, Tx} = Msg,
                    #data{latest = {sign, deposit_tx, _DTx}} = D) ->
     next_state(dep_half_signed,
-               send_deposit_created_msg(Tx, D#data{latest = undefined}));
-awaiting_signature(cast, {?SIGNED, withdraw_tx, Tx},
+               send_deposit_created_msg(
+                 Tx, log(rcv, ?SIGNED, Msg, D#data{latest = undefined})));
+awaiting_signature(cast, {?SIGNED, withdraw_tx, Tx} = Msg,
                    #data{latest = {sign, withdraw_tx, _DTx}} = D) ->
     next_state(wdraw_half_signed,
-               send_withdraw_created_msg(Tx, D#data{latest = undefined}));
-awaiting_signature(cast, {?SIGNED, ?FND_CREATED, SignedTx},
+               send_withdraw_created_msg(
+                 Tx, log(rcv, ?SIGNED, Msg, D#data{latest = undefined})));
+awaiting_signature(cast, {?SIGNED, ?FND_CREATED, SignedTx} = Msg,
                    #data{role = responder,
                          latest = {sign, ?FND_CREATED, HSCTx}} = D) ->
     NewSignedTx = aetx_sign:add_signatures(
                     HSCTx, aetx_sign:signatures(SignedTx)),
-    D1 = send_funding_signed_msg(NewSignedTx, D#data{create_tx = NewSignedTx}),
+    D1 = send_funding_signed_msg(
+           NewSignedTx,
+           log(rcv, ?SIGNED, Msg, D#data{create_tx = NewSignedTx})),
     report(on_chain_tx, NewSignedTx, D1),
     {ok, D2} = start_min_depth_watcher(?WATCH_FND, NewSignedTx, D1),
     next_state(awaiting_locked, D2);
-awaiting_signature(cast, {?SIGNED, ?DEP_CREATED, SignedTx},
+awaiting_signature(cast, {?SIGNED, ?DEP_CREATED, SignedTx} = Msg,
                    #data{latest = {sign, ?DEP_CREATED, HSCTx}} = D) ->
     NewSignedTx = aetx_sign:add_signatures(
                     HSCTx, aetx_sign:signatures(SignedTx)),
     D1 = send_deposit_signed_msg(NewSignedTx, D),
     report(on_chain_tx, NewSignedTx, D1),
     {ok, D2} = start_min_depth_watcher(?WATCH_DEP, NewSignedTx, D1),
-    next_state(awaiting_locked, D2);
-awaiting_signature(cast, {?SIGNED, ?WDRAW_CREATED, SignedTx},
+    next_state(awaiting_locked,
+               log(rcv, ?SIGNED, Msg, D2));
+awaiting_signature(cast, {?SIGNED, ?WDRAW_CREATED, SignedTx} = Msg,
                    #data{latest = {sign, ?WDRAW_CREATED, HSCTx}} = D) ->
     NewSignedTx = aetx_sign:add_signatures(
                     HSCTx, aetx_sign:signatures(SignedTx)),
     D1 = send_withdraw_signed_msg(NewSignedTx, D),
     report(on_chain_tx, NewSignedTx, D1),
     {ok, D2} = start_min_depth_watcher(?WATCH_WDRAW, NewSignedTx, D1),
-    next_state(awaiting_locked, D2);
-awaiting_signature(cast, {?SIGNED, ?UPDATE, SignedTx}, D) ->
-    D1 = send_update_msg(SignedTx,
-                         D#data{state = aesc_offchain_state:add_half_signed_tx(SignedTx, D#data.state)}),
-    next_state(awaiting_update_ack, D1#data{latest = undefined});
-awaiting_signature(cast, {?SIGNED, ?UPDATE_ACK, SignedTx},
+    next_state(awaiting_locked, log(rcv, ?SIGNED, Msg, D2));
+awaiting_signature(cast, {?SIGNED, ?UPDATE, SignedTx} = Msg, D) ->
+    D1 = send_update_msg(
+           SignedTx,
+           D#data{state = aesc_offchain_state:add_half_signed_tx(
+                            SignedTx, D#data.state)}),
+    next_state(awaiting_update_ack,
+               log(rcv, ?SIGNED, Msg, D1#data{latest = undefined}));
+awaiting_signature(cast, {?SIGNED, ?UPDATE_ACK, SignedTx} = Msg,
                    #data{latest = {sign, ?UPDATE_ACK, OCTx}, opts = Opts} = D) ->
     NewSignedTx = aetx_sign:add_signatures(
                     OCTx, aetx_sign:signatures(SignedTx)),
     D1 = send_update_ack_msg(NewSignedTx, D),
     State = aesc_offchain_state:add_signed_tx(NewSignedTx, D1#data.state, Opts),
-    D2 = D1#data{state = State},
+    D2 = D1#data{log   = log_msg(rcv, ?SIGNED, Msg, D1#data.log),
+                 state = State},
     next_state(open, D2);
-awaiting_signature(cast, {?UPDATE, _Msg},
+awaiting_signature(cast, {?UPDATE, Msg},
                    #data{latest = {sign, Upd, _}} = D) when Upd==?UPDATE;
                                                             Upd==?UPDATE_ACK ->
     D1 = send_update_err_msg(fallback_to_stable_state(D)),
-    next_state(open, D1);
-awaiting_signature(cast, {?SIGNED, ?SHUTDOWN, SignedTx}, D) ->
+    next_state(open, log(rcv, ?SIGNED, Msg, D1));
+awaiting_signature(cast, {?SIGNED, ?SHUTDOWN, SignedTx} = Msg, D) ->
     D1 = send_shutdown_msg(SignedTx, D),
-    D2 = D1#data{latest = {shutdown, SignedTx}},
+    D2 = D1#data{latest = {shutdown, SignedTx},
+                 log    = log_msg(rcv, ?SIGNED, Msg, D1#data.log)},
     next_state(closing, D2);
-awaiting_signature(cast, {?SIGNED, ?SHUTDOWN_ACK, SignedTx},
+awaiting_signature(cast, {?SIGNED, ?SHUTDOWN_ACK, SignedTx} = Msg,
                    #data{latest = {sign, ?SHUTDOWN_ACK, CMTx}} = D) ->
     NewSignedTx = aetx_sign:add_signatures(
                     CMTx, aetx_sign:signatures(SignedTx)),
     D1 = send_shutdown_ack_msg(NewSignedTx, D),
-    D2 = D1#data{latest = undefined},
+    D2 = D1#data{latest = undefined,
+                 log    = log_msg(rcv, ?SIGNED, Msg, D1#data.log)},
     report(on_chain_tx, NewSignedTx, D1),
     close(close_mutual, D2);
 awaiting_signature(timeout, awaiting_signature = T, D) ->
@@ -553,8 +643,8 @@ accepted(cast, {?FND_CREATED, Msg}, #data{role = responder} = D) ->
         {ok, SignedTx, D1} ->
             report(info, funding_created, D1),
             lager:debug("funding_created: ~p", [SignedTx]),
-            ok = request_signing(?FND_CREATED, aetx_sign:tx(SignedTx), D1),
-            D2 = D1#data{latest = {sign, ?FND_CREATED, SignedTx}},
+            D2 = request_signing(
+                   ?FND_CREATED, aetx_sign:tx(SignedTx), SignedTx, D1),
             next_state(awaiting_signature, D2)
         %% {error, _} = Error ->
         %%     close(Error, D)
@@ -708,8 +798,8 @@ awaiting_initial_state(cast, {?UPDATE, Msg}, #data{role = responder} = D) ->
         {ok, SignedTx, D1} ->
             lager:debug("update_msg checks out", []),
             report(info, update, D1),
-            ok = request_signing(?UPDATE_ACK, aetx_sign:tx(SignedTx), D1),
-            D2 = D1#data{latest = {sign, ?UPDATE_ACK, SignedTx}},
+            D2 = request_signing(
+                   ?UPDATE_ACK, aetx_sign:tx(SignedTx), SignedTx, D1),
             next_state(awaiting_signature, D2);
         {error,_} = Error ->
             %% TODO: do we do a dispute challenge here?
@@ -753,11 +843,12 @@ awaiting_update_ack(timeout, awaiting_update_ack = T, D) ->
 awaiting_update_ack({call, _}, _Req, D) ->
     postpone(D).
 
+awaiting_leave_ack(enter, _OldSt, _D) -> keep_state_and_data;
 awaiting_leave_ack(cast, {?LEAVE_ACK, Msg}, D) ->
     lager:debug("received leave_ack", []),
     case check_leave_ack_msg(Msg, D) of
         {ok, D1} ->
-            report_update(D1),
+            report_leave(D1),
             close(leave, D1);
         {error, _} = Err ->
             close(Err, D)
@@ -769,9 +860,9 @@ awaiting_leave_ack(timeout, awaiting_leave_ack = T, D) ->
 awaiting_leave_ack(cast, {?LEAVE, Msg}, D) ->
     case check_leave_msg(Msg, D) of
         {ok, D1} ->
-            send_leave_ack_msg(D1),
-            report_update(D1),
-            close(leave, D1);
+            D2 = send_leave_ack_msg(D1),
+            report_leave(D2),
+            close(leave, D2);
         {error, _} = Err ->
             close(Err, D)
     end;
@@ -785,8 +876,8 @@ awaiting_deposit_update(cast, {?UPDATE, Msg}, D) ->
     case check_deposit_update_msg(Msg, D) of
         {ok, SignedTx, D1} ->
             report(info, deposit_update, D1),
-            ok = request_signing(?UPDATE_ACK, aetx_sign:tx(SignedTx), D1),
-            D2 = D1#data{latest = {sign, ?UPDATE_ACK, SignedTx}},
+            D2 = request_signing(
+                   ?UPDATE_ACK, aetx_sign:tx(SignedTx), SignedTx, D1),
             next_state(awaiting_signature, D2);
         {error, _} = Error ->
             close(Error, D)
@@ -806,8 +897,8 @@ awaiting_withdraw_update(cast, {?UPDATE, Msg}, D) ->
     case check_withdraw_update_msg(Msg, D) of
         {ok, SignedTx, D1} ->
             report(info, withdraw_update, D1),
-            ok = request_signing(?UPDATE_ACK, aetx_sign:tx(SignedTx), D1),
-            D2 = D1#data{latest = {sign, ?UPDATE_ACK, SignedTx}},
+            D2 = request_signing(
+                   ?UPDATE_ACK, aetx_sign:tx(SignedTx), SignedTx, D1),
             next_state(awaiting_signature, D2);
         {error, _} = Error ->
             close(Error, D)
@@ -845,6 +936,7 @@ funding_locked_complete(D) ->
     D1   = D#data{state = aesc_offchain_state:add_signed_tx(D#data.create_tx,
                                                             D#data.state,
                                                             D#data.opts)},
+    initialize_cache(D1),
     next_state(open, D1).
 
 open(enter, _OldSt, D) ->
@@ -859,8 +951,8 @@ open(cast, {?UPDATE, Msg}, D) ->
     case check_update_msg(normal, Msg, D) of
         {ok, SignedTx, D1} ->
             report(info, update, D1),
-            ok = request_signing(?UPDATE_ACK, aetx_sign:tx(SignedTx), D1),
-            D2 = D1#data{latest = {sign, ?UPDATE_ACK, SignedTx}},
+            D2 = request_signing(
+                   ?UPDATE_ACK, aetx_sign:tx(SignedTx), SignedTx, D1),
             next_state(awaiting_signature, D2);
         {error,_} = Error ->
             %% TODO: do we do a dispute challenge here?
@@ -871,8 +963,8 @@ open(cast, {?DEP_CREATED, Msg}, D) ->
         {ok, SignedTx, D1} ->
             report(info, deposit_created, D1),
             lager:debug("deposit_created: ~p", [SignedTx]),
-            ok = request_signing(?DEP_CREATED, aetx_sign:tx(SignedTx), D1),
-            D2 = D1#data{latest = {sign, ?DEP_CREATED, SignedTx}},
+            D2 = request_signing(
+                   ?DEP_CREATED, aetx_sign:tx(SignedTx), SignedTx, D1),
             next_state(awaiting_signature, D2)
     end;
 open(cast, {?WDRAW_CREATED, Msg}, D) ->
@@ -880,8 +972,8 @@ open(cast, {?WDRAW_CREATED, Msg}, D) ->
         {ok, SignedTx, D1} ->
             report(info, withdraw_created, D1),
             lager:debug("withdraw_created: ~p", [SignedTx]),
-            ok = request_signing(?WDRAW_CREATED, aetx_sign:tx(SignedTx), D1),
-            D2 = D1#data{latest = {sign, ?WDRAW_CREATED, SignedTx}},
+            D2 = request_signing(
+                   ?WDRAW_CREATED, aetx_sign:tx(SignedTx), SignedTx, D1),
             next_state(awaiting_signature, D2)
     end;
 open(cast, {?INBAND_MSG, Msg}, D) ->
@@ -899,8 +991,9 @@ open({call, From}, Request, D) ->
 open(cast, {?LEAVE, Msg}, D) ->
     case check_leave_msg(Msg, D) of
         {ok, D1} ->
+            lager:debug("received leave msg", []),
             send_leave_ack_msg(D1),
-            report(info, leave, D1),
+            report_leave(D1),
             close(leave, D1);
         {error, _} = Err ->
             close(Err, D)
@@ -908,8 +1001,8 @@ open(cast, {?LEAVE, Msg}, D) ->
 open(cast, {?SHUTDOWN, Msg}, D) ->
     case check_shutdown_msg(Msg, D) of
         {ok, SignedTx, D1} ->
-            ok = request_signing(?SHUTDOWN_ACK, aetx_sign:tx(SignedTx), D1),
-            D2 = D1#data{latest = {sign, ?SHUTDOWN_ACK, SignedTx}},
+            D2 = request_signing(
+                   ?SHUTDOWN_ACK, aetx_sign:tx(SignedTx), SignedTx, D1),
             next_state(awaiting_signature, D2);
         {error, E} ->
             close({shutdown_error, E}, D)
@@ -943,13 +1036,15 @@ closing(cast, {closing_signed, _Msg}, D) ->  %% TODO: not using this, right?
 disconnected(cast, {?CH_REESTABL, _Msg}, D) ->
     next_state(closing, D).
 
-close(close_mutual, D) ->
+close(Reason, D) ->
+    close_(Reason, log(evt, close, Reason, D)).
+
+close_(close_mutual, D) ->
     report(info, close_mutual, D),
     {stop, normal, D};
-close(leave, D) ->
-    report(info, leave, D),
+close_(leave, D) ->
     {stop, normal, D};
-close(Reason, D) ->
+close_(Reason, D) ->
     try send_error_msg(Reason, D)
     catch error:_ -> ignore
     end,
@@ -973,7 +1068,11 @@ send_error_msg(Reason, #data{session = Sn} = D) ->
 
 handle_call(St, Req, From, #data{} = D) ->
     lager:debug("handle_call(~p, ~p, ~p, ~p)", [St, Req, From, D]),
-    handle_call_(St, Req, From, D).
+    try handle_call_(St, Req, From, D)
+    catch
+        error:Error ->
+            keep_state(D, [{reply, From, {error, Error}}])
+    end.
 
 handle_call_(open, {upd_transfer, FromPub, ToPub, Amount}, From,
             #data{opts = #{initiator := I,
@@ -993,9 +1092,8 @@ handle_call_(open, {upd_deposit, #{amount := Amt} = Opts}, From,
         error         -> ok
     end,
     {ok, DepTx} = dep_tx_for_signing(Opts#{from => FromPub}, D),
-    ok = request_signing(deposit_tx, DepTx, D),
+    D1 = request_signing(deposit_tx, DepTx, D),
     gen_statem:reply(From, ok),
-    D1 = D#data{latest = {sign, deposit_tx, DepTx}},
     next_state(awaiting_signature, D1);
 handle_call_(open, {upd_withdraw, #{amount := Amt} = Opts}, From,
              #data{} = D) when is_integer(Amt), Amt > 0 ->
@@ -1006,20 +1104,18 @@ handle_call_(open, {upd_withdraw, #{amount := Amt} = Opts}, From,
         error         -> ok
     end,
     {ok, DepTx} = wdraw_tx_for_signing(Opts#{to => ToPub}, D),
-    ok = request_signing(withdraw_tx, DepTx, D),
+    D1 = request_signing(withdraw_tx, DepTx, D),
     gen_statem:reply(From, ok),
-    D1 = D#data{latest = {sign, withdraw_tx, DepTx}},
     next_state(awaiting_signature, D1);
 handle_call_(open, leave, From, #data{} = D) ->
-    ok = send_leave_msg(D),
+    D1 = send_leave_msg(D),
     gen_statem:reply(From, ok),
-    next_state(awaiting_leave_ack, D);
+    next_state(awaiting_leave_ack, D1);
 handle_call_(open, shutdown, From, #data{state = State} = D) ->
     try  {_Round, Latest} = aesc_offchain_state:get_latest_signed_tx(State),
          {ok, CloseTx} = close_mutual_tx(Latest, D),
-         ok = request_signing(?SHUTDOWN, CloseTx, D),
+         D1 = request_signing(?SHUTDOWN, CloseTx, D),
          gen_statem:reply(From, ok),
-         D1 = D#data{latest = {sign, ?SHUTDOWN, CloseTx}},
          next_state(awaiting_signature, D1)
     catch
         error:E ->
@@ -1050,6 +1146,15 @@ handle_call_(_, get_state, From, #data{ on_chain_id = ChanId
           state_hash=> StateHash,
           round     => Round},
     keep_state(D, [{reply, From, {ok, Result}}]);
+handle_call_(_St, get_history, From, #data{log = Log} = D) ->
+    keep_state(D, [{reply, From, win_to_list(Log)}]);
+handle_call_(_St, {change_config, Key, Value}, From, D) ->
+    case handle_change_config(Key, Value, D) of
+        {ok, Reply, D1} ->
+            keep_state(D1, [{reply, From, Reply}]);
+        {error, _} = Error ->
+            keep_state(D, [{reply, From, Error}])
+    end;
 handle_call_(St, _Req, _From, D) when ?TRANSITION_STATE(St) ->
     postpone(D);
 handle_call_(_St, _Req, From, D) ->
@@ -1072,6 +1177,7 @@ error_binary(E) when is_atom(E) ->
 
 terminate(Reason, _State, Data) ->
     report(info, {died, Reason}, Data),
+    report(debug, {log, win_to_list(Data#data.log)}, Data),
     ok.
 
 code_change(_OldVsn, OldState, OldData, _Extra) ->
@@ -1106,7 +1212,8 @@ send_open_msg(#data{opts       = Opts,
            , initiator            => Initiator
            },
     aesc_session_noise:channel_open(Sn, Msg),
-    Data#data{channel_id = ChannelId}.
+    Data#data{ channel_id = ChannelId
+             , log = log_msg(snd, ?CH_OPEN, Msg, Data#data.log) }.
 
 check_open_msg(#{ chain_hash           := ChainHash
                 , temporary_channel_id := ChanId
@@ -1115,7 +1222,7 @@ check_open_msg(#{ chain_hash           := ChainHash
                 , initiator_amount     := InitiatorAmt
                 , responder_amount     := ResponderAmt
                 , channel_reserve      := ChanReserve
-                , initiator            := InitiatorPubkey},
+                , initiator            := InitiatorPubkey} = Msg,
                #data{opts = Opts} = Data) ->
     %% TODO: Implement more checks
     case aec_chain:genesis_hash() of
@@ -1127,38 +1234,42 @@ check_open_msg(#{ chain_hash           := ChainHash
                      , initiator_amount   => InitiatorAmt
                      , responder_amount   => ResponderAmt
                      , channel_reserve    => ChanReserve},
-            {ok, Data#data{channel_id = ChanId,
-                           opts       = Opts1}};
+            {ok, Data#data{
+                   channel_id = ChanId,
+                   opts       = Opts1,
+                   log        = log_msg(rcv, ?CH_OPEN, Msg, Data#data.log) }};
         _ ->
             {error, chain_hash_mismatch}
     end.
 
 send_reestablish_msg(#data{ opts = #{ existing_channel_id  := ChId
                                     , offchain_tx := OffChainTx }
-                          , session = Sn} = Data) ->
+                          , session = Sn } = Data) ->
     ChainHash = aec_chain:genesis_hash(),
     TxBin = aetx_sign:serialize_to_binary(OffChainTx),
     Msg = #{ chain_hash => ChainHash
            , channel_id => ChId
            , data       => TxBin },
     aesc_session_noise:channel_reestablish(Sn, Msg),
-    Data#data{channel_id = ChId,
+    Data#data{channel_id  = ChId,
               on_chain_id = ChId,
-              latest = {reestablish, OffChainTx} }.
+              latest      = {reestablish, OffChainTx},
+              log         = log_msg(snd, ?CH_REESTABL, Msg, Data#data.log)}.
 
 check_reestablish_msg(#{ chain_hash := ChainHash
                        , channel_id := ChId
-                       , data       := TxBin },
-                      #data{opts = Opts} = Data) ->
+                       , data       := TxBin } = Msg,
+                      #data{state = State} = Data) ->
     case get_channel(ChainHash, ChId) of
-        {ok, Channel} ->
+        {ok, _Channel} ->
             SignedTx = aetx_sign:deserialize_from_binary(TxBin),
-            case aesc_offchain_state:check_reestablish_tx(
-                   SignedTx, Channel, Opts) of
+            case aesc_offchain_state:check_reestablish_tx(SignedTx, State) of
                 {ok, NewState} ->
+                    Log1 = log_msg(rcv, ?CH_REESTABL, Msg, Data#data.log),
                     {ok, Data#data{ channel_id  = ChId
                                   , on_chain_id = ChId
-                                  , state       = NewState}};
+                                  , state       = NewState
+                                  , log         = Log1}};
                 {error, _} = TxErr ->
                     TxErr
             end;
@@ -1170,21 +1281,23 @@ send_reestablish_ack_msg(#data{ state       = State
                               , on_chain_id = ChId
                               , session     = Sn } = Data) ->
     ChainHash = aec_chain:genesis_hash(),
-    SignedTx = aesc_offchain_state:get_latest_signed_tx(State),
+    {_, SignedTx} = aesc_offchain_state:get_latest_signed_tx(State),
     TxBin = aetx_sign:serialize_to_binary(SignedTx),
     Msg = #{ chain_hash  => ChainHash
            , channel_id  => ChId
            , data        => TxBin },
     aesc_session_noise:channel_reestablish_ack(Sn, Msg),
-    Data#data{latest = undefined}.
+    Data#data{ latest = undefined
+             , log = log_msg(snd, ?CH_REEST_ACK, Msg, Data#data.log) }.
 
-check_reestablish_ack_msg(#{ data := TxBin } = Msg, #data{} = Data) ->
+check_reestablish_ack_msg(#{ data := TxBin } = Msg, Data) ->
     SignedTx = aetx_sign:deserialize_from_binary(TxBin),
     run_checks(
       [ fun chk_chain_hash/3
       , fun chk_channel_id/3
       , fun chk_dual_sigs/3
       , fun chk_same_tx/3
+      , fun log_reestabl_ack_msg/3
       ], Msg, SignedTx, Data).
 
 run_checks([F|Funs], Msg, SignedTx, Data) ->
@@ -1192,7 +1305,9 @@ run_checks([F|Funs], Msg, SignedTx, Data) ->
         {true, _} ->
             run_checks(Funs, Msg, SignedTx, Data);
         {false, Err} ->
-            {error, Err}
+            {error, Err};
+        {data, Data1} ->
+            run_checks(Funs, Msg, SignedTx, Data1)
     end;
 run_checks([], _, _, Data) ->
     {ok, Data}.
@@ -1209,9 +1324,12 @@ chk_dual_sigs(_, SignedTx, #data{ state = State }) ->
      signatures_invalid}.
 
 chk_same_tx(_, SignedTx, #data{ state = State }) ->
-    {_, MySignedTx} = aesc_offchain_state:get_signed_tx(State),
+    {_, MySignedTx} = aesc_offchain_state:get_latest_signed_tx(State),
     {aetx_sign:serialize_to_binary(SignedTx)
-     == aex_sign:serialize_to_binary(MySignedTx), offchain_state_mismatch}.
+     == aetx_sign:serialize_to_binary(MySignedTx), offchain_state_mismatch}.
+
+log_reestabl_ack_msg(Msg, _, #data{log = L} = D) ->
+    {data, D#data{log = log_msg(rcv, ?CH_REEST_ACK, Msg, L)}}.
 
 get_channel(ChainHash, ChId) ->
     case aec_chain:genesis_hash() of
@@ -1239,7 +1357,7 @@ send_channel_accept(#data{opts          = Opts,
            , responder            => Responder
            },
     aesc_session_noise:channel_accept(Sn, Msg),
-    Data.
+    Data#data{log = log_msg(snd, ?CH_ACCEPT, Msg, Data#data.log)}.
 
 check_accept_msg(#{ chain_hash           := ChainHash
                   , temporary_channel_id := ChanId
@@ -1247,14 +1365,16 @@ check_accept_msg(#{ chain_hash           := ChainHash
                   , initiator_amount     := _InitiatorAmt
                   , responder_amount     := _ResponderAmt
                   , channel_reserve      := _ChanReserve
-                  , responder            := Responder},
+                  , responder            := Responder} = Msg,
                  #data{channel_id = ChanId,
                        opts = Opts} = Data) ->
     %% TODO: implement more checks
     case aec_chain:genesis_hash() of
         ChainHash ->
-            {ok, Data#data{opts = Opts#{ minimum_depth => MinDepth
-                                       , responder     => Responder}}};
+            Log1 = log_msg(rcv, ?CH_ACCEPT, Msg, Data#data.log),
+            {ok, Data#data{ opts = Opts#{ minimum_depth => MinDepth
+                                        , responder     => Responder}
+                          , log = Log1 }};
         _ ->
             {error, chain_hash_mismatch}
     end.
@@ -1393,13 +1513,13 @@ send_funding_created_msg(SignedTx, #data{channel_id = Ch,
     Msg = #{ temporary_channel_id => Ch
            ,  data                => TxBin},
     aesc_session_noise:funding_created(Sn, Msg),
-    Data.
+    log(snd, ?FND_CREATED, Msg, Data).
 
 check_funding_created_msg(#{ temporary_channel_id := ChanId
-                           , data                 := TxBin},
-                          #data{channel_id = ChanId} = Data) ->
+                           , data                 := TxBin } = Msg,
+                          #data{ channel_id = ChanId} = Data) ->
     SignedTx = aetx_sign:deserialize_from_binary(TxBin),
-    {ok, SignedTx, Data}.
+    {ok, SignedTx, log(rcv, ?FND_CREATED, Msg, Data)}.
 
 send_funding_signed_msg(SignedTx, #data{channel_id = Ch,
                                         session    = Sn} = Data) ->
@@ -1407,13 +1527,13 @@ send_funding_signed_msg(SignedTx, #data{channel_id = Ch,
     Msg = #{ temporary_channel_id  => Ch
            , data                  => TxBin},
     aesc_session_noise:funding_signed(Sn, Msg),
-    Data.
+    log(snd, ?FND_CREATED, Msg, Data).
 
 check_funding_signed_msg(#{ temporary_channel_id := ChanId
-                          , data                 := TxBin},
-                          #data{channel_id = ChanId} = Data) ->
+                          , data                 := TxBin} = Msg,
+                          #data{ channel_id = ChanId } = Data) ->
     SignedTx = aetx_sign:deserialize_from_binary(TxBin),
-    {ok, SignedTx, Data}.
+    {ok, SignedTx, log(rcv, ?FND_SIGNED, Msg, Data)}.
 
 send_funding_locked_msg(#data{channel_id  = TmpChanId,
                               on_chain_id = OnChainId,
@@ -1421,17 +1541,17 @@ send_funding_locked_msg(#data{channel_id  = TmpChanId,
     Msg = #{ temporary_channel_id => TmpChanId
            , channel_id           => OnChainId },
     aesc_session_noise:funding_locked(Sn, Msg),
-    Data.
+    log(snd, ?FND_LOCKED, Msg, Data).
 
 check_funding_locked_msg(#{ temporary_channel_id := TmpChanId
-                          , channel_id           := OnChainId },
+                          , channel_id           := OnChainId } = Msg,
                          #data{channel_id  = MyTmpChanId,
                                on_chain_id = MyOnChainId} = Data) ->
     case TmpChanId == MyTmpChanId of
         true ->
             case OnChainId == MyOnChainId of
                 true ->
-                    {ok, Data};
+                    {ok, log(rcv, ?FND_LOCKED, Msg, Data)};
                 false ->
                     {error, channel_id_mismatch}
             end;
@@ -1445,13 +1565,13 @@ send_deposit_created_msg(SignedTx, #data{on_chain_id = Ch,
     Msg = #{ channel_id => Ch
            , data       => TxBin},
     aesc_session_noise:deposit_created(Sn, Msg),
-    Data.
+    log(snd, ?DEP_CREATED, Msg, Data).
 
 check_deposit_created_msg(#{ channel_id := ChanId
-                           , data       := TxBin},
+                           , data       := TxBin} = Msg,
                           #data{on_chain_id = ChanId} = Data) ->
     SignedTx = aetx_sign:deserialize_from_binary(TxBin),
-    {ok, SignedTx, Data}.
+    {ok, SignedTx, log(rcv, ?DEP_CREATED, Msg, Data)}.
 
 send_deposit_signed_msg(SignedTx, #data{on_chain_id = Ch,
                                         session     = Sn} = Data) ->
@@ -1459,30 +1579,30 @@ send_deposit_signed_msg(SignedTx, #data{on_chain_id = Ch,
     Msg = #{ channel_id  => Ch
            , data        => TxBin},
     aesc_session_noise:deposit_signed(Sn, Msg),
-    Data.
+    log(snd, ?DEP_SIGNED, Msg, Data).
 
 check_deposit_signed_msg(#{ channel_id := ChanId
-                          , data       := TxBin},
+                          , data       := TxBin} = Msg,
                           #data{on_chain_id = ChanId} = Data) ->
     SignedTx = aetx_sign:deserialize_from_binary(TxBin),
-    {ok, SignedTx, Data}.
+    {ok, SignedTx, log(rcv, ?DEP_SIGNED, Msg, Data)}.
 
 send_deposit_locked_msg(TxHash, #data{on_chain_id = ChanId,
                                       session     = Sn} = Data) ->
     Msg = #{ channel_id => ChanId
            , data       => TxHash },
     aesc_session_noise:deposit_locked(Sn, Msg),
-    Data.
+    log(snd, ?DEP_LOCKED, Msg, Data).
 
 check_deposit_locked_msg(#{ channel_id := ChanId
-                          , data       := TxHash },
+                          , data       := TxHash } = Msg,
                          SignedTx,
                          #data{on_chain_id = MyChanId} = Data) ->
     case ChanId == MyChanId of
         true ->
             case aetx_sign:hash(SignedTx) of
                 TxHash ->
-                    {ok, Data};
+                    {ok, log(rcv, ?DEP_LOCKED, Msg, Data)};
                 _ ->
                     {error, deposit_tx_hash_mismatch}
             end;
@@ -1491,7 +1611,7 @@ check_deposit_locked_msg(#{ channel_id := ChanId
     end.
 
 check_deposit_update_msg(#{ channel_id := ChanId
-                          , data       := TxBin },
+                          , data       := TxBin } = Msg,
                          #data{ on_chain_id = ChanId
                               , latest = {deposit, SignedDepTx}
                               , state = State
@@ -1511,7 +1631,7 @@ check_deposit_update_msg(#{ channel_id := ChanId
                     NewStTx = aesc_offchain_state:make_update_tx(Updates, State, Opts),
                     case NewStTx == UpdTx of
                         true ->
-                            {ok, SignedUpdTx, D};
+                            {ok, SignedUpdTx, log(rcv, ?UPDATE, Msg, D)};
                         false ->
                             {error, invalid_deposit_update}
                     end;
@@ -1529,13 +1649,13 @@ send_withdraw_created_msg(SignedTx, #data{on_chain_id = Ch,
     Msg = #{ channel_id => Ch
            , data       => TxBin},
     aesc_session_noise:wdraw_created(Sn, Msg),
-    Data.
+    log(snd, ?WDRAW_CREATED, Msg, Data).
 
 check_withdraw_created_msg(#{ channel_id := ChanId
-                            , data       := TxBin},
+                            , data       := TxBin} = Msg,
                            #data{on_chain_id = ChanId} = Data) ->
     SignedTx = aetx_sign:deserialize_from_binary(TxBin),
-    {ok, SignedTx, Data}.
+    {ok, SignedTx, log(rcv, ?WDRAW_CREATED, Msg, Data)}.
 
 send_withdraw_signed_msg(SignedTx, #data{on_chain_id = Ch,
                                          session     = Sn} = Data) ->
@@ -1543,30 +1663,30 @@ send_withdraw_signed_msg(SignedTx, #data{on_chain_id = Ch,
     Msg = #{ channel_id  => Ch
            , data        => TxBin},
     aesc_session_noise:wdraw_signed(Sn, Msg),
-    Data.
+    log(snd, ?WDRAW_SIGNED, Msg, Data).
 
 check_withdraw_signed_msg(#{ channel_id := ChanId
-                           , data       := TxBin},
+                           , data       := TxBin} = Msg,
                           #data{on_chain_id = ChanId} = Data) ->
     SignedTx = aetx_sign:deserialize_from_binary(TxBin),
-    {ok, SignedTx, Data}.
+    {ok, SignedTx, log(rcv, ?WDRAW_SIGNED, Msg, Data)}.
 
 send_withdraw_locked_msg(TxHash, #data{on_chain_id = ChanId,
                                        session     = Sn} = Data) ->
     Msg = #{ channel_id => ChanId
            , data       => TxHash },
     aesc_session_noise:wdraw_locked(Sn, Msg),
-    Data.
+    log(snd, ?WDRAW_LOCKED, Msg, Data).
 
 check_withdraw_locked_msg(#{ channel_id := ChanId
-                           , data       := TxHash },
+                           , data       := TxHash } = Msg,
                           SignedTx,
                           #data{on_chain_id = MyChanId} = Data) ->
     case ChanId == MyChanId of
         true ->
             case aetx_sign:hash(SignedTx) of
                 TxHash ->
-                    {ok, Data};
+                    {ok, log(rcv, ?WDRAW_LOCKED, Msg, Data)};
                 _ ->
                     {error, withdraw_tx_hash_mismatch}
             end;
@@ -1575,7 +1695,7 @@ check_withdraw_locked_msg(#{ channel_id := ChanId
     end.
 
 check_withdraw_update_msg(#{ channel_id := ChanId
-                           , data       := TxBin },
+                           , data       := TxBin } = Msg,
                           #data{ on_chain_id = ChanId
                                , latest = {withdraw, SignedDepTx}
                                , state = State
@@ -1595,7 +1715,7 @@ check_withdraw_update_msg(#{ channel_id := ChanId
                     NewStTx = aesc_offchain_state:make_update_tx(Updates, State, Opts),
                     case NewStTx == UpdTx of
                         true ->
-                            {ok, SignedUpdTx, D};
+                            {ok, SignedUpdTx, log(rcv, ?UPDATE, Msg, D)};
                         false ->
                             {error, invalid_withdraw_update}
                     end;
@@ -1613,7 +1733,7 @@ send_update_msg(SignedTx, #data{ on_chain_id = OnChainId
     Msg = #{ channel_id => OnChainId
            , data       => TxBin },
     aesc_session_noise:update(Sn, Msg),
-    Data.
+    log(snd, ?UPDATE, Msg, Data).
 
 check_update_msg(Type, Msg, D) ->
     lager:debug("check_update_msg(~p)", [Msg]),
@@ -1625,22 +1745,23 @@ check_update_msg(Type, Msg, D) ->
     end.
 
 check_update_msg_(Type, #{ channel_id := ChanId
-                         , data       := TxBin },
+                         , data       := TxBin } = Msg,
                   #data{ on_chain_id = ChanId } = D) ->
     try aetx_sign:deserialize_from_binary(TxBin) of
         SignedTx ->
-            check_signed_update_tx(Type, SignedTx, D)
+            check_signed_update_tx(Type, SignedTx, Msg, D)
     catch
         error:E ->
             lager:error("CAUGHT ~p, trace = ~p", [E, erlang:get_stacktrace()]),
             {error, {deserialize, E}}
     end.
 
-check_signed_update_tx(Type, SignedTx, #data{state = State, opts = Opts} = D) ->
+check_signed_update_tx(Type, SignedTx, Msg,
+                       #data{state = State, opts = Opts} = D) ->
     lager:debug("check_signed_update_tx(~p)", [SignedTx]),
     case check_update_tx(Type, SignedTx, State, Opts) of
         ok ->
-            {ok, SignedTx, D};
+            {ok, SignedTx, log(rcv, ?UPDATE, Msg, D)};
         {error, _} = Error ->
             Error
     end.
@@ -1661,21 +1782,24 @@ check_update_ack_msg(Msg, D) ->
     end.
 
 check_update_ack_msg_(#{ channel_id := ChanId
-                       , data       := TxBin },
+                       , data       := TxBin } = Msg,
                       #data{on_chain_id = ChanId} = D) ->
     try aetx_sign:deserialize_from_binary(TxBin) of
         SignedTx ->
-            check_signed_update_ack_tx(SignedTx, D)
+            check_signed_update_ack_tx(SignedTx, Msg, D)
     catch
         error:E ->
             lager:error("CAUGHT ~p, trace = ~p", [E, erlang:get_stacktrace()]),
             {error, {deserialize, E}}
     end.
 
-check_signed_update_ack_tx(SignedTx, #data{state = State, opts = Opts} = D) ->
+check_signed_update_ack_tx(SignedTx, Msg,
+                           #data{state = State, opts = Opts} = D) ->
     HalfSignedTx = aesc_offchain_state:get_latest_half_signed_tx(State),
     try  ok = check_update_ack_(SignedTx, HalfSignedTx),
-         {ok, D#data{state = aesc_offchain_state:add_signed_tx(SignedTx, State, Opts)}}
+         {ok, D#data{state = aesc_offchain_state:add_signed_tx(
+                               SignedTx, State, Opts),
+                     log = log_msg(rcv, ?UPDATE_ACK, Msg, D#data.log)}}
     catch
         error:E ->
             lager:error("CAUGHT ~p, trace = ~p", [E, erlang:get_stacktrace()]),
@@ -1697,9 +1821,8 @@ handle_upd_transfer(FromPub, ToPub, Amount, From, #data{ state = State
                                                        , opts = Opts } = D) ->
     Updates = [aesc_offchain_state:op_transfer(FromPub, ToPub, Amount)],
     try  Tx1 = aesc_offchain_state:make_update_tx(Updates, State, Opts),
-         ok = request_signing(?UPDATE, Tx1, D),
+         D1 = request_signing(?UPDATE, Tx1, D),
          gen_statem:reply(From, ok),
-         D1 = D#data{latest = {sign, ?UPDATE, Tx1}},
          next_state(awaiting_signature, D1)
     catch
         error:Reason ->
@@ -1711,12 +1834,13 @@ send_leave_msg(#data{ on_chain_id = ChId
                     , session     = Session} = Data) ->
     Msg = #{ channel_id => ChId },
     aesc_session_noise:leave(Session, Msg),
-    Data.
+    log(snd, ?LEAVE, Msg, Data).
 
-check_leave_msg(#{ channel_id := ChId }, #data{on_chain_id = ChId0} = Data) ->
+check_leave_msg(#{ channel_id := ChId } = Msg,
+                #data{on_chain_id = ChId0} = Data) ->
     case ChId == ChId0 of
         true ->
-            {ok, Data};
+            {ok, log(rcv, ?LEAVE, Msg, Data)};
         false ->
             {error, channel_id_mismatch}
     end.
@@ -1725,12 +1849,13 @@ send_leave_ack_msg(#data{ on_chain_id = ChId
                         , session     = Session} = Data) ->
     Msg = #{ channel_id => ChId },
     aesc_session_noise:leave(Session, Msg),
-    Data.
+    log(snd, ?LEAVE_ACK, Msg, Data).
 
-check_leave_ack_msg(#{channel_id := ChId}, #data{on_chain_id = ChId0} = Data) ->
+check_leave_ack_msg(#{channel_id := ChId} = Msg,
+                    #data{on_chain_id = ChId0} = Data) ->
     case ChId == ChId0 of
         true ->
-            {ok, Data};
+            {ok, log(rcv, ?LEAVE_ACK, Msg, Data)};
         false ->
             {error, channel_id_mismatch}
     end.
@@ -1738,12 +1863,12 @@ check_leave_ack_msg(#{channel_id := ChId}, #data{on_chain_id = ChId0} = Data) ->
 send_shutdown_msg(SignedTx, #data{session = Session} = Data) ->
     Msg = shutdown_msg(SignedTx, Data),
     aesc_session_noise:shutdown(Session, Msg),
-    Data.
+    log(snd, ?SHUTDOWN, Msg, Data).
 
 send_shutdown_ack_msg(SignedTx, #data{session = Session} = Data) ->
     Msg = shutdown_msg(SignedTx, Data),
     aesc_session_noise:shutdown_ack(Session, Msg),
-    Data.
+    log(snd, ?SHUTDOWN_ACK, Msg, Data).
 
 shutdown_msg(SignedTx, #data{ on_chain_id = OnChainId }) ->
     TxBin = aetx_sign:serialize_to_binary(SignedTx),
@@ -1751,7 +1876,7 @@ shutdown_msg(SignedTx, #data{ on_chain_id = OnChainId }) ->
      , data       => TxBin }.
 
 
-check_shutdown_msg(#{channel_id := ChanId, data := TxBin} = _Msg,
+check_shutdown_msg(#{channel_id := ChanId, data := TxBin} = Msg,
                    #data{on_chain_id = ChanId, state = State} = D) ->
     SignedTx = aetx_sign:deserialize_from_binary(TxBin),
     {_, LatestSignedTx} = aesc_offchain_state:get_latest_signed_tx(State),
@@ -1763,7 +1888,7 @@ check_shutdown_msg(#{channel_id := ChanId, data := TxBin} = _Msg,
     case (serialize_close_mutual_tx(FakeTxI) ==
               serialize_close_mutual_tx(RealTxI)) of
         true ->
-            {ok, SignedTx, D};
+            {ok, SignedTx, log(rcv, ?SHUTDOWN, Msg, D)};
         false ->
             {error, shutdown_tx_validation}
     end.
@@ -1772,21 +1897,21 @@ serialize_close_mutual_tx(Tx) ->
     {_, Elems} = aesc_close_mutual_tx:serialize(Tx),
     lists:keydelete(nonce, 1, Elems).
 
-check_shutdown_ack_msg(#{data := TxBin} = _Msg,
+check_shutdown_ack_msg(#{data := TxBin} = Msg,
                        #data{latest = {shutdown, MySignedTx}} = D) ->
     SignedTx = aetx_sign:deserialize_from_binary(TxBin),
     case aetx_sign:signatures(SignedTx) of
         [_,_] ->
-            check_shutdown_msg_(SignedTx, MySignedTx, D);
+            check_shutdown_msg_(SignedTx, MySignedTx, Msg, D);
         _ ->
             {error, not_mutually_signed}
     end.
 
-check_shutdown_msg_(SignedTx, MySignedTx, D) ->
+check_shutdown_msg_(SignedTx, MySignedTx, Msg, D) ->
     %% TODO: More thorough checking
     case (aetx_sign:tx(SignedTx) == aetx_sign:tx(MySignedTx)) of
         true ->
-            {ok, SignedTx, D};
+            {ok, SignedTx, log(rcv, ?SHUTDOWN_ACK, Msg, D)};
         false ->
             {error, shutdown_tx_mismatch}
     end.
@@ -1799,13 +1924,14 @@ send_inband_msg(To, Info, #data{on_chain_id = ChanId,
          , to         => To
          , info       => Info },
     aesc_session_noise:inband_msg(Session, M),
-    D.
+    log(snd, ?INBAND_MSG, M, D).
 
 check_inband_msg(#{ channel_id := ChanId
                   , from       := From
-                  , to         := To }, #data{on_chain_id = ChanId} = D) ->
+                  , to         := To } = Msg,
+                 #data{on_chain_id = ChanId} = D) ->
     case {my_account(D), other_account(D)} of
-        {To, From}     ->  {ok, D};
+        {To, From}     ->  {ok, log(rcv, ?INBAND_MSG, Msg, D)};
         {To, _Other}   ->  {error, invalid_sender};
         {_Other, From} ->  {error, invalid_recipient};
         _ ->
@@ -1817,9 +1943,7 @@ check_inband_msg(_, _) ->
 fallback_to_stable_state(#data{state = State} = D) ->
     D#data{state = aesc_offchain_state:fallback_to_stable_state(State)}.
 
-
-
-tx_round(Tx)            -> call_cb(Tx, round, []).
+tx_round(Tx) -> call_cb(Tx, round, []).
 
 -spec call_cb(aetx:tx(), atom(), list()) -> any().
 call_cb(Tx, F, Args) ->
@@ -1832,14 +1956,13 @@ specialize_cb(Tx) ->
 do_apply(M, F, A) ->
     apply(M, F, A).
 
-
 send_update_ack_msg(SignedTx, #data{ on_chain_id = OnChainId
                                    , session     = Sn} = Data) ->
     TxBin = aetx_sign:serialize_to_binary(SignedTx),
     Msg = #{ channel_id => OnChainId
            , data       => TxBin },
     aesc_session_noise:update_ack(Sn, Msg),
-    Data.
+    log(snd, ?UPDATE_ACK, Msg, Data).
 
 send_update_err_msg(#data{ state = State
                          , on_chain_id = ChanId
@@ -1850,17 +1973,19 @@ send_update_err_msg(#data{ state = State
            , round      => Round },
     aesc_session_noise:update_error(Sn, Msg),
     report(conflict, Msg, Data),
-    Data.
+    log(snd, ?UPDATE_ERR, Msg, Data).
 
 check_update_err_msg(#{ channel_id := ChanId
-                      , round      := Round },
+                      , round      := Round } = Msg,
                      #data{on_chain_id = ChanId0,
                            state = State} = D) ->
     case ChanId == ChanId0 of
         true ->
             case aesc_offchain_state:get_fallback_state(State) of
                 {Round, State1} ->
-                    {ok, D#data{state = State1}};
+                    {ok, D#data{state = State1,
+                                log = log_msg(
+                                        rcv, ?UPDATE_ERR, Msg, D#data.log)}};
                 _Other ->
                     lager:debug("Fallback state mismatch: ~p/~p",
                                 [Round, _Other]),
@@ -1870,11 +1995,15 @@ check_update_err_msg(#{ channel_id := ChanId
             {error, chain_id_mismatch}
     end.
 
-request_signing(Tag, Obj, #data{client = Client} = D) ->
+request_signing(Tag, Obj, #data{} = D) ->
+    request_signing(Tag, Obj, Obj, D).
+
+request_signing(Tag, Obj, Ref, #data{client = Client} = D) ->
     Msg = rpt_message(sign, Tag, Obj, D),
     Client ! {?MODULE, self(), Msg},
     lager:debug("signing(~p) requested", [Tag]),
-    ok.
+    D#data{ latest = {sign, Tag, Ref}
+          , log    = log_msg(req, sign, Msg, D#data.log)}.
 
 default_minimum_depth(initiator  ) -> undefined;
 default_minimum_depth(responder) -> ?MINIMUM_DEPTH.
@@ -1919,24 +2048,52 @@ gproc_name(Id, Role) ->
 evt(_Msg) ->
     ok.
 
+initialize_cache(#data{ on_chain_id = ChId
+                      , state       = State } = D) ->
+    aesc_state_cache:new(ChId, my_account(D), State).
+
+cache_state(#data{ on_chain_id = ChId
+                 , state       = State } = D) ->
+    aesc_state_cache:update(ChId, my_account(D), State).
+
+-spec handle_change_config(_Key::atom(), _Value::any(), #data{}) ->
+                                  {ok, _Reply::any(), #data{}}
+                                | {error, Reason::atom()}.
+
+handle_change_config(log_keep, Keep, #data{log = L} = D)
+  when is_integer(Keep), Keep >= 0 ->
+    {ok, ok, D#data{log = L#w{keep = Keep}}};
+handle_change_config(_, _, _) ->
+    {error, invalid_config}.
+
+
 report_update(#data{state = State, last_reported_update = Last} = D) ->
     case aesc_offchain_state:get_latest_signed_tx(State) of
         {Last, _} ->
             D;
         {New, SignedTx} ->
             report(update, SignedTx, D),
+            cache_state(D),
             D#data{last_reported_update = New}
     end.
 
-report_tags() ->
-    [info, update, conflict, message, error, on_chain_tx].
+report_leave(#data{state = State} = D) ->
+    {_, SignedTx} = aesc_offchain_state:get_latest_signed_tx(State),
+    report(leave, SignedTx, D),
+    cache_state(D).
 
+report_tags() ->
+    maps:keys(default_report_flags()).
+
+%% See `report_tags()` above: This map needs to contain all recognized tags.
 default_report_flags() ->
     #{ info         => true
      , update       => true
+     , leave        => true
      , conflict     => true
      , message      => true
      , error        => true
+     , debug        => false
      , on_chain_tx  => true}.
 
 report(Tag, St, D) -> report_info(do_rpt(Tag, D), Tag, St, D).
@@ -1968,3 +2125,14 @@ do_rpt(Tag, #data{opts = #{report := Rpt}}) ->
         error:_ ->
             false
     end.
+
+log(Op, Type, M, #data{log = Log0} = D) ->
+    D#data{log = log_msg(Op, Type, M, Log0)}.
+
+log_msg(Op, Type, M, #w{n = N, a = A, keep = Keep} = W) when N < Keep ->
+    W#w{n = N+1, a = [{Op, Type, os:timestamp(), M}|A]};
+log_msg(Op, Type, M, #w{a = A} = W) ->
+    W#w{n = 1, a = [{Op, Type, os:timestamp(), M}], b = A}.
+
+win_to_list(#w{a = A, b = B}) ->
+    A ++ B.

--- a/apps/aechannel/src/aesc_fsm.erl
+++ b/apps/aechannel/src/aesc_fsm.erl
@@ -9,6 +9,7 @@
          upd_transfer/4, %% (fsm() , from(), to(), amount())
          upd_deposit/2,  %% (fsm() , map())
          upd_withdraw/2, %% (fsm() , map())
+         leave/1,
          shutdown/1,     %% (fsm())
          client_died/1,  %% (fsm())
          inband_msg/3,
@@ -32,6 +33,7 @@
 
 %% FSM states
 -export([initialized/3,
+         reestablish_init/3,
          accepted/3,
          awaiting_open/3,
          awaiting_signature/3,
@@ -40,6 +42,7 @@
          awaiting_update_ack/3,
          awaiting_deposit_update/3,
          awaiting_withdraw_update/3,
+         awaiting_leave_ack/3,
          half_signed/3,
          signed/3,
          dep_half_signed/3,
@@ -153,6 +156,8 @@ message(Fsm, {T, _} = Msg) when T =:= ?CH_OPEN
                               ; T =:= ?WDRAW_ERR
                               ; T =:= ?INBAND_MSG
                               ; T =:= disconnect
+                              ; T =:= ?LEAVE
+                              ; T =:= ?LEAVE_ACK
                               ; T =:= ?SHUTDOWN
                               ; T =:= ?SHUTDOWN_ACK
                               ; T =:= ?CH_REESTABL ->
@@ -202,6 +207,7 @@ timer_for_state(St, #data{opts = #{timeouts := TOs}} = D) ->
 
 timer_subst(open                    ) -> idle;
 timer_subst(awaiting_open           ) -> idle;
+timer_subst(reestablish_init        ) -> accept;
 timer_subst(awaiting_signature      ) -> sign;
 timer_subst(awaiting_locked         ) -> funding_lock;
 timer_subst(awaiting_initial_state  ) -> accept;
@@ -267,9 +273,15 @@ inband_msg(Fsm, To, Msg) ->
     lager:debug("inband_msg(~p, ~p, ~p)", [Fsm, To, Msg]),
     gen_statem:call(Fsm, {inband_msg, To, Msg}).
 
+
 -spec get_state(pid()) -> {ok, #{}}.
 get_state(Fsm) ->
     gen_statem:call(Fsm, get_state).
+
+leave(Fsm) ->
+    lager:debug("leave(~p)", [Fsm]),
+    gen_statem:call(Fsm, leave).
+
 
 shutdown(Fsm) ->
     lager:debug("shutdown(~p)", [Fsm]),
@@ -307,11 +319,14 @@ init(#{role := Role} = Arg) ->
     %% TODO: Amend the fsm above to include this step. We have transport-level
     %% connectivity, but not yet agreement on the channel parameters. We will next send
     %% a channel_open() message and await a channel_accept().
-    case Role of
-        initiator ->
+    case {Role, Opts} of
+        {initiator, #{ existing_channel_id := _ }} ->
+            {ok, reestablish_init, send_reestablish_msg(Data),
+             [timer_for_state(reestablish_init, Data)]};
+        {initiator, _} ->
             {ok, initialized, send_open_msg(Data),
                         [timer_for_state(initialized, Data)]};
-        responder ->
+        {responder, _} ->
             {ok, awaiting_open, Data,
                         [timer_for_state(awaiting_open, Data)]}
     end.
@@ -405,6 +420,15 @@ awaiting_open(cast, {?CH_OPEN, Msg}, #data{role = responder} = D) ->
         {error, _} = Error ->
             close(Error, D)
     end;
+awaiting_open(cast, {?CH_REESTABL, Msg}, #data{role = responder} = D) ->
+    case check_reestablish_msg(Msg, D) of
+        {ok, D1} ->
+            report(info, channel_reestablished, D1),
+            gproc_register(D1),
+            next_state(open, send_reestablish_ack_msg(D1));
+        {error, _} = Error ->
+            close(Error, D)
+    end;
 awaiting_open(timeout, awaiting_open = T, D) ->
     close({timeout, T}, D);
 awaiting_open(cast, {?DISCONNECT, _Msg}, D) ->
@@ -432,6 +456,21 @@ initialized(cast, {?DISCONNECT, _Msg}, D) ->
 initialized({call, From}, Req, D) ->
     handle_call(initialized, Req, From, D).
 
+reestablish_init(enter, _OldSt, _D) -> keep_state_and_data;
+reestablish_init(cast, {?CH_REEST_ACK, Msg}, D) ->
+    case check_reestablish_ack_msg(Msg, D) of
+        {ok, D1} ->
+            report(info, channel_reestablished, D1),
+            next_state(open, D1);
+        {error, _} = Err ->
+            close(Err, D)
+    end;
+reestablish_init(timeout, reestablish_init = T, D) ->
+    close({timeout, T}, D);
+reestablish_init(cast, {?DISCONNECT, _Msg}, D) ->
+    close(disconnect, D);
+reestablish_init({call, From}, Req, D) ->
+    handle_call(reestablish_init, Req, From, D).
 
 awaiting_signature(enter, _OldSt, _D) -> keep_state_and_data;
 awaiting_signature(cast, {?SIGNED, create_tx, Tx},
@@ -714,6 +753,33 @@ awaiting_update_ack(timeout, awaiting_update_ack = T, D) ->
 awaiting_update_ack({call, _}, _Req, D) ->
     postpone(D).
 
+awaiting_leave_ack(cast, {?LEAVE_ACK, Msg}, D) ->
+    lager:debug("received leave_ack", []),
+    case check_leave_ack_msg(Msg, D) of
+        {ok, D1} ->
+            report_update(D1),
+            close(leave, D1);
+        {error, _} = Err ->
+            close(Err, D)
+    end;
+awaiting_leave_ack(cast, {?DISCONNECT, _Msg}, D) ->
+    close(disconnect, D);
+awaiting_leave_ack(timeout, awaiting_leave_ack = T, D) ->
+    close({timeout, T}, D);
+awaiting_leave_ack(cast, {?LEAVE, Msg}, D) ->
+    case check_leave_msg(Msg, D) of
+        {ok, D1} ->
+            send_leave_ack_msg(D1),
+            report_update(D1),
+            close(leave, D1);
+        {error, _} = Err ->
+            close(Err, D)
+    end;
+awaiting_leave_ack(cast, _Msg, D) ->
+    postpone(D);
+awaiting_leave_ack({call, _From}, _Req, D) ->
+    postpone(D).
+
 awaiting_deposit_update(enter, _OldSt, _D) -> keep_state_and_data;
 awaiting_deposit_update(cast, {?UPDATE, Msg}, D) ->
     case check_deposit_update_msg(Msg, D) of
@@ -830,6 +896,15 @@ open(cast, {?INBAND_MSG, Msg}, D) ->
     keep_state(NewD);
 open({call, From}, Request, D) ->
     handle_call(open, Request, From, D);
+open(cast, {?LEAVE, Msg}, D) ->
+    case check_leave_msg(Msg, D) of
+        {ok, D1} ->
+            send_leave_ack_msg(D1),
+            report(info, leave, D1),
+            close(leave, D1);
+        {error, _} = Err ->
+            close(Err, D)
+    end;
 open(cast, {?SHUTDOWN, Msg}, D) ->
     case check_shutdown_msg(Msg, D) of
         {ok, SignedTx, D1} ->
@@ -870,6 +945,9 @@ disconnected(cast, {?CH_REESTABL, _Msg}, D) ->
 
 close(close_mutual, D) ->
     report(info, close_mutual, D),
+    {stop, normal, D};
+close(leave, D) ->
+    report(info, leave, D),
     {stop, normal, D};
 close(Reason, D) ->
     try send_error_msg(Reason, D)
@@ -932,6 +1010,10 @@ handle_call_(open, {upd_withdraw, #{amount := Amt} = Opts}, From,
     gen_statem:reply(From, ok),
     D1 = D#data{latest = {sign, withdraw_tx, DepTx}},
     next_state(awaiting_signature, D1);
+handle_call_(open, leave, From, #data{} = D) ->
+    ok = send_leave_msg(D),
+    gen_statem:reply(From, ok),
+    next_state(awaiting_leave_ack, D);
 handle_call_(open, shutdown, From, #data{state = State} = D) ->
     try  {_Round, Latest} = aesc_offchain_state:get_latest_signed_tx(State),
          {ok, CloseTx} = close_mutual_tx(Latest, D),
@@ -1047,6 +1129,94 @@ check_open_msg(#{ chain_hash           := ChainHash
                      , channel_reserve    => ChanReserve},
             {ok, Data#data{channel_id = ChanId,
                            opts       = Opts1}};
+        _ ->
+            {error, chain_hash_mismatch}
+    end.
+
+send_reestablish_msg(#data{ opts = #{ existing_channel_id  := ChId
+                                    , offchain_tx := OffChainTx }
+                          , session = Sn} = Data) ->
+    ChainHash = aec_chain:genesis_hash(),
+    TxBin = aetx_sign:serialize_to_binary(OffChainTx),
+    Msg = #{ chain_hash => ChainHash
+           , channel_id => ChId
+           , data       => TxBin },
+    aesc_session_noise:channel_reestablish(Sn, Msg),
+    Data#data{channel_id = ChId,
+              on_chain_id = ChId,
+              latest = {reestablish, OffChainTx} }.
+
+check_reestablish_msg(#{ chain_hash := ChainHash
+                       , channel_id := ChId
+                       , data       := TxBin },
+                      #data{opts = Opts} = Data) ->
+    case get_channel(ChainHash, ChId) of
+        {ok, Channel} ->
+            SignedTx = aetx_sign:deserialize_from_binary(TxBin),
+            case aesc_offchain_state:check_reestablish_tx(
+                   SignedTx, Channel, Opts) of
+                {ok, NewState} ->
+                    {ok, Data#data{ channel_id  = ChId
+                                  , on_chain_id = ChId
+                                  , state       = NewState}};
+                {error, _} = TxErr ->
+                    TxErr
+            end;
+        {error, _} = ChErr ->
+            ChErr
+    end.
+
+send_reestablish_ack_msg(#data{ state       = State
+                              , on_chain_id = ChId
+                              , session     = Sn } = Data) ->
+    ChainHash = aec_chain:genesis_hash(),
+    SignedTx = aesc_offchain_state:get_latest_signed_tx(State),
+    TxBin = aetx_sign:serialize_to_binary(SignedTx),
+    Msg = #{ chain_hash  => ChainHash
+           , channel_id  => ChId
+           , data        => TxBin },
+    aesc_session_noise:channel_reestablish_ack(Sn, Msg),
+    Data#data{latest = undefined}.
+
+check_reestablish_ack_msg(#{ data := TxBin } = Msg, #data{} = Data) ->
+    SignedTx = aetx_sign:deserialize_from_binary(TxBin),
+    run_checks(
+      [ fun chk_chain_hash/3
+      , fun chk_channel_id/3
+      , fun chk_dual_sigs/3
+      , fun chk_same_tx/3
+      ], Msg, SignedTx, Data).
+
+run_checks([F|Funs], Msg, SignedTx, Data) ->
+    case F(Msg, SignedTx, Data) of
+        {true, _} ->
+            run_checks(Funs, Msg, SignedTx, Data);
+        {false, Err} ->
+            {error, Err}
+    end;
+run_checks([], _, _, Data) ->
+    {ok, Data}.
+
+chk_chain_hash(#{ chain_hash := CH }, _, _) ->
+    {CH == aec_chain:genesis_hash(), chain_hash_mismatch}.
+
+chk_channel_id(#{ channel_id := ChId }, _, #data{ on_chain_id = OCId }) ->
+    {ChId == OCId, channel_id_mismatch}.
+
+chk_dual_sigs(_, SignedTx, #data{ state = State }) ->
+    [_,_] = aetx_sign:signatures(SignedTx),
+    {ok == aesc_offchain_state:verify_signatures(SignedTx, State),
+     signatures_invalid}.
+
+chk_same_tx(_, SignedTx, #data{ state = State }) ->
+    {_, MySignedTx} = aesc_offchain_state:get_signed_tx(State),
+    {aetx_sign:serialize_to_binary(SignedTx)
+     == aex_sign:serialize_to_binary(MySignedTx), offchain_state_mismatch}.
+
+get_channel(ChainHash, ChId) ->
+    case aec_chain:genesis_hash() of
+        ChainHash ->
+            aec_chain:get_channel(ChId);
         _ ->
             {error, chain_hash_mismatch}
     end.
@@ -1535,6 +1705,34 @@ handle_upd_transfer(FromPub, ToPub, Amount, From, #data{ state = State
         error:Reason ->
             lager:error("CAUGHT ~p, trace = ~p", [Reason, erlang:get_stacktrace()]),
             keep_state(D, [{reply, From, {error, Reason}}])
+    end.
+
+send_leave_msg(#data{ on_chain_id = ChId
+                    , session     = Session} = Data) ->
+    Msg = #{ channel_id => ChId },
+    aesc_session_noise:leave(Session, Msg),
+    Data.
+
+check_leave_msg(#{ channel_id := ChId }, #data{on_chain_id = ChId0} = Data) ->
+    case ChId == ChId0 of
+        true ->
+            {ok, Data};
+        false ->
+            {error, channel_id_mismatch}
+    end.
+
+send_leave_ack_msg(#data{ on_chain_id = ChId
+                        , session     = Session} = Data) ->
+    Msg = #{ channel_id => ChId },
+    aesc_session_noise:leave(Session, Msg),
+    Data.
+
+check_leave_ack_msg(#{channel_id := ChId}, #data{on_chain_id = ChId0} = Data) ->
+    case ChId == ChId0 of
+        true ->
+            {ok, Data};
+        false ->
+            {error, channel_id_mismatch}
     end.
 
 send_shutdown_msg(SignedTx, #data{session = Session} = Data) ->

--- a/apps/aechannel/src/aesc_fsm_min_depth_watcher.erl
+++ b/apps/aechannel/src/aesc_fsm_min_depth_watcher.erl
@@ -49,10 +49,10 @@ handle_info({gproc_ps_event, top_changed, _},
             #{callback_mod := Mod, parent := Parent, chan_id := ChanId} = St,
             case Mod:minimum_depth_achieved(
                    Parent, ChanId, close, undefined) of
-                continue ->
-                    {noreply, St};
-                stop ->
-                    {stop, normal, St}
+                ok ->
+                    {noreply, St}
+                %% stop ->
+                %%     {stop, normal, St}
             end;
         _ ->
             {noreply, St}
@@ -119,9 +119,9 @@ check_status(#{parent := Parent, chan_id := ChanId,
                 ok ->
                     {noreply, St#{funding_locked => true,
                                   type    => undefined,
-                                  tx_hash => undefined}};
-                stop ->
-                    {stop, normal, St}
+                                  tx_hash => undefined}}
+                %% stop ->
+                %%     {stop, normal, St}
             end;
         _ ->
             lager:debug("min_depth not yet achieved", []),

--- a/apps/aechannel/src/aesc_offchain_state.erl
+++ b/apps/aechannel/src/aesc_offchain_state.erl
@@ -23,7 +23,7 @@
         , check_initial_update_tx/3   %%  (SignedTx, State, Opts)
         , check_update_tx/3           %%  (SignedTx, State, Opts)
         , check_reestablish_tx/2      %%  (SignedTx, State) -> {ok,NewSt} | error()
-        , is_latest_signed_tx/2       %%  (SignedTx, State) -> bookean()
+        , is_latest_signed_tx/2       %%  (SignedTx, State) -> boolean()
         , verify_signatures/2         %%  (SignedTx, State)
         , make_update_tx/3            %%  (Updates, State, Opts) -> Tx
         , add_signed_tx/3             %%  (SignedTx, State0, Opts) -> State

--- a/apps/aechannel/src/aesc_offchain_state.erl
+++ b/apps/aechannel/src/aesc_offchain_state.erl
@@ -74,7 +74,7 @@ new_(#{ initiator          := InitiatorPubKey
 
 recover_from_offchain_tx(#{ existing_channel_id := ChId
                           , offchain_tx         := SignedTx } = Opts) ->
-    case aesc_state_cache:fetch(ChId, my_pubkey(Opts)) of
+    case aesc_state_cache:reestablish(ChId, my_pubkey(Opts)) of
         {ok, #state{} = State} ->
             case is_latest_signed_tx(SignedTx, State) of
                 true ->

--- a/apps/aechannel/src/aesc_session_noise.erl
+++ b/apps/aechannel/src/aesc_session_noise.erl
@@ -93,6 +93,9 @@ accept(Port, Opts) ->
       ?MODULE, {self(), {accept, Port, Opts}}, ?GEN_SERVER_OPTS).
 
 init({Parent, Op}) ->
+    %% trap exits to avoid ugly crash reports. We rely on the monitor to
+    %% ensure that we close when the fsm dies
+    process_flag(trap_exit, true),
     proc_lib:init_ack(Parent, {ok, self()}),
     ParentMonRef = monitor(process, Parent),
     St = establish(Op, #st{parent = Parent,

--- a/apps/aechannel/src/aesc_session_noise.erl
+++ b/apps/aechannel/src/aesc_session_noise.erl
@@ -16,6 +16,7 @@
        , deposit_signed/2
        , deposit_locked/2
        , channel_reestablish/2
+       , channel_reestablish_ack/2
        , update/2
        , update_ack/2
        , update_error/2
@@ -29,6 +30,8 @@
        , wdraw_error/2
        , error/2
        , inband_msg/2
+       , leave/2
+       , leave_ack/2
        , shutdown/2
        , shutdown_ack/2]).
 
@@ -52,6 +55,7 @@ deposit_created    (Session, Msg) -> cast(Session, {msg, ?DEP_CREATED  , Msg}).
 deposit_signed     (Session, Msg) -> cast(Session, {msg, ?DEP_SIGNED   , Msg}).
 deposit_locked     (Session, Msg) -> cast(Session, {msg, ?DEP_LOCKED   , Msg}).
 channel_reestablish(Session, Msg) -> cast(Session, {msg, ?CH_REESTABL  , Msg}).
+channel_reestablish_ack(Sn , Msg) -> cast(Sn     , {msg, ?CH_REEST_ACK , Msg}).
 update             (Session, Msg) -> cast(Session, {msg, ?UPDATE       , Msg}).
 update_ack         (Session, Msg) -> cast(Session, {msg, ?UPDATE_ACK   , Msg}).
 update_error       (Session, Msg) -> cast(Session, {msg, ?UPDATE_ERR   , Msg}).
@@ -65,6 +69,8 @@ wdraw_locked       (Session, Msg) -> cast(Session, {msg, ?WDRAW_LOCKED , Msg}).
 wdraw_error        (Session, Msg) -> cast(Session, {msg, ?WDRAW_ERR    , Msg}).
 error              (Session, Msg) -> cast(Session, {msg, ?ERROR        , Msg}).
 inband_msg         (Session, Msg) -> cast(Session, {msg, ?INBAND_MSG   , Msg}).
+leave              (Session, Msg) -> cast(Session, {msg, ?LEAVE        , Msg}).
+leave_ack          (Session, Msg) -> cast(Session, {msg, ?LEAVE_ACK    , Msg}).
 shutdown           (Session, Msg) -> cast(Session, {msg, ?SHUTDOWN     , Msg}).
 shutdown_ack       (Session, Msg) -> cast(Session, {msg, ?SHUTDOWN_ACK , Msg}).
 

--- a/apps/aechannel/src/aesc_state_cache.erl
+++ b/apps/aechannel/src/aesc_state_cache.erl
@@ -4,10 +4,13 @@
 -export([
           start_link/0
         , new/3
+        , reestablish/2
         , update/3
         , fetch/2
         , delete/1
         ]).
+
+-export([minimum_depth_achieved/4]).
 
 -export([
           init/1
@@ -18,14 +21,32 @@
         , code_change/3
         ]).
 
--record(st, {}).
+-export([
+         table_specs/1
+        ]).
+
+%% for diagnostics
+-export([
+         cache_status/1
+        ]).
+
+-define(MIN_DEPTH, 4).
+-record(st, {mons_chid = ets:new(mons_chid, [ordered_set]),
+             mons_ref  = ets:new(mons_ref, [set]),
+             watchers  = ets:new(watchers, [set]),
+             min_depth = ?MIN_DEPTH}).
 -record(ch, {id, state}).
+-record(pch, {id, pubkeys = [], state}).
 
 -define(SERVER, ?MODULE).
 -define(TAB, ?MODULE).
+-define(PTAB, ?MODULE).
 
 new(ChId, PubKey, State) ->
-    gen_server:call(?SERVER, {new, ChId, PubKey, State}).
+    gen_server:call(?SERVER, {new, ChId, PubKey, self(), State}).
+
+reestablish(ChId, PubKey) ->
+    gen_server:call(?SERVER, {reestablish, ChId, PubKey, self()}).
 
 update(ChId, PubKey, State) ->
     gen_server:cast(?SERVER, {update, ChId, PubKey, State}).
@@ -35,6 +56,25 @@ fetch(ChId, PubKey) ->
 
 delete(ChId) ->
     gen_server:cast(?SERVER, {delete, ChId}).
+
+cache_status(ChId) ->
+    gen_server:call(?SERVER, {cache_status, ChId}).
+
+minimum_depth_achieved(_, ChId, close, _) ->
+    gen_server:call(?SERVER, {min_depth_achieved, ChId, self()}).
+
+table_specs(Mode) ->
+    [
+     {?MODULE, [
+                 aec_db:tab_copies(Mode)
+               , {type, ordered_set}
+               , {record_name, pch}
+               , {attributes, record_info(fields, pch)}
+               , {user_properties, [{vsn, table_vsn(pch)}]}
+               ]}
+    ].
+
+table_vsn(_) -> 1.
 
 start_link() ->
     case ets:info(?TAB, name) of
@@ -49,12 +89,22 @@ start_link() ->
 init([]) ->
     {ok, #st{}}.
 
-handle_call({new, ChId, PubKey, State}, _From, St) ->
+handle_call({new, ChId, PubKey, Pid, State}, _From, St) ->
     case ets:insert_new(?TAB, #ch{id = key(ChId, PubKey), state = State}) of
         true ->
-            {reply, ok, St};
+            St1 = monitor_fsm(Pid, ChId, PubKey, St),
+            {reply, ok, St1};
         false ->
             {reply, {error, exists}, St}
+    end;
+handle_call({reestablish, ChId, PubKey, Pid}, _From, St) ->
+    case try_reestablish_cached(ChId, PubKey) of
+        {ok, Result} ->
+            St1 = monitor_fsm(Pid, ChId, PubKey,
+                              remove_watcher(ChId, St)),
+            {reply, {ok, Result}, St1};
+        {error, _} = Error ->
+            {reply, Error, St}
     end;
 handle_call({fetch, ChId, PubKey}, _From, St) ->
     case ets:lookup(?TAB, key(ChId, PubKey)) of
@@ -63,6 +113,11 @@ handle_call({fetch, ChId, PubKey}, _From, St) ->
         [] ->
             {reply, error, St}
     end;
+handle_call({min_depth_achieved, ChId, _Watcher}, _From, St) ->
+    lager:debug("min_depth_achieved - ~p gone", [ChId]),
+    {reply, ok, delete_for_chid(ChId, St)};
+handle_call({cache_status, ChId}, _From, St) ->
+    {reply, cache_status_(ChId), St};
 handle_call(_Req, _From, St) ->
     {reply, {error, unknown_request}, St}.
 
@@ -70,12 +125,26 @@ handle_cast({update, ChId, PubKey, State}, St) ->
     ets:update_element(?TAB, key(ChId, PubKey), {#ch.state, State}),
     {noreply, St};
 handle_cast({delete, ChId}, St) ->
-    ets:select_delete(
-      ?TAB, [{ #ch{id = key(ChId, '_'), _ = '_'}, [], [true] }]),
-    {noreply, St};
+    {noreply, delete_for_chid(ChId, St)};
 handle_cast(_Msg, St) ->
     {noreply, St}.
 
+handle_info({'DOWN', MRef, process, _Pid, _}, St) ->
+    case lookup_by_mref(MRef, St) of
+        {ChId, PubKey} ->
+            move_state_to_persistent(ChId),
+            lager:debug("state moved (~p). Cache status: ~p",
+                        [ChId, cache_status_(ChId)]),
+            St1 = remove_monitor(MRef, ChId, PubKey, St),
+            case channel_watcher(ChId, St) of
+                {ok, _WPid} ->
+                    {noreply, St1};
+                error ->
+                    {noreply, start_watcher(ChId, St1)}
+            end;
+        error ->
+            {noreply, St}
+    end;
 handle_info(_Msg, St) ->
     {noreply, St}.
 
@@ -87,3 +156,150 @@ code_change(_FromVsn, St, _Extra) ->
 
 key(ChId, PubKey) ->
     {ChId, PubKey}.
+
+cache_status_(ChId) ->
+    InRam = ets:select(
+              ?TAB, [{ #ch{id = key(ChId, '$1'), _ = '_'}, [], ['$1']}]),
+    OnDisk = ([] =/= mnesia:dirty_read(?PTAB, ChId)),
+    [ {in_ram, InRam}
+    , {on_disk, OnDisk}].
+
+
+try_reestablish_cached(ChId, PubKey) ->
+    case ets:lookup(?TAB, key(ChId, PubKey)) of
+        [#ch{state = State}] ->
+            {ok, State};
+        [] ->
+            case read_persistent(ChId) of
+                {ok, Pubkeys, State} ->
+                    ets:insert(
+                      ?TAB, [#ch{id = key(ChId, PK), state = State}
+                             || PK <- Pubkeys]),
+                    delete_persistent(ChId),
+                    {ok, State};
+                error ->
+                    {error, not_found}
+            end
+    end.
+
+move_state_to_persistent(ChId) ->
+    Found = ets:select(
+              ?TAB, [{ #ch{id = key(ChId, '_'), _ = '_'}, [], ['$_'] }]),
+    case Found of
+        [] -> ok;
+        [#ch{id = {_,PKa}, state = A}, #ch{id = {_,PKb}, state = A}] ->
+            Pch = #pch{id = ChId, pubkeys = [PKa, PKb], state = A},
+            write_persistent(Pch);
+        [#ch{id = {_,PKa}, state = A}, #ch{id = {_,PKb}, state = B}] ->
+            Pch0 = #pch{id = ChId, pubkeys = [PKa, PKb]},
+            ToSave = case {aesc_offchain_state:get_latest_signed_tx(A),
+                           aesc_offchain_state:get_latest_signed_tx(B)} of
+                         {{Ra,_}, {Rb,_}} when Ra > Rb ->
+                             Pch0#pch{state = A};
+                         {{Ra,_}, {Rb,_}} when Ra =< Rb ->
+                             %% TODO: when (if at all) could this be == ?
+                             Pch0#pch{state = B}
+                     end,
+            write_persistent(ToSave);
+        [#ch{id = {_, PK}, state = State}] ->
+            Pch = #pch{id = ChId, pubkeys = [PK], state = State},
+            write_persistent(Pch)
+    end,
+    ets:select_delete(?TAB, [{ #ch{id = key(ChId,'_'), _ = '_'}, [], [true] }]),
+    ok.
+
+write_persistent(Pch) ->
+    activity(fun() -> mnesia:write(?PTAB, Pch, write) end).
+
+read_persistent(ChId) ->
+    activity(fun() ->
+                     case mnesia:read(?PTAB, ChId) of
+                         [#pch{pubkeys = PKs, state = State}] ->
+                             {ok, PKs, State};
+                         [] ->
+                             error
+                     end
+             end).
+
+delete_persistent(ChId) ->
+    activity(fun() -> mnesia:delete(?PTAB, ChId, write) end).
+
+activity(F) ->
+    aec_db:ensure_transaction(F).
+
+
+monitor_fsm(Pid, ChId, PubKey, #st{mons_ref = MR, mons_chid = MC} = St) ->
+    MRef = erlang:monitor(process, Pid),
+    ets:insert(MR, {MRef, ChId, PubKey}),
+    ets:insert(MC, {{ChId, PubKey}, MRef}),
+    St.
+
+lookup_by_mref(MRef, #st{mons_ref = MR}) ->
+    case ets:lookup(MR, MRef) of
+        [{_, ChId, PubKey}] ->
+            {ChId, PubKey};
+        [] ->
+            error
+    end.
+
+remove_monitor(MRef, ChId, PubKey, #st{mons_ref = MR, mons_chid = MC} = St) ->
+    ets:delete(MR, MRef),
+    ets:delete(MC, {ChId, PubKey}),
+    St.
+
+remove_monitor_by_chid(ChId, #st{mons_chid = MC} = St) ->
+    Found = ets:select(MC, [{ {{ChId, '$1'}, '$2'}, [], [{{'$1','$2'}}] }]),
+    lists:foldl(
+      fun({PubKey, MRef}, St1) ->
+              remove_monitor(MRef, ChId, PubKey, St1)
+      end, St, Found).
+
+channel_watcher(ChId, #st{watchers = Ws}) ->
+    case ets:lookup(Ws, ChId) of
+        [{_, Pid}] ->
+            case is_process_alive(Pid) of
+                true ->
+                    lager:debug("watcher already running: ~p (~p)",
+                                [Pid, ChId]),
+                    {ok, Pid};
+                false ->
+                    lager:debug("ERROR: watcher ~p (~p) not running",
+                                [Pid, ChId]),
+                    error
+            end;
+        [] ->
+            error
+    end.
+
+start_watcher(ChId, #st{watchers = Ws, min_depth = Min} = St) ->
+    {ok, Pid} = aesc_fsm_min_depth_watcher:watch_for_channel_close(
+                  ChId, Min, ?MODULE),
+    lager:debug("watcher started for ~p: ~p", [ChId, Pid]),
+    ets:insert(Ws, {ChId, Pid}),
+    St.
+
+remove_watcher(ChId, #st{watchers = Ws} = St) ->
+    case ets:lookup(Ws, ChId) of
+        [{_, Pid}] ->
+            unlink(Pid),
+            exit(Pid, kill),
+            ets:delete(Ws, ChId);
+        [] ->
+            ok
+    end,
+    St.
+
+delete_for_chid(ChId, St) ->
+    Res = delete_state(
+            ChId, remove_watcher(
+                    ChId, remove_monitor_by_chid(
+                            ChId, St))),
+    delete_persistent(ChId),
+    lager:debug("delete_for_chid ~p; cache_status: ~p",
+                [ChId, cache_status_(ChId)]),
+    Res.
+
+delete_state(ChId, St) ->
+    ets:select_delete(
+      ?TAB, [{ #ch{id = key(ChId, '_'), _ = '_'}, [], [true] }]),
+    St.

--- a/apps/aechannel/src/aesc_state_cache.erl
+++ b/apps/aechannel/src/aesc_state_cache.erl
@@ -1,0 +1,89 @@
+-module(aesc_state_cache).
+-behaviour(gen_server).
+
+-export([
+          start_link/0
+        , new/3
+        , update/3
+        , fetch/2
+        , delete/1
+        ]).
+
+-export([
+          init/1
+        , handle_call/3
+        , handle_cast/2
+        , handle_info/2
+        , terminate/2
+        , code_change/3
+        ]).
+
+-record(st, {}).
+-record(ch, {id, state}).
+
+-define(SERVER, ?MODULE).
+-define(TAB, ?MODULE).
+
+new(ChId, PubKey, State) ->
+    gen_server:call(?SERVER, {new, ChId, PubKey, State}).
+
+update(ChId, PubKey, State) ->
+    gen_server:cast(?SERVER, {update, ChId, PubKey, State}).
+
+fetch(ChId, PubKey) ->
+    gen_server:call(?SERVER, {fetch, ChId, PubKey}).
+
+delete(ChId) ->
+    gen_server:cast(?SERVER, {delete, ChId}).
+
+start_link() ->
+    case ets:info(?TAB, name) of
+        undefined ->
+            ets:new(?MODULE, [ordered_set, public, named_table,
+                              {keypos, #ch.id}]);
+        _ ->
+            ok
+    end,
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+init([]) ->
+    {ok, #st{}}.
+
+handle_call({new, ChId, PubKey, State}, _From, St) ->
+    case ets:insert_new(?TAB, #ch{id = key(ChId, PubKey), state = State}) of
+        true ->
+            {reply, ok, St};
+        false ->
+            {reply, {error, exists}, St}
+    end;
+handle_call({fetch, ChId, PubKey}, _From, St) ->
+    case ets:lookup(?TAB, key(ChId, PubKey)) of
+        [#ch{state = State}] ->
+            {reply, {ok, State}, St};
+        [] ->
+            {reply, error, St}
+    end;
+handle_call(_Req, _From, St) ->
+    {reply, {error, unknown_request}, St}.
+
+handle_cast({update, ChId, PubKey, State}, St) ->
+    ets:update_element(?TAB, key(ChId, PubKey), {#ch.state, State}),
+    {noreply, St};
+handle_cast({delete, ChId}, St) ->
+    ets:select_delete(
+      ?TAB, [{ #ch{id = key(ChId, '_'), _ = '_'}, [], [true] }]),
+    {noreply, St};
+handle_cast(_Msg, St) ->
+    {noreply, St}.
+
+handle_info(_Msg, St) ->
+    {noreply, St}.
+
+terminate(_Reason, _St) ->
+    ok.
+
+code_change(_FromVsn, St, _Extra) ->
+    {ok, St}.
+
+key(ChId, PubKey) ->
+    {ChId, PubKey}.

--- a/apps/aechannel/src/aesc_state_cache.erl
+++ b/apps/aechannel/src/aesc_state_cache.erl
@@ -22,7 +22,8 @@
         ]).
 
 -export([
-         table_specs/1
+          table_specs/1
+        , check_tables/1
         ]).
 
 %% for diagnostics
@@ -73,6 +74,12 @@ table_specs(Mode) ->
                , {user_properties, [{vsn, table_vsn(pch)}]}
                ]}
     ].
+
+check_tables(Acc) ->
+    lists:foldl(
+      fun({Tab, Spec}, Acc1) ->
+              aec_db:check_table(Tab, Spec, Acc1)
+      end, Acc, table_specs(disc)).
 
 table_vsn(_) -> 1.
 

--- a/apps/aechannel/src/aesc_sup.erl
+++ b/apps/aechannel/src/aesc_sup.erl
@@ -1,0 +1,17 @@
+-module(aesc_sup).
+-behaviour(supervisor).
+
+-export([
+          start_link/0
+        , init/1
+        ]).
+
+-define(SERVER, ?MODULE).
+-define(CHILD(Mod,N,Type), {Mod,{Mod,start_link,[]},permanent,N,Type,[Mod]}).
+
+
+start_link() ->
+    supervisor:start_link({local, ?SERVER}, ?MODULE, []).
+
+init([]) ->
+    {ok, {{one_for_one, 5, 10}, [?CHILD(aesc_state_cache, 5000, worker)]}}.

--- a/apps/aechannel/test/aesc_fsm_SUITE.erl
+++ b/apps/aechannel/test/aesc_fsm_SUITE.erl
@@ -15,6 +15,8 @@
         , end_per_suite/1
         , init_per_group/2
         , end_per_group/2
+        , init_per_testcase/2
+        , end_per_testcase/2
         ]).
 
 %% test case exports
@@ -25,6 +27,8 @@
         , deposit/1
         , withdraw/1
         , leave_reestablish/1
+        , leave_reestablish_close/1
+        , change_config_get_history/1
         , multiple_channels/1
         ]).
 
@@ -37,6 +41,7 @@
 -define(OP_WITHDRAW, 1).
 -define(OP_DEPOSIT , 2).
 
+-define(LOG(E), ct:log("LINE ~p <== ~p", [?LINE, E])).
 
 -define(MINIMUM_DEPTH, 3).
 
@@ -53,6 +58,8 @@ groups() ->
       , deposit
       , withdraw
       , leave_reestablish
+      , leave_reestablish_close
+      , change_config_get_history
       , multiple_channels
       ]
      }
@@ -103,6 +110,15 @@ end_per_group(_Group, Config) ->
     _Config1 = stop_node(dev1, Config),
     ok.
 
+init_per_testcase(leave_reestablish, Config) ->
+    [{debug, true} | Config];
+init_per_testcase(_, Config) ->
+    Config.
+
+end_per_testcase(_Case, _Config) ->
+    ok.
+
+
 stop_node(N, Config) ->
     aecore_suite_utils:stop_node(N, Config),
     Config.
@@ -113,42 +129,37 @@ stop_node(N, Config) ->
 %%%===================================================================
 
 create_channel(Cfg) ->
+    Debug = get_debug(Cfg),
     #{ i := #{fsm := FsmI, channel_id := ChannelId} = I
      , r := #{} = R} = create_channel_([{port, 9325}|Cfg]),
     ok = rpc(dev1, aesc_fsm, shutdown, [FsmI]),
-    _ = await_signing_request(shutdown, I),
-    _ = await_signing_request(shutdown_ack, R),
+    _ = await_signing_request(shutdown, I, ?TIMEOUT, Debug),
+    _ = await_signing_request(shutdown_ack, R, ?TIMEOUT, Debug),
     SignedTx = await_on_chain_report(I, ?TIMEOUT),
     SignedTx = await_on_chain_report(R, ?TIMEOUT), % same tx
     wait_for_signed_transaction_in_block(dev1, SignedTx),
     verify_close_mutual_tx(SignedTx, ChannelId),
+    check_info(500),
     ok.
 
 inband_msgs(Cfg) ->
-    #{ i := #{fsm := FsmI, channel_id := ChannelId} = I
+    #{ i := #{fsm := FsmI} = I
      , r := #{} = R
      , spec := #{ initiator := _PubI
                 , responder := PubR }} = create_channel_([{port,9326}|Cfg]),
-    check_info(),
     ok = rpc(dev1, aesc_fsm, inband_msg, [FsmI, PubR, <<"i2r hello">>]),
-    receive_from_fsm(
-      message, R, fun(#{info := #{info := <<"i2r hello">>}}) -> ok end, 1000, true),
+    {ok,_} =receive_from_fsm(
+              message, R,
+              fun(#{info := #{info := <<"i2r hello">>}}) -> ok end, 1000, true),
 
-    ok = rpc(dev1, aesc_fsm, shutdown, [FsmI]),
-    _ = await_signing_request(shutdown, I),
-    _ = await_signing_request(shutdown_ack, R),
-    SignedTx = await_on_chain_report(I, ?TIMEOUT),
-    SignedTx = await_on_chain_report(R, ?TIMEOUT), % same tx
-    wait_for_signed_transaction_in_block(dev1, SignedTx),
-    verify_close_mutual_tx(SignedTx, ChannelId),
-    ok.
+    shutdown_(I, R),
+    check_info(500).
 
 upd_transfer(Cfg) ->
     #{ i := #{fsm := FsmI, channel_id := ChannelId} = I
      , r := #{} = R
      , spec := #{ initiator := PubI
                 , responder := PubR }} = create_channel_([{port,9326}|Cfg]),
-    check_info(),
     {I0, R0} = do_update(PubI, PubR, 2, I, R, true),
     {I1, R1} = update_bench(I0, R0),
     ok = rpc(dev1, aesc_fsm, shutdown, [FsmI]),
@@ -158,7 +169,9 @@ upd_transfer(Cfg) ->
     SignedTx = await_on_chain_report(R, ?TIMEOUT), % same tx
     wait_for_signed_transaction_in_block(dev1, SignedTx),
     verify_close_mutual_tx(SignedTx, ChannelId),
+    check_info(500),
     ok.
+
 
 update_bench(I, R) ->
     {Time, I1, R1} = do_n(1000, fun update_volley/2, I, R),
@@ -199,9 +212,8 @@ deposit(Cfg) ->
     ct:log("I = ~p", [I]),
     #{initiator_amount := IAmt0, responder_amount := RAmt0} = I,
     {IAmt0, RAmt0, _, _Round0 = 1} = check_fsm_state(FsmI),
-    check_info(),
+    check_info(0),
     ok = rpc(dev1, aesc_fsm, upd_deposit, [FsmI, #{amount => Deposit}]),
-    check_info(),
     {I1, _} = await_signing_request(deposit_tx, I),
     {_R1, _} = await_signing_request(deposit_created, R),
     SignedTx = await_on_chain_report(I1, ?TIMEOUT),
@@ -218,7 +230,7 @@ deposit(Cfg) ->
     #{initiator_amount := IAmt2, responder_amount := RAmt2} = I1,
     Expected = {IAmt2, RAmt2},
     {Expected, Expected} = {{IAmt0 + Deposit, RAmt0}, Expected},
-    check_info(100).
+    check_info(500).
 
 withdraw(Cfg) ->
     Withdrawal = 2,
@@ -229,9 +241,8 @@ withdraw(Cfg) ->
     ct:log("I = ~p", [I]),
     #{initiator_amount := IAmt0, responder_amount := RAmt0} = I,
     {IAmt0, RAmt0, _, _Round0 = 1} = check_fsm_state(FsmI),
-    check_info(),
+    check_info(0),
     ok = rpc(dev1, aesc_fsm, upd_withdraw, [FsmI, #{amount => Withdrawal}]),
-    check_info(),
     {I1, _} = await_signing_request(withdraw_tx, I),
     {_R1, _} = await_signing_request(withdraw_created, R),
     SignedTx = await_on_chain_report(I1, ?TIMEOUT),
@@ -247,35 +258,103 @@ withdraw(Cfg) ->
     #{initiator_amount := IAmt2, responder_amount := RAmt2} = I1,
     Expected = {IAmt2, RAmt2},
     {Expected, Expected} = {{IAmt0 - Withdrawal, RAmt0}, Expected},
-    check_info(100).
+    check_info(500).
 
 leave_reestablish(Cfg) ->
+    leave_reestablish(9329, Cfg).
+
+leave_reestablish(Port, Cfg) ->
+    Debug = get_debug(Cfg),
+    {I0, R0, Spec0} = channel_spec(Cfg),
     #{ i := #{fsm := FsmI} = I
      , r := #{} = R
      , spec := #{ initiator := _PubI
-                , responder := _PubR }} = create_channel_([{port, 9329}|Cfg]),
+                , responder := _PubR }} =
+        create_channel_from_spec(I0, R0, Spec0, Port, Debug),
     ct:log("I = ~p", [I]),
-    #{initiator_amount := IAmt0, responder_amount := RAmt0} = I,
-    ok = rpc(dev1, aesc_fsm, upd_withdraw, [FsmI, #{amount => Withdrawal}]),
-    check_info(),
-    {I1, _} = await_signing_request(withdraw_tx, I),
-    {_R1, _} = await_signing_request(withdraw_created, R),
-    mine_blocks(dev1, 4),
+    ok = rpc(dev1, aesc_fsm, leave, [FsmI]),
+    {ok,Li} = await_leave(I, ?TIMEOUT, Debug),
+    {ok,Lr} = await_leave(R, ?TIMEOUT, Debug),
+    SignedTx = maps:get(info, Li),
+    SignedTx = maps:get(info, Lr),
+    {ok,_} = receive_from_fsm(info, I, fun died_normal/1, ?TIMEOUT, Debug),
+    {ok,_} = receive_from_fsm(info, R, fun died_normal/1, ?TIMEOUT, Debug),
+    %%
+    %% reestablish
+    %%
+    ChId = maps:get(channel_id, R),
+    check_info(500),
+    ct:log("reestablishing ...", []),
+    reestablish(ChId, I0, R0, SignedTx, Spec0, Port+1, Debug).
+
+leave_reestablish_close(Cfg) ->
+    Debug = get_debug(Cfg),
+    #{i := I, r := R, spec := Spec} = leave_reestablish(9332, Cfg),
+    #{initiator := PubI, responder := PubR} = Spec,
+    {I1, R1} = do_update(PubI, PubR, 1, I, R, Debug),
+    shutdown_(I1, R1).
+
+change_config_get_history(Cfg) ->
+    #{ i := #{fsm := FsmI} = I
+     , r := #{} = R } = create_channel_([{port,9335}|Cfg]),
+    Log = rpc(dev1, aesc_fsm, get_history, [FsmI]),
+    ok = check_history(Log),
+    ok = rpc(dev1, aesc_fsm, change_config, [FsmI, log_keep, 17]),
+    Status = rpc(dev1, sys, get_status, [FsmI]),
+    check_w_param(17,Status),
+    {error, invalid_config} =
+        rpc(dev1, aesc_fsm, change_config, [FsmI, log_keep, -1]),
+    {error, invalid_config} =
+        rpc(dev1, aesc_fsm, change_config, [FsmI, invalid, config]),
+    shutdown_(I, R),
+    check_info(500).
+
+check_history(Log) ->
+    %% Expected events for initiator so far, in reverse cronological order
+    Expected = [{rcv, funding_locked},
+                {snd, funding_locked},
+                {rcv, funding_signed},
+                {snd, funding_created},
+                {rcv, signed},
+                {req, sign},
+                {rcv, channel_accept},
+                {snd, channel_open}],
+    ok = check_log(Expected, Log).
+
+check_w_param(N, Status) ->
+    match_tuple(fun({w,_,Keep,_,_}) ->
+                        N = Keep,  %% crash if no match
+                        ok;
+                   (_) -> error
+               end, Status).
+
+match_tuple(F, Term) when is_tuple(Term) ->
+    case F(Term) of
+        ok ->
+            ok;
+        error ->
+            match_tuple(F, tuple_to_list(Term))
+    end;
+match_tuple(F, [H|T]) ->
+    case match_tuple(F, H) of
+        ok    -> ok;
+        error -> match_tuple(F, T)
+    end;
+match_tuple(_, _) -> error.
+
+
+check_log([{Op, Type}|T], [{Op, Type, _, _}|T1]) ->
+    check_log(T, T1);
+check_log([H|_], [H1|_]) ->
+    ct:log("ERROR: Expected ~p in log; got ~p", [H, H1]),
+    error(log_inconsistent);
+check_log([_|_], []) ->
+    %% the log is a sliding window; events may be flushed at the tail
+    ok;
+check_log([], _) ->
     ok.
 
-inband_msgs(Cfg) ->
-    #{ i := #{fsm := FsmI} = _I
-     , r := #{fsm := FsmR} = R
-     , spec := #{ initiator := _PubI
-                , responder := PubR }} = create_channel_([{port,9326}|Cfg]),
-    check_info(),
-    ok = rpc(dev1, aesc_fsm, inband_msg, [FsmI, PubR, <<"i2r hello">>]),
-    receive_from_fsm(
-      message, R, fun(#{info := #{info := <<"i2r hello">>}}) -> ok end, 1000, true),
-    rpc(dev1, erlang, exit, [FsmI, kill]),
-    rpc(dev1, erlang, exit, [FsmR, kill]),
-    check_info(1000),
-    ok.
+died_normal(#{info := {died,normal}}) -> ok.
 
 multiple_channels(Cfg) ->
     ct:log("spawning multiple channels", []),
@@ -303,6 +382,17 @@ multiple_channels(Cfg) ->
     ct:comment(Fmt, Args),
     [P ! die || P <- Cs],
     ok.
+
+shutdown_(#{fsm := FsmI, channel_id := ChannelId} = I, R) ->
+    ok = rpc(dev1, aesc_fsm, shutdown, [FsmI]),
+    _ = await_signing_request(shutdown, I),
+    _ = await_signing_request(shutdown_ack, R),
+    SignedTx = await_on_chain_report(I, ?TIMEOUT),
+    SignedTx = await_on_chain_report(R, ?TIMEOUT), % same tx
+    wait_for_signed_transaction_in_block(dev1, SignedTx),
+    verify_close_mutual_tx(SignedTx, ChannelId),
+    ok.
+
 
 collect_acks([Pid | Pids], Tag, N) ->
     Timeout = 30000 + (N div 10)*5000,  % wild guess
@@ -337,13 +427,16 @@ ch_loop(I, R, Parent) ->
     end.
 
 create_channel_(Cfg) ->
-    create_channel_(Cfg, true).
+    create_channel_(Cfg, get_debug(Cfg)).
 
 create_channel_(Cfg, Debug) ->
+    {I, R, Spec} = channel_spec(Cfg),
+    Port = proplists:get_value(port, Cfg, 9325),
+    create_channel_from_spec(I, R, Spec, Port, Debug).
+
+channel_spec(Cfg) ->
     I = ?config(initiator, Cfg),
     R = ?config(responder, Cfg),
-
-    Port = proplists:get_value(port, Cfg, 9325),
 
     %% dynamic key negotiation
     Proto = <<"Noise_NN_25519_ChaChaPoly_BLAKE2b">>,
@@ -361,8 +454,11 @@ create_channel_(Cfg, Debug) ->
              client           => self(),
              noise            => [{noise, Proto}],
              timeouts         => #{idle => 20000},
-             report_info      => true},
+             report           => #{debug => true} },
+    {I, R, Spec}.
 
+create_channel_from_spec(
+  I, R, #{initiator_amount := IAmt, responder_amount := RAmt} = Spec, Port, Debug) ->
     {ok, FsmR} = rpc(dev1, aesc_fsm, respond, [Port, Spec], Debug),
     {ok, FsmI} = rpc(dev1, aesc_fsm, initiate, ["localhost", Port, Spec], Debug),
 
@@ -370,6 +466,9 @@ create_channel_(Cfg, Debug) ->
 
     I1 = I#{fsm => FsmI, initiator_amount => IAmt, responder_amount => RAmt},
     R1 = R#{fsm => FsmR, initiator_amount => IAmt, responder_amount => RAmt},
+
+    {ok, _} = receive_from_fsm(info, R1, channel_open, ?TIMEOUT, Debug),
+    {ok, _} = receive_from_fsm(info, I1, channel_accept, ?TIMEOUT, Debug),
 
     {I2, R2} = try await_create_tx_i(I1, R1, Debug)
                catch
@@ -388,16 +487,45 @@ create_channel_(Cfg, Debug) ->
     SignedTx = await_on_chain_report(R2, ?TIMEOUT), % same tx
     wait_for_signed_transaction_in_block(dev1, SignedTx),
     mine_blocks(dev1, ?MINIMUM_DEPTH, Debug),
-    check_info(),
     %% in case of multiple channels starting in parallel - the mining above
     %% has no effect (the blocks are mined in another process)
     %% The following line makes sure this process is blocked until the proper
     %% height is reached
     aecore_suite_utils:wait_for_height(aecore_suite_utils:node_name(dev1),
                                        CurrentHeight + ?MINIMUM_DEPTH),
-    I3 = await_open_report(I2, ?TIMEOUT, Debug),
-    R3 = await_open_report(R2, ?TIMEOUT, Debug),
-    #{i => I3, r => R3, spec => Spec}.
+    {ok, _} = receive_from_fsm(info, R2, own_funding_locked, ?TIMEOUT, Debug),
+    {ok, _} = receive_from_fsm(info, I2, own_funding_locked, ?TIMEOUT, Debug),
+    I3 = await_funding_locked(I2, ?TIMEOUT, Debug),
+    R3 = await_funding_locked(R2, ?TIMEOUT, Debug),
+    I4 = await_update(I3, ?TIMEOUT, Debug),
+    R4 = await_update(R3, ?TIMEOUT, Debug),
+    I5 = await_open_report(I4, ?TIMEOUT, Debug),
+    R5 = await_open_report(R4, ?TIMEOUT, Debug),
+    check_info(500, Debug),
+    #{i => I5, r => R5, spec => Spec}.
+
+reestablish(ChId, I0, R0, SignedTx, Spec0, Port, Debug) ->
+    {IAmt, RAmt} = tx_amounts(SignedTx),
+    I = set_amounts(IAmt, RAmt, I0),
+    R = set_amounts(IAmt, RAmt, R0),
+    Spec = Spec0#{existing_channel_id => ChId, offchain_tx => SignedTx,
+                  initiator_amount => IAmt, responder_amount => RAmt},
+    {ok, FsmR} = rpc(dev1, aesc_fsm, respond,
+                     [Port, Spec]),
+    {ok, FsmI} = rpc(dev1, aesc_fsm, initiate,
+                     ["localhost", Port, Spec], Debug),
+    I1 = await_open_report(I#{fsm => FsmI}, ?TIMEOUT, Debug),
+    R1 = await_open_report(R#{fsm => FsmR}, ?TIMEOUT, Debug),
+    check_info(500),
+    #{i => I1, r => R1, spec => Spec}.
+
+tx_amounts(SignedTx) ->
+    {Mod, TxI} = aetx:specialize_callback(aetx_sign:tx(SignedTx)),
+    {Mod:initiator_amount(TxI),
+     Mod:responder_amount(TxI)}.
+
+set_amounts(IAmt, RAmt, Map) ->
+    Map#{initiator_amount => IAmt, responder_amount => RAmt}.
 
 verify_close_mutual_tx(SignedTx, ChannelId) ->
     {channel_close_mutual_tx, Tx} = aetx:specialize_type(aetx_sign:tx(SignedTx)),
@@ -412,12 +540,30 @@ await_create_tx_i(I, R, Debug) ->
     await_funding_created_p(I1, R, Debug).
 
 await_funding_created_p(I, R, Debug) ->
+    receive_from_fsm(info, R, funding_created, ?TIMEOUT, Debug),
     {R1, _} = await_signing_request(funding_created, R, Debug),
     await_funding_signed_i(I, R1, Debug).
 
 await_funding_signed_i(I, R, Debug) ->
     receive_info(I, funding_signed, Debug),
     {I, R}.
+
+await_funding_locked(#{role := Role} = R, Timeout, Debug) ->
+    {ok, Msg} = receive_from_fsm(info, R, funding_locked, Timeout, Debug),
+    log(Debug, "~p got funding_locked: ~p", [Role, Msg]),
+    R#{channel_id => maps:get(channel_id, Msg)}.
+
+await_update(#{channel_id := ChId} = R, Timeout, Debug) ->
+    {ok, _Msg} = receive_from_fsm(
+                   update, R,
+                   fun(#{ channel_id := ChId1
+                         , info := SignedTx }) ->
+                           true =
+                               ChId1 == ChId
+                               andalso
+                               element(1, SignedTx) == signed_tx
+                   end, Timeout, Debug),
+    R.
 
 await_signing_request(Tag, R) ->
     await_signing_request(Tag, R, ?TIMEOUT, true).
@@ -426,7 +572,6 @@ await_signing_request(Tag, R, Debug) ->
     await_signing_request(Tag, R, ?TIMEOUT, Debug).
 
 await_signing_request(Tag, #{fsm := Fsm, priv := Priv} = R, Timeout, Debug) ->
-    check_info(0, Debug),
     receive {aesc_fsm, Fsm, #{type := sign, tag := Tag, info := Tx} = Msg} ->
             log(Debug, "await_signing(~p, ~p) <- ~p", [Tag, Fsm, Msg]),
             SignedTx = aec_test_utils:sign_tx(Tx, [Priv]),
@@ -443,8 +588,7 @@ await_on_chain_report(#{fsm := Fsm}, Timeout) ->
               error(timeout)
     end.
 
-await_open_report(#{fsm := Fsm} = R, Timeout, Debug) ->
-    check_info(0, Debug),
+await_open_report(#{fsm := Fsm} = R, Timeout, _Debug) ->
     receive {aesc_fsm, Fsm, #{type := report, tag := info, info := open} = Msg} ->
                 {ok, ChannelId} = maps:find(channel_id, Msg),
                 R#{channel_id => ChannelId}
@@ -452,47 +596,91 @@ await_open_report(#{fsm := Fsm} = R, Timeout, Debug) ->
               error(timeout)
     end.
 
-receive_info(R, Msg, Debug) ->
-    receive_from_fsm(info, R, Msg, ?LONG_TIMEOUT, Debug).
+await_leave(#{channel_id := ChId0} = R, Timeout, Debug) ->
+    receive_from_fsm(
+      leave, R,
+      fun(#{channel_id := ChId, info := SignedTx})
+            when ChId == ChId0, element(1, SignedTx) == signed_tx ->
+              ok
+      end, Timeout, Debug).
 
-receive_from_fsm(Tag, #{role := Role, fsm := Fsm}, Info, Timeout, Debug)
+receive_info(R, Msg, Debug) ->
+    {ok, _} = receive_from_fsm(info, R, Msg, ?LONG_TIMEOUT, Debug).
+
+receive_from_fsm(Tag, R, Info, Timeout, Debug) ->
+    {ok, _} = receive_from_fsm(Tag, R, Info, Timeout, Debug, false).
+
+receive_from_fsm(Tag, #{role := Role, fsm := Fsm} = R, Info, Timeout, Debug, _Cont)
   when is_atom(Info) ->
+    log(Debug, "receive_from_fsm_(~p, ~p, ~p, ~p, ~p, _Cont)",
+        [Tag, R, Info, Timeout, Debug]),
     receive
         {aesc_fsm, Fsm, #{type := _Type, tag := Tag, info := Info} = Msg} ->
             log(Debug, "~p: received ~p:~p", [Role, Tag, Msg]),
-            ok
+            {ok, Msg}
     after Timeout ->
+            flush(),
             error(timeout)
     end;
-receive_from_fsm(Tag, #{role := Role, fsm := Fsm}, Msg, Timeout, Debug) ->
+receive_from_fsm(Tag, R, Msg, Timeout, Debug, Cont) ->
+    TRef = erlang:start_timer(Timeout, self(), receive_from_fsm),
+    receive_from_fsm_(Tag, R, Msg, TRef, Debug, Cont).
+
+receive_from_fsm_(Tag, #{role := Role, fsm := Fsm} = R, Msg, TRef, Debug, Cont) ->
+    log(Debug, "receive_from_fsm_(~p, ~p, ~p, ~p, ~p, ~p)",
+        [Tag, R, Msg, TRef, Debug, Cont]),
     receive
         {aesc_fsm, Fsm, #{type := Type, tag := Tag} = Msg1} ->
             log(Debug, "~p: received ~p:~p/~p", [Role, Type, Tag, Msg1]),
-            match_msgs(Msg, Msg1)
-    after Timeout ->
+            try match_msgs(Msg, Msg1, Cont)
+            catch
+                throw:continue ->
+                    ct:log("Failed match: ~p", [Msg1]),
+                    receive_from_fsm_(Tag, R, Msg, TRef, Debug, Cont)
+            after
+                erlang:cancel_timer(TRef)
+            end;
+        {timeout, TRef, receive_from_fsm} ->
+            flush(),
             error(timeout)
     end.
 
-match_msgs(F, Msg) when is_function(F, 1) ->
-    F(Msg);
-match_msgs(M, #{info := M}) ->
-    ok;
-match_msgs(M, M) ->
-    ok;
-match_msgs(A, B) ->
+flush() ->
+    receive M ->
+            ct:log("<== ~p", [M]),
+            flush()
+    after 0 ->
+            ok
+    end.
+
+match_msgs(F, Msg, Cont) when is_function(F, 1) ->
+    try F(Msg), {ok, Msg}
+    catch
+        error:_ ->
+            if Cont ->
+                    throw(continue);
+               true ->
+                    ct:log("Message doesn't match fun: ~p / ~p", [Msg]),
+                    error({message_mismatch, [Msg]})
+            end
+    end;
+match_msgs(M, #{info := M} = Msg, _) ->
+    {ok, Msg};
+match_msgs(M, M, _) ->
+    {ok, M};
+match_msgs(_, _, true) ->
+    throw(continue);
+match_msgs(A, B, false) ->
     ct:log("Messages don't match: ~p / ~p", [A, B]),
     erlang:error({message_mismatch, [A, B]}).
-
-
-check_info() -> check_info(0, true).
 
 check_info(Timeout) -> check_info(Timeout, true).
 
 check_info(Timeout, Debug) ->
     receive
-        {aesc_fsm, Fsm, ChanId, {Tag, Msg}} = Info ->
-            log(Debug, "Received ~p: ~p", [Tag, Info]),
-            [{Fsm, ChanId, Msg}|check_info(Timeout, Debug)]
+        Msg when element(1, Msg) == aesc_fsm ->
+            log(Debug, "UNEXPECTED: ~p", [Msg]),
+            [Msg|check_info(Timeout, Debug)]
     after Timeout ->
             []
     end.
@@ -644,3 +832,7 @@ check_fsm_state(Fsm) ->
     Hash = aec_trees:hash(Trees),
     StateHash = Hash, %% assert same root hash
     {IAmt, RAmt, StateHash, Round}.
+
+get_debug(Config) ->
+    proplists:get_bool(debug, Config).
+

--- a/apps/aecore/src/aec_db.erl
+++ b/apps/aecore/src/aec_db.erl
@@ -13,6 +13,7 @@
          tables/1,                      % for e.g. test database setup
          clear_db/0,                    % mostly for test purposes
          tab_copies/1,                  % for create_tables hooks
+         check_table/3,                 % for check_tables hooks
          persisted_valid_genesis_block/0
         ]).
 
@@ -625,21 +626,24 @@ ensure_mnesia_tables(Mode, Storage) ->
     end.
 
 check_mnesia_tables([{Table, Spec}|Left], Acc) ->
-    NewAcc = try mnesia:table_info(Table, user_properties) of
-                 [{vsn, Vsn}] ->
-                     case proplists:get_value(user_properties, Spec) of
-                         [{vsn, Vsn}] -> Acc;
-                         [{vsn, Old}] -> [{vsn_fail, Table,
-                                           [{expected, Vsn},
-                                            {got, Old}]}
-                                          |Acc]
-                     end;
-                 Other -> [{missing_version, Table, Other}|Acc]
-             catch _:_ -> [{missing_table, Table}|Acc]
-             end,
+    NewAcc = check_table(Table, Spec, Acc),
     check_mnesia_tables(Left, NewAcc);
 check_mnesia_tables([], Acc) ->
     fold_hooks('$aec_db_check_tables', Acc).
+
+check_table(Table, Spec, Acc) ->
+    try mnesia:table_info(Table, user_properties) of
+        [{vsn, Vsn}] ->
+            case proplists:get_value(user_properties, Spec) of
+                [{vsn, Vsn}] -> Acc;
+                [{vsn, Old}] -> [{vsn_fail, Table,
+                                  [{expected, Vsn},
+                                   {got, Old}]}
+                                 |Acc]
+            end;
+        Other -> [{missing_version, Table, Other}|Acc]
+    catch _:_ -> [{missing_table, Table}|Acc]
+    end.
 
 ensure_schema_storage_mode(ram) ->
     case disc_db_exists() of

--- a/apps/aecore/src/aec_db.erl
+++ b/apps/aecore/src/aec_db.erl
@@ -12,6 +12,7 @@
          load_database/0,               % called in aecore app start phase
          tables/1,                      % for e.g. test database setup
          clear_db/0,                    % mostly for test purposes
+         tab_copies/1,                  % for create_tables hooks
          persisted_valid_genesis_block/0
         ]).
 

--- a/deployment/ansible/deploy.yml
+++ b/deployment/ansible/deploy.yml
@@ -58,7 +58,7 @@
           port: 3114
       chain:
         persist: true
-        db_path: "./db70"
+        db_path: "./db71"
       keypair:
         dir: "keys"
         password: "{{ vault_keys_password|default('secret') }}"

--- a/docs/release-notes/RELEASE-NOTES-0.19.0.md
+++ b/docs/release-notes/RELEASE-NOTES-0.19.0.md
@@ -4,10 +4,11 @@
 It:
 * Removes `key_hash` field from micro blocks. This impacts consensus.
 * Fixes a bug when a trusted peer changes its IP, it was crashing instead of just ignoring the change.
-* Fine tunes deposit and withdrawal channel transactions being produced for the user.
+* Fine-tunes deposit and withdrawal channel transactions being produced for the user.
   This does not impact channels' protocol
 * Adds export command to epoch. The chain can be exported in a binary format (Erlang disk_log of serialized blocks) using the command `epoch export FILENAME`. The first record in the log is a map containing the genesis hash, the hostname and the date and time; the blocks are stored from top to genesis.
 * Refines status code 400 as 404 for call object retrieval API `/tx/{tx_hash}/contract-call` when transaction still pending.
+* Adds a database table for caching state channel data on disk
 
 [this-release]: https://github.com/aeternity/epoch/releases/tag/v0.19.0
 


### PR DESCRIPTION
- add mnesia table for persistent caching
- move cached data to mnesia once fsms terminate
- wait for 4 blocks after channel is gone from state tree
- fix multiple_channels test case bug (reusing same nonce)
- annotate fsms by test case for simpler debugging
- add gproc names for finding fsm by role or pubkey