### PR TITLE
Pt 160014862 missing db table

### DIFF
--- a/apps/aecore/test/aecore_errorfree_SUITE.erl
+++ b/apps/aecore/test/aecore_errorfree_SUITE.erl
@@ -1,0 +1,72 @@
+%% Test that when starting a node no errors are written in the log file
+
+-module(aecore_errorfree_SUITE).
+
+%% common_test exports
+-export(
+   [
+    all/0, 
+    init_per_suite/1, end_per_suite/1,
+    init_per_testcase/2, end_per_testcase/2
+   ]).
+
+%% test case exports
+-export(
+   [ application_test/1 ]).
+
+
+-include_lib("common_test/include/ct.hrl").
+
+all() ->
+    [ application_test ].
+
+init_per_suite(Config) ->
+    ok = application:ensure_started(erlexec),
+    DataDir = ?config(data_dir, Config),
+    TopDir = aecore_suite_utils:top_dir(DataDir),
+    Config1 = [{symlink_name, "latest.errorfree"},
+               {top_dir, TopDir},
+               {test_module, ?MODULE}] ++ Config,
+    aecore_suite_utils:make_shortcut(Config1),
+    ct:log("Environment = ~p", [[{args, init:get_arguments()},
+                                 {node, node()},
+                                 {cookie, erlang:get_cookie()}]]),
+    aecore_suite_utils:create_configs(Config1),
+    aecore_suite_utils:make_multi(Config1),
+    [{nodes, [aecore_suite_utils:node_tuple(dev1),
+              aecore_suite_utils:node_tuple(dev2)]} | Config1].
+
+end_per_suite(Config) ->
+    aecore_suite_utils:stop_node(dev1, Config),
+    aecore_suite_utils:stop_node(dev2, Config),
+    ok.
+
+init_per_testcase(_Case, Config) ->
+    ct:log("testcase pid: ~p", [self()]),
+    [{tc_start, os:timestamp()}|Config].
+
+end_per_testcase(_Case, Config) ->
+    Ts0 = ?config(tc_start, Config),
+    ct:log("Events during TC: ~p", [[{N, aecore_suite_utils:all_events_since(N, Ts0)}
+                                     || {_,N} <- ?config(nodes, Config)]]),
+    ok.
+
+%% ============================================================
+%% Test cases
+%% ============================================================
+
+application_test(Config) ->
+    aecore_suite_utils:start_node(dev1, Config),
+    N1 = aecore_suite_utils:node_name(dev1),
+    aecore_suite_utils:connect(N1),
+    aecore_suite_utils:start_node(dev2, Config),
+    N2 = aecore_suite_utils:node_name(dev2),
+    aecore_suite_utils:connect(N2),
+    {ok, _Blocks} = aecore_suite_utils:mine_key_blocks(N1, 8),
+    aecore_suite_utils:stop_node(dev1, Config),
+    aecore_suite_utils:stop_node(dev2, Config),
+
+    [] = aecore_suite_utils:errors_in_logs([dev1, dev2], Config),
+
+    ok.
+


### PR DESCRIPTION
Sporadically on CI we seem to not be able to find a database table in the test case aeu_requests. This test is a remainder from early days added to allert us when a started system had errors in its logs.

I cannot understand why this happens. Locally I have run this test with combinations of other tests in an attempt to reproduce it. No luck. I tried reproducing it on CI by pushing it a few times, no luck.

I wrote a completely new test that can replace the old one and also added some more info in the test case to help when the test fails again. In the long run, we can remove the test, but I would like to understand the cause of this.

Made use of this patch to cleanup aec_db a bit.