### PR TITLE
Add transaction hash to aetx:process/5

### DIFF
--- a/apps/aechannel/src/aesc_close_mutual_tx.erl
+++ b/apps/aechannel/src/aesc_close_mutual_tx.erl
@@ -16,7 +16,7 @@
          nonce/1,
          origin/1,
          check/5,
-         process/5,
+         process/6,
          signers/2,
          serialization_template/1,
          serialize/1,
@@ -136,14 +136,15 @@ check(#channel_close_mutual_tx{initiator_amount_final = InitiatorAmount,
             end
     end.
 
--spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) ->
+-spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
+              non_neg_integer(), binary()) ->
         {ok, aec_trees:trees()}.
 process(#channel_close_mutual_tx{initiator_amount_final = InitiatorAmount,
                                  responder_amount_final = ResponderAmount,
                                  ttl                    = _TTL,
                                  fee                    = _Fee,
                                  nonce                  = Nonce} = Tx,
-        _Context, Trees, _Height, _ConsensusVersion) ->
+        _Context, Trees, _Height, _ConsensusVersion, _TxHash) ->
     ChannelId     = channel_hash(Tx),
     AccountsTree0 = aec_trees:accounts(Trees),
     ChannelsTree0 = aec_trees:channels(Trees),

--- a/apps/aechannel/src/aesc_close_mutual_tx.erl
+++ b/apps/aechannel/src/aesc_close_mutual_tx.erl
@@ -137,8 +137,7 @@ check(#channel_close_mutual_tx{initiator_amount_final = InitiatorAmount,
     end.
 
 -spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
-              non_neg_integer(), binary()) ->
-        {ok, aec_trees:trees()}.
+              non_neg_integer(), binary() | no_tx_hash) -> {ok, aec_trees:trees()}.
 process(#channel_close_mutual_tx{initiator_amount_final = InitiatorAmount,
                                  responder_amount_final = ResponderAmount,
                                  ttl                    = _TTL,

--- a/apps/aechannel/src/aesc_close_solo_tx.erl
+++ b/apps/aechannel/src/aesc_close_solo_tx.erl
@@ -114,8 +114,7 @@ check(#channel_close_solo_tx{payload    = Payload,
                                         Payload, PoI, Height, Trees).
 
 -spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
-              non_neg_integer(), binary()) ->
-        {ok, aec_trees:trees()}.
+              non_neg_integer(), binary() | no_tx_hash) -> {ok, aec_trees:trees()}.
 process(#channel_close_solo_tx{payload    = Payload,
                                poi        = PoI,
                                fee        = Fee,

--- a/apps/aechannel/src/aesc_close_solo_tx.erl
+++ b/apps/aechannel/src/aesc_close_solo_tx.erl
@@ -16,7 +16,7 @@
          nonce/1,
          origin/1,
          check/5,
-         process/5,
+         process/6,
          signers/2,
          serialization_template/1,
          serialize/1,
@@ -113,12 +113,14 @@ check(#channel_close_solo_tx{payload    = Payload,
     aesc_utils:check_solo_close_payload(ChannelId, FromPubKey, Nonce, Fee,
                                         Payload, PoI, Height, Trees).
 
--spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) ->
+-spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
+              non_neg_integer(), binary()) ->
         {ok, aec_trees:trees()}.
 process(#channel_close_solo_tx{payload    = Payload,
                                poi        = PoI,
                                fee        = Fee,
-                               nonce      = Nonce} = Tx, _Context, Trees, Height, _ConsensusVersion) ->
+                               nonce      = Nonce} = Tx, _Context, Trees,
+        Height, _ConsensusVersion, _TxHash) ->
     ChannelId  = channel_hash(Tx),
     FromPubKey = from_pubkey(Tx),
     aesc_utils:process_solo_close(ChannelId, FromPubKey, Nonce, Fee,

--- a/apps/aechannel/src/aesc_create_tx.erl
+++ b/apps/aechannel/src/aesc_create_tx.erl
@@ -17,7 +17,7 @@
          nonce/1,
          origin/1,
          check/5,
-         process/5,
+         process/6,
          signers/2,
          serialization_template/1,
          serialize/1,
@@ -145,14 +145,15 @@ check(#channel_create_tx{initiator_amount   = InitiatorAmount,
             Error
     end.
 
--spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) ->
+-spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
+              non_neg_integer(), binary()) ->
         {ok, aec_trees:trees()}.
 process(#channel_create_tx{initiator_amount   = InitiatorAmount,
                            responder_amount   = ResponderAmount,
                            fee                = Fee,
                            state_hash         = _StateHash,
                            nonce              = Nonce} = CreateTx, _Context, Trees0, _Height,
-                                                  _ConsensusVersion) ->
+        _ConsensusVersion, _TxHash) ->
     InitiatorPubKey = initiator_pubkey(CreateTx),
     ResponderPubKey = responder_pubkey(CreateTx),
 

--- a/apps/aechannel/src/aesc_create_tx.erl
+++ b/apps/aechannel/src/aesc_create_tx.erl
@@ -146,8 +146,7 @@ check(#channel_create_tx{initiator_amount   = InitiatorAmount,
     end.
 
 -spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
-              non_neg_integer(), binary()) ->
-        {ok, aec_trees:trees()}.
+              non_neg_integer(), binary() | no_tx_hash) -> {ok, aec_trees:trees()}.
 process(#channel_create_tx{initiator_amount   = InitiatorAmount,
                            responder_amount   = ResponderAmount,
                            fee                = Fee,

--- a/apps/aechannel/src/aesc_deposit_tx.erl
+++ b/apps/aechannel/src/aesc_deposit_tx.erl
@@ -18,7 +18,7 @@
          origin/1,
          amount/1,
          check/5,
-         process/5,
+         process/6,
          signers/2,
          serialization_template/1,
          serialize/1,
@@ -142,13 +142,15 @@ check(#channel_deposit_tx{amount     = Amount,
             Error
     end.
 
--spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) ->
+-spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
+              non_neg_integer(), binary()) ->
         {ok, aec_trees:trees()}.
 process(#channel_deposit_tx{amount     = Amount,
                             fee        = Fee,
                             state_hash = StateHash,
                             round      = Round,
-                            nonce      = Nonce} = Tx, _Context, Trees, _Height, _ConsensusVersion) ->
+                            nonce      = Nonce} = Tx, _Context, Trees,
+        _Height, _ConsensusVersion, _TxHash) ->
     ChannelId = channel_hash(Tx),
     FromPubKey = from_pubkey(Tx),
     AccountsTree0 = aec_trees:accounts(Trees),

