### PR TITLE
Pt 160091716 adapt system tests

### DIFF
--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -3953,7 +3953,7 @@ ws_refused_on_limit_reached(_Config) ->
             fun(_) ->
                 %% try to connect a WS client; assert it does not connect and
                 %% is waiting
-                {error, still_connecting, WaitingPid} = ws_start_link(),
+                {error, {still_connecting, WaitingPid}} = ws_start_link(),
                 MaxWsCount = open_websockets_count(),
                 WaitingPid
             end,

--- a/apps/aehttp/test/aehttp_ws_test_utils.erl
+++ b/apps/aehttp/test/aehttp_ws_test_utils.erl
@@ -71,7 +71,7 @@ start_channel(Host, Port, RoleA, Opts) when is_atom(RoleA) ->
         {ok, Pid} = Res ->
             set_role(Pid, RoleA),
             Res;
-        {error, _, _} = Err -> Err
+        {error, _} = Err -> Err
     end.
 
 
@@ -95,7 +95,7 @@ wait_for_connect(Pid) ->
         timeout ->
             case process_info(Pid) of
                 undefined -> {error, rejected};
-                _ -> {error, still_connecting, Pid}
+                _ -> {error, {still_connecting, Pid}}
             end
     end.
 

--- a/system_test/aest_channels_SUITE.erl
+++ b/system_test/aest_channels_SUITE.erl
@@ -106,10 +106,10 @@ end_per_suite(_Config) -> ok.
 test_simple_same_node_channel(Cfg) ->
     ChannelOpts = #{
         initiator_node => node1,
-        initiator_account => ?BOB,
+        initiator_id => ?BOB,
         initiator_amount => 80,
         responder_node => node1,
-        responder_account => ?ALICE,
+        responder_id => ?ALICE,
         responder_amount => 80
     },
     simple_channel_test(ChannelOpts, Cfg).
@@ -117,19 +117,19 @@ test_simple_same_node_channel(Cfg) ->
 test_simple_different_nodes_channel(Cfg) ->
     ChannelOpts = #{
         initiator_node => node1,
-        initiator_account => ?BOB,
+        initiator_id   => ?BOB,
         initiator_amount => 80,
         responder_node => node2,
-        responder_account => ?ALICE,
+        responder_id => ?ALICE,
         responder_amount => 80
     },
     simple_channel_test(ChannelOpts, Cfg).
 
 simple_channel_test(ChannelOpts, Cfg) ->
     #{
-        initiator_account := IAccount,
+        initiator_id     := IAccount,
         initiator_amount := IAmt,
-        responder_account := RAccount,
+        responder_id     := RAccount,
         responder_amount := RAmt
     } = ChannelOpts,
 

--- a/system_test/aest_sync_SUITE.erl
+++ b/system_test/aest_sync_SUITE.erl
@@ -479,8 +479,8 @@ add_spend_txs(Node, SenderAcct, N, NonceStart) ->
 add_spend_tx(Node, #{ pubkey := SendPubKey, privkey := SendSecKey }, Nonce) ->
     #{ public := RecvPubKey, secret := RecvSecKey } = enacl:sign_keypair(),
     PayLoad = iolist_to_binary(io_lib:format("~p", [Node])),
-    Params = #{ sender => aec_id:create(account, SendPubKey)
-              , recipient => aec_id:create(account, RecvPubKey)
+    Params = #{ sender_id => aec_id:create(account, SendPubKey)
+              , recipient_id => aec_id:create(account, RecvPubKey)
               , amount => 10000
               , fee => 100
               , ttl => 10000000


### PR DESCRIPTION
With the new API using ids the system tests fail. This patch makes the system tests compatible to use of id in API.