### PR TITLE
PT-157931784 Sophia TTL type

### DIFF
--- a/apps/aecontract/test/aecontract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_SUITE.erl
@@ -724,19 +724,22 @@ sophia_typed_calls(_Cfg) ->
 %%  - Failing calls
 sophia_oracles(_Cfg) ->
     state(aect_test_utils:new_state()),
+    RelativeTTL       = fun(Delta)  -> {variant, 0, [Delta]} end,
+    FixedTTL          = fun(Height) -> {variant, 1, [Height]} end,
     Acc               = ?call(new_account, 1000000),
     Ct = <<CtId:256>> = ?call(create_contract, Acc, oracles, {}, #{amount => 100000}),
     QueryFee          = 100,
     TTL               = 15,
-    CtId              = ?call(call_contract, Acc, Ct, registerOracle, word, {CtId, 0, QueryFee, TTL}),
+    CtId              = ?call(call_contract, Acc, Ct, registerOracle, word, {CtId, 0, QueryFee, FixedTTL(TTL)}),
     Question          = <<"Manchester United vs Brommapojkarna">>,
-    QId               = ?call(call_contract, Acc, Ct, createQuery, word, {Ct, Question, QueryFee, 5, 5}, #{amount => QueryFee}),
+    QId               = ?call(call_contract, Acc, Ct, createQuery, word,
+                                {Ct, Question, QueryFee, RelativeTTL(5), RelativeTTL(5)}, #{amount => QueryFee}),
     Question          = ?call(call_contract, Acc, Ct, getQuestion, string, {CtId, QId}),
     QueryFee          = ?call(call_contract, Acc, Ct, queryFee, word, Ct),
     none              = ?call(call_contract, Acc, Ct, getAnswer, {option, word}, {CtId, QId}),
     {}                = ?call(call_contract, Acc, Ct, respond, {tuple, []}, {CtId, QId, 0, 4001}),
     {some, 4001}      = ?call(call_contract, Acc, Ct, getAnswer, {option, word}, {CtId, QId}),
-    {}                = ?call(call_contract, Acc, Ct, extendOracle, {tuple, []}, {Ct, 0, TTL + 10}),
+    {}                = ?call(call_contract, Acc, Ct, extendOracle, {tuple, []}, {Ct, 0, FixedTTL(TTL + 10)}),
 
     %% Test complex answers
     Ct1 = ?call(create_contract, Acc, oracles, {}, #{amount => 100000}),

--- a/apps/aecontract/test/aecontract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_SUITE.erl
@@ -852,7 +852,7 @@ ttl_scenario_create_and_extend(Start0, Extend0, Stop0) ->
       || Start <- List(Start0), Extend <- List(Extend0), Stop <- List(Stop0),
          TTLo <- [ T || Extend == false, T <- ttls(Start, [Stop]) ] ++
                  [ T || Extend /= false, T <- ttls(Start, [Extend + 5]) ],
-         TTLe = {delta, _} <- [ 0 || Extend == false ] ++
+         TTLe = {delta, _} <- [ {delta, 0} || Extend == false ] ++
                               [ T || Extend /= false, T <- ttls(ttl_height(Start, TTLo), [Stop]) ] ].
 
 %% Base scenario for failing or unnecessary extends.

--- a/apps/aecore/src/aec_vm_chain.erl
+++ b/apps/aecore/src/aec_vm_chain.erl
@@ -110,7 +110,7 @@ spend(RecipientId, Amount, State = #state{ account = ContractKey }) ->
 
 %%    Oracle
 -spec oracle_register(aec_keys:pubkey(), binary(), non_neg_integer(),
-                      non_neg_integer(), aeso_sophia:type(), aeso_sophia:type(), chain_state()) ->
+                      aeo_oracles:ttl(), aeso_sophia:type(), aeso_sophia:type(), chain_state()) ->
     {ok, aec_keys:pubkey(), chain_state()} | {error, term()}.
 oracle_register(AccountKey,_Sign, QueryFee, TTL, QueryFormat, ResponseFormat,
                 State = #state{account = ContractKey}) ->
@@ -127,7 +127,7 @@ oracle_register(AccountKey,_Sign, QueryFee, TTL, QueryFormat, ResponseFormat,
           query_format    => BinaryQueryFormat,
           response_format => BinaryResponseFormat,
           query_fee       => QueryFee,
-          oracle_ttl      => {delta, TTL},
+          oracle_ttl      => TTL,
           ttl             => 0, %% Not used.
           fee             => 0},
     {ok, Tx} = aeo_register_tx:new(Spec),
@@ -160,8 +160,8 @@ oracle_query(Oracle, Q, Value, QTTL, RTTL,
                            oracle_id     => aec_id:create(oracle, Oracle),
                            query         => QueryData,
                            query_fee     => Value,
-                           query_ttl     => {delta, QTTL},
-                           response_ttl  => {delta, RTTL},
+                           query_ttl     => QTTL,
+                           response_ttl  => RTTL,
                            fee           => 0,
                            ttl           => 0 %% Not used
                           }),
@@ -193,7 +193,7 @@ oracle_extend(Oracle,_Sign, TTL, State) ->
     {ok, Tx} =
         aeo_extend_tx:new(#{oracle_id  => aec_id:create(oracle, Oracle),
                             nonce      => Nonce,
-                            oracle_ttl => {delta, TTL},
+                            oracle_ttl => TTL,
                             fee        => 0,
                             ttl        => 0 %% Not used
                            }),

--- a/apps/aeoracle/test/aeoracle_SUITE.erl
+++ b/apps/aeoracle/test/aeoracle_SUITE.erl
@@ -198,7 +198,7 @@ extend_oracle_negative_dynamic_fee(Cfg) ->
 
     %% Test minimum fee for increasing TTL.
     ?assertEqual({error, too_low_fee}, F(#{oracle_ttl => {delta, 0}, fee => 0})),
-    ?assertMatch({ok, _}             , F(#{oracle_ttl => {delta, 0}, fee => MinFee})),
+    ?assertEqual({error, zero_relative_oracle_extension_ttl}, F(#{oracle_ttl => {delta, 0}, fee => MinFee})),
     ?assertEqual({error, too_low_fee}, F(#{oracle_ttl => {delta, 1}, fee => MinFee})),
     ?assertMatch({ok, _}             , F(#{oracle_ttl => {delta, 1}, fee => 1 + MinFee})),
     ?assertMatch({ok, _}             , F(#{oracle_ttl => {delta, 999}, fee => 1 + MinFee})),

--- a/apps/aesophia/src/aeso_ast_infer_types.erl
+++ b/apps/aesophia/src/aeso_ast_infer_types.erl
@@ -74,12 +74,15 @@ global_env() ->
     Fun1    = fun(S, T) -> Fun([S], T) end,
     TVar    = fun(X) -> {tvar, Ann, "'" ++ X} end,
     Signature = {id, Ann, "signature"},
-    TTL       = Int,
+    TTL       = {qid, Ann, ["Chain", "ttl"]},
     Fee       = Int,
     [A, Q, R, K, V] = lists:map(TVar, ["a", "q", "r", "k", "v"]),
      %% Option constructors
     [{"None", Option(A)},
      {"Some", Fun1(A, Option(A))},
+     %% TTL constructors
+     {"RelativeTTL", Fun1(Int, TTL)},
+     {"FixedTTL",    Fun1(Int, TTL)},
      %% Spend transaction.
      {["Chain","spend"], Fun([Address, Int], Unit)},
      %% Environment variables

--- a/apps/aesophia/src/aeso_ast_to_icode.erl
+++ b/apps/aesophia/src/aeso_ast_to_icode.erl
@@ -143,7 +143,7 @@ ast_body(?qid_app(["Oracle", "register"], [Acct, Sign, QFee, TTL], _, ?oracle_t(
     prim_call(?PRIM_CALL_ORACLE_REGISTER, #integer{value = 0},
               [ast_body(Acct, Icode), ast_body(Sign, Icode), ast_body(QFee, Icode), ast_body(TTL, Icode),
                ast_type_value(QType, Icode), ast_type_value(RType, Icode)],
-              [word, word, word, word, typerep, typerep], word);
+              [word, word, word, ttl_t(Icode), typerep, typerep], word);
 
 ast_body(?qid_app(["Oracle", "query_fee"], [Oracle], _, _), Icode) ->
     prim_call(?PRIM_CALL_ORACLE_QUERY_FEE, #integer{value = 0},
@@ -152,12 +152,12 @@ ast_body(?qid_app(["Oracle", "query_fee"], [Oracle], _, _), Icode) ->
 ast_body(?qid_app(["Oracle", "query"], [Oracle, Q, QFee, QTTL, RTTL], [_, QType, _, _, _], _), Icode) ->
     prim_call(?PRIM_CALL_ORACLE_QUERY, ast_body(QFee, Icode),
               [ast_body(Oracle, Icode), ast_body(Q, Icode), ast_body(QTTL, Icode), ast_body(RTTL, Icode)],
-              [word, ast_type(QType, Icode), word, word], word);
+              [word, ast_type(QType, Icode), ttl_t(Icode), ttl_t(Icode)], word);
 
 ast_body(?qid_app(["Oracle", "extend"], [Oracle, Sign, TTL], _, _), Icode) ->
     prim_call(?PRIM_CALL_ORACLE_EXTEND, #integer{value = 0},
               [ast_body(Oracle, Icode), ast_body(Sign, Icode), ast_body(TTL, Icode)],
-              [word, word, word], {tuple, []});
+              [word, word, ttl_t(Icode)], {tuple, []});
 
 ast_body(?qid_app(["Oracle", "respond"], [Oracle, Query, Sign, R], [_, _, _, RType], _), Icode) ->
     prim_call(?PRIM_CALL_ORACLE_RESPOND, #integer{value = 0},
@@ -469,6 +469,8 @@ ast_typerep(Type) -> ast_typerep(Type, aeso_icode:new([])).
 
 ast_typerep({id, _, Name}, Icode) ->
     lookup_type_id(Name, [], Icode);
+ast_typerep({qid, _, Name}, Icode) ->
+    lookup_type_id(Name, [], Icode);
 ast_typerep({con, _, _}, _) ->
     word;   %% Contract type
 ast_typerep({app_t, _, {id, _, Name}, Args}, Icode) ->
@@ -494,6 +496,9 @@ ast_typerep({variant_t, Cons}, Icode) ->
                   {constr_t, _, _, Args} = Con,
                   [ ast_typerep(Arg, Icode) || Arg <- Args ]
                 end || Con <- Cons ]}.
+
+ttl_t(Icode) ->
+    ast_typerep({qid, [], ["Chain", "ttl"]}, Icode).
 
 lookup_type_id(Name, Args, #{ types := Types }) ->
     case maps:get(Name, Types, undefined) of

--- a/apps/aesophia/src/aeso_icode.erl
+++ b/apps/aesophia/src/aeso_icode.erl
@@ -21,11 +21,14 @@
                    , arg_list()
                    , expr()
                    , aeso_sophia:type()}.
+
+-type type_name() :: string() | [string()].
+
 -type icode() :: #{ contract_name => string()
                   , functions => [fun_dec()]
                   , env => [bindings()]
                   , state_type => aeso_sophia:type()
-                  , types => #{ string() => type_def() }
+                  , types => #{ type_name() => type_def() }
                   , type_vars => #{ string() => aeso_sophia:type() }
                   , constructors => #{ string() => integer() }  %% name to tag
                   , options => [any()]
@@ -44,7 +47,7 @@ new(Options) ->
      , state_type => {tuple, []}
      , types => builtin_types()
      , type_vars => #{}
-     , constructors => #{}
+     , constructors => builtin_constructors()
      , options => Options}.
 
 builtin_types() ->
@@ -60,7 +63,12 @@ builtin_types() ->
      , "list"         => fun([A]) -> {list, A} end
      , "option"       => fun([A]) -> {option, A} end
      , "map"          => fun([K, V]) -> map_typerep(K, V) end
+     , ["Chain", "ttl"] => fun([]) -> {variant, [[word], [word]]} end
      }.
+
+builtin_constructors() ->
+    #{ "RelativeTTL" => 0
+     , "FixedTTL"    => 1 }.
 
 map_typerep(K, V) ->
     {list, {tuple, [K, V]}}.  %% Lists of key-value pairs for now

--- a/apps/aesophia/test/contracts/oracles.aes
+++ b/apps/aesophia/test/contracts/oracles.aes
@@ -1,7 +1,7 @@
 contract Oracles =
 
   type fee = int
-  type ttl = int
+  type ttl = Chain.ttl
 
   type query_t  = string
   type answer_t = int
@@ -63,8 +63,8 @@ contract Oracles =
   datatype complexAnswer   = NoAnswer | Answer(complexQuestion, string, int)
 
   function complexOracle(question, sig) =
-    let o = Oracle.register(Contract.address, sig, 0, 1000) : oracle(complexQuestion, complexAnswer)
-    let q = Oracle.query(o, question, 0, 100, 100)
+    let o = Oracle.register(Contract.address, sig, 0, FixedTTL(1000)) : oracle(complexQuestion, complexAnswer)
+    let q = Oracle.query(o, question, 0, RelativeTTL(100), RelativeTTL(100))
     Oracle.respond(o, q, sig, Answer(question, "magic", 1337))
     Oracle.get_answer(o, q)
 

--- a/apps/aesophia/test/contracts/oracles_err.aes
+++ b/apps/aesophia/test/contracts/oracles_err.aes
@@ -4,8 +4,8 @@ contract OraclesErr =
     o    : oracle(string, int),
     q    : string,
     qfee  : int,
-    qttl : int,
-    rttl : int) : oracle_query(string, int) =
+    qttl : Chain.ttl,
+    rttl : Chain.ttl) : oracle_query(string, int) =
     let x = Oracle.query(o, q, qfee, qttl, rttl)
     switch(0) 1 => ()
     x // Never reached.

--- a/apps/aesophia/test/contracts/remote_oracles.aes
+++ b/apps/aesophia/test/contracts/remote_oracles.aes
@@ -4,21 +4,21 @@ contract Oracles =
     (address,
      signature,
      int,
-     int) => oracle(string, int)
+     Chain.ttl) => oracle(string, int)
 
   function createQuery :
     (oracle(string, int),
      string,
      int,
-     int,
-     int) => oracle_query(string, int)
+     Chain.ttl,
+     Chain.ttl) => oracle_query(string, int)
 
   function unsafeCreateQuery :
     (oracle(string, int),
      string,
      int,
-     int,
-     int) => oracle_query(string, int)
+     Chain.ttl,
+     Chain.ttl) => oracle_query(string, int)
 
   function respond :
     (oracle(string, int),
@@ -32,8 +32,8 @@ contract OraclesErr =
     (oracle(string, int),
      string,
      int,
-     int,
-     int) => oracle_query(string, int)
+     Chain.ttl,
+     Chain.ttl) => oracle_query(string, int)
 
 contract RemoteOracles =
 
@@ -42,7 +42,7 @@ contract RemoteOracles =
       acct : address,
       sign : signature,
       qfee : int,
-      ttl  : int) : oracle(string, int) =
+      ttl  : Chain.ttl) : oracle(string, int) =
     r.registerOracle(acct, sign, qfee, ttl)
 
   public function callCreateQuery(
@@ -51,8 +51,8 @@ contract RemoteOracles =
     o     : oracle(string, int),
     q     : string,
     qfee  : int,
-    qttl  : int,
-    rttl  : int) : oracle_query(string, int) =
+    qttl  : Chain.ttl,
+    rttl  : Chain.ttl) : oracle_query(string, int) =
     require(value =< Call.value, "insufficient value")
     r.createQuery(value = value, o, q, qfee, qttl, rttl)
 
@@ -63,8 +63,8 @@ contract RemoteOracles =
     o     : oracle(string, int),
     q     : string,
     qfee  : int,
-    qttl  : int,
-    rttl  : int) : oracle_query(string, int) =
+    qttl  : Chain.ttl,
+    rttl  : Chain.ttl) : oracle_query(string, int) =
     r.unsafeCreateQuery(value = value, o, q, qfee, qttl, rttl)
 
   // Do not use in production!
@@ -74,8 +74,8 @@ contract RemoteOracles =
     o     : oracle(string, int),
     q     : string,
     qfee  : int,
-    qttl  : int,
-    rttl  : int) : oracle_query(string, int) =
+    qttl  : Chain.ttl,
+    rttl  : Chain.ttl) : oracle_query(string, int) =
     r.unsafeCreateQueryThenErr(value = value, o, q, qfee, qttl, rttl)
 
   // Do not use in production!
