### PR TITLE
Pt 159829816 inet blocks aec_peers

### DIFF
--- a/apps/aecore/src/aec_peer_connection.erl
+++ b/apps/aecore/src/aec_peer_connection.erl
@@ -635,7 +635,7 @@ handle_first_ping(S, RemotePingObj) ->
             end,
 
             NewS = maps:remove(first_ping_tref, S#{ port => Port }),
-            case aec_peers:peer_accepted(PeerInfo, self()) of
+            case aec_peers:peer_accepted(PeerInfo, maps:get(address, NewS), self()) of
                 {error, _} = Error ->
                     gen_server:cast(self(), stop),
                     {Error, NewS};

--- a/apps/aecore/src/aec_peers.erl
+++ b/apps/aecore/src/aec_peers.erl
@@ -983,7 +983,7 @@ on_resolve_hostname(Ref, Host, #state{ hostnames = HostMap } = State) ->
 -spec on_add_peer(inet:ip_address(), peer(), state()) -> state().
 on_add_peer(SourceAddr, Peer, State0) ->
     #state{ hostnames = HostMap } = State0,
-    State = maybe_unblock(State0#state{hostnames = maps:remove(Peer#peer.host, HostMap)}),
+    State = maybe_unblock(State0#state{hostnames = maps:remove(to_list(Peer#peer.host), HostMap)}),
     PeerId  = peer_id(Peer),
     #peer{ pubkey = PPK, address = PA, port = PP } = Peer,
     case is_local(PeerId, State) orelse is_blocked(PeerId, State) of

--- a/apps/aecore/src/aec_peers.erl
+++ b/apps/aecore/src/aec_peers.erl
@@ -48,7 +48,7 @@
 
 %% API only to be used by aec_peer_connection.
 -export([peer_connected/2]).
--export([peer_accepted/2]).
+-export([peer_accepted/3]).
 -export([connection_failed/2]).
 -export([connection_closed/2]).
 
@@ -299,15 +299,10 @@ peer_connected(PeerId, PeerCon) ->
 %% @doc Informs that an inbound connection has been accepted.
 %% If it returns `temporary' the connection should be closed as soon as
 %% the first ping has been responded.
--spec peer_accepted(peer_info(), pid())
+-spec peer_accepted(peer_info(), inet:ip_address(), pid())
     -> permanent | temporary | {error, term()}.
-peer_accepted(PeerInfo, PeerCon) ->
-    #{ host := Host } = PeerInfo,
-    case inet:getaddr(to_list(Host), inet) of
-        {error, _} = Error -> Error;
-        {ok, Addr} ->
-            gen_server:call(?MODULE, {peer_accepted, Addr, PeerInfo, PeerCon})
-    end.
+peer_accepted(PeerInfo, Addr, PeerCon) ->
+    gen_server:call(?MODULE, {peer_accepted, Addr, PeerInfo, PeerCon}).
 
 %% @doc Informs that a connection failed unexpectedly; either when connecting
 %% or while already being connected.

--- a/apps/aecore/src/aec_peers.erl
+++ b/apps/aecore/src/aec_peers.erl
@@ -155,7 +155,7 @@ check_env() ->
 add_trusted(PeerInfos) when is_list(PeerInfos) ->
     lists:foreach(fun(I) -> add_trusted(I) end, PeerInfos);
 add_trusted(PeerInfo) ->
-    api_add_peer(undefined, PeerInfo, true).
+    async_add_peer(undefined, PeerInfo, true).
 
 %% @doc Adds a normal peer or a list of normal peers.
 %% The IP address of the node that gave us this peer must be specified.
@@ -163,7 +163,7 @@ add_trusted(PeerInfo) ->
 add_peers(SourceAddr, PeerInfos) when is_list(PeerInfos) ->
     lists:foreach(fun(I) -> add_peers(SourceAddr, I) end, PeerInfos);
 add_peers(SourceAddr, PeerInfo) ->
-    api_add_peer(SourceAddr, PeerInfo, false).
+    async_add_peer(SourceAddr, PeerInfo, false).
 
 %% @doc Removes a peer; if connected, closes the connection.
 %% At the moment also removes peer from the blocked list.
@@ -476,16 +476,6 @@ is_local(PeerId, State) ->
 peer_info(#peer{ host = H, port = P, pubkey = PK }) ->
     #{ host => H, port => P, pubkey => PK }.
 
-%% Creates a peer record from peer's information map.
--spec peer(peer_info(), boolean())
-    -> {ok, peer()} | {error, term()}.
-peer(PeerInfo, IsTrusted) ->
-    #{ host := Host } = PeerInfo,
-    case inet:getaddr(to_list(Host), inet) of
-        {error, _} = Error -> Error;
-        {ok, Addr} -> {ok, peer(Addr, PeerInfo, IsTrusted)}
-    end.
-
 %% Creates a peer record from peer's information and resolved address.
 -spec peer(inet:ip_address(), peer_info(), boolean()) -> peer().
 peer(PeerAddr, PeerInfo, IsTrusted) ->
@@ -554,22 +544,31 @@ update_ping_metrics(Outcome) ->
 %--- API CALLS HELPER FUNCTIONS ------------------------------------------------
 
 %% Adds or update a peer; called in the caller's process.
--spec api_add_peer(inet:ip_address() | undefined, peer_info(), boolean()) -> ok.
-api_add_peer(SourceAddr0, PeerInfo, IsTrusted) ->
-    case peer(PeerInfo, IsTrusted) of
-        {error, nxdomain} ->
-            #{ host := Host } = PeerInfo,
-            epoch_sync:info("Peer ~p - failed to resolve hostname ~p; "
-                            "retrying later", [ppp(PeerInfo), Host]),
-            gen_server:cast(?MODULE, {resolve_peer, SourceAddr0,
-                                      PeerInfo, IsTrusted});
-        {ok, Peer} ->
-            SourceAddr = case SourceAddr0 of
-                undefined -> Peer#peer.address;
-                _ -> SourceAddr0
-            end,
-            gen_server:cast(?MODULE, {add_peer, SourceAddr, Peer})
-    end.
+%% We should not block the caller, so we just spawn to make this happen in 
+%% the background. If the process silently fails in the background, we 
+%% will be able to detect that in the logs since we won't be able to
+%% connect.
+-spec async_add_peer(inet:ip_address() | undefined, peer_info(), boolean()) -> ok.
+async_add_peer(SourceAddr0, #{ host := Host} = PeerInfo, IsTrusted) ->
+    spawn(fun() ->
+             case inet:getaddr(to_list(Host), inet) of
+                 {error, nxdomain} ->
+                     epoch_sync:info("Peer ~p - failed to resolve hostname ~p; "
+                                     "retrying later", [ppp(PeerInfo), Host]),
+                     gen_server:cast(?MODULE, {resolve_peer, SourceAddr0,
+                                               PeerInfo, IsTrusted});
+                 {ok, Addr} when SourceAddr0 == undefined ->
+                     epoch_sync:info("PEER undefined address ~p ~p -> ~p", [Host, SourceAddr0, Addr]),
+                     Peer = peer(Addr, PeerInfo, IsTrusted),
+                     gen_server:cast(?MODULE, {add_peer, Addr, Peer});
+                 {ok, Addr} when SourceAddr0 =/= undefined ->
+                     %% IP address has changed
+                     epoch_sync:info("IP address of peer changed ~p ~p -> ~p", [Host, SourceAddr0, Addr]),
+                     Peer = peer(Addr, PeerInfo, IsTrusted),
+                     gen_server:cast(?MODULE, {add_peer, SourceAddr0, Peer})
+             end
+          end), 
+    ok.
 
 -spec count(connections | inbound | outbound | blocked | peers
             | verified | unverified | available | standby | hostnames, state())
@@ -968,30 +967,14 @@ on_resolve_peer(SourceAddr, PeerInfo, IsTrusted, State) ->
             State#state{ hostnames = HostMap2 }
     end.
 
-%% Handles hostname resolution event.
+%% Handles timeout of hostname resolution event.
 -spec on_resolve_hostname(reference(), string(), state()) -> state().
-on_resolve_hostname(Ref, Host, State) ->
-    #state{ hostnames = HostMap } = State,
+on_resolve_hostname(Ref, Host, #state{ hostnames = HostMap } = State) ->
     case maps:find(Host, HostMap) of
         {ok, {Ref, RetryCount, PeerMap}} ->
-            case inet:getaddr(Host, inet) of
-                {error, nxdomain} ->
-                    epoch_sync:info("Failed to resolve hostname ~p", [Host]),
-                    HostData = {undefined, RetryCount + 1, PeerMap},
-                    HostMap2 = resolver_schedule(Host, HostData, HostMap),
-                    State#state{ hostnames = HostMap2 };
-                {ok, Addr} ->
-                    HostMap2 = maps:remove(Host, HostMap),
-                    State2 = State#state{ hostnames = HostMap2 },
-                    maps:fold(fun
-                        (_, {undefined, PeerInfo, IsTrusted}, S) ->
-                            Peer = peer(Addr, PeerInfo, IsTrusted),
-                            on_add_peer(Addr, Peer, S);
-                        (_, {SourceAddr, PeerInfo, IsTrusted}, S) ->
-                            Peer = peer(Addr, PeerInfo, IsTrusted),
-                            on_add_peer(SourceAddr, Peer, S)
-                    end, State2, PeerMap)
-            end;
+            [ async_add_peer(SourceAddr, PeerInfo, IsTrusted) || 
+                {SourceAddr, PeerInfo, IsTrusted} <- maps:values(PeerMap) ],
+            State#state{ hostnames = HostMap#{ Host => {undefined, RetryCount + 1, PeerMap}}};
         _ ->
             State
     end.
@@ -999,7 +982,8 @@ on_resolve_hostname(Ref, Host, State) ->
 %% Handles event adding a new peer to the pool.
 -spec on_add_peer(inet:ip_address(), peer(), state()) -> state().
 on_add_peer(SourceAddr, Peer, State0) ->
-    State = maybe_unblock(State0),
+    #state{ hostnames = HostMap } = State0,
+    State = maybe_unblock(State0#state{hostnames = maps:remove(Peer#peer.host, HostMap)}),
     PeerId  = peer_id(Peer),
     #peer{ pubkey = PPK, address = PA, port = PP } = Peer,
     case is_local(PeerId, State) orelse is_blocked(PeerId, State) of

--- a/apps/aecore/test/aec_peers_tests.erl
+++ b/apps/aecore/test/aec_peers_tests.erl
@@ -184,12 +184,6 @@ test_single_normal_peer() ->
 
     aec_peers:add_peers(Source, Peer),
 
-    ?assertMatch([Peer], aec_peers:available_peers()),
-    ?assertMatch([Peer], aec_peers:available_peers(both)),
-    ?assertMatch([], aec_peers:available_peers(verified)),
-    ?assertMatch([Peer], aec_peers:available_peers(unverified)),
-    ?assertEqual(1, aec_peers:count(available)),
-
     {ok, Conn} = ?assertCalled(connect, [#{ r_pubkey := PubKey }], {ok, _}, 200),
 
     ?assertMatch([], aec_peers:connected_peers()),

--- a/docs/release-notes/RELEASE-NOTES-0.21.0.md
+++ b/docs/release-notes/RELEASE-NOTES-0.21.0.md
@@ -7,6 +7,7 @@ It:
 * Fixes miner fee reward calculations, was too generous before. This impacts consensus.
 * Modifies the minimum static component of the fee of oracle transactions to `1` - as for all other transactions. This impacts consensus.
 * Increases beneficiary reward delay to 180 key blocks / generations. This impacts consensus.
+* Fixed sporadically seen timeout errors in sync when inet:getaddr took too much time to resolve
 
 [this-release]: https://github.com/aeternity/epoch/releases/tag/v0.21.0
 [digishield_v3]: https://github.com/zawy12/difficulty-algorithms/issues/9

--- a/system_test/aest_perf_SUITE_data/epoch.yaml.mustache
+++ b/system_test/aest_perf_SUITE_data/epoch.yaml.mustache
@@ -33,6 +33,7 @@ mining:
     beneficiary: "ak$2VoAhMd7tVJrDYM5vPJwFRjueZyirDJumVJNeBWL9j1eNTHsRx"
     autostart: {{mining.autostart}}
     micro_block_cycle: 100
+    expected_mine_rate: 1000
     cuckoo:
         miner:
             executable: mean16s-generic

--- a/system_test/aest_sync_SUITE.erl
+++ b/system_test/aest_sync_SUITE.erl
@@ -211,7 +211,7 @@ new_node_joins_network(Cfg) ->
     EndTime = erlang:system_time(seconds),
     %% Average mining time per block
     MiningTime = ((EndTime - StartTime) * 1000) div Length,
-    ct:log("Mining time per block ~p for ~p blocks", [MiningTime, Length]),
+    ct:log("Mining time per block ~p ms for ~p blocks", [MiningTime, Length]),
 
     Top1 = get_top(old_node1),
     ct:log("Node 1 top: ~p", [Top1]),

--- a/system_test/aest_sync_SUITE_data/epoch.yaml.mustache
+++ b/system_test/aest_sync_SUITE_data/epoch.yaml.mustache
@@ -33,6 +33,7 @@ mining:
     beneficiary: "ak$2VoAhMd7tVJrDYM5vPJwFRjueZyirDJumVJNeBWL9j1eNTHsRx"
     autostart: true
     micro_block_cycle: 100
+    expected_mine_rate: 1000
     cuckoo:
         miner:
             executable: mean16s-generic


### PR DESCRIPTION
If inet:getaddr takes too much time, we spend overtime in aec_sync or aec_peers loops. This has caused a number of timeout errors.

This in one go solves tickets reported in:
PT-159829816, PT-159648052, and PT-159490846 

System tests pass locally as well as on a faster machine.