--- a/apps/aechannel/src/aesc_deposit_tx.erl
+++ b/apps/aechannel/src/aesc_deposit_tx.erl
@@ -143,8 +143,7 @@ check(#channel_deposit_tx{amount     = Amount,
     end.
 
 -spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
-              non_neg_integer(), binary()) ->
-        {ok, aec_trees:trees()}.
+              non_neg_integer(), binary() | no_tx_hash) -> {ok, aec_trees:trees()}.
 process(#channel_deposit_tx{amount     = Amount,
                             fee        = Fee,
                             state_hash = StateHash,

--- a/apps/aechannel/src/aesc_offchain_tx.erl
+++ b/apps/aechannel/src/aesc_offchain_tx.erl
@@ -100,8 +100,7 @@ check(#channel_offchain_tx{
     {ok, Trees}.
 
 -spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
-              non_neg_integer(), binary()) ->
-        {ok, aec_trees:trees()}.
+              non_neg_integer(), binary() | no_tx_hash) -> {ok, aec_trees:trees()}.
 process(#channel_offchain_tx{}, _Context, _Trees, _Height, _ConsensusVersion,
        _TxHash) ->
     error(off_chain_tx).

--- a/apps/aechannel/src/aesc_offchain_tx.erl
+++ b/apps/aechannel/src/aesc_offchain_tx.erl
@@ -11,7 +11,7 @@
          nonce/1,
          origin/1,
          check/5,
-         process/5,
+         process/6,
          signers/2,
          serialization_template/1,
          serialize/1,
@@ -99,9 +99,11 @@ check(#channel_offchain_tx{
     %% TODO: implement checks relevant to off-chain
     {ok, Trees}.
 
--spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) ->
+-spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
+              non_neg_integer(), binary()) ->
         {ok, aec_trees:trees()}.
-process(#channel_offchain_tx{}, _Context, _Trees, _Height, _ConsensusVersion) ->
+process(#channel_offchain_tx{}, _Context, _Trees, _Height, _ConsensusVersion,
+       _TxHash) ->
     error(off_chain_tx).
 
 -spec signers(tx(), aec_trees:trees()) -> {ok, list(aec_keys:pubkey())}.

--- a/apps/aechannel/src/aesc_settle_tx.erl
+++ b/apps/aechannel/src/aesc_settle_tx.erl
@@ -122,8 +122,7 @@ check(#channel_settle_tx{initiator_amount_final = InitiatorAmount,
     end.
 
 -spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
-              non_neg_integer(), binary()) ->
-        {ok, aec_trees:trees()}.
+              non_neg_integer(), binary() | no_tx_hash) -> {ok, aec_trees:trees()}.
 process(#channel_settle_tx{initiator_amount_final = InitiatorAmount,
                            responder_amount_final = ResponderAmount,
                            fee                    = Fee,

--- a/apps/aechannel/src/aesc_settle_tx.erl
+++ b/apps/aechannel/src/aesc_settle_tx.erl
@@ -16,7 +16,7 @@
          nonce/1,
          origin/1,
          check/5,
-         process/5,
+         process/6,
          signers/2,
          serialization_template/1,
          serialize/1,
@@ -121,12 +121,14 @@ check(#channel_settle_tx{initiator_amount_final = InitiatorAmount,
             Error
     end.
 
--spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) ->
+-spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
+              non_neg_integer(), binary()) ->
         {ok, aec_trees:trees()}.
 process(#channel_settle_tx{initiator_amount_final = InitiatorAmount,
                            responder_amount_final = ResponderAmount,
                            fee                    = Fee,
-                           nonce                  = Nonce} = Tx, _Context, Trees, _Height, _ConsensusVersion) ->
+                           nonce                  = Nonce} = Tx, _Context,
+        Trees, _Height, _ConsensusVersion, _TxHash) ->
     ChannelId = channel_hash(Tx),
     FromPubKey = from_pubkey(Tx),
     AccountsTree0 = aec_trees:accounts(Trees),

--- a/apps/aechannel/src/aesc_slash_tx.erl
+++ b/apps/aechannel/src/aesc_slash_tx.erl
@@ -115,8 +115,7 @@ check(#channel_slash_tx{payload    = Payload,
 
 
 -spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
-              non_neg_integer(), binary()) ->
-        {ok, aec_trees:trees()}.
+              non_neg_integer(), binary() | no_tx_hash) -> {ok, aec_trees:trees()}.
 process(#channel_slash_tx{payload    = Payload,
                           poi        = PoI,
                           fee        = Fee,

--- a/apps/aechannel/src/aesc_slash_tx.erl
+++ b/apps/aechannel/src/aesc_slash_tx.erl
@@ -16,7 +16,7 @@
          nonce/1,
          origin/1,
          check/5,
-         process/5,
+         process/6,
          signers/2,
          serialization_template/1,
          serialize/1,
@@ -114,12 +114,14 @@ check(#channel_slash_tx{payload    = Payload,
                                    Payload, PoI, Height, Trees).
 
 
--spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) ->
+-spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
+              non_neg_integer(), binary()) ->
         {ok, aec_trees:trees()}.
 process(#channel_slash_tx{payload    = Payload,
                           poi        = PoI,
                           fee        = Fee,
-                          nonce      = Nonce} = Tx, _Context, Trees, Height, _ConsensusVersion) ->
+                          nonce      = Nonce} = Tx, _Context, Trees, Height,
+        _ConsensusVersion, _TxHash) ->
     ChannelId  = channel_hash(Tx),
     FromPubKey = from_pubkey(Tx),
     aesc_utils:process_slash(ChannelId, FromPubKey, Nonce, Fee,

--- a/apps/aechannel/src/aesc_snapshot_solo_tx.erl
+++ b/apps/aechannel/src/aesc_snapshot_solo_tx.erl
@@ -16,7 +16,7 @@
          nonce/1,
          origin/1,
          check/5,
-         process/5,
+         process/6,
          signers/2,
          serialization_template/1,
          serialize/1,
@@ -109,11 +109,13 @@ check(#channel_snapshot_solo_tx{payload    = Payload,
     aesc_utils:check_solo_snapshot_payload(ChannelId, FromPubKey, Nonce, Fee,
                                         Payload, Height, Trees).
 
--spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) ->
+-spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
+              non_neg_integer(), binary()) ->
         {ok, aec_trees:trees()}.
 process(#channel_snapshot_solo_tx{payload    = Payload,
                                fee        = Fee,
-                               nonce      = Nonce} = Tx, _Context, Trees, _Height, _ConsensusVersion) ->
+                               nonce      = Nonce} = Tx, _Context, Trees,
+        _Height, _ConsensusVersion, _TxHash) ->
     ChannelId  = channel_hash(Tx),
     FromPubKey = from_pubkey(Tx),
     aesc_utils:process_solo_snapshot(ChannelId, FromPubKey, Nonce, Fee, Payload, Trees).

