### PR TITLE
PT-160016525 contract types

### DIFF
--- a/apps/aecontract/test/aecontract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_SUITE.erl
@@ -681,7 +681,8 @@ sophia_typed_calls(_Cfg) ->
     16     = ?call(call_contract, Acc, Client, get_n, word, {}),
     {}     = ?call(call_contract, Acc, Client, square, {tuple, []}, {}),
     256    = ?call(call_contract, Acc, Client, get_n, word, {}),
-    300    = ?call(account_balance, Server),
+    {}     = ?call(call_contract, Acc, Client, tip_server, {tuple, []}, {}, #{amount => 100}),
+    400    = ?call(account_balance, Server),
     ok.
 
 %% Oracles tests

--- a/apps/aecontract/test/aecontract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_SUITE.erl
@@ -631,7 +631,7 @@ sophia_identity(_Cfg) ->
     42    = ?call(call_contract,   Acc1, IdC, main, word, 42),
     99    = ?call(call_contract,   Acc1, RemC, call, word, {IdC, 99}),
     RemC2 = ?call(create_contract, Acc1, remote_call, {}, #{amount => 100}),
-    77    = ?call(call_contract,   Acc1, RemC2, staged_call, word, {RemC, IdC, 77}),
+    77    = ?call(call_contract,   Acc1, RemC2, staged_call, word, {IdC, RemC, 77}),
     ok.
 
 sophia_state(_Cfg) ->

--- a/apps/aecontract/test/aecontract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_SUITE.erl
@@ -24,6 +24,7 @@
         , sophia_identity/1
         , sophia_state/1
         , sophia_spend/1
+        , sophia_typed_calls/1
         , sophia_oracles/1
         , sophia_oracles_qfee__basic/1
         , sophia_oracles_qfee__qfee_in_query_above_qfee_in_oracle_is_awarded_to_oracle/1
@@ -96,6 +97,7 @@ groups() ->
     , {sophia,     [sequence], [ sophia_identity,
                                  sophia_state,
                                  sophia_spend,
+                                 sophia_typed_calls,
                                  sophia_oracles,
                                  {group, sophia_oracles_query_fee_happy_path},
                                  {group, sophia_oracles_query_fee_happy_path_remote},
@@ -665,6 +667,21 @@ sophia_spend(_Cfg) ->
     2021000      = ?call(call_contract, Acc1, Ct1, get_balance_of, word, Acc2),
     4000         = ?call(call_contract, Acc1, Ct1, get_balance_of, word, Ct1),
     5000         = ?call(call_contract, Acc1, Ct1, get_balance_of, word, Ct2),
+    ok.
+
+sophia_typed_calls(_Cfg) ->
+    state(aect_test_utils:new_state()),
+    Acc    = ?call(new_account, 1000000),
+    Server = ?call(create_contract, Acc, multiplication_server, {}),
+    Client = ?call(create_contract, Acc, contract_types, Server, #{amount => 1000}),
+    2      = ?call(call_contract, Acc, Client, get_n, word, {}),
+    {}     = ?call(call_contract, Acc, Client, square, {tuple, []}, {}),
+    4      = ?call(call_contract, Acc, Client, get_n, word, {}),
+    {}     = ?call(call_contract, Acc, Client, square, {tuple, []}, {}),
+    16     = ?call(call_contract, Acc, Client, get_n, word, {}),
+    {}     = ?call(call_contract, Acc, Client, square, {tuple, []}, {}),
+    256    = ?call(call_contract, Acc, Client, get_n, word, {}),
+    300    = ?call(account_balance, Server),
     ok.
 
 %% Oracles tests

--- a/apps/aesophia/src/aeso_ast_infer_types.erl
+++ b/apps/aesophia/src/aeso_ast_infer_types.erl
@@ -76,13 +76,10 @@ global_env() ->
     Signature = {id, Ann, "signature"},
     TTL       = Int,
     Fee       = Int,
-    [A, B, Q, R, K, V] = lists:map(TVar, ["a", "b", "q", "r", "k", "v"]),
+    [A, Q, R, K, V] = lists:map(TVar, ["a", "q", "r", "k", "v"]),
      %% Option constructors
     [{"None", Option(A)},
      {"Some", Fun1(A, Option(A))},
-     %% Placeholder for inter-contract calls until we get proper type checking
-     %% of contracts.
-     {"raw_call", Fun([Address, String, Int, Int, A], B)},
      %% Spend transaction. Also not the proper version.
      {"raw_spend", Fun([Address, Int], Unit)},
      %% Environment variables

--- a/apps/aesophia/src/aeso_ast_infer_types.erl
+++ b/apps/aesophia/src/aeso_ast_infer_types.erl
@@ -79,6 +79,7 @@ global_env() ->
      {["Call",     "caller"],       Address},
      {["Call",     "value"],        Int},
      {["Call",     "gas_price"],    Int},
+     {["Call",     "gas_left"],     Fun([], Int)},
      {["Chain",    "balance"],      Fun1(Address, Int)},
      {["Chain",    "block_hash"],   Fun1(Int, Int)},
      {["Chain",    "coinbase"],     Address},

--- a/apps/aesophia/src/aeso_ast_infer_types.erl
+++ b/apps/aesophia/src/aeso_ast_infer_types.erl
@@ -80,8 +80,8 @@ global_env() ->
      %% Option constructors
     [{"None", Option(A)},
      {"Some", Fun1(A, Option(A))},
-     %% Spend transaction. Also not the proper version.
-     {"raw_spend", Fun([Address, Int], Unit)},
+     %% Spend transaction.
+     {["Chain","spend"], Fun([Address, Int], Unit)},
      %% Environment variables
      %% {["Contract", "owner"],   Int},    %% Not in EVM?
      {["Contract", "address"],      Address},

--- a/apps/aesophia/src/aeso_ast_infer_types.erl
+++ b/apps/aesophia/src/aeso_ast_infer_types.erl
@@ -153,9 +153,11 @@ infer_contract_top(TypeEnv, Defs0) ->
 infer_constant({letval, Attrs,_Pattern, Type, E}) ->
     create_type_defs([]),
     ets:new(type_vars, [set, named_table, public]),
+    create_type_errors(),
     {typed, _, _, PatType} =
         infer_expr(global_env(), {typed, Attrs, E, arg_type(Type)}),
     T = instantiate(PatType),
+    destroy_and_report_type_errors(),
     ets:delete(type_vars),
     destroy_type_defs(),
     T.

--- a/apps/aesophia/src/aeso_ast_infer_types.erl
+++ b/apps/aesophia/src/aeso_ast_infer_types.erl
@@ -631,9 +631,14 @@ type_key({Tag, _, QName}) when Tag =:= qid; Tag =:= qcon -> QName.
 
 %% Contract entrypoints take two named arguments (gas : int = Call.gas_left(), value : int = 0).
 contract_call_type({fun_t, Ann, [], Args, Ret}) ->
-    Named = fun(Name, Default) -> {named_arg_t, Ann, {id, Ann, Name}, {id, Ann, "int"}, Default} end,
-    {fun_t, Ann, [Named("gas",   {app, Ann, {qid, Ann, ["Call", "gas_left"]}, []}),
-                  Named("value", {int, Ann, 0})], Args, Ret}.
+    Id    = fun(X) -> {id, Ann, X} end,
+    Int   = Id("int"),
+    Typed = fun(E, T) -> {typed, Ann, E, T} end,
+    Named = fun(Name, Default) -> {named_arg_t, Ann, Id(Name), Int, Default} end,
+    {fun_t, Ann, [Named("gas",   Typed({app, Ann, Typed({qid, Ann, ["Call", "gas_left"]},
+                                                        {fun_t, Ann, [], [], Int}),
+                                        []}, Int)),
+                  Named("value", Typed({int, Ann, 0}, Int))], Args, Ret}.
 
 insert_contract(Id, Contents) ->
     Key = type_key(Id),

--- a/apps/aesophia/src/aeso_ast_to_icode.erl
+++ b/apps/aesophia/src/aeso_ast_to_icode.erl
@@ -92,10 +92,10 @@ ast_type(T, Icode) ->
     ast_typerep(T, Icode).
 
 -define(id_app(Fun, Args, ArgTypes, OutType),
-    {app, _, {typed, _, {id, _, Fun}, {fun_t, _, ArgTypes, OutType}}, Args}).
+    {app, _, {typed, _, {id, _, Fun}, {fun_t, _, _, ArgTypes, OutType}}, Args}).
 
 -define(qid_app(Fun, Args, ArgTypes, OutType),
-    {app, _, {typed, _, {qid, _, Fun}, {fun_t, _, ArgTypes, OutType}}, Args}).
+    {app, _, {typed, _, {qid, _, Fun}, {fun_t, _, _, ArgTypes, OutType}}, Args}).
 
 -define(oracle_t(Q, R), {app_t, _, {id, _, "oracle"}, [Q, R]}).
 -define(query_t(Q, R),  {app_t, _, {id, _, "oracle_query"}, [Q, R]}).
@@ -313,7 +313,7 @@ ast_body({con, _, "None"}, _Icode) ->
     #list{elems = []};
 ast_body({app, _, {typed, _, {con, _, "Some"}, _}, [Elem]}, Icode) ->
     #tuple{cpts = [ast_body(Elem, Icode)]};
-ast_body({typed, _, {con, _, "Some"}, {fun_t, _, [A], _}}, Icode) ->
+ast_body({typed, _, {con, _, "Some"}, {fun_t, _, _, [A], _}}, Icode) ->
     #lambda{ args = [#arg{name = "x", type = ast_type(A, Icode)}]
            , body = #tuple{cpts = [#var_ref{name = "x"}]} };
 ast_body({con, _, Name}, Icode) ->
@@ -473,7 +473,7 @@ ast_typerep({record_t,Fields}, Icode) ->
                 {field_t, _, _, T} = Field,
                 ast_typerep(T, Icode)
               end || Field <- Fields]};
-ast_typerep({fun_t,_,_,_}, _Icode) ->
+ast_typerep({fun_t,_,_,_,_}, _Icode) ->
     function;
 ast_typerep({alias_t, T}, Icode) -> ast_typerep(T, Icode);
 ast_typerep({variant_t, Cons}, Icode) ->

--- a/apps/aesophia/src/aeso_ast_to_icode.erl
+++ b/apps/aesophia/src/aeso_ast_to_icode.erl
@@ -124,6 +124,8 @@ ast_body(?qid_app(["Chain", "balance"], [Address], _, _), Icode) ->
     #prim_balance{ address = ast_body(Address, Icode) };
 ast_body(?qid_app(["Chain", "block_hash"], [Height], _, _), Icode) ->
     #prim_block_hash{ height = ast_body(Height, Icode) };
+ast_body(?qid_app(["Call", "gas_left"], [], _, _), _Icode) ->
+    prim_gas_left;
 ast_body({qid, _, ["Contract", "address"]}, _Icode)      -> prim_contract_address;
 ast_body({qid, _, ["Contract", "balance"]}, _Icode)      -> #prim_balance{ address = prim_contract_address };
 ast_body({qid, _, ["Call",     "origin"]}, _Icode)       -> prim_call_origin;

--- a/apps/aesophia/src/aeso_ast_to_icode.erl
+++ b/apps/aesophia/src/aeso_ast_to_icode.erl
@@ -102,7 +102,7 @@ ast_type(T, Icode) ->
 -define(option_t(A),    {app_t, _, {id, _, "option"}, [A]}).
 -define(map_t(K, V),    {app_t, _, {id, _, "map"}, [K, V]}).
 
-ast_body(?id_app("raw_spend", [To, Amount], _, _), Icode) ->
+ast_body(?qid_app(["Chain","spend"], [To, Amount], _, _), Icode) ->
     prim_call(?PRIM_CALL_SPEND, ast_body(Amount, Icode), [ast_body(To, Icode)], [word], {tuple, []});
 
 %% Chain environment
@@ -128,8 +128,8 @@ ast_body({qid, _, ["Chain", "balance"]}, _Icode) ->
     error({underapplied_primitive, 'Chain.balance'});
 ast_body({qid, _, ["Chain", "block_hash"]}, _Icode) ->
     error({underapplied_primitive, 'Chain.block_hash'});
-ast_body({id, _, "raw_spend"}, _Icode) ->
-    error({underapplied_primitive, raw_spend});
+ast_body({qid, _, ["Chain", "spend"]}, _Icode) ->
+    error({underapplied_primitive, 'Chain.spend'});
 
 %% State
 ast_body({id, _, "state"}, _Icode) -> prim_state;

--- a/apps/aesophia/src/aeso_ast_to_icode.erl
+++ b/apps/aesophia/src/aeso_ast_to_icode.erl
@@ -301,6 +301,8 @@ ast_body({typed, _, {con, _, "Some"}, {fun_t, _, _, [A], _}}, Icode) ->
     #lambda{ args = [#arg{name = "x", type = ast_type(A, Icode)}]
            , body = #tuple{cpts = [#var_ref{name = "x"}]} };
 %% Typed contract calls
+ast_body({proj, _, {typed, _, Addr, {con, _, _}}, {id, _, "address"}}, Icode) ->
+    ast_body(Addr, Icode);  %% Values of contract types _are_ addresses.
 ast_body({app, _, {typed, _, {proj, _, {typed, _, Addr, {con, _, Contract}}, {id, _, FunName}},
                              {fun_t, _, NamedT, ArgsT, OutT}}, Args0}, Icode) ->
     NamedArgs = [Arg || Arg = {named_arg, _, _, _} <- Args0],

--- a/apps/aesophia/src/aeso_ast_to_icode.erl
+++ b/apps/aesophia/src/aeso_ast_to_icode.erl
@@ -102,20 +102,6 @@ ast_type(T, Icode) ->
 -define(option_t(A),    {app_t, _, {id, _, "option"}, [A]}).
 -define(map_t(K, V),    {app_t, _, {id, _, "map"}, [K, V]}).
 
-ast_body(?id_app("raw_call", [To, Fun, Gas, Value, {typed, _, Arg, ArgT}], _, OutT), Icode) ->
-    %% TODO: temp hack before we have contract calls properly in the type checker
-    {Args, ArgTypes} =
-        case Arg of %% Hack: pack unary argument in tuple
-            %% Already a tuple.
-            {tuple, _,_Elems} -> {Arg, ArgT};
-            _ -> {{tuple, [], [Arg]}, {tuple_t, [], [ArgT]}}
-        end,
-    #prim_call_contract{ gas      = ast_body(Gas, Icode),
-                         address  = ast_body(To, Icode),
-                         value    = ast_body(Value, Icode),
-                         arg      = #tuple{cpts = [ast_body(X, Icode) || X <- [Fun , Args]]},
-                         arg_type = {tuple, [string , ast_typerep(ArgTypes, Icode)]},
-                         out_type = ast_typerep(OutT, Icode) };
 ast_body(?id_app("raw_spend", [To, Amount], _, _), Icode) ->
     prim_call(?PRIM_CALL_SPEND, ast_body(Amount, Icode), [ast_body(To, Icode)], [word], {tuple, []});
 
@@ -142,8 +128,6 @@ ast_body({qid, _, ["Chain", "balance"]}, _Icode) ->
     error({underapplied_primitive, 'Chain.balance'});
 ast_body({qid, _, ["Chain", "block_hash"]}, _Icode) ->
     error({underapplied_primitive, 'Chain.block_hash'});
-ast_body({id, _, "raw_call"}, _Icode) ->
-    error({underapplied_primitive, raw_call});
 ast_body({id, _, "raw_spend"}, _Icode) ->
     error({underapplied_primitive, raw_spend});
 

--- a/apps/aesophia/src/aeso_icode_to_asm.erl
+++ b/apps/aesophia/src/aeso_icode_to_asm.erl
@@ -372,6 +372,8 @@ assemble_expr(_Funs, _Stack, _Tail, prim_call_value) ->
     [i(?CALLVALUE)];
 assemble_expr(_Funs, _Stack, _Tail, prim_gas_price) ->
     [i(?GASPRICE)];
+assemble_expr(_Funs, _Stack, _Tail, prim_gas_left) ->
+    [i(?GAS)];
 assemble_expr(_Funs, _Stack, _Tail, prim_coinbase) ->
     [i(?COINBASE)];
 assemble_expr(_Funs, _Stack, _Tail, prim_timestamp) ->

--- a/apps/aesophia/src/aeso_parser.erl
+++ b/apps/aesophia/src/aeso_parser.erl
@@ -190,11 +190,16 @@ exprAtom() ->
         ])
     end).
 