@@ -85,8 +85,8 @@ contract RemoteOracles =
     o     : oracle(string, int),
     q     : string,
     qfee  : int,
-    qttl  : int,
-    rttl  : int) : oracle_query(string, int) =
+    qttl  : Chain.ttl,
+    rttl  : Chain.ttl) : oracle_query(string, int) =
     let x = r.unsafeCreateQuery(value = value, o, q, qfee, qttl, rttl)
     switch(0) 1 => ()
     x // Never reached.

--- a/apps/aevm/src/aevm_ae_primops.erl
+++ b/apps/aevm/src/aevm_ae_primops.erl
@@ -118,8 +118,12 @@ call_chain(Callback, State) ->
         {error, _} = Err -> Err
     end.
 
+%% Sophia representation of aeo_oracles:ttl().
+oracle_ttl_t() ->
+    {variant_t, [{delta, [word]}, {block, [word]}]}.
+
 oracle_call_register(_Value, Data, State) ->
-    ArgumentTypes = [word, word, word, word, typerep, typerep],
+    ArgumentTypes = [word, word, word, oracle_ttl_t(), typerep, typerep],
     [Acct, Sign, QFee, TTL, QType, RType] = get_args(ArgumentTypes, Data),
     Callback =
         fun(API, ChainState) ->