--- a/apps/aechannel/src/aesc_snapshot_solo_tx.erl
+++ b/apps/aechannel/src/aesc_snapshot_solo_tx.erl
@@ -110,8 +110,7 @@ check(#channel_snapshot_solo_tx{payload    = Payload,
                                         Payload, Height, Trees).
 
 -spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
-              non_neg_integer(), binary()) ->
-        {ok, aec_trees:trees()}.
+              non_neg_integer(), binary() | no_tx_hash) -> {ok, aec_trees:trees()}.
 process(#channel_snapshot_solo_tx{payload    = Payload,
                                fee        = Fee,
                                nonce      = Nonce} = Tx, _Context, Trees,

--- a/apps/aechannel/src/aesc_withdraw_tx.erl
+++ b/apps/aechannel/src/aesc_withdraw_tx.erl
@@ -18,7 +18,7 @@
          origin/1,
          amount/1,
          check/5,
-         process/5,
+         process/6,
          signers/2,
          serialization_template/1,
          serialize/1,
@@ -140,13 +140,15 @@ check(#channel_withdraw_tx{amount       = Amount,
             Error
     end.
 
--spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) ->
+-spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
+              non_neg_integer(), binary()) ->
         {ok, aec_trees:trees()}.
 process(#channel_withdraw_tx{amount       = Amount,
                              fee          = Fee,
                              state_hash   = StateHash,
                              round        = Round,
-                             nonce        = Nonce} = Tx, _Context, Trees, _Height, _ConsensusVersion) ->
+                             nonce        = Nonce} = Tx, _Context, Trees,
+        _Height, _ConsensusVersion, _TxHash) ->
     ChannelId = channel_hash(Tx),
     ToPubKey = to_pubkey(Tx),
     AccountsTree0 = aec_trees:accounts(Trees),

--- a/apps/aechannel/src/aesc_withdraw_tx.erl
+++ b/apps/aechannel/src/aesc_withdraw_tx.erl
@@ -141,8 +141,7 @@ check(#channel_withdraw_tx{amount       = Amount,
     end.
 
 -spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
-              non_neg_integer(), binary()) ->
-        {ok, aec_trees:trees()}.
+              non_neg_integer(), binary() | no_tx_hash) -> {ok, aec_trees:trees()}.
 process(#channel_withdraw_tx{amount       = Amount,
                              fee          = Fee,
                              state_hash   = StateHash,

--- a/apps/aechannel/test/aesc_test_utils.erl
+++ b/apps/aechannel/test/aesc_test_utils.erl
@@ -168,7 +168,8 @@ set_channel(Channel, State) ->
 apply_on_trees_without_sigs_check([SignedTx], Trees, Height, ConsensusVersion) ->
     Tx = aetx_sign:tx(SignedTx),
     {ok, Trees1} = aetx:check(Tx, Trees, Height, ConsensusVersion),
-    {ok, Trees2} = aetx:process(Tx, Trees1, Height, ConsensusVersion),
+    {ok, Trees2} = aetx:process(Tx, Trees1, Height, ConsensusVersion,
+                                aetx_sign:hash(SignedTx)),
     {ok, [SignedTx], Trees2}.
 
 %%%===================================================================

--- a/apps/aechannel/test/aesc_test_utils.erl
+++ b/apps/aechannel/test/aesc_test_utils.erl
@@ -168,8 +168,8 @@ set_channel(Channel, State) ->
 apply_on_trees_without_sigs_check([SignedTx], Trees, Height, ConsensusVersion) ->
     Tx = aetx_sign:tx(SignedTx),
     {ok, Trees1} = aetx:check(Tx, Trees, Height, ConsensusVersion),
-    {ok, Trees2} = aetx:process(Tx, Trees1, Height, ConsensusVersion,
-                                aetx_sign:hash(SignedTx)),
+    {ok, Trees2} = aetx:process_with_tx_hash(Tx, Trees1, Height, ConsensusVersion,
+                                             aetx_sign:hash(SignedTx)),
     {ok, [SignedTx], Trees2}.
 
 %%%===================================================================

--- a/apps/aecontract/src/aect_call_tx.erl
+++ b/apps/aecontract/src/aect_call_tx.erl
@@ -152,8 +152,7 @@ signers(Tx, _) ->
     {ok, [caller_pubkey(Tx)]}.
 
 -spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
-              non_neg_integer(), binary()) ->
-        {ok, aec_trees:trees()}.
+              non_neg_integer(), binary() | no_tx_hash) -> {ok, aec_trees:trees()}.
 process(#contract_call_tx{nonce = Nonce,
                           fee = Fee, gas =_Gas, gas_price = GasPrice, amount = Value
                          } = CallTx, Context, Trees1, Height,

--- a/apps/aecontract/src/aect_call_tx.erl
+++ b/apps/aecontract/src/aect_call_tx.erl
@@ -18,7 +18,7 @@
          nonce/1,
          origin/1,
          check/5,
-         process/5,
+         process/6,
          signers/2,
          serialization_template/1,
          serialize/1,
@@ -151,11 +151,13 @@ check(#contract_call_tx{nonce = Nonce,
 signers(Tx, _) ->
     {ok, [caller_pubkey(Tx)]}.
 
--spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) ->
+-spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
+              non_neg_integer(), binary()) ->
         {ok, aec_trees:trees()}.
 process(#contract_call_tx{nonce = Nonce,
                           fee = Fee, gas =_Gas, gas_price = GasPrice, amount = Value
-                         } = CallTx, Context, Trees1, Height, ConsensusVersion) ->
+                         } = CallTx, Context, Trees1, Height,
+        ConsensusVersion, _TxHash) ->
 
     %% Transfer the attached funds to the callee (before calling the contract!)
     CallerPubKey = caller_pubkey(CallTx),

--- a/apps/aecontract/src/aect_create_tx.erl
+++ b/apps/aecontract/src/aect_create_tx.erl
@@ -18,7 +18,7 @@
          nonce/1,
          origin/1,
          check/5,
-         process/5,
+         process/6,
          signers/2,
          serialization_template/1,
          serialize/1,
@@ -205,7 +205,8 @@ check(#contract_create_tx{nonce = Nonce,
 signers(#contract_create_tx{} = Tx, _) ->
     {ok, [owner_pubkey(Tx)]}.
 
--spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) ->
+-spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
+              non_neg_integer(), binary()) ->
         {ok, aec_trees:trees()}.
 process(#contract_create_tx{nonce      = Nonce,
                             vm_version = _VmVersion,
@@ -214,7 +215,7 @@ process(#contract_create_tx{nonce      = Nonce,
                             gas_price  = GasPrice,
                             deposit    = _Deposit,
                             fee        = Fee} = CreateTx,
-        Context, Trees0, Height, ConsensusVersion) ->
+        Context, Trees0, Height, ConsensusVersion, _TxHash) ->
     OwnerPubKey = owner_pubkey(CreateTx),
 
     {ContractPubKey, Contract, Trees1} = create_contract(CreateTx, Trees0),