+arg_expr() ->
+    ?LAZY_P(
+        choice([ ?RULE(id(), tok('='), expr(), {named_arg, [], _1, _3})
+               , expr() ])).
+
 elim() ->
     ?LAZY_P(
     choice(
     [ {proj, keyword('.'), id()}
-    , ?RULE(paren_list(expr()), {app, [], _1})
+    , ?RULE(paren_list(arg_expr()), {app, [], _1})
     , ?RULE(keyword('{'), comma_sep(field_assignment()), tok('}'), {rec_upd, _1, _2})
     , ?RULE(keyword('['), expr(), keyword(']'), {map_get, _1, _2})
     ])).
@@ -373,7 +378,7 @@ tuple_t(_Ann, [Type]) -> Type;  %% Not a tuple
 tuple_t(Ann, Types)   -> {tuple_t, Ann, Types}.
 
 fun_t(Domains, Type) ->
-    lists:foldr(fun({Dom, Ann}, T) -> {fun_t, Ann, Dom, T} end,
+    lists:foldr(fun({Dom, Ann}, T) -> {fun_t, Ann, [], Dom, T} end,
                 Type, Domains).
 
 tuple_e(Ann, [])      -> {unit, Ann};

--- a/apps/aesophia/src/aeso_syntax.erl
+++ b/apps/aesophia/src/aeso_syntax.erl
@@ -15,7 +15,7 @@
 -export_type([bin_op/0, un_op/0]).
 -export_type([decl/0, letbind/0, typedef/0]).
 -export_type([arg/0, field_t/0, constructor_t/0]).
--export_type([type/0, constant/0, expr/0, field/1, stmt/0, alt/0, lvalue/0, pat/0]).
+-export_type([type/0, constant/0, expr/0, arg_expr/0, field/1, stmt/0, alt/0, lvalue/0, pat/0]).
 -export_type([ast/0]).
 
 -type ast() :: [decl()].
@@ -56,12 +56,14 @@
 
 -type constructor_t() :: {constr_t, ann(), con(), [type()]}.
 
--type type() :: {fun_t, ann(), [type()], type()}
+-type type() :: {fun_t, ann(), [named_arg_t()], [type()], type()}
               | {app_t, ann(), type(), [type()]}
               | {tuple_t, ann(), [type()]}
               | id()  | qid()
               | con() | qcon()  %% contracts
               | tvar().
+
+-type named_arg_t() :: {named_arg_t, ann(), id(), type(), expr()}.
 
 -type constant()
     :: {int, ann(), integer()}
@@ -82,7 +84,7 @@
     :: {lam, ann(), [arg()], expr()}
      | {'if', ann(), expr(), expr(), expr()}
      | {switch, ann(), expr(), [alt()]}
-     | {app, ann(), expr(), [expr()]}
+     | {app, ann(), expr(), [arg_expr()]}
      | {proj, ann(), expr(), id()}
      | {tuple, ann(), [expr()]}
      | {list, ann(), [expr()]}
@@ -96,6 +98,8 @@
      | {op(), ann()}
      | id() | qid() | con() | qcon()
      | constant().
+
+-type arg_expr() :: expr() | {named_arg, ann(), id(), expr()}.
 
 %% When lvalue is a projection this is sugar for accessing fields in nested
 %% records. For instance,

--- a/apps/aesophia/src/aeso_syntax.erl
+++ b/apps/aesophia/src/aeso_syntax.erl
@@ -11,7 +11,7 @@
 -export([get_ann/1, get_ann/2, get_ann/3]).
 
 -export_type([ann_line/0, ann_col/0, ann_origin/0, ann_format/0, ann/0]).
--export_type([name/0, id/0, con/0, tvar/0, op/0]).
+-export_type([name/0, id/0, con/0, qid/0, qcon/0, tvar/0, op/0]).
 -export_type([bin_op/0, un_op/0]).
 -export_type([decl/0, letbind/0, typedef/0]).
 -export_type([arg/0, field_t/0, constructor_t/0]).

--- a/apps/aesophia/src/aeso_syntax_utils.erl
+++ b/apps/aesophia/src/aeso_syntax_utils.erl
@@ -29,6 +29,7 @@ used_ids({letfun, _, _, Args, _, E}) -> used_ids({bind, Args, E});
 used_ids({letrec, _, Decls})         -> used_ids(Decls);
 %% Args
 used_ids({arg, _, X, _}) -> used_ids(X);
+used_ids({named_arg, _, _, E}) -> used_ids(E);
 %% Constants
 used_ids({int, _, _})    -> none();
 used_ids({bool, _, _})   -> none();
@@ -81,7 +82,8 @@ used_types({record_t, Fs})         -> used_types(Fs);
 used_types({variant_t, Cs})        -> used_types(Cs);
 used_types({field_t, _, _, T})     -> used_types(T);
 used_types({constr_t, _, _, Ts})   -> used_types(Ts);
-used_types({fun_t, _, Args, T})    -> used_types([T | Args]);
+used_types({fun_t, _, Named, Args, T}) -> used_types([T | Named ++ Args]);
+used_types({named_arg_t, _, _, T, _}) -> used_types(T);
 used_types({app_t, _, T, Ts})      -> used_types([T | Ts]);
 used_types({tuple_t, _, Ts})       -> used_types(Ts);
 used_types({id, _, X})             -> one(X);

--- a/apps/aesophia/test/contracts/complex_types.aes
+++ b/apps/aesophia/test/contracts/complex_types.aes
@@ -1,5 +1,18 @@
 
+contract Remote =
+  function up_to       : (int)               => list(int)
+  function sum         : (list(int))         => int
+  function some_string : ()                  => string
+  function pair        : (int, string)       => (int, string)
+  function squares     : (int)               => list((int, int))
+  function filter_some : (list(option(int))) => list(int)
+  function all_some    : (list(option(int))) => option(list(int))
+
 contract ComplexTypes =
+
+  record state = { worker : Remote }
+
+  function init(worker) = {worker = worker}
 
   function sum_acc(xs, n) =
     switch(xs)
@@ -20,22 +33,22 @@ contract ComplexTypes =
   record answer('a) = {label : string, result : 'a}
 
   function remote_triangle(worker, n) : answer(int) =
-    let xs = raw_call(worker, "up_to", 100000, 0, n) : list(int)
-    let t  = raw_call(worker, "sum",   100000, 0, xs)
+    let xs = worker.up_to(gas = 100000, n)
+    let t  = worker.sum(xs)
     { label = "answer:", result = t }
 
   function remote_list(n) : list(int) =
-    raw_call(Contract.address, "up_to", 100000, 0, n)
+    state.worker.up_to(n)
 
   function some_string() = "string"
 
   function remote_string() : string =
-    raw_call(Contract.address, "some_string", 10000, 0, ())
+    state.worker.some_string()
 
   function pair(x : int, y : string) = (x, y)
 
   function remote_pair(n : int, s : string) : (int, string) =
-    raw_call(Contract.address, "pair", 10000, 0, (n, s))
+    state.worker.pair(gas = 10000, n, s)
 
   function map(f, xs) =
     switch(xs)
@@ -46,7 +59,7 @@ contract ComplexTypes =
     map((i) => (i, i * i), up_to(n))
 
   function remote_squares(n) : list((int, int)) =
-    raw_call(Contract.address, "squares", 10000, 0, n)
+    state.worker.squares(n)
 
   // option types
 
@@ -57,7 +70,7 @@ contract ComplexTypes =
       Some(x) :: ys => x :: filter_some(ys)
 
   function remote_filter_some(xs : list(option(int))) : list(int) =
-    raw_call(Contract.address, "filter_some", 10000, 0, xs)
+    state.worker.filter_some(xs)
 
   function all_some(xs : list(option(int))) : option(list(int)) =
     switch(xs)
@@ -69,5 +82,5 @@ contract ComplexTypes =
           Some(xs) => Some(x :: xs)
 
   function remote_all_some(xs : list(option(int))) : option(list(int)) =
-    raw_call(Contract.address, "all_some", 10000, 0, xs)
+    state.worker.all_some(gas = 10000, xs)
 

--- a/apps/aesophia/test/contracts/contract_types.aes
+++ b/apps/aesophia/test/contracts/contract_types.aes
@@ -1,0 +1,17 @@
+
+contract OtherContract =
+
+  function multiply : (int, int) => int
+
+contract ThisContract =
+
+  record state = { server : OtherContract, n : int }
+
+  function init(server : OtherContract) =
+    { server = server, n = 2 }
+
+  function square() =
+    put(state{ n @ n = state.server.multiply(value = 100, n, n) })
+
+  function get_n() = state.n
+

--- a/apps/aesophia/test/contracts/contract_types.aes
+++ b/apps/aesophia/test/contracts/contract_types.aes
@@ -15,3 +15,6 @@ contract ThisContract =
 
   function get_n() = state.n
 
+  function tip_server() =
+    Chain.spend(state.server.address, Call.value)
+

--- a/apps/aesophia/test/contracts/dutch_auction.aes
+++ b/apps/aesophia/test/contracts/dutch_auction.aes
@@ -12,7 +12,7 @@ contract DutchAuction =
   // Add to work around current lack of predefined functions
   private function spend(to, amount) =
     let total = Contract.balance
-    raw_spend(to, amount)
+    Chain.spend(to, amount)
     total - amount
 
   private function abort(err : string) =

--- a/apps/aesophia/test/contracts/environment.aes
+++ b/apps/aesophia/test/contracts/environment.aes
@@ -1,14 +1,25 @@
 
 // Testing primitives for accessing the block chain environment
+contract Interface =
+  function contract_address : () => address
+  function call_origin      : () => address
+  function call_caller      : () => address
+  function call_value       : () => int
 
 contract Environment =
+
+  record state = {remote : Interface}
+
+  function init(remote) = {remote = remote}
+
+  function set_remote(remote) = put({remote = remote})
 
   // -- Information about the this contract ---
 
   // Address
   function contract_address() : address = Contract.address
   function nested_address(who) : address =
-    raw_call(who, "contract_address", 1000, 0, ())
+    who.contract_address(gas = 1000)
 
   // Balance
   function contract_balance() : int = Contract.balance
@@ -18,17 +29,17 @@ contract Environment =
   // Origin
   function call_origin()   : address = Call.origin
   function nested_origin() : address =
-    raw_call(Contract.address, "call_origin", 1000, 0, ())
+    state.remote.call_origin()
 
   // Caller
   function call_caller() : address = Call.caller
   function nested_caller() : address =
-    raw_call(Contract.address, "call_caller", 1000, 0, ())
+    state.remote.call_caller()
 
   // Value
   function call_value() : int = Call.value
   function nested_value(value : int) : int =
-    raw_call(Contract.address, "call_value", 1000, value, ())
+    state.remote.call_value(value = value / 2)
 
   // Gas price
   function call_gas_price() : int = Call.gas_price

--- a/apps/aesophia/test/contracts/factorial.aes
+++ b/apps/aesophia/test/contracts/factorial.aes
@@ -1,13 +1,15 @@
 // An implementation of the factorial function where each recursive
-// call is to the caller. Not the cheapest way to compute factorial.
+// call is to another contract. Not the cheapest way to compute factorial.
+contract FactorialServer =
+  function fac : (int) => int
+
 contract Factorial =
 
-  function main(worker : address) : int =
-    raw_call(worker, "fac", 100000, 0, (10, 0))
+  record state = {worker : FactorialServer}
+
+  function init(worker) = {worker = worker}
 
   function fac(x : int) : int =
-    if(x == 0)
-      1
-    else
-      x * raw_call(Call.caller, "fac", 100000, 0, (x - 1, 0))
+    if(x == 0) 1
+    else x * state.worker.fac(x - 1)
 

--- a/apps/aesophia/test/contracts/fundme.aes
+++ b/apps/aesophia/test/contracts/fundme.aes
@@ -19,7 +19,7 @@ contract FundMe =
     if(!b) abort(err)
 
   private function spend(args : spend_args) =
-    raw_spend(args.recipient, args.amount)
+    Chain.spend(args.recipient, args.amount)
 
   public function init(beneficiary, deadline, goal) : state =
     { contributions = {},

--- a/apps/aesophia/test/contracts/multiplication_server.aes
+++ b/apps/aesophia/test/contracts/multiplication_server.aes
@@ -1,0 +1,7 @@
+
+contract MultiplicationServer =
+
+  function multiply(x : int, y : int) =
+    switch(Call.value >= 100)
+      true => x * y
+

--- a/apps/aesophia/test/contracts/oracles.aes
+++ b/apps/aesophia/test/contracts/oracles.aes
@@ -42,7 +42,7 @@ contract Oracles =
   function respond(o    : oracle_id,
                    q    : query_id,
                    sign : signature,
-                   r    : answer_t) =
+                   r    : answer_t) : () =
     Oracle.respond(o, q, sign, r)
 
   function getQuestion(o : oracle_id,

--- a/apps/aesophia/test/contracts/remote_call.aes
+++ b/apps/aesophia/test/contracts/remote_call.aes
@@ -1,15 +1,17 @@
 
+contract Remote1 =
+  function main : (int) => int
+
+contract Remote2 =
+  function call : (Remote1, int) => int
+
 contract RemoteCall =
 
-    function call(r : address, x : int) : int =
-        let gas   = 10000
-        let value = 10
-        raw_call(r, "main", gas, value, x)
+    function call(r : Remote1, x : int) : int =
+        r.main(gas = 10000, value = 10, x)
 
-    function call42(r : address) : int = call(r, 42)
-
-    function staged_call(r1 : address, r2 : address, x : int) =
-        raw_call(r1, "call", 20000, 0, (r2, x))
+    function staged_call(r1 : Remote1, r2 : Remote2, x : int) =
+        r2.call(r1, x)
 
     function plus(x, y) = x + y
 

--- a/apps/aesophia/test/contracts/remote_oracles.aes
+++ b/apps/aesophia/test/contracts/remote_oracles.aes
@@ -1,66 +1,103 @@
+contract Oracles =
+
+  function registerOracle :
+    (address,
+     signature,
+     int,
+     int) => oracle(string, int)
+
+  function createQuery :
+    (oracle(string, int),
+     string,
+     int,
+     int,
+     int) => oracle_query(string, int)
+
+  function unsafeCreateQuery :
+    (oracle(string, int),
+     string,
+     int,
+     int,
+     int) => oracle_query(string, int)
+
+  function respond :
+    (oracle(string, int),
+     oracle_query(string, int),
+     signature,
+     int) => ()
+
+contract OraclesErr =
+
+  function unsafeCreateQueryThenErr :
+    (oracle(string, int),
+     string,
+     int,
+     int,
+     int) => oracle_query(string, int)
+
 contract RemoteOracles =
 
   public function callRegisterOracle(
-    r : address,
-    acct : address,
-    sign : signature,
-    qfee : int,
-    ttl  : int) : oracle(string, int) =
-    raw_call(r, "registerOracle", 1234567890, 0, (acct, sign, qfee, ttl))
+      r    : Oracles,
+      acct : address,
+      sign : signature,
+      qfee : int,
+      ttl  : int) : oracle(string, int) =
+    r.registerOracle(acct, sign, qfee, ttl)
 
   public function callCreateQuery(
-    r : address,
+    r     : Oracles,
     value : int,
-    o    : oracle(string, int),
-    q    : string,
-    qfee : int,
-    qttl : int,
-    rttl : int) : oracle_query(string, int) =
+    o     : oracle(string, int),
+    q     : string,
+    qfee  : int,
+    qttl  : int,
+    rttl  : int) : oracle_query(string, int) =
     require(value =< Call.value, "insufficient value")
