### PR TITLE
System smoke tests on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -491,10 +491,6 @@ jobs:
           command: |
             docker build -t ${DOCKERHUB_REPO:?}:local .
       - run:
-          name: Install system tests dependancies
-          command: |
-            sudo -u ubuntu -E -H make system-test-deps
-      - run:
           name: System Tests
           no_output_timeout: 2h
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -623,9 +623,7 @@ workflows:
       - docker_system_smoke_tests:
           filters:
             branches:
-              ignore:
-                - env/dev1
-                - env/dev2
+              only: master
 
       - test:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -607,8 +607,6 @@ workflows:
               ignore:
                 - env/dev1
                 - env/dev2
-            tags:
-              only: /^v.*$/
 
       - eunit:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -242,6 +242,14 @@ references:
         docker-compose logs
       when: always
 
+  install_system_test_deps: &install_system_test_deps
+    run:
+      name: Build local docker image
+      command: |
+        docker build -t ${DOCKERHUB_REPO:?}:local .
+
+  system_test_logs: &system_test_logs system_test/logs
+
 jobs:
   build:
     <<: *container_config
@@ -486,10 +494,7 @@ jobs:
       - *install_otp
       - *install_libsodium
       - *prepare_ubuntu_user
-      - run:
-          name: Build local docker image
-          command: |
-            docker build -t ${DOCKERHUB_REPO:?}:local .
+      - *install_system_test_deps
       - run:
           name: System Tests
           no_output_timeout: 2h
@@ -497,9 +502,29 @@ jobs:
             sudo -u ubuntu -E -H make system-test
       - *fail_notification_system_test
       - store_test_results:
-          path: system_test/logs
+          path: *system_test_logs
       - store_artifacts:
-          path: system_test/logs
+          path: *system_test_logs
+
+  docker_system_smoke_tests:
+    <<: *machine_config
+    steps:
+      - checkout
+      - *install_os_deps
+      - *install_otp
+      - *install_libsodium
+      - *prepare_ubuntu_user
+      - *install_system_test_deps
+      - run:
+          name: System Smoke Tests
+          no_output_timeout: 1h
+          command: |
+            sudo -u ubuntu -E -H make smoke-test-run
+      - *fail_notification_system_test
+      - store_test_results:
+          path: *system_test_logs
+      - store_artifacts:
+          path: *system_test_logs
 
   deploy_integration:
     <<: *infrastructure_config
@@ -594,6 +619,13 @@ workflows:
               ignore: /.*/
             tags:
               only: /^v.*$/
+
+      - docker_system_smoke_tests:
+          filters:
+            branches:
+              ignore:
+                - env/dev1
+                - env/dev2
 
       - test:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -779,8 +779,8 @@ workflows:
   chain_snapshots:
     triggers:
       - schedule:
-          # run At minute 0 past hour 0 and 12. UTC
-          cron: "0 0,12 * * *"
+          # run At minute 0 past hour 0. UTC
+          cron: "0 0 * * *"
           filters:
             branches:
               only:

--- a/Makefile
+++ b/Makefile
@@ -187,16 +187,13 @@ docker-clean:
 	@echo "Deleting images..."
 	@docker image prune -a -f $(ST_DOCKER_FILTER)
 
-smoke-test: system-test-deps docker smoke-test-run
+smoke-test: docker smoke-test-run
 
 smoke-test-run:
 	@./rebar3 as system_test do ct $(ST_CT_FLAGS) --suite=aest_sync_SUITE,aest_commands_SUITE,aest_peers_SUITE
 
 system-test:
 	@./rebar3 as system_test do ct $(ST_CT_FLAGS) $(CT_TEST_FLAGS)
-
-system-test-deps:
-#	docker pull aeternity/epoch:latest
 
 aevm-test: aevm-test-deps
 	@./rebar3 eunit --application=aevm
@@ -343,7 +340,7 @@ internal-distclean: $$(KIND)
 	internal-start internal-stop internal-attach internal-clean internal-compile-deps \
 	dialyzer \
 	docker docker-clean \
-	test smoke-test smoke-test-run system-test system-test-deps aevm-test-deps\
+	test smoke-test smoke-test-run system-test aevm-test-deps\
 	kill killall \
 	clean distclean \
 	swagger swagger-docs swagger-check swagger-version-check \

--- a/Makefile
+++ b/Makefile
@@ -198,9 +198,6 @@ system-test:
 system-test-deps:
 #	docker pull aeternity/epoch:latest
 
-TESTNET_DB_BACKUP_FILE = mnesia_18.196.250.42_uat_db_backup_1524700922.gz
-TESTNET_DB_BACKUP_BASE_URL = https://9305-99802036-gh.circle-artifacts.com/0/tmp/chain_snapshots/18.196.250.42/tmp
-
 aevm-test: aevm-test-deps
 	@./rebar3 eunit --application=aevm
 


### PR DESCRIPTION
Delivers https://www.pivotaltracker.com/story/show/159034542
The work as part of this PR assesses running system tests as part of PR and concludes that it is still too slow, hence enables only on master. Optimization for running as part of PR CI is tracked as https://www.pivotaltracker.com/story/show/160128182