### PR TITLE
Expand race detection to cover all state update operations

### DIFF
--- a/apps/aechannel/src/aesc_codec.erl
+++ b/apps/aechannel/src/aesc_codec.erl
@@ -33,6 +33,7 @@
 %% -type length()      :: i2bytes().
 -type amount()      :: i8bytes().
 -type pubkey()      :: bin32().
+-type error_code()  :: i2bytes().
 
 -define(PUBKEY_SIZE, 32).
 
@@ -324,20 +325,25 @@ dec_update_ack(<< ChanId:32/binary
      , data   => Data }.
 
 -type update_err_msg() :: #{ channel_id := chan_id()
-                           , round      := non_neg_integer() }.
+                           , round      := non_neg_integer()
+                           , error_code := error_code() }.
 
 -spec enc_update_err(update_err_msg()) -> binary().
 enc_update_err(#{ channel_id := ChanId
-                , round      := Round }) ->
+                , round      := Round
+                , error_code := ErrCode }) ->
     << ?ID_UPDATE_ERR:1 /unit:8
      , ChanId        :32/binary
-     , Round         :4 /unit:8 >>.
+     , Round         :4 /unit:8
+     , ErrCode       :2 /unit:8 >>.
 
 -spec dec_update_err(binary()) -> update_err_msg().
-dec_update_err(<< ChanId:32/binary
-                , Round :4/unit:8 >>) ->
+dec_update_err(<< ChanId :32/binary
+                , Round  :4/unit:8
+                , ErrCode:2/unit:8 >>) ->
     #{ channel_id => ChanId
-     , round      => Round }.
+     , round      => Round
+     , error_code => ErrCode }.
 
 -type deposit_msg() :: #{ channel_id := chan_id()
                         , data       := binary()}.
@@ -394,20 +400,25 @@ dec_dep_locked(<< ChanId:32/binary
      , data       => Data }.
 
 -type dep_err_msg() :: #{ channel_id := chan_id()
-                        , round      := non_neg_integer() }.
+                        , round      := non_neg_integer()
+                        , error_code := error_code() }.
 
 -spec enc_dep_err(dep_err_msg()) -> binary().
 enc_dep_err(#{ channel_id := ChanId
-             , round      := Round }) ->
+             , round      := Round
+             , error_code := ErrCode }) ->
     << ?ID_DEP_ERR:1 /unit:8
      , ChanId        :32/binary
-     , Round         :4 /unit:8 >>.
+     , Round         :4 /unit:8
+     , ErrCode       :2 /unit:8 >>.
 
 -spec dec_dep_err(binary()) -> dep_err_msg().
-dec_dep_err(<< ChanId:32/binary
-             , Round :4 /unit:8 >>) ->
+dec_dep_err(<< ChanId :32/binary
+             , Round  :4 /unit:8
+             , ErrCode:2 /unit:8 >>) ->
     #{ channel_id => ChanId
-     , round      => Round }.
+     , round      => Round
+     , error_code => ErrCode }.
 
 -type withdrawal_msg() :: #{ channel_id := chan_id()
                            , data       := binary()}.
@@ -464,20 +475,25 @@ dec_wdraw_locked(<< ChanId:32/binary
      , data       => Data }.
 
 -type wdraw_err_msg() :: #{ channel_id := chan_id()
-                          , round      := non_neg_integer() }.
+                          , round      := non_neg_integer()
+                          , error_code := error_code() }.
 
 -spec enc_wdraw_err(wdraw_err_msg()) -> binary().
 enc_wdraw_err(#{ channel_id := ChanId
-               , round      := Round }) ->
+               , round      := Round
+               , error_code := ErrCode }) ->
     << ?ID_WDRAW_ERR:1 /unit:8
      , ChanId       :32/binary
-     , Round        :4 /unit:8 >>.
+     , Round        :4 /unit:8
+     , ErrCode      :2 /unit:8 >>.
 
 -spec dec_wdraw_err(binary()) -> wdraw_err_msg().
-dec_wdraw_err(<< ChanId:32/binary
-               , Round:4 /unit:8 >>) ->
+dec_wdraw_err(<< ChanId :32/binary
+               , Round  :4 /unit:8
+               , ErrCode:2 /unit:8 >>) ->
     #{ channel_id => ChanId
-     , round      => Round }.
+     , round      => Round
+     , error_code => ErrCode }.
 
 -type error_msg() :: #{ channel_id := chan_id()
                       , data       := binary() }.

--- a/apps/aechannel/src/aesc_codec.hrl
+++ b/apps/aechannel/src/aesc_codec.hrl
@@ -54,3 +54,7 @@
 -define(DISCONNECT, disconnect).
 -define(SIGNED, signed).
 -define(MIN_DEPTH_ACHIEVED, minimum_depth_achieved).
+
+%% Error codes
+-define(ERR_VALIDATION, 1).
+-define(ERR_CONFLICT  , 2).

--- a/apps/aechannel/src/aesc_fsm.erl
+++ b/apps/aechannel/src/aesc_fsm.erl
@@ -2086,9 +2086,9 @@ conflict_msg_type(?WDRAW_CREATED) -> ?WDRAW_ERR.
 send_conflict_msg(?UPDATE, Sn, Msg) ->
     aesc_session_noise:update_error(Sn, Msg);
 send_conflict_msg(?DEP_CREATED, Sn, Msg) ->
-    aesc_session_noise:deposit_error(Sn, Msg);
+    aesc_session_noise:dep_error(Sn, Msg);
 send_conflict_msg(?WDRAW_CREATED, Sn, Msg) ->
-    aesc_session_noise:withdraw_error(Sn,Msg).
+    aesc_session_noise:wdraw_error(Sn,Msg).
 
 
 check_update_err_msg(#{ channel_id := ChanId


### PR DESCRIPTION
Update races may happen also for withdrawals and deposits, and for
any combination of these, and updates. Introduce a state attribute
signaling ongoing update, and use common conflict handling for all
operations that trigger an offchain state change.

See [PT #159361988](https://www.pivotaltracker.com/story/show/159361988)