@@ -281,7 +282,7 @@ spend(SenderPubKey, ReceiverPubKey, Value, Fee, Nonce,
             Trees2;
         aetx_transaction ->
             {ok, Trees2} =
-                aetx:process(SpendTx, Trees1, Height, ConsensusVersion),
+                aetx:process_no_tx_hash(SpendTx, Trees1, Height, ConsensusVersion),
             Trees2
     end.
 

--- a/apps/aecontract/src/aect_create_tx.erl
+++ b/apps/aecontract/src/aect_create_tx.erl
@@ -206,8 +206,7 @@ signers(#contract_create_tx{} = Tx, _) ->
     {ok, [owner_pubkey(Tx)]}.
 
 -spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
-              non_neg_integer(), binary()) ->
-        {ok, aec_trees:trees()}.
+              non_neg_integer(), binary() | no_tx_hash) -> {ok, aec_trees:trees()}.
 process(#contract_create_tx{nonce      = Nonce,
                             vm_version = _VmVersion,
                             amount     = Amount,

--- a/apps/aecontract/src/aect_create_tx.erl
+++ b/apps/aecontract/src/aect_create_tx.erl
@@ -281,7 +281,7 @@ spend(SenderPubKey, ReceiverPubKey, Value, Fee, Nonce,
             Trees2;
         aetx_transaction ->
             {ok, Trees2} =
-                aetx:process_no_tx_hash(SpendTx, Trees1, Height, ConsensusVersion),
+                aetx:process(SpendTx, Trees1, Height, ConsensusVersion),
             Trees2
     end.
 

--- a/apps/aecore/src/aec_spend_tx.erl
+++ b/apps/aecore/src/aec_spend_tx.erl
@@ -143,7 +143,7 @@ check(#spend_tx{} = SpendTx, _Context, Trees, Height, _ConsensusVersion) ->
 signers(#spend_tx{} = Tx, _) -> {ok, [sender_pubkey(Tx)]}.
 
 -spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
-              non_neg_integer(), binary()) -> {ok, aec_trees:trees()}.
+              non_neg_integer(), binary() | no_tx_hash) -> {ok, aec_trees:trees()}.
 process(#spend_tx{amount = Amount,
                   fee = Fee,
                   nonce = Nonce} = Tx, _Context, Trees0, _Height,

--- a/apps/aecore/src/aec_spend_tx.erl
+++ b/apps/aecore/src/aec_spend_tx.erl
@@ -13,7 +13,7 @@
          origin/1,
          recipient/1,
          check/5,
-         process/5,
+         process/6,
          signers/2,
          serialization_template/1,
          serialize/1,
@@ -142,10 +142,13 @@ check(#spend_tx{} = SpendTx, _Context, Trees, Height, _ConsensusVersion) ->
 -spec signers(tx(), aec_trees:trees()) -> {ok, [aec_keys:pubkey()]}.
 signers(#spend_tx{} = Tx, _) -> {ok, [sender_pubkey(Tx)]}.
 
--spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) -> {ok, aec_trees:trees()}.
+-spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
+              non_neg_integer(), binary()) -> {ok, aec_trees:trees()}.
 process(#spend_tx{amount = Amount,
                   fee = Fee,
-                  nonce = Nonce} = Tx, _Context, Trees0, _Height, _ConsensusVersion) ->
+                  nonce = Nonce} = Tx, _Context, Trees0, _Height,
+        _ConsensusVersion,
+        _TxHash) ->
     SenderPubkey = sender_pubkey(Tx),
     {ok, RecipientPubkey} = resolve_recipient(Tx, Trees0),
     AccountsTrees0 = aec_trees:accounts(Trees0),

--- a/apps/aecore/src/aec_trees.erl
+++ b/apps/aecore/src/aec_trees.erl
@@ -353,7 +353,9 @@ apply_txs_on_state_trees([SignedTx | Rest], ValidTxs, InvalidTxs, Trees0, Height
             Tx = aetx_sign:tx(SignedTx),
             case aetx:check(Tx, Trees0, Height, ConsensusVersion) of
                 {ok, Trees1} ->
-                    {ok, Trees2} = aetx:process(Tx, Trees1, Height, ConsensusVersion),
+                    {ok, Trees2} = aetx:process(Tx, Trees1, Height,
+                                                ConsensusVersion,
+                                                aetx_sign:hash(SignedTx)),
                     apply_txs_on_state_trees(Rest, [SignedTx | ValidTxs], InvalidTxs,
                                              Trees2, Height, ConsensusVersion, Strict);
                 {error, Reason} when Strict ->

--- a/apps/aecore/src/aec_trees.erl
+++ b/apps/aecore/src/aec_trees.erl
@@ -353,9 +353,9 @@ apply_txs_on_state_trees([SignedTx | Rest], ValidTxs, InvalidTxs, Trees0, Height
             Tx = aetx_sign:tx(SignedTx),
             case aetx:check(Tx, Trees0, Height, ConsensusVersion) of
                 {ok, Trees1} ->
-                    {ok, Trees2} = aetx:process(Tx, Trees1, Height,
-                                                ConsensusVersion,
-                                                aetx_sign:hash(SignedTx)),
+                    {ok, Trees2} = aetx:process_with_tx_hash(Tx, Trees1, Height,
+                                                             ConsensusVersion,
+                                                             aetx_sign:hash(SignedTx)),
                     apply_txs_on_state_trees(Rest, [SignedTx | ValidTxs], InvalidTxs,
                                              Trees2, Height, ConsensusVersion, Strict);
                 {error, Reason} when Strict ->

--- a/apps/aecore/test/aec_spend_tx_tests.erl
+++ b/apps/aecore/test/aec_spend_tx_tests.erl
@@ -95,7 +95,8 @@ process_test_() ->
                                                  payload => <<"foo">>}),
               <<"foo">> = aec_spend_tx:payload(aetx:tx(SpendTx)),
               {ok, StateTree0} = aetx:check(SpendTx, StateTree0, 20, ?PROTOCOL_VERSION),
-              {ok, StateTree} = aetx:process(SpendTx, StateTree0, 20, ?PROTOCOL_VERSION),
+              {ok, StateTree} = aetx:process_no_tx_hash(SpendTx, StateTree0, 20,
+                                             ?PROTOCOL_VERSION),
 
               ResultAccountsTree = aec_trees:accounts(StateTree),
               {value, ResultSenderAccount} = aec_accounts_trees:lookup(?SENDER_PUBKEY, ResultAccountsTree),