-    raw_call(r, "createQuery", 1234567890, value, (o, q, qfee, qttl, rttl))
+    r.createQuery(value = value, o, q, qfee, qttl, rttl)
 
   // Do not use in production!
   public function callUnsafeCreateQuery(
-    r : address,
+    r     : Oracles,
     value : int,
-    o    : oracle(string, int),
-    q    : string,
-    qfee : int,
-    qttl : int,
-    rttl : int) : oracle_query(string, int) =
-    raw_call(r, "unsafeCreateQuery", 1234567890, value, (o, q, qfee, qttl, rttl))
+    o     : oracle(string, int),
+    q     : string,
+    qfee  : int,
+    qttl  : int,
+    rttl  : int) : oracle_query(string, int) =
+    r.unsafeCreateQuery(value = value, o, q, qfee, qttl, rttl)
 
   // Do not use in production!
   public function callUnsafeCreateQueryThenErr(
-    r : address,
+    r     : OraclesErr,
     value : int,
-    o    : oracle(string, int),
-    q    : string,
-    qfee : int,
-    qttl : int,
-    rttl : int) : oracle_query(string, int) =
-    raw_call(r, "unsafeCreateQueryThenErr", 1234567890, value, (o, q, qfee, qttl, rttl))
+    o     : oracle(string, int),
+    q     : string,
+    qfee  : int,
+    qttl  : int,
+    rttl  : int) : oracle_query(string, int) =
+    r.unsafeCreateQueryThenErr(value = value, o, q, qfee, qttl, rttl)
 
   // Do not use in production!
   public function callUnsafeCreateQueryAndThenErr(
-    r : address,
+    r     : Oracles,
     value : int,
-    o    : oracle(string, int),
-    q    : string,
-    qfee : int,
-    qttl : int,
-    rttl : int) : oracle_query(string, int) =
-    let x = raw_call(r, "unsafeCreateQuery", 1234567890, value, (o, q, qfee, qttl, rttl))
+    o     : oracle(string, int),
+    q     : string,
+    qfee  : int,
+    qttl  : int,
+    rttl  : int) : oracle_query(string, int) =
+    let x = r.unsafeCreateQuery(value = value, o, q, qfee, qttl, rttl)
     switch(0) 1 => ()
     x // Never reached.
 
   public function callRespond(
-    r : address,
+    r    : Oracles,
     o    : oracle(string, int),
     q    : oracle_query(string, int),
     sign : signature,
     qr   : int) =
