### PR TITLE
Check for generation not only key block in aec_sync

### DIFF
--- a/docs/release-notes/RELEASE-NOTES-0.20.0.md
+++ b/docs/release-notes/RELEASE-NOTES-0.20.0.md
@@ -12,6 +12,7 @@ It:
 * Adds block timestamp validation - see [Consensus](https://github.com/aeternity/protocol/blob/master/consensus/consensus.md) for details.
   This affects consensus.
 * Implements a micro block cycle time (currently 3 seconds between micro blocks) to adhere to the added validation.
+* Fix a bug in sync algorithm, the sync could get stuck on a missing micro block.
 
 [this-release]: https://github.com/aeternity/epoch/releases/tag/v0.20.0
 


### PR DESCRIPTION
When identifying blocks that do not need to be synced we have to look
at the whole generation, not only the keyblock.

PT - https://www.pivotaltracker.com/story/show/159791019