@@ -134,7 +138,7 @@ oracle_call_query(Value, Data, State) ->
     OracleKey = <<Oracle:256>>,
     case call_chain1(fun(API, ChainState) -> API:oracle_query_format(OracleKey, ChainState) end, State) of
         {ok, QueryType} ->
-            ArgumentTypes = [word, QueryType, word, word],
+            ArgumentTypes = [word, QueryType, oracle_ttl_t(), oracle_ttl_t()],
             [_Oracle, Q, QTTL, RTTL] = get_args(ArgumentTypes, Data),
             Callback = fun(API, ChainState) ->
                 case API:oracle_query(OracleKey, Q, _QFee=Value, QTTL, RTTL, ChainState) of
@@ -161,7 +165,7 @@ oracle_call_respond(_Value, Data, State) ->
 
 
 oracle_call_extend(_Value, Data, State) ->
-    ArgumentTypes = [word, word, word],
+    ArgumentTypes = [word, word, oracle_ttl_t()],
     [Oracle, Sign, TTL] = get_args(ArgumentTypes, Data),
     Callback = fun(API, ChainState) -> API:oracle_extend(<<Oracle:256>>, Sign, TTL, ChainState) end,
     call_chain(Callback, State).

--- a/apps/aevm/src/aevm_chain_api.erl
+++ b/apps/aevm/src/aevm_chain_api.erl
@@ -44,7 +44,7 @@
 -callback oracle_register(Account :: pubkey(),
                           Sign :: binary(),
                           QueryFee :: non_neg_integer(),
-                          TTL :: non_neg_integer(),
+                          TTL :: aeo_oracles:ttl(),
                           DecodedQType :: aeso_sophia:type(),
                           DecodedRType :: aeso_sophia:type(),
                           ChainState :: chain_state()) ->
