### PR TITLE
Check configured beneficiary

### DIFF
--- a/apps/aeutils/priv/epoch_config_schema.json
+++ b/apps/aeutils/priv/epoch_config_schema.json
@@ -302,6 +302,7 @@
         "mining" : {
             "type" : "object",
             "additionalProperties" : false,
+            "required" : ["beneficiary"],
             "properties" : {
                 "autostart" : {
                     "description" :
@@ -316,7 +317,9 @@
                 "beneficiary" : {
                     "description" :
                     "Public key of beneficiary account that will receive fees from mining on a node.",
-                    "type" : "string"
+                    "type" : "string",
+                    "example" : "ak$2VoAhMd7tVJrDYM5vPJwFRjueZyirDJumVJNeBWL9j1eNTHsRx",
+                    "pattern": "^ak\$[1-9A-HJ-NP-Za-km-z]*$"
                 },
                 "expected_mine_rate" : {
                     "description" : "Expected mine rate (milliseconds) between blocks. Used in governance.",

--- a/apps/aeutils/priv/epoch_config_schema.json
+++ b/apps/aeutils/priv/epoch_config_schema.json
@@ -318,7 +318,7 @@
                     "description" :
                     "Public key of beneficiary account that will receive fees from mining on a node.",
                     "type" : "string",
-                    "example" : "ak$2VoAhMd7tVJrDYM5vPJwFRjueZyirDJumVJNeBWL9j1eNTHsRx",
+                    "example" : "ak$DummyPubKeyDoNotEverUse999999999999999999999999999",
                     "pattern": "^ak\$[1-9A-HJ-NP-Za-km-z]*$"
                 },
                 "expected_mine_rate" : {

--- a/apps/aeutils/src/aeu_env.erl
+++ b/apps/aeutils/src/aeu_env.erl
@@ -241,6 +241,8 @@ pp_error({{validation_failed, Errors}, _}) ->
 pp_error(Other) ->
     Other.
 
+pp_error_({error, {schema_file_not_found, Schema}}) ->
+    io:fwrite("Schema not found : ~s~n", [Schema]);
 pp_error_({error, [{data_invalid, Schema, Type, Value, Pos}]}) ->
     SchemaStr = jsx:prettify(jsx:encode(Schema)),
     PosStr = pp_pos(Pos),
@@ -392,7 +394,12 @@ check_validation(Res, _JSON, F, Mode) ->
     end.
 
 validate_(Schema, JSON) ->
-    jesse:validate_with_schema(load_schema(Schema), JSON, []).
+    case filelib:is_regular(Schema) of
+        true ->
+            jesse:validate_with_schema(load_schema(Schema), JSON, []);
+        false ->
+            {error, {schema_file_not_found, Schema}}
+    end.
 
 schema() ->
     filename:join(code:priv_dir(aeutils),

--- a/apps/aeutils/test/data/epoch_full.yaml
+++ b/apps/aeutils/test/data/epoch_full.yaml
@@ -104,7 +104,7 @@ mining:
     expected_mine_rate: 300000
     micro_block_cycle: 3000
     # Public key of beneficiary account that will receive fees from mining on a node.
-    beneficiary: "encoded_beneficiary_pubkey_to_be_replaced"
+    beneficiary: "ak$2VoAhMd7tVJrDYM5vPJwFRjueZyirDJumVJNeBWL9j1eNTHsRx"
     cuckoo:
         miner:
             # Executable binary of the miner.

--- a/apps/aeutils/test/data/epoch_full.yaml
+++ b/apps/aeutils/test/data/epoch_full.yaml
@@ -104,7 +104,7 @@ mining:
     expected_mine_rate: 300000
     micro_block_cycle: 3000
     # Public key of beneficiary account that will receive fees from mining on a node.
-    beneficiary: "ak$2VoAhMd7tVJrDYM5vPJwFRjueZyirDJumVJNeBWL9j1eNTHsRx"
+    beneficiary: "ak$DummyPubKeyDoNotEverUse999999999999999999999999999"
     cuckoo:
         miner:
             # Executable binary of the miner.

--- a/apps/aeutils/test/data/epoch_no_newline.yaml
+++ b/apps/aeutils/test/data/epoch_no_newline.yaml
@@ -68,7 +68,7 @@ mining:
     # Expected mine rate (milliseconds) between blocks. Used in governance.
     expected_mine_rate: 300000
     # Public key of beneficiary account that will receive fees from mining on a node.
-    beneficiary: "ak$2VoAhMd7tVJrDYM5vPJwFRjueZyirDJumVJNeBWL9j1eNTHsRx"
+    beneficiary: "ak$DummyPubKeyDoNotEverUse999999999999999999999999999"
     cuckoo:
         miner:
             # Executable binary of the miner.

--- a/apps/aeutils/test/data/epoch_no_newline.yaml
+++ b/apps/aeutils/test/data/epoch_no_newline.yaml
@@ -67,6 +67,8 @@ mining:
     attempt_timeout: 3600000
     # Expected mine rate (milliseconds) between blocks. Used in governance.
     expected_mine_rate: 300000
+    # Public key of beneficiary account that will receive fees from mining on a node.
+    beneficiary: "ak$2VoAhMd7tVJrDYM5vPJwFRjueZyirDJumVJNeBWL9j1eNTHsRx"
     cuckoo:
         miner:
             # Executable binary of the miner.

--- a/apps/aeutils/test/data/epoch_no_peers.yaml
+++ b/apps/aeutils/test/data/epoch_no_peers.yaml
@@ -1,2 +1,6 @@
 ---
 peers: []
+
+mining:
+    beneficiary: "ak$2VoAhMd7tVJrDYM5vPJwFRjueZyirDJumVJNeBWL9j1eNTHsRx"
+

--- a/apps/aeutils/test/data/epoch_no_peers.yaml
+++ b/apps/aeutils/test/data/epoch_no_peers.yaml
@@ -2,5 +2,5 @@
 peers: []
 
 mining:
-    beneficiary: "ak$2VoAhMd7tVJrDYM5vPJwFRjueZyirDJumVJNeBWL9j1eNTHsRx"
+    beneficiary: "ak$DummyPubKeyDoNotEverUse999999999999999999999999999"
 

--- a/apps/aeutils/test/data/epoch_testnet.yaml
+++ b/apps/aeutils/test/data/epoch_testnet.yaml
@@ -11,4 +11,4 @@ chain:
 mining:
     autostart: true
     # Public key of beneficiary account that will receive fees from mining on a node.
-    beneficiary: "ak$2VoAhMd7tVJrDYM5vPJwFRjueZyirDJumVJNeBWL9j1eNTHsRx"
+    beneficiary: "ak$DummyPubKeyDoNotEverUse999999999999999999999999999"

--- a/apps/aeutils/test/data/epoch_testnet.yaml
+++ b/apps/aeutils/test/data/epoch_testnet.yaml
@@ -11,4 +11,4 @@ chain:
 mining:
     autostart: true
     # Public key of beneficiary account that will receive fees from mining on a node.
-    beneficiary: "encoded_beneficiary_pubkey_to_be_replaced"
+    beneficiary: "ak$2VoAhMd7tVJrDYM5vPJwFRjueZyirDJumVJNeBWL9j1eNTHsRx"


### PR DESCRIPTION
 * Make beneficiary required in the configuration file.
 * Give a better error message when the schema given to check_config
   doesn't exists.