@@ -118,7 +119,8 @@ process_test_() ->
                                                  nonce => 11,
                                                  payload => <<"foo">>}),
               {ok, StateTree0} = aetx:check(SpendTx, StateTree0, 20, ?PROTOCOL_VERSION),
-              {ok, StateTree} = aetx:process(SpendTx, StateTree0, 20, ?PROTOCOL_VERSION),
+              {ok, StateTree} = aetx:process_no_tx_hash(SpendTx, StateTree0, 20,
+                                             ?PROTOCOL_VERSION),
 
               ResultAccountsTree = aec_trees:accounts(StateTree),
               {value, ResultAccount} = aec_accounts_trees:lookup(?SENDER_PUBKEY, ResultAccountsTree),

--- a/apps/aecore/test/aec_spend_tx_tests.erl
+++ b/apps/aecore/test/aec_spend_tx_tests.erl
@@ -95,7 +95,7 @@ process_test_() ->
                                                  payload => <<"foo">>}),
               <<"foo">> = aec_spend_tx:payload(aetx:tx(SpendTx)),
               {ok, StateTree0} = aetx:check(SpendTx, StateTree0, 20, ?PROTOCOL_VERSION),
-              {ok, StateTree} = aetx:process_no_tx_hash(SpendTx, StateTree0, 20,
+              {ok, StateTree} = aetx:process(SpendTx, StateTree0, 20,
                                              ?PROTOCOL_VERSION),
 
               ResultAccountsTree = aec_trees:accounts(StateTree),
@@ -119,7 +119,7 @@ process_test_() ->
                                                  nonce => 11,
                                                  payload => <<"foo">>}),
               {ok, StateTree0} = aetx:check(SpendTx, StateTree0, 20, ?PROTOCOL_VERSION),
-              {ok, StateTree} = aetx:process_no_tx_hash(SpendTx, StateTree0, 20,
+              {ok, StateTree} = aetx:process(SpendTx, StateTree0, 20,
                                              ?PROTOCOL_VERSION),
 
               ResultAccountsTree = aec_trees:accounts(StateTree),

--- a/apps/aens/src/aens_claim_tx.erl
+++ b/apps/aens/src/aens_claim_tx.erl
@@ -17,7 +17,7 @@
          nonce/1,
          origin/1,
          check/5,
-         process/5,
+         process/6,
          signers/2,
          serialization_template/1,
          serialize/1,
@@ -114,11 +114,12 @@ check(#ns_claim_tx{nonce = Nonce, fee = Fee, name = Name, name_salt = NameSalt} 
             {error, Reason}
     end.
 
--spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) ->
+-spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
+              non_neg_integer(), binary()) ->
         {ok, aec_trees:trees()}.
 process(#ns_claim_tx{nonce = Nonce, fee = Fee, name = PlainName,
                      name_salt = NameSalt} = ClaimTx,
-        _Context, Trees0, Height, _ConsensusVersion) ->
+        _Context, Trees0, Height, _ConsensusVersion, _TxHash) ->
     AccountPubKey = account_pubkey(ClaimTx),
     AccountsTree0 = aec_trees:accounts(Trees0),
     NSTree0 = aec_trees:ns(Trees0),

--- a/apps/aens/src/aens_claim_tx.erl
+++ b/apps/aens/src/aens_claim_tx.erl
@@ -115,8 +115,7 @@ check(#ns_claim_tx{nonce = Nonce, fee = Fee, name = Name, name_salt = NameSalt} 
     end.
 
 -spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
-              non_neg_integer(), binary()) ->
-        {ok, aec_trees:trees()}.
+              non_neg_integer(), binary() | no_tx_hash) -> {ok, aec_trees:trees()}.
 process(#ns_claim_tx{nonce = Nonce, fee = Fee, name = PlainName,
                      name_salt = NameSalt} = ClaimTx,
         _Context, Trees0, Height, _ConsensusVersion, _TxHash) ->

--- a/apps/aens/src/aens_preclaim_tx.erl
+++ b/apps/aens/src/aens_preclaim_tx.erl
@@ -17,7 +17,7 @@
          nonce/1,
          origin/1,
          check/5,
-         process/5,
+         process/6,
          signers/2,
          serialization_template/1,
          serialize/1,
@@ -104,10 +104,11 @@ check(#ns_preclaim_tx{nonce = Nonce, fee = Fee} = Tx,
         {error, Reason} -> {error, Reason}
     end.
 
--spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) ->
+-spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
+              non_neg_integer(), binary()) ->
         {ok, aec_trees:trees()}.
 process(#ns_preclaim_tx{fee = Fee, nonce = Nonce} = PreclaimTx,
-        _Context, Trees0, Height, _ConsensusVersion) ->
+        _Context, Trees0, Height, _ConsensusVersion, _TxHash) ->
     AccountPubKey = account_pubkey(PreclaimTx),
     AccountsTree0 = aec_trees:accounts(Trees0),
     NSTree0 = aec_trees:ns(Trees0),

--- a/apps/aens/src/aens_preclaim_tx.erl
+++ b/apps/aens/src/aens_preclaim_tx.erl
@@ -105,8 +105,7 @@ check(#ns_preclaim_tx{nonce = Nonce, fee = Fee} = Tx,
     end.
 
 -spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
-              non_neg_integer(), binary()) ->
-        {ok, aec_trees:trees()}.
+              non_neg_integer(), binary() | no_tx_hash) -> {ok, aec_trees:trees()}.
 process(#ns_preclaim_tx{fee = Fee, nonce = Nonce} = PreclaimTx,
         _Context, Trees0, Height, _ConsensusVersion, _TxHash) ->
     AccountPubKey = account_pubkey(PreclaimTx),

--- a/apps/aens/src/aens_revoke_tx.erl
+++ b/apps/aens/src/aens_revoke_tx.erl
@@ -109,8 +109,7 @@ check(#ns_revoke_tx{nonce = Nonce, fee = Fee} = Tx,
     end.
 
 -spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
-              non_neg_integer(), binary()) ->
-        {ok, aec_trees:trees()}.
+              non_neg_integer(), binary() | no_tx_hash) -> {ok, aec_trees:trees()}.
 process(#ns_revoke_tx{fee = Fee, nonce = Nonce} = Tx,
         _Context, Trees0, Height, _ConsensusVersion, _TxHash) ->
     AccountPubKey = account_pubkey(Tx),

--- a/apps/aens/src/aens_revoke_tx.erl
+++ b/apps/aens/src/aens_revoke_tx.erl
@@ -16,7 +16,7 @@
          nonce/1,
          origin/1,
          check/5,