@@ -53,8 +53,8 @@
 -callback oracle_query(Oracle :: pubkey(),
                        Query :: term(),
                        Value :: non_neg_integer(),
-                       QueryTTL :: non_neg_integer(),
-                       ResponseTTL :: non_neg_integer(),
+                       QueryTTL :: aeo_oracles:ttl(),
+                       ResponseTTL :: aeo_oracles:ttl(),
                        ChainState :: chain_state()) ->
     {ok, QueryId :: pubkey(), chain_state()} | {error, term()}.
 
@@ -67,7 +67,7 @@
 
 -callback oracle_extend(Oracle :: pubkey(),
                         Sign :: binary(),
-                        TTL :: non_neg_integer(),
+                        TTL :: aeo_oracles:ttl(),
                         ChainState :: chain_state()) ->
     {ok, chain_state()} | {error, term()}.
 

--- a/apps/aevm/src/aevm_eeevm.erl
+++ b/apps/aevm/src/aevm_eeevm.erl
@@ -68,10 +68,8 @@ eval_code(State) ->
     try {ok, loop(valid_jumpdests(State))}
     catch
         throw:?aevm_eval_error(What, StateOut) ->
-            ?TEST_LOG("Code evaluation error at ~s in~n~s",
-                      [aeb_disassemble:format_address(aevm_eeevm_state:cp(StateOut)),
-                       aeb_disassemble:format(aevm_eeevm_state:code(StateOut),
-                                              fun(F,D) -> ?TEST_LOG(F,D) end)]),
+            ?TEST_LOG("Code evaluation error at ~s",
+                      [aeb_disassemble:format_address(aevm_eeevm_state:cp(StateOut))]),
 	    %% Throw away new storage on error.
             {error, What, old_store(State, StateOut)};
 	throw:?AEVM_SIGNAL(Signal, StateOut) ->