-    raw_call(r, "respond", 1234567890, 0, (o, q, sign, qr))
+    r.respond(o, q, sign, qr)
 
   private function abort(err : string) =
     switch(0) 1 => ()

--- a/apps/aesophia/test/contracts/remote_value_on_err.aes
+++ b/apps/aesophia/test/contracts/remote_value_on_err.aes
@@ -1,11 +1,15 @@
+contract ValueOnErr =
+  function err : () => int
+  function ok  : () => int
+
 contract RemoteValueOnErr =
 
   public function callErr(
-    r : address,
+    r : ValueOnErr,
     value : int) : int =
-    raw_call(r, "err", 1234567890, value, ())
+    r.err(value = value)
 
   public function callOk(
-    r : address,
+    r : ValueOnErr,
     value : int) : int =
-    raw_call(r, "ok", 1234567890, value, ())
+    r.ok(value = value)

--- a/apps/aesophia/test/contracts/spend_test.aes
+++ b/apps/aesophia/test/contracts/spend_test.aes
@@ -1,4 +1,7 @@
 
+contract SpendContract =
+  function withdraw : (int) => int
+
 contract SpendTest =
 
   function spend(to, amount) =
@@ -10,12 +13,11 @@ contract SpendTest =
     spend(Call.caller, amount)
 
   function withdraw_from(account, amount) =
-    // Pretend (amount, 0 ) is a 1 tuple.
-    raw_call(account, "withdraw", 12000, 0, amount)
+    account.withdraw(amount)
     withdraw(amount)
 
   function spend_from(from, to, amount) =
-    raw_call(from, "withdraw", 12000, 0, amount)
+    from.withdraw(amount)
     raw_spend(to, amount)
     Chain.balance(to)
 

--- a/apps/aesophia/test/contracts/spend_test.aes
+++ b/apps/aesophia/test/contracts/spend_test.aes
@@ -6,7 +6,7 @@ contract SpendTest =
 
   function spend(to, amount) =
     let total = Contract.balance
-    raw_spend(to, amount)
+    Chain.spend(to, amount)
     total - amount
 
   function withdraw(amount) : int =
@@ -18,7 +18,7 @@ contract SpendTest =
 
   function spend_from(from, to, amount) =
     from.withdraw(amount)
-    raw_spend(to, amount)
+    Chain.spend(to, amount)
     Chain.balance(to)
 
   function get_balance() = Contract.balance

--- a/docs/release-notes/RELEASE-NOTES-0.21.0.md
+++ b/docs/release-notes/RELEASE-NOTES-0.21.0.md
@@ -2,7 +2,7 @@
 
 [This release][this-release] is focused on TODOFILLMEIN.
 It:
-* Adds support for type aliases to the Sophia compiler.
+* Adds support for type aliases and typed contract calls to the Sophia compiler.
 * Changes the target (difficulty) calculation algorithm to use [DigiShield v3][digishield_v3]. This impacts consensus.
 * Fixes miner fee reward calculations, was too generous before. This impacts consensus.
 * Modifies the minimum static component of the fee of oracle transactions to `1` - as for all other transactions. This impacts consensus.


### PR DESCRIPTION
Closes [PT-160016525](https://www.pivotaltracker.com/story/show/160016525).

This PR replaces the primitive `raw_call` by properly typed contract addresses. Example:

```
contract Server =
  function foo : int => int

contract Client =
  function do_stuff(s : Server, x : int) =
    s.foo(x)
```
To set gas limit and supply tokens to a call there is a facility for optional named arguments, and contract calls take two of these: `gas : int` and `value : int`. For instance
```
  function do_stuff(s : Server, x : int) =
    s.foo(value = 100, x)
```
To get the address of a contract value there's a field `address : address`:
```
  function server_addr(s : Server) : address = s.address
```