### PR TITLE
mine few more blocks to prevent micro forks

### DIFF
--- a/apps/aecore/test/aecore_sync_SUITE.erl
+++ b/apps/aecore/test/aecore_sync_SUITE.erl
@@ -417,7 +417,12 @@ mine_and_compare(N1, Config) ->
     AllNodes = [N || {_, N} <- ?config(nodes, Config)],
     PrevTop = rpc:call(N1, aec_chain, top_block, [], 5000),
     %% If there are txs in the mempool, there will be an additional micro block.
-    {ok, [KeyBlock | _Blocks]} = aecore_suite_utils:mine_key_blocks(N1, 2),
+    %% Micor blocks may result in micro forks, so we need to mine sufficiently many
+    %% blocks.
+    %% Better to use: aecore_suite_utils:mine_blocks_until_txs_on_chain/3, but
+    %% then we need to pass on the TxHashes... which this test structure does
+    %% make difficult.
+    {ok, [KeyBlock | _Blocks]} = aecore_suite_utils:mine_key_blocks(N1, 4),
     true = aec_blocks:is_key_block(KeyBlock),
     NewTop = rpc:call(N1, aec_chain, top_block, [], 5000),
     true = (NewTop =/= PrevTop),


### PR DESCRIPTION
Considerably reduced possibility to hit one of the intermitting failures of our test suite.

This fixes one test in series:
https://www.pivotaltracker.com/story/show/156154502