-         process/5,
+         process/6,
          signers/2,
          serialization_template/1,
          serialize/1,
@@ -108,10 +108,11 @@ check(#ns_revoke_tx{nonce = Nonce, fee = Fee} = Tx,
         {error, Reason} -> {error, Reason}
     end.
 
--spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) ->
+-spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
+              non_neg_integer(), binary()) ->
         {ok, aec_trees:trees()}.
 process(#ns_revoke_tx{fee = Fee, nonce = Nonce} = Tx,
-        _Context, Trees0, Height, _ConsensusVersion) ->
+        _Context, Trees0, Height, _ConsensusVersion, _TxHash) ->
     AccountPubKey = account_pubkey(Tx),
     NameHash = name_hash(Tx),
     AccountsTree0 = aec_trees:accounts(Trees0),

--- a/apps/aens/src/aens_transfer_tx.erl
+++ b/apps/aens/src/aens_transfer_tx.erl
@@ -124,8 +124,7 @@ check(#ns_transfer_tx{nonce = Nonce, fee = Fee} = Tx,
     end.
 
 -spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
-              non_neg_integer(), binary()) ->
-        {ok, aec_trees:trees()}.
+              non_neg_integer(), binary() | no_tx_hash) -> {ok, aec_trees:trees()}.
 process(#ns_transfer_tx{fee = Fee, nonce = Nonce} = TransferTx,
         _Context, Trees0, _Height, _ConsensusVersion, _TxHash) ->
     NameHash = name_hash(TransferTx),

--- a/apps/aens/src/aens_transfer_tx.erl
+++ b/apps/aens/src/aens_transfer_tx.erl
@@ -17,7 +17,7 @@
          nonce/1,
          origin/1,
          check/5,
-         process/5,
+         process/6,
          signers/2,
          serialization_template/1,
          serialize/1,
@@ -123,10 +123,11 @@ check(#ns_transfer_tx{nonce = Nonce, fee = Fee} = Tx,
         {error, Reason} -> {error, Reason}
     end.
 
--spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) ->
+-spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
+              non_neg_integer(), binary()) ->
         {ok, aec_trees:trees()}.
 process(#ns_transfer_tx{fee = Fee, nonce = Nonce} = TransferTx,
-        _Context, Trees0, _Height, _ConsensusVersion) ->
+        _Context, Trees0, _Height, _ConsensusVersion, _TxHash) ->
     NameHash = name_hash(TransferTx),
     AccountPubKey = account_pubkey(TransferTx),
     AccountsTree0 = aec_trees:accounts(Trees0),

--- a/apps/aens/src/aens_update_tx.erl
+++ b/apps/aens/src/aens_update_tx.erl
@@ -125,8 +125,7 @@ check(#ns_update_tx{nonce = Nonce, fee = Fee, name_ttl = NTTL} = Tx,
     end.
 
 -spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
-              non_neg_integer(), binary()) ->
-        {ok, aec_trees:trees()}.
+              non_neg_integer(), binary() | no_tx_hash) -> {ok, aec_trees:trees()}.
 process(#ns_update_tx{nonce = Nonce, fee = Fee} = UpdateTx,
         _Context, Trees0, Height, _ConsensusVersion, _TxHash) ->
     AccountPubKey = account_pubkey(UpdateTx),

--- a/apps/aens/src/aens_update_tx.erl
+++ b/apps/aens/src/aens_update_tx.erl
@@ -17,7 +17,7 @@
          nonce/1,
          origin/1,
          check/5,
-         process/5,
+         process/6,
          signers/2,
          serialization_template/1,
          serialize/1,
@@ -124,10 +124,11 @@ check(#ns_update_tx{nonce = Nonce, fee = Fee, name_ttl = NTTL} = Tx,
         {error, Reason} -> {error, Reason}
     end.
 
--spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) ->
+-spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
+              non_neg_integer(), binary()) ->
         {ok, aec_trees:trees()}.
 process(#ns_update_tx{nonce = Nonce, fee = Fee} = UpdateTx,
-        _Context, Trees0, Height, _ConsensusVersion) ->
+        _Context, Trees0, Height, _ConsensusVersion, _TxHash) ->
     AccountPubKey = account_pubkey(UpdateTx),
     NameHash = name_hash(UpdateTx),
     AccountsTree0 = aec_trees:accounts(Trees0),

--- a/apps/aeoracle/src/aeo_extend_tx.erl
+++ b/apps/aeoracle/src/aeo_extend_tx.erl
@@ -18,7 +18,7 @@
          nonce/1,
          origin/1,
          check/5,
-         process/5,
+         process/6,
          signers/2,
          serialize/1,
          serialization_template/1,
@@ -115,10 +115,11 @@ check(#oracle_extend_tx{nonce = Nonce, oracle_ttl = OTTL, fee = Fee} = Tx,
 signers(#oracle_extend_tx{} = Tx, _) ->
     {ok, [oracle_pubkey(Tx)]}.
 
--spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) ->
+-spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
+              non_neg_integer(), binary()) ->
         {ok, aec_trees:trees()}.
 process(#oracle_extend_tx{nonce = Nonce, fee = Fee, oracle_ttl = OTTL} = Tx,
-        _Context, Trees0, _Height, _ConsensusVersion) ->
+        _Context, Trees0, _Height, _ConsensusVersion, _TxHash) ->
     OraclePK      = aec_id:specialize(oracle(Tx), oracle),
     AccountsTree0 = aec_trees:accounts(Trees0),
     OraclesTree0  = aec_trees:oracles(Trees0),

--- a/apps/aeoracle/src/aeo_extend_tx.erl
+++ b/apps/aeoracle/src/aeo_extend_tx.erl
@@ -116,8 +116,7 @@ signers(#oracle_extend_tx{} = Tx, _) ->
     {ok, [oracle_pubkey(Tx)]}.
 
 -spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
-              non_neg_integer(), binary()) ->
-        {ok, aec_trees:trees()}.
+              non_neg_integer(), binary() | no_tx_hash) -> {ok, aec_trees:trees()}.
 process(#oracle_extend_tx{nonce = Nonce, fee = Fee, oracle_ttl = OTTL} = Tx,
         _Context, Trees0, _Height, _ConsensusVersion, _TxHash) ->
     OraclePK      = aec_id:specialize(oracle(Tx), oracle),

--- a/apps/aeoracle/src/aeo_query_tx.erl
+++ b/apps/aeoracle/src/aeo_query_tx.erl
@@ -18,7 +18,7 @@
          nonce/1,
          origin/1,
          check/5,
-         process/5,
+         process/6,
          signers/2,
          serialization_template/1,
          serialize/1,