--- a/test/contract_sophia_bytecode_aevm_SUITE.erl
+++ b/test/contract_sophia_bytecode_aevm_SUITE.erl
@@ -332,8 +332,8 @@ oracles(_Cfg) ->
     Env0 = initial_state(#{}),
     Env1 = create_contract(101, Code, "()", Env0),
     QFee = 100,
-    {101, Env2} = successful_call(101, word, registerOracle, "(101, 3, "++ integer_to_list(QFee) ++", 10)", Env1),
-    {Q, Env3}   = successful_call(101, word, createQuery, "(101, \"why?\", "++ integer_to_list(QFee) ++", 10, 11)", Env2, #{value => QFee}),
+    {101, Env2} = successful_call(101, word, registerOracle, "(101, 3, "++ integer_to_list(QFee) ++", (0, 10))", Env1),
+    {Q, Env3}   = successful_call(101, word, createQuery, "(101, \"why?\", "++ integer_to_list(QFee) ++", (0, 10), (0, 11))", Env2, #{value => QFee}),
     QArg        = integer_to_list(Q),
     OandQArg    = "(101, "++ QArg ++")",
     none        = successful_call_(101, {option, word}, getAnswer, OandQArg, Env3),
@@ -341,19 +341,19 @@ oracles(_Cfg) ->
     {some, 42}  = successful_call_(101, {option, word}, getAnswer, OandQArg, Env4),
     <<"why?">>  = successful_call_(101, string, getQuestion, OandQArg, Env4),
     QFee        = successful_call_(101, word, queryFee, "101", Env4),
-    {{}, Env5}  = successful_call(101, {tuple, []}, extendOracle, "(101, 1111, 100)", Env4),
+    {{}, Env5}  = successful_call(101, {tuple, []}, extendOracle, "(101, 1111, (0, 100))", Env4),
     #{oracles :=
           #{101 := #{
              nonce := 1,
              query_format := string,
              response_format := word,
              sign := 3,
-             ttl := 100}},
+             ttl := {delta, 100}}},
       oracle_queries :=
           #{Q := #{ oracle := 101,
                     query := <<"why?">>,
-                    q_ttl := 10,
-                    r_ttl := 11,
+                    q_ttl := {delta, 10},
+                    r_ttl := {delta, 11},
                     answer := {some, 42} }}} = Env5,
     ok.
 


### PR DESCRIPTION
Closes [PT-157931784](https://www.pivotaltracker.com/story/show/157931784).

Adds a builtin datatype
```
datatype Chain.ttl = RelativeTTL(int) | FixedTTL(int)
```
and changes the Oracle API to take values of this type instead of plain `int`s.