### PR TITLE
SC: prune channel contract calls

### DIFF
--- a/apps/aecontract/src/aect_call_state_tree.erl
+++ b/apps/aecontract/src/aect_call_state_tree.erl
@@ -17,6 +17,7 @@
         , new_with_backend/1
         , iterator/1
         , prune/2
+        , prune_without_backend/1
         , root_hash/1]).
 
 -ifdef(TEST).
@@ -59,6 +60,10 @@ new_with_backend(Hash) ->
 -spec prune(aec_blocks:height(), aec_trees:trees()) -> aec_trees:trees().
 prune(_,Trees) ->
     aec_trees:set_calls(Trees, empty_with_backend()).
+
+-spec prune_without_backend(aec_trees:trees()) -> aec_trees:trees().
+prune_without_backend(Trees) ->
+    aec_trees:set_calls(Trees, empty()).
 
 -spec insert_call(aect_call:call(), tree()) -> tree().
 insert_call(Call, Tree = #call_tree{ calls = CtTree}) ->

--- a/apps/aecontract/src/aect_channel_contract.erl
+++ b/apps/aecontract/src/aect_channel_contract.erl
@@ -93,12 +93,10 @@ run(ContractPubKey, VmVersion, Call, CallData, CallStack, Round, Trees0) ->
     {CallRes, Trees} = aect_dispatch:run(VmVersion, CallDef),
     aect_utils:insert_call_in_trees(CallRes, Trees).
 
-get_call(Contract, Caller, Round, Trees) ->
-    CallsTree = aec_trees:calls(Trees),
+get_call(Contract, Caller, Round, CallsTree) ->
     CallId = aect_call:id(Caller, Round, Contract),
     case aect_call_state_tree:lookup_call(Contract, CallId, CallsTree) of
         none -> {error, call_not_found};
         {value, Call} -> {ok, Call}
     end.
-
 

--- a/apps/aehttp/src/sc_ws_handler.erl
+++ b/apps/aehttp/src/sc_ws_handler.erl
@@ -333,7 +333,7 @@ process_incoming(#{<<"action">> := <<"get">>,
     end;
 process_incoming(#{<<"action">> := <<"clean_contract_calls">>}, State) ->
     ok = aesc_fsm:prune_local_calls(fsm_pid(State)),
-    {reply, ok_response(calls_prunned)};
+    {reply, ok_response(calls_pruned)};
 process_incoming(#{<<"action">> := <<"get">>,
                    <<"tag">>    := <<"balances">>,
                    <<"payload">> := #{<<"accounts">> := Accounts}} = R, State) ->

--- a/apps/aehttp/src/sc_ws_handler.erl
+++ b/apps/aehttp/src/sc_ws_handler.erl
@@ -331,6 +331,9 @@ process_incoming(#{<<"action">> := <<"get">>,
             end;
         _ -> {reply, error_response(R, broken_hexcode)}
     end;
+process_incoming(#{<<"action">> := <<"clean_contract_calls">>}, State) ->
+    ok = aesc_fsm:prune_local_calls(fsm_pid(State)),
+    {reply, ok_response(calls_prunned)};
 process_incoming(#{<<"action">> := <<"get">>,
                    <<"tag">>    := <<"balances">>,
                    <<"payload">> := #{<<"accounts">> := Accounts}} = R, State) ->
@@ -615,6 +618,9 @@ error_response(Req, Reason) ->
     #{<<"action">>  => <<"error">>,
       <<"payload">> => #{<<"request">> => Req,
                          <<"reason">> => Reason}}.
+
+ok_response(Action) ->
+    #{<<"action">>  => Action}.
 
 hex_decode(Hex) ->
     try {ok, aeu_hex:hexstring_decode(Hex)}

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -4847,10 +4847,10 @@ sc_ws_contract_(Config, TestName, Owner) ->
     %% helper lambdas for pruning and call not found
     PruneCalls =
         fun(ConnPid) ->
-            ok = ?WS:register_test_for_channel_events(ConnPid, [calls_prunned]),
+            ok = ?WS:register_test_for_channel_events(ConnPid, [calls_pruned]),
             ?WS:send(ConnPid, <<"clean_contract_calls">>, #{}),
-            ok = ?WS:wait_for_channel_event(ConnPid, calls_prunned),
-            ok = ?WS:unregister_test_for_channel_events(ConnPid, [calls_prunned])
+            ok = ?WS:wait_for_channel_event(ConnPid, calls_pruned),
+            ok = ?WS:unregister_test_for_channel_events(ConnPid, [calls_pruned])
         end,
     CallMissingCall =
         fun(UnsignedStateTx00, ConnPid) ->

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -4849,7 +4849,7 @@ sc_ws_contract_(Config, TestName, Owner) ->
         fun(ConnPid) ->
             ok = ?WS:register_test_for_channel_events(ConnPid, [calls_pruned]),
             ?WS:send(ConnPid, <<"clean_contract_calls">>, #{}),
-            ok = ?WS:wait_for_channel_event(ConnPid, calls_pruned),
+            {ok, _} = ?WS:wait_for_channel_event(ConnPid, calls_pruned),
             ok = ?WS:unregister_test_for_channel_events(ConnPid, [calls_pruned])
         end,
     CallMissingCall =

--- a/docs/release-notes/RELEASE-NOTES-0.20.0.md
+++ b/docs/release-notes/RELEASE-NOTES-0.20.0.md
@@ -6,6 +6,8 @@ It:
 * Adds http API interface `/tx/contract/create/compute` for creating contracts.
 * Fixes a bug in internal DB storage of micro forks.
 * Caps the gas operand of the `CALL` opcode in the VM with the available machine gas before performing the inner call. This impacts consensus.
+* Adds support for pruning contract calls in state channels. It is up to the
+  channel participant when to do it.
 
 [this-release]: https://github.com/aeternity/epoch/releases/tag/v0.20.0
 


### PR DESCRIPTION
PT [SC: Prune calls subtree on every update](https://www.pivotaltracker.com/story/show/159655632)

Prune contract calls on each channel round. The state of each round contains only call objects created by this exact round. Older calls are still kept locally for the user to inspect and prune manually but they are no longer part of the channel's state tree and their pruning has no impact on channel's `state_hash`

This is a prerequisite for forcing progess on-chain