@@ -164,10 +164,12 @@ check(#oracle_query_tx{nonce = Nonce, query_fee = QFee, query_ttl = QTTL,
 signers(#oracle_query_tx{} = Tx, _) ->
     {ok, [sender_pubkey(Tx)]}.
 
--spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) ->
+-spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
+              non_neg_integer(), binary()) ->
         {ok, aec_trees:trees()}.
 process(#oracle_query_tx{nonce = Nonce, fee = Fee,
-                         query_fee = QueryFee} = QueryTx, _Context, Trees0, Height, _ConsensusVersion) ->
+                         query_fee = QueryFee} = QueryTx, _Context, Trees0,
+        Height, _ConsensusVersion, _TxHash) ->
     SenderPubKey  = sender_pubkey(QueryTx),
     OraclePubKey  = oracle_pubkey(QueryTx),
     AccountsTree0 = aec_trees:accounts(Trees0),

--- a/apps/aeoracle/src/aeo_query_tx.erl
+++ b/apps/aeoracle/src/aeo_query_tx.erl
@@ -165,8 +165,7 @@ signers(#oracle_query_tx{} = Tx, _) ->
     {ok, [sender_pubkey(Tx)]}.
 
 -spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
-              non_neg_integer(), binary()) ->
-        {ok, aec_trees:trees()}.
+              non_neg_integer(), binary() | no_tx_hash) -> {ok, aec_trees:trees()}.
 process(#oracle_query_tx{nonce = Nonce, fee = Fee,
                          query_fee = QueryFee} = QueryTx, _Context, Trees0,
         Height, _ConsensusVersion, _TxHash) ->

--- a/apps/aeoracle/src/aeo_register_tx.erl
+++ b/apps/aeoracle/src/aeo_register_tx.erl
@@ -18,7 +18,7 @@
          nonce/1,
          origin/1,
          check/5,
-         process/5,
+         process/6,
          signers/2,
          serialization_template/1,
          serialize/1,
@@ -139,10 +139,11 @@ check(#oracle_register_tx{nonce = Nonce, oracle_ttl = OTTL, fee = Fee} = Tx,
 signers(#oracle_register_tx{} = Tx, _) ->
     {ok, [account_pubkey(Tx)]}.
 
--spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) ->
+-spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
+              non_neg_integer(), binary()) ->
         {ok, aec_trees:trees()}.
 process(#oracle_register_tx{nonce = Nonce, fee = Fee} = RegisterTx,
-        _Ctxt, Trees0, Height, _ConsensusVersion) ->
+        _Ctxt, Trees0, Height, _ConsensusVersion, _TxHash) ->
     AccountPubKey = aec_id:specialize(account(RegisterTx), account),
     AccountsTree0 = aec_trees:accounts(Trees0),
     OraclesTree0  = aec_trees:oracles(Trees0),

--- a/apps/aeoracle/src/aeo_register_tx.erl
+++ b/apps/aeoracle/src/aeo_register_tx.erl
@@ -140,8 +140,7 @@ signers(#oracle_register_tx{} = Tx, _) ->
     {ok, [account_pubkey(Tx)]}.
 
 -spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
-              non_neg_integer(), binary()) ->
-        {ok, aec_trees:trees()}.
+              non_neg_integer(), binary() | no_tx_hash) -> {ok, aec_trees:trees()}.
 process(#oracle_register_tx{nonce = Nonce, fee = Fee} = RegisterTx,
         _Ctxt, Trees0, Height, _ConsensusVersion, _TxHash) ->
     AccountPubKey = aec_id:specialize(account(RegisterTx), account),

--- a/apps/aeoracle/src/aeo_response_tx.erl
+++ b/apps/aeoracle/src/aeo_response_tx.erl
@@ -133,8 +133,7 @@ signers(#oracle_response_tx{} = Tx, _) ->
     {ok, [oracle_pubkey(Tx)]}.
 
 -spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
-              non_neg_integer(), binary()) ->
-        {ok, aec_trees:trees()}.
+              non_neg_integer(), binary() | no_tx_hash) -> {ok, aec_trees:trees()}.
 process(#oracle_response_tx{nonce = Nonce, query_id = QId, response = Response,
                             fee = Fee} = Tx,
         _Context, Trees0, Height, _ConsensusVersion, _TxHash) ->

--- a/apps/aeoracle/src/aeo_response_tx.erl
+++ b/apps/aeoracle/src/aeo_response_tx.erl
@@ -18,7 +18,7 @@
          nonce/1,
          origin/1,
          check/5,
-         process/5,
+         process/6,
          signers/2,
          serialization_template/1,
          serialize/1,
@@ -132,11 +132,12 @@ check(#oracle_response_tx{nonce = Nonce, query_id = QId, fee = Fee} = Tx,
 signers(#oracle_response_tx{} = Tx, _) ->
     {ok, [oracle_pubkey(Tx)]}.
 
--spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) ->
+-spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
+              non_neg_integer(), binary()) ->
         {ok, aec_trees:trees()}.
 process(#oracle_response_tx{nonce = Nonce, query_id = QId, response = Response,
                             fee = Fee} = Tx,
-        _Context, Trees0, Height, _ConsensusVersion) ->
+        _Context, Trees0, Height, _ConsensusVersion, _TxHash) ->
     OraclePubKey  = oracle_pubkey(Tx),
     AccountsTree0 = aec_trees:accounts(Trees0),
     OraclesTree0  = aec_trees:oracles(Trees0),

--- a/apps/aetx/src/aetx.erl
+++ b/apps/aetx/src/aetx.erl
@@ -15,8 +15,8 @@
         , new/2
         , nonce/1
         , origin/1
-        , process_no_tx_hash/4
-        , process/5
+        , process/4
+        , process_with_tx_hash/5
         , process_from_contract/4
         , serialize_for_client/1
         , serialize_to_binary/1
