### PR TITLE
Allow more than one suite to be specified

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,15 @@ EUNIT_TEST_FLAGS ?=
 CT_TEST_FLAGS ?=
 ST_CT_FLAGS = --dir system_test --logdir system_test/logs
 
+null  :=
+space := $(null) # space
+comma := ,
+
+comma-separate = $(subst ${space},${comma},$(strip $1))
+space-separate = $(subst ${comma},${space},$(strip $1))
+
 ifdef SUITE
-CT_TEST_FLAGS += --suite=$(SUITE)_SUITE
+CT_TEST_FLAGS += --suite=$(call comma-separate,$(foreach suite,$(call space-separate,${SUITE}),${suite}_SUITE))
 unexport SUITE
 endif
 


### PR DESCRIPTION
Usage example:
```
$ make test SUITE=apps/aecontract/test/aecontract,test/aevm_chain,apps/aecore/test/aecore_txs
```