### PR TITLE
Delete unused minimum tx fee for contract and channel txs

### DIFF
--- a/apps/aechannel/src/aesc_close_mutual_tx.erl
+++ b/apps/aechannel/src/aesc_close_mutual_tx.erl
@@ -34,7 +34,6 @@
 
 -define(CHANNEL_CLOSE_MUTUAL_TX_VSN, 1).
 -define(CHANNEL_CLOSE_MUTUAL_TX_TYPE, channel_close_mutual_tx).
--define(CHANNEL_CLOSE_MUTUAL_TX_FEE, 4).
 
 -record(channel_close_mutual_tx, {
           channel_id              :: aec_id:id(),

--- a/apps/aechannel/src/aesc_close_solo_tx.erl
+++ b/apps/aechannel/src/aesc_close_solo_tx.erl
@@ -30,7 +30,6 @@
 
 -define(CHANNEL_CLOSE_SOLO_TX_VSN, 1).
 -define(CHANNEL_CLOSE_SOLO_TX_TYPE, channel_close_solo_tx).
--define(CHANNEL_CLOSE_SOLO_TX_FEE, 4).
 
 -type vsn() :: non_neg_integer().
 

--- a/apps/aechannel/src/aesc_create_tx.erl
+++ b/apps/aechannel/src/aesc_create_tx.erl
@@ -48,7 +48,6 @@
 
 -define(CHANNEL_CREATE_TX_VSN, 1).
 -define(CHANNEL_CREATE_TX_TYPE, channel_create_tx).
--define(CHANNEL_CREATE_TX_FEE, 4).
 
 -type vsn() :: non_neg_integer().
 

--- a/apps/aechannel/src/aesc_deposit_tx.erl
+++ b/apps/aechannel/src/aesc_deposit_tx.erl
@@ -37,7 +37,6 @@
 
 -define(CHANNEL_DEPOSIT_TX_VSN, 1).
 -define(CHANNEL_DEPOSIT_TX_TYPE, channel_deposit_tx).
--define(CHANNEL_DEPOSIT_TX_FEE, 4).
 
 -type vsn() :: non_neg_integer().
 

--- a/apps/aechannel/src/aesc_settle_tx.erl
+++ b/apps/aechannel/src/aesc_settle_tx.erl
@@ -30,7 +30,6 @@
 
 -define(CHANNEL_SETTLE_TX_VSN, 1).
 -define(CHANNEL_SETTLE_TX_TYPE, channel_settle_tx).
--define(CHANNEL_SETTLE_TX_FEE, 4).
 
 -type vsn() :: non_neg_integer().
 

--- a/apps/aechannel/src/aesc_slash_tx.erl
+++ b/apps/aechannel/src/aesc_slash_tx.erl
@@ -30,7 +30,6 @@
 
 -define(CHANNEL_SLASH_TX_VSN, 1).
 -define(CHANNEL_SLASH_TX_TYPE, channel_slash_tx).
--define(CHANNEL_SLASH_TX_FEE, 0).
 
 -type vsn() :: non_neg_integer().
 

--- a/apps/aechannel/src/aesc_snapshot_solo_tx.erl
+++ b/apps/aechannel/src/aesc_snapshot_solo_tx.erl
@@ -30,7 +30,6 @@
 
 -define(CHANNEL_SNAPSHOT_SOLO_TX_VSN, 1).
 -define(CHANNEL_SNAPSHOT_SOLO_TX_TYPE, channel_snapshot_solo_tx).
--define(CHANNEL_SNAPSHOT_SOLO_TX_FEE, 4).
 
 -type vsn() :: non_neg_integer().
 

--- a/apps/aechannel/src/aesc_withdraw_tx.erl
+++ b/apps/aechannel/src/aesc_withdraw_tx.erl
@@ -38,7 +38,6 @@
 
 -define(CHANNEL_WITHDRAW_TX_VSN, 1).
 -define(CHANNEL_WITHDRAW_TX_TYPE, channel_withdraw_tx).
--define(CHANNEL_WITHDRAW_TX_FEE, 4).
 
 -type vsn() :: non_neg_integer().
 

--- a/apps/aecontract/src/aect_call_tx.erl
+++ b/apps/aecontract/src/aect_call_tx.erl
@@ -41,7 +41,6 @@
 
 -define(CONTRACT_CALL_TX_VSN, 1).
 -define(CONTRACT_CALL_TX_TYPE, contract_call_tx).
--define(CONTRACT_CALL_TX_FEE, 2).
 
 -define(is_non_neg_integer(X), (is_integer(X) andalso (X >= 0))).
 

--- a/apps/aecontract/src/aect_create_tx.erl
+++ b/apps/aecontract/src/aect_create_tx.erl
@@ -42,7 +42,6 @@
 
 -define(CONTRACT_CREATE_TX_VSN, 1).
 -define(CONTRACT_CREATE_TX_TYPE, contract_create_tx).
--define(CONTRACT_CREATE_TX_FEE, 4).
 
 %% Should this be in a header file somewhere?
 -define(PUB_SIZE, 32).


### PR DESCRIPTION
In scope of https://www.pivotaltracker.com/story/show/158423604
(The main PR is #1470 , this is a cleanup PR.)

----

Similar macros are present in `aeo_*_tx.erl`. (Dealt with in PR #1470 .)

(`ORACLE_TTL_FEE` in `aeo_utils` is related to state tree objects created by oracle txs.)