@@ -222,16 +222,16 @@ check_from_contract(#aetx{ cb = CB, tx = Tx }, Trees, Height, ConsensusVersion) 
     CB:check(Tx, aetx_contract, Trees, Height, ConsensusVersion).
 
 
--spec process_no_tx_hash(Tx :: tx(), Trees :: aec_trees:trees(), Height :: non_neg_integer(),
+-spec process(Tx :: tx(), Trees :: aec_trees:trees(), Height :: non_neg_integer(),
               ConsensusVersion :: non_neg_integer()) ->
     {ok, NewTrees :: aec_trees:trees()}.
-process_no_tx_hash(Tx, Trees, Height, ConsensusVersion) ->
-    process(Tx, Trees, Height, ConsensusVersion, no_tx_hash).
+process(Tx, Trees, Height, ConsensusVersion) ->
+    process_with_tx_hash(Tx, Trees, Height, ConsensusVersion, no_tx_hash).
 
--spec process(Tx :: tx(), Trees :: aec_trees:trees(), Height :: non_neg_integer(),
+-spec process_with_tx_hash(Tx :: tx(), Trees :: aec_trees:trees(), Height :: non_neg_integer(),
               ConsensusVersion :: non_neg_integer(), TxHash :: binary() | no_tx_hash) ->
     {ok, NewTrees :: aec_trees:trees()}.
-process(#aetx{ cb = CB, tx = Tx }, Trees, Height, ConsensusVersion, TxHash) ->
+process_with_tx_hash(#aetx{ cb = CB, tx = Tx }, Trees, Height, ConsensusVersion, TxHash) ->
     CB:process(Tx, aetx_transaction, Trees, Height, ConsensusVersion, TxHash).
 
 -spec process_from_contract(Tx :: tx(), Trees :: aec_trees:trees(), Height :: non_neg_integer(),

--- a/apps/aetx/src/aetx.erl
+++ b/apps/aetx/src/aetx.erl
@@ -131,7 +131,7 @@
 -callback process(Tx :: tx_instance(), Context :: tx_context(),
                   Trees :: aec_trees:trees(), Height :: non_neg_integer(),
                   ConsensusVersion :: non_neg_integer(),
-                  TxHash :: binary()) ->
+                  TxHash :: binary() | no_tx_hash) ->
     {ok, NewTrees :: aec_trees:trees()}.
 
 -callback serialize(Tx :: tx_instance()) ->
@@ -226,10 +226,10 @@ check_from_contract(#aetx{ cb = CB, tx = Tx }, Trees, Height, ConsensusVersion) 
               ConsensusVersion :: non_neg_integer()) ->
     {ok, NewTrees :: aec_trees:trees()}.
 process_no_tx_hash(Tx, Trees, Height, ConsensusVersion) ->
-    process(Tx, Trees, Height, ConsensusVersion, <<>>).
+    process(Tx, Trees, Height, ConsensusVersion, no_tx_hash).
 
 -spec process(Tx :: tx(), Trees :: aec_trees:trees(), Height :: non_neg_integer(),
-              ConsensusVersion :: non_neg_integer(), TxHash :: binary()) ->
+              ConsensusVersion :: non_neg_integer(), TxHash :: binary() | no_tx_hash) ->
     {ok, NewTrees :: aec_trees:trees()}.
 process(#aetx{ cb = CB, tx = Tx }, Trees, Height, ConsensusVersion, TxHash) ->
     CB:process(Tx, aetx_transaction, Trees, Height, ConsensusVersion, TxHash).
@@ -239,7 +239,7 @@ process(#aetx{ cb = CB, tx = Tx }, Trees, Height, ConsensusVersion, TxHash) ->
     {ok, NewTrees :: aec_trees:trees()}.
 
 process_from_contract(#aetx{ cb = CB, tx = Tx }, Trees, Height, ConsensusVersion) ->
-    CB:process(Tx, aetx_contract, Trees, Height, ConsensusVersion, <<>>).
+    CB:process(Tx, aetx_contract, Trees, Height, ConsensusVersion, no_tx_hash).
 
 -spec serialize_for_client(Tx :: tx()) -> map().
 serialize_for_client(#aetx{ cb = CB, type = Type, tx = Tx }) ->

--- a/apps/aetx/src/aetx.erl
+++ b/apps/aetx/src/aetx.erl
@@ -15,7 +15,8 @@
         , new/2
         , nonce/1
         , origin/1
-        , process/4
+        , process_no_tx_hash/4
+        , process/5
         , process_from_contract/4
         , serialize_for_client/1
         , serialize_to_binary/1
@@ -129,7 +130,8 @@
 
 -callback process(Tx :: tx_instance(), Context :: tx_context(),
                   Trees :: aec_trees:trees(), Height :: non_neg_integer(),
-                  ConsensusVersion :: non_neg_integer()) ->
+                  ConsensusVersion :: non_neg_integer(),
+                  TxHash :: binary()) ->
     {ok, NewTrees :: aec_trees:trees()}.
 
 -callback serialize(Tx :: tx_instance()) ->
@@ -219,18 +221,25 @@ check(AeTx = #aetx{ cb = CB, tx = Tx }, Trees, Height, ConsensusVersion) ->
 check_from_contract(#aetx{ cb = CB, tx = Tx }, Trees, Height, ConsensusVersion) ->
     CB:check(Tx, aetx_contract, Trees, Height, ConsensusVersion).
 
--spec process(Tx :: tx(), Trees :: aec_trees:trees(), Height :: non_neg_integer(),
+
+-spec process_no_tx_hash(Tx :: tx(), Trees :: aec_trees:trees(), Height :: non_neg_integer(),
               ConsensusVersion :: non_neg_integer()) ->
     {ok, NewTrees :: aec_trees:trees()}.
-process(#aetx{ cb = CB, tx = Tx }, Trees, Height, ConsensusVersion) ->
-    CB:process(Tx, aetx_transaction, Trees, Height, ConsensusVersion).
+process_no_tx_hash(Tx, Trees, Height, ConsensusVersion) ->
+    process(Tx, Trees, Height, ConsensusVersion, <<>>).
+
+-spec process(Tx :: tx(), Trees :: aec_trees:trees(), Height :: non_neg_integer(),
+              ConsensusVersion :: non_neg_integer(), TxHash :: binary()) ->
+    {ok, NewTrees :: aec_trees:trees()}.
+process(#aetx{ cb = CB, tx = Tx }, Trees, Height, ConsensusVersion, TxHash) ->
+    CB:process(Tx, aetx_transaction, Trees, Height, ConsensusVersion, TxHash).
 
 -spec process_from_contract(Tx :: tx(), Trees :: aec_trees:trees(), Height :: non_neg_integer(),
                             ConsensusVersion :: non_neg_integer()) ->
     {ok, NewTrees :: aec_trees:trees()}.
 
 process_from_contract(#aetx{ cb = CB, tx = Tx }, Trees, Height, ConsensusVersion) ->
-    CB:process(Tx, aetx_contract, Trees, Height, ConsensusVersion).
+    CB:process(Tx, aetx_contract, Trees, Height, ConsensusVersion, <<>>).
 
 -spec serialize_for_client(Tx :: tx()) -> map().
 serialize_for_client(#aetx{ cb = CB, type = Type, tx = Tx }) ->


### PR DESCRIPTION
PT [Expand aetx:process callback with TxHash](https://www.pivotaltracker.com/story/show/159887336)
This is a requirement for forcing of progress where the call's id will use the transaction hash for its contract id.

Tracked as a separate PT for easier review