### PR TITLE
Pt 159497193 coinbase in vm state

### DIFF
--- a/apps/aecontract/src/aect_call_tx.erl
+++ b/apps/aecontract/src/aect_call_tx.erl
@@ -221,6 +221,8 @@ run_contract(#contract_call_tx{ nonce  = _Nonce
     ContractsTree  = aec_trees:contracts(Trees),
     Contract       = aect_state_tree:get_contract(ContractPubkey, ContractsTree),
     Code           = aect_contracts:code(Contract),
+    {ok, KeyBlock} = aec_chain:get_key_block_by_height(Height),
+    Beneficiary = aec_blocks:beneficiary(KeyBlock),
     CallDef = #{ caller     => CallerPubkey
                , contract   => ContractPubkey
                , gas        => Gas
@@ -232,6 +234,7 @@ run_contract(#contract_call_tx{ nonce  = _Nonce
                , call       => Call
                , height     => Height
                , trees      => Trees
+               , beneficiary => Beneficiary
                },
     aect_dispatch:run(VmVersion, CallDef).
 

--- a/apps/aecontract/src/aect_channel_contract.erl
+++ b/apps/aecontract/src/aect_channel_contract.erl
@@ -1,4 +1,5 @@
 -module(aect_channel_contract).
+-include_lib("apps/aecore/include/blocks.hrl").
 -include("aecontract.hrl").
 
 -export([new/6,
@@ -44,7 +45,7 @@ run_new(ContractPubKey, Call, CallData, Round, Trees0) ->
                  %% We do not want the execution off chain and
                  %% on chain to be different so the coinbase
                  %% instruction will allways return 0.
-               , beneficiary => 0
+               , beneficiary => <<0:?BENEFICIARY_PUB_BYTES/unit:8>>
                },
     {CallRes, Trees} = aect_dispatch:run(VmVersion, CallDef),
     case aect_call:return_type(CallRes) of
@@ -99,7 +100,7 @@ run(ContractPubKey, VmVersion, Call, CallData, CallStack, Round, Trees0,
                  %% We do not want the execution off chain and
                  %% on chain to be different so the coinbase
                  %% instruction will allways return 0.
-               , beneficiary => 0
+               , beneficiary => <<0:?BENEFICIARY_PUB_BYTES/unit:8>>
                },
     {CallRes, Trees} = aect_dispatch:run(VmVersion, CallDef),
     aect_utils:insert_call_in_trees(CallRes, Trees).

--- a/apps/aecontract/src/aect_channel_contract.erl
+++ b/apps/aecontract/src/aect_channel_contract.erl
@@ -30,17 +30,21 @@ run_new(ContractPubKey, Call, CallData, Round, Trees0) ->
     CallStack = [], %% TODO: should we have a call stack for create_tx also
                     %% when creating a contract in a contract.
     VmVersion = aect_contracts:vm_version(Contract),
-    CallDef = #{ caller     => OwnerPubKey
-               , contract   => ContractPubKey
-               , gas        => 10000000
-               , gas_price  => 1
-               , call_data  => CallData
-               , amount     => 0
-               , call_stack => CallStack
-               , code       => Code
-               , call       => Call
-               , height     => Round
-               , trees      => Trees0
+    CallDef = #{ caller      => OwnerPubKey
+               , contract    => ContractPubKey
+               , gas         => 10000000
+               , gas_price   => 1
+               , call_data   => CallData
+               , amount      => 0
+               , call_stack  => CallStack
+               , code        => Code
+               , call        => Call
+               , height      => Round
+               , trees       => Trees0
+                 %% We do not want the execution off chain and
+                 %% on chain to be different so the coinbase
+                 %% instruction will allways return 0.
+               , beneficiary => 0
                },
     {CallRes, Trees} = aect_dispatch:run(VmVersion, CallDef),
     case aect_call:return_type(CallRes) of
@@ -92,6 +96,10 @@ run(ContractPubKey, VmVersion, Call, CallData, CallStack, Round, Trees0,
                , call       => Call
                , height     => Round
                , trees      => Trees0
+                 %% We do not want the execution off chain and
+                 %% on chain to be different so the coinbase
+                 %% instruction will allways return 0.
+               , beneficiary => 0
                },
     {CallRes, Trees} = aect_dispatch:run(VmVersion, CallDef),
     aect_utils:insert_call_in_trees(CallRes, Trees).

--- a/apps/aecontract/src/aect_create_tx.erl
+++ b/apps/aecontract/src/aect_create_tx.erl
@@ -296,20 +296,24 @@ run_contract(#contract_create_tx{ nonce      =_Nonce
     Caller = owner_pubkey(Tx),
     CallStack = [], %% TODO: should we have a call stack for create_tx also
                     %% when creating a contract in a contract.
+    {ok, KeyBlock} = aec_chain:get_key_block_by_height(Height),
+    Beneficiary = aec_blocks:beneficiary(KeyBlock),
 
-    CallDef = #{ caller     => Caller
-               , contract   => ContractPubKey
-               , gas        => Gas
-               , gas_price  => GasPrice
-               , call_data  => CallData
-               , amount     => 0 %% Initial call takes no amount
-               , call_stack => CallStack
-               , code       => Code
-               , call       => Call
-               , height     => Height
-               , trees      => Trees
+    CallDef = #{ caller      => Caller
+               , contract    => ContractPubKey
+               , gas         => Gas
+               , gas_price   => GasPrice
+               , call_data   => CallData
+               , amount      => 0 %% Initial call takes no amount
+               , call_stack  => CallStack
+               , code        => Code
+               , call        => Call
+               , height      => Height
+               , trees       => Trees
+               , beneficiary => Beneficiary
                },
     aect_dispatch:run(VmVersion, CallDef).
+
 
 initialize_contract(#contract_create_tx{nonce      = Nonce,
                                         vm_version = VmVersion,

--- a/apps/aecontract/src/aect_dispatch.erl
+++ b/apps/aecontract/src/aect_dispatch.erl
@@ -87,8 +87,8 @@ call_AEVM_01_Solidity_01(#{ contract   := ContractPubKey
 
 set_env(ContractPubKey, Height, Trees, API, VmVersion) ->
     ChainState = aec_vm_chain:new_state(Trees, Height, ContractPubKey),
-    MiningBeneficiarry = aec_conductor:get_beneficiary(),
-    #{currentCoinbase   => MiningBeneficiarry,
+    {ok, <<MiningBeneficiary:?PUB_SIZE/unit:8>>} = aec_conductor:get_beneficiary(),
+    #{currentCoinbase   => MiningBeneficiary,
       %% TODO: get the right difficulty (Tracked as #159522571)
       currentDifficulty => 0,
       %% TODO: implement gas limit in governance and blocks. (Tracked as #159427123)
@@ -125,7 +125,9 @@ call_common(#{ caller     := CallerPubKey
         value      => Value,
         call_stack => CallStack
     }),
-    try aevm_eeevm_state:init(Spec#{exec => Exec}, #{trace => false}) of
+    try aevm_eeevm_state:init(Spec#{exec => Exec},
+			      #{trace => false
+			       }) of
         InitState ->
             %% Update gas_used depending on exit type.
             try aevm_eeevm:eval(InitState) of

--- a/apps/aecontract/src/aect_dispatch.erl
+++ b/apps/aecontract/src/aect_dispatch.erl
@@ -87,14 +87,14 @@ call_AEVM_01_Solidity_01(#{ contract   := ContractPubKey
 
 set_env(ContractPubKey, Height, Trees, API, VmVersion) ->
     ChainState = aec_vm_chain:new_state(Trees, Height, ContractPubKey),
-    %% {ok, MinerPubkey} = aec_keys:pubkey(),
-    #{currentCoinbase   => <<>>, %% MinerPubkey,
-      %% TODO: get the right difficulty
+    MiningBeneficiarry = aec_conductor:get_beneficiary(),
+    #{currentCoinbase   => MiningBeneficiarry,
+      %% TODO: get the right difficulty (Tracked as #159522571)
       currentDifficulty => 0,
-      %% TODO: implement gas limit in governance and blocks.
+      %% TODO: implement gas limit in governance and blocks. (Tracked as #159427123)
       currentGasLimit   => 100000000000,
       currentNumber     => Height,
-      %% TODO: should be set before starting block candidate.
+      %% TODO: should be set before starting block candidate. (Tracked as #159522630)
       currentTimestamp  => aeu_time:now_in_msecs(),
       chainState        => ChainState,
       chainAPI          => API,
@@ -127,7 +127,6 @@ call_common(#{ caller     := CallerPubKey
     }),
     try aevm_eeevm_state:init(Spec#{exec => Exec}, #{trace => false}) of
         InitState ->
-            %% TODO: Nicer error handling - do more in check.
             %% Update gas_used depending on exit type.
             try aevm_eeevm:eval(InitState) of
                 {ok, #{gas := GasLeft, out := Out, chain_state := ChainState}} ->
@@ -143,7 +142,7 @@ call_common(#{ caller     := CallerPubKey
                 {error, Error, _} ->
                     %% Execution resulting in VM exception.
                     %% Gas used, but other state not affected.
-                    %% TODO: Use up the right amount of gas depending on error
+                    %% TODO: Use up the right amount of gas depending on error (#159522821)
                     %% TODO: Store error code in state tree
                     {create_call(Gas, error, Error, Call), Trees}
             catch T:E ->

--- a/apps/aecontract/src/aect_sophia.erl
+++ b/apps/aecontract/src/aect_sophia.erl
@@ -66,7 +66,8 @@ simple_call(Code, Function, Argument) ->
             Contract = aect_contracts:new(Owner, 1, VmVersion, Code, Deposit),
             DummyPubKey = aect_contracts:pubkey(Contract),
             Trees1 = insert_contract(Contract, Trees),
-            ChainState  = aec_vm_chain:new_state(Trees1, BlockHeight, DummyPubKey),
+            ChainState =
+                aec_vm_chain:new_state(Trees1, BlockHeight, DummyPubKey),
             Spec = #{ code => Code
                     , address => 1 %% Address 0 is for primcals.
                     , caller => 0
@@ -75,7 +76,7 @@ simple_call(Code, Function, Argument) ->
                     , gasPrice => 1
                     , origin => 0
                     , value => Amount
-                    , currentCoinbase => 1
+                    , currentCoinbase => 0
                     , currentDifficulty => 1
                     , currentGasLimit => 1000000
                     , currentNumber => 1
@@ -96,7 +97,8 @@ insert_contract(Contract, Trees) ->
     CTrees1 = aect_state_tree:insert_contract(Contract, CTrees),
     aec_trees:set_contracts(Trees, CTrees1).
 
--spec encode_call_data(binary(), binary(), binary()) -> {ok, binary()} | {error, binary()}.
+-spec encode_call_data(binary(), binary(), binary()) ->
+                              {ok, binary()} | {error, binary()}.
 encode_call_data(Contract, Function, Argument) ->
     try create_call(Contract, Function, Argument) of
         Data when is_binary(Data) ->

--- a/apps/aecontract/src/aect_sophia.erl
+++ b/apps/aecontract/src/aect_sophia.erl
@@ -56,7 +56,7 @@ simple_call(Code, Function, Argument) ->
     case create_call(Code, Function, Argument) of
         {error, E} -> {error, E};
         CallData ->
-            %% TODO: proper setup of chain state!
+            %% TODO: proper setup of chain state! Tracked as #160281213
             Owner = <<123456:32/unit:8>>,
             {Block, Trees} = aec_chain:top_block_with_state(),
             BlockHeight = aec_blocks:height(Block) + 1,

--- a/apps/aecontract/test/aecontract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_SUITE.erl
@@ -165,58 +165,9 @@ init_per_testcase(_, Cfg) ->
     mock(),
     Cfg.
 
-%% init_per_testcase(TC, Cfg) ->
-%%     case lists:member(TC, mock_cases()) of
-%%         true -> mock();
-%%         false -> ok
-%%     end,
-%%     Cfg;
-
-%% init_per_testcase(TC, Cfg) ->
-%%     case lists:member(TC, mock_cases()) of
-%%         true -> unmock();
-%%         false -> ok
-%%     end,
-%%     Cfg;
 end_per_testcase(_, Cfg) ->
     unmock(),
     Cfg.
-
-%% mock_cases() ->
-%%     [ create_contract_negative
-%%     , create_contract_init_error
-%%     , create_contract
-%%     , create_contract_with_gas_price_zero
-%%     , call_contract_negative_insufficient_funds
-%%     , call_contract
-%%     , call_contract_with_gas_price_zero
-%%     , call_contract_error_value
-%%     , state_tree
-%%     , sophia_identity
-%%     , sophia_state
-%%     , sophia_match_bug
-%%     , sophia_spend
-%%     , sophia_typed_calls
-%%     , sophia_oracles
-%%     , sophia_oracles_qfee__basic
-%%     , sophia_oracles_qfee__basic__remote
-%%     , sophia_oracles_qfee__qfee_in_query_above_qfee_in_oracle_is_awarded_to_oracle
-%%     , sophia_oracles_qfee__qfee_in_query_above_qfee_in_oracle_is_awarded_to_oracle__remote
-%%     , sophia_oracles_qfee__tx_value_above_qfee_in_query_is_awarded_to_oracle
-%%     , sophia_oracles_qfee__tx_value_above_qfee_in_query_is_awarded_to_oracle__remote
-%%     , sophia_oracles_qfee__qfee_in_query_below_qfee_in_oracle_errs
-%%     , sophia_oracles_qfee__qfee_in_query_below_qfee_in_oracle_errs__remote
-%%     , sophia_oracles_qfee__query_tx_value_below_qfee_takes_from_rich_oracle
-%%     , sophia_oracles_qfee__query_tx_value_below_qfee_does_not_take_from_poor_oracle
-%%     , sophia_oracles_qfee__query_tx_value_below_qfee_does_not_take_from_rich_oracle_thanks_to_contract_check
-%%     , sophia_oracles_qfee__query_tx_value_below_qfee_takes_from_rich_oracle__remote
-%%     , sophia_oracles_qfee__query_tx_value_below_qfee_does_not_take_from_poor_oracle__remote
-%%     , sophia_oracles_qfee__query_tx_value_below_qfee_does_not_take_from_rich_oracle_thanks_to_contract_check__remote
-%%     , sophia_oracles_qfee__remote_contract_query_value_below_qfee_takes_from_rich_oracle__remote
-%%     , sophia_oracles_qfee__remote_contract_query_value_below_qfee_does_not_take_from_poor_oracle__remote
-
-%%     ].
-
 
 %%%===================================================================
 %%% Create contract

--- a/apps/aecore/src/aec_conductor.erl
+++ b/apps/aecore/src/aec_conductor.erl
@@ -50,6 +50,7 @@
         , start_mining/0
         , stop_mining/0
         , handoff_leader/0
+        , get_beneficiary/0
         ]).
 
 %% Chain API

--- a/apps/aecore/test/aecore_txs_SUITE.erl
+++ b/apps/aecore/test/aecore_txs_SUITE.erl
@@ -196,7 +196,7 @@ check_coinbase_validation(Config) ->
     {ok, TxH2} =
         call_contract_tx(N1, Ct1, "save_coinbase", "()", 1,  2,  100),
     {ok, _} =
-        aecore_suite_utils:mine_blocks_until_txs_on_chain(N1, [TxH1, TxH2], 2),
+        aecore_suite_utils:mine_blocks_until_txs_on_chain(N1, [TxH1, TxH2], 10),
 
     %% Start a second node with distinct beneficiary.
     aecore_suite_utils:start_node(dev2, Config),

--- a/apps/aehttp/test/aehttp_contracts_SUITE.erl
+++ b/apps/aehttp/test/aehttp_contracts_SUITE.erl
@@ -30,9 +30,9 @@
          dutch_auction_contract/1,
          environment_contract/1,
          identity_contract/1,
-	 maps_contract/1,
+         maps_contract/1,
          simple_storage_contract/1,
-	 spend_test_contract/1,
+         spend_test_contract/1,
          null/1
         ]).
 

--- a/apps/aesophia/test/contracts/chain.aes
+++ b/apps/aesophia/test/contracts/chain.aes
@@ -1,4 +1,13 @@
-// Try to test chain interactions
+// Test more advanced chain interactions
 
 contract Chain =
+
+  record state = { last_bf : address }
+
+  function init() : state =
+    {last_bf = Contract.address}
+
   function miner() = Chain.coinbase
+
+  function save_coinbase() =
+    put(state{last_bf = Chain.coinbase})

--- a/apps/aesophia/test/contracts/chain.aes
+++ b/apps/aesophia/test/contracts/chain.aes
@@ -1,0 +1,4 @@
+// Try to test chain interactions
+
+contract Chain =
+  function miner() = Chain.coinbase

--- a/apps/aevm/src/aevm_ae_primops.erl
+++ b/apps/aevm/src/aevm_ae_primops.erl
@@ -49,9 +49,10 @@ call_(Value, Data, State) ->
                 aens_call(PrimOp, Value, Data, State)
         end
     catch _T:_Err ->
-            _Trace = erlang:get_stacktrace(), %% Absent from non-test bytecode.
             ?TEST_LOG("Primop illegal call ~p:~p:~p~n~p:~p(~p, ~p, State)",
-                      [_T, _Err, _Trace, ?MODULE, ?FUNCTION_NAME, Value, Data]),
+                      [_T, _Err,
+                       erlang:get_stacktrace(), %% Absent from non-test bytecode.
+                       ?MODULE, ?FUNCTION_NAME, Value, Data]),
             %% TODO: Better error for illegal call.
             {error, out_of_gas}
     end.

--- a/apps/aevm/src/aevm_ae_primops.erl
+++ b/apps/aevm/src/aevm_ae_primops.erl
@@ -49,12 +49,11 @@ call_(Value, Data, State) ->
                 aens_call(PrimOp, Value, Data, State)
         end
     catch _T:_Err ->
-        ?TEST_LOG("Primop illegal call ~p:~p:~p~n~p:~p(~p, ~p, State)",
-                  [_T, _Err,
-                   erlang:get_stacktrace(), %% Absent from non-test bytecode.
-                   ?MODULE, ?FUNCTION_NAME, Value, Data]),
-	%% TODO: Better error for illegal call.
-        {error, out_of_gas}
+            _Trace = erlang:get_stacktrace(), %% Absent from non-test bytecode.
+            ?TEST_LOG("Primop illegal call ~p:~p:~p~n~p:~p(~p, ~p, State)",
+                      [_T, _Err, _Trace, ?MODULE, ?FUNCTION_NAME, Value, Data]),
+            %% TODO: Better error for illegal call.
+            {error, out_of_gas}
     end.
 
 %% ------------------------------------------------------------------
@@ -65,7 +64,8 @@ spend_call(Value, Data, State) ->
     [Recipient] = get_args([word], Data),
     %% TODO: This assumes that we are spending to an account
     RecipientId = aec_id:create(account, <<Recipient:256>>),
-    Callback = fun(API, ChainState) -> API:spend(RecipientId, Value, ChainState) end,
+    Callback = fun(API, ChainState) ->
+                       API:spend(RecipientId, Value, ChainState) end,
     call_chain(Callback, State).
 
 %% ------------------------------------------------------------------

--- a/docs/release-notes/RELEASE-NOTES-0.21.0.md
+++ b/docs/release-notes/RELEASE-NOTES-0.21.0.md
@@ -18,6 +18,7 @@ It:
 * Changes micro block gossip to use Light micro blocks, containing only Tx hashes. In most cases the receiving node
   has already seen all transactions so this saves bandwidth. This bumps the P2P_PROTOCOL_VSN.
 * Fine-tunes the determinism of the computation of the dynamic component of the fee of oracle transactions related to TTL of objects (oracles, queries, responses) on state trees, moving floating point computations to integer based ones. This impacts consensus.
+* Fixes coinbase instruction in aevm. This impacts consensus.
 
 [this-release]: https://github.com/aeternity/epoch/releases/tag/v0.21.0
 [digishield_v3]: https://github.com/zawy12/difficulty-algorithms/issues/9

--- a/docs/release-notes/RELEASE-NOTES-0.21.0.md
+++ b/docs/release-notes/RELEASE-NOTES-0.21.0.md
@@ -18,7 +18,6 @@ It:
 * Changes micro block gossip to use Light micro blocks, containing only Tx hashes. In most cases the receiving node
   has already seen all transactions so this saves bandwidth. This bumps the P2P_PROTOCOL_VSN.
 * Fine-tunes the determinism of the computation of the dynamic component of the fee of oracle transactions related to TTL of objects (oracles, queries, responses) on state trees, moving floating point computations to integer based ones. This impacts consensus.
-* Fixes coinbase instruction in aevm. This impacts consensus.
 
 [this-release]: https://github.com/aeternity/epoch/releases/tag/v0.21.0
 [digishield_v3]: https://github.com/zawy12/difficulty-algorithms/issues/9

--- a/test/aevm_chain_SUITE.erl
+++ b/test/aevm_chain_SUITE.erl
@@ -7,6 +7,7 @@
 
 %% common_test exports
 -export([ all/0
+        , end_per_testcase/2
         , groups/0
         ]).
 
@@ -63,6 +64,12 @@ setup_chain() ->
     InitS = aec_vm_chain:new_state(Trees, 1, Contract1),
     {[Account1, Account2, Contract1, Contract2], InitS}.
 
+end_per_testcase(spend, _) ->
+    teardown_chain();
+end_per_testcase(contracts, _) ->
+    teardown_chain();
+end_per_testcase(_, _) -> ok.
+
 teardown_chain() ->
     meck:unload(aec_blocks),
     meck:unload(aec_chain),
@@ -113,7 +120,6 @@ spend(_Cfg) ->
     AccBal2  = AccBal1 + Amount,
     {error, insufficient_funds}
              = aec_vm_chain:spend(AccId, 1000000, S1),
-    teardown_chain(),
     ok.
 
 %%%===================================================================
@@ -124,7 +130,6 @@ contracts(_Cfg) ->
     {[_Acc, _Acc2, Contract1, Contract2], S} = setup_chain(),
     _S1 = lists:foldl(fun({Value, Arg}, S0) -> make_call(Contract1, Contract2, Value, Arg, S0) end,
                       S, [{(I - 3) * 100, I + 100} || I <- lists:seq(1, 10)]),
-    teardown_chain(),
     ok.
 
 make_call(From, To, Value, Arg, S) ->


### PR DESCRIPTION
Need two more test cases:
With a contract that uses the current coinbase (beneficiary):

- [x] Mine the contract with one miner/beneficiary, then verify on another node with another miner. 
- [x]  Mine the contract in a state channel (off-chain) then force progress on chain, ensure same result. This will be done after merging both force progress and this PR. Tracked as: https://www.pivotaltracker.com/story/show/160166715
- [x] Document how coinbase should be "caculated" in off-chain contract execution (in protocol). Tracked as: https://www.pivotaltracker.com/story/show/160198892 https://github.com/aeternity/protocol/pull/190
- [x] Document that coinbase is beneficiary of previous key block (in protocol). Also tracked in https://www.pivotaltracker.com/story/show/160198892 https://github.com/aeternity/protocol/pull/190

Tested with old bad implementation:
```
  set_env(ContractPubKey, Height, Trees, Beneficiary, API, VmVersion) ->
    ChainState = aec_vm_chain:new_state(Trees, Height, ContractPubKey),
    {ok, <<Bene:?BENEFICIARY_PUB_BYTES/unit:8>>} = aec_conductor:get_beneficiary(),
    #{currentCoinbase   => Bene, 
```
Fails:
```
%%% aecore_txs_SUITE ==> check_coinbase_validation: FAILED
%%% aecore_txs_SUITE ==> tx_not_syncing

```

- [x] Future refactoring to make the process function functional again: https://www.pivotaltracker.com/story/show/160281213
