### PR TITLE
Update system tests

### DIFF
--- a/system_test/aest_commands_SUITE.erl
+++ b/system_test/aest_commands_SUITE.erl
@@ -23,7 +23,7 @@
 %=== MACROS ====================================================================
 
 -define(MINING_TIMEOUT, 2000).
--define(STARTUP_TIMEOUT, 5000).
+-define(STARTUP_TIMEOUT, 20000).
 
 -define(NODE1, #{
     name    => node1,

--- a/system_test/aest_peers_SUITE.erl
+++ b/system_test/aest_peers_SUITE.erl
@@ -120,7 +120,7 @@ test_peer_discovery(Cfg) ->
     ok.
 
 test_inbound_limitation(Cfg) ->
-    Length = 30,
+    Length = 50,
     StartupTimeout = proplists:get_value(node_startup_time, Cfg),
     NodeConfig = #{
         ping_interval => 5000,

--- a/system_test/aest_peers_SUITE.erl
+++ b/system_test/aest_peers_SUITE.erl
@@ -78,10 +78,9 @@ all() -> [
 ].
 
 init_per_suite(Config) ->
-    [
-        {node_startup_time, 20000}, %% Time may take to get the node to respond to http
-        {node_shutdown_time, 20000} %% Time it may take to stop node cleanly
-    |Config].
+    [ {node_startup_time, 20000}, %% Time may take to get the node to respond to http
+      {node_shutdown_time, 20000} %% Time it may take to stop node cleanly
+    | Config].
 
 init_per_testcase(_TC, Config) ->
     aest_nodes:ct_setup(Config).

--- a/system_test/aest_peers_SUITE.erl
+++ b/system_test/aest_peers_SUITE.erl
@@ -161,7 +161,7 @@ test_inbound_limitation(Cfg) ->
     wait_for_internal_api([node4], StartupTimeout),
 
     T2 = erlang:system_time(millisecond),
-    wait_for_value({height, Length * 2}, [node1, node2, node3, node4], ?MINING_TIMEOUT * Length, Cfg),
+    wait_for_value({height, Length * 2 + 1}, [node1, node2, node3, node4], ?MINING_TIMEOUT * Length, Cfg),
 
     try_until(T2 + 3 * ping_interval(),
             fun() ->

--- a/system_test/aest_peers_SUITE.erl
+++ b/system_test/aest_peers_SUITE.erl
@@ -130,18 +130,16 @@ test_inbound_limitation(Cfg) ->
     setup([?NODE1, ?NODE2, ?NODE3, ?NODE4], NodeConfig, Cfg),
     start_node(node1, Cfg),
     start_node(node2, Cfg),
-    wait_for_value({height, 0}, [node1, node2], StartupTimeout, Cfg),
     wait_for_internal_api([node1, node2], StartupTimeout),
 
     % Retrieve node1 peer address.
     #{outbound := [Node1PeerAddr]} = get_peers(node2),
 
     start_node(node3, Cfg),
-    wait_for_value({height, 0}, [node1, node2, node3], StartupTimeout, Cfg),
     wait_for_internal_api([node3], StartupTimeout),
 
     T1 = erlang:system_time(millisecond),
-    wait_for_value({height, Length}, [node1, node2, node3], ?MINING_TIMEOUT * Length, Cfg),
+    wait_for_value({height, Length + 1}, [node1, node2, node3], ?MINING_TIMEOUT * Length, Cfg),
 
     try_until(T1 + 3 * ping_interval(),
             fun() ->

--- a/system_test/aest_sync_SUITE.erl
+++ b/system_test/aest_sync_SUITE.erl
@@ -153,9 +153,7 @@ end_per_suite(_Config) -> ok.
 %% A node with a newer version of the code can join and synchronize
 %% to a cluster of older nodes.
 new_node_joins_network(Cfg) ->
-    Length = 20,
     NodeStartupTime = proplists:get_value(node_startup_time, Cfg),
-
     Compatible = "aeternity/epoch:local", %% Latest version it should be compatible with
                                           %% Change if comptibility with previous version
                                           %% should be guaranteed
@@ -184,7 +182,12 @@ new_node_joins_network(Cfg) ->
     %% Starts a chain with two nodes
     start_node(old_node1, Cfg),
     start_node(old_node2, Cfg),
+    T0 = erlang:system_time(seconds),
     wait_for_value({height, 0}, [old_node1, old_node2], NodeStartupTime, Cfg),
+    StartupTime = erlang:system_time(seconds) - T0,
+
+    Length = max(20, 5 + proplists:get_value(blocks_per_second, Cfg) * StartupTime),
+
 
     %% Mines for 20 blocks and calculate the average mining time
     StartTime = os:timestamp(),

--- a/system_test/aest_sync_SUITE.erl
+++ b/system_test/aest_sync_SUITE.erl
@@ -130,11 +130,10 @@ all() -> [
 init_per_suite(Config) ->
     %% Some parameters depend on the speed and capacity of the docker containers:
     %% timers must be less than gen_server:call timeout.
-    [
-        {blocks_per_second, 3},
-        {node_startup_time, 20000}, %% Time may take to get the node to respond to http
-        {node_shutdown_time, 20000} %% Time it may take to stop node cleanly
-    |Config].
+    [ {blocks_per_second, 3},
+      {node_startup_time, 10000}, %% Time may take to get the node to respond to http
+      {node_shutdown_time, 20000} %% Time it may take to stop node cleanly
+    | Config].
 
 init_per_testcase(quick_start_stop, Config) ->
     aest_nodes:ct_setup([{verify_logs, false}|Config]);

--- a/system_test/aest_sync_SUITE.erl
+++ b/system_test/aest_sync_SUITE.erl
@@ -349,19 +349,22 @@ stop_and_continue_sync(Cfg) ->
          false ->
             start_node(node1, Cfg),
             %% should sync with about 10 blocks per second, hence 100ms per block
-            wait_for_value({height, Length}, [node2], (Length - Height) * ?MINING_TIMEOUT, Cfg),
+            wait_for_value({height, Length + 1}, [node2], (Length - Height) * ?MINING_TIMEOUT, Cfg),
             B2 = get_block(node2, Length),
             C1 = get_block(node1, Length),
             ct:log("Node 2 at height ~p: ~p and  Node 1 at same height ~p~n", [Length, B2, C1]),
             if C1 == B1 ->
-                ct:log("This test showed that sync can be interrupted");
-               C1 =/= B2 ->
-                ct:log("Tested non-interesting branch, node2 synced with node1")
-                %% skip here?
-            end,
-            ?assertEqual(C1, B2),
-            ?assertNotEqual(undefined, C1),
-            ?assertNotEqual(undefined, B2)
+                  ct:log("This tests sync can be interrupted, node1 unchanged"),
+                  ?assertEqual(C1, B2);
+               C1 == B2 ->
+                  ?assertNotEqual(undefined, C1),
+                  ?assertNotEqual(undefined, B2),
+                  ct:log("Tested non-interesting branch, node1 copied node2"),
+                  {skip, need_longer_chain};
+               true ->
+                  ct:log("Nodes not in sync, that's an error"),
+                  ?assertEqual(C1, B2)
+            end
     end.
 
 tx_pool_sync(Cfg) ->

--- a/system_test/aest_sync_SUITE.erl
+++ b/system_test/aest_sync_SUITE.erl
@@ -39,7 +39,6 @@
 %=== MACROS ====================================================================
 
 -define(MINING_TIMEOUT,   3000).
--define(SYNC_TIMEOUT,      100).
 
 -define(STANDALONE_NODE, #{
     name    => standalone_node,

--- a/system_test/aest_sync_SUITE.erl
+++ b/system_test/aest_sync_SUITE.erl
@@ -211,9 +211,9 @@ new_node_joins_network(Cfg) ->
     %% Starts a third node and check it synchronize with the first two
     start_node(new_node1, Cfg),
     wait_for_value({height, 0}, [new_node1], NodeStartupTime, Cfg),
-    ct:log("Node 3 ready to go"),
 
-    %% Waits enough for node 3 to sync but not for it to build a new chain
+    %% Starting http interface takes more time than sync, but:
+    %% Wait enough for node 3 to sync but not for it to build a new chain
     wait_for_value({height, Length}, [new_node1], MiningTime * 3, Cfg),
     ct:log("Node 3 on same height"),
     Height3 = get_block(new_node1, Length),

--- a/system_test/aest_sync_SUITE.erl
+++ b/system_test/aest_sync_SUITE.erl
@@ -311,7 +311,7 @@ stop_and_continue_sync(Cfg) ->
     NodeStartupTime = proplists:get_value(node_startup_time, Cfg),
 
     %% Create a chain long enough to need 10 seconds to fetch it
-    Length = BlocksPerSecond * 30,
+    Length = BlocksPerSecond * 50,
 
     setup_nodes([#{ name    => node1,
                     peers   => [node2],


### PR DESCRIPTION
Synchronizing is faster than before and chains have to be longer to make interesting tests.

This cleans up system tests a bit and should make them more stable on different machines.

[finishes PT-159567374]