### PR TITLE
Fix system test for delayed reward

### DIFF
--- a/system_test/aest_channels_SUITE.erl
+++ b/system_test/aest_channels_SUITE.erl
@@ -18,7 +18,8 @@
 -import(aest_nodes, [
     setup_nodes/2,
     start_node/2,
-    wait_for_value/4
+    wait_for_value/4,
+    wait_for_startup/3
 ]).
 
 -import(aest_api, [
@@ -137,6 +138,7 @@ simple_channel_test(ChannelOpts, Cfg) ->
     NodeNames = [node1, node2],
     start_node(node1, Cfg),
     start_node(node2, Cfg),
+    wait_for_startup([node1, node2], 4, Cfg),  %% make sure there is some money in accounts
     wait_balance(NodeNames, ?MIKE, 1000, 10000, Cfg),
 
     tx_spend(node1, ?MIKE, IAccount, 200, 1, Cfg),

--- a/system_test/aest_channels_SUITE_data/epoch.yaml.mustache
+++ b/system_test/aest_channels_SUITE_data/epoch.yaml.mustache
@@ -34,6 +34,7 @@ chain:
 mining:
     autostart: true
     beneficiary: {{config.beneficiary}}
+    beneficiary_reward_delay: 0
     cuckoo:
         miner:
             executable: mean16s-generic

--- a/system_test/aest_sync_SUITE.erl
+++ b/system_test/aest_sync_SUITE.erl
@@ -451,7 +451,7 @@ tx_pool_sync(Cfg) ->
 
     %% Give the sync a moment to finish
     #{ height := Height2 } = get_top(node2),
-    wait_for_value({height, Height2 + 5}, [node1], 5 * ?MINING_TIMEOUT, Cfg),
+    wait_for_value({height, Height2 + 8}, [node1], 8 * ?MINING_TIMEOUT, Cfg),
 
     {ok, 200, MempoolTxs1B} = request(node1, 'GetTxs', #{}),
     {11, _} = {length(MempoolTxs1B), MempoolTxs1B},


### PR DESCRIPTION
Delayed rewards make system test for channels fail, because test depends on mined rewards in accounts.