### PR TITLE
SC HTTP API: handle broken proof of inclusion

### DIFF
--- a/apps/aehttp/src/aehttp_helpers.erl
+++ b/apps/aehttp/src/aehttp_helpers.erl
@@ -356,8 +356,13 @@ parse_map_to_atom_keys() ->
 poi_decode(PoIKey) ->
     fun(_Req, State) ->
         PoIBin = maps:get(PoIKey, State),
-        PoI = aec_trees:deserialize_poi(PoIBin),
-        {ok, maps:put(PoIKey, PoI, State)}
+        try aec_trees:deserialize_poi(PoIBin) of
+            PoI ->
+                {ok, maps:put(PoIKey, PoI, State)}
+        catch
+            _:_ ->
+                {error, {400, [], #{<<"reason">> => <<"Invalid proof of inclusion">>}}}
+        end
     end.
 
 

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -2666,6 +2666,14 @@ state_channels_close_solo(ChannelId, MinerPubkey) ->
                                fun get_channel_close_solo/1,
                                fun aesc_close_solo_tx:new/1, MinerPubkey),
     test_invalid_hash({account_pubkey, MinerPubkey}, from_id, Encoded, fun get_channel_close_solo/1),
+    BrokenPoIs = [<<>>, <<"hejsan svejsan">>],
+    lists:foreach(
+        fun(BrokenPoI) ->
+            EncBrokenPoI =  aec_base58c:encode(poi, BrokenPoI),
+            {ok, 400, #{<<"reason">> := <<"Invalid proof of inclusion">>}}
+                = get_channel_close_solo(maps:put(poi, EncBrokenPoI, Encoded))
+        end,
+        BrokenPoIs),
     ok.
 
 state_channels_slash(ChannelId, MinerPubkey) ->
@@ -2683,6 +2691,15 @@ state_channels_slash(ChannelId, MinerPubkey) ->
                                fun get_channel_slash/1,
                                fun aesc_slash_tx:new/1, MinerPubkey),
     test_invalid_hash({account_pubkey, MinerPubkey}, from_id, Encoded, fun get_channel_slash/1),
+
+    BrokenPoIs = [<<>>, <<"hejsan svejsan">>],
+    lists:foreach(
+        fun(BrokenPoI) ->
+            EncBrokenPoI =  aec_base58c:encode(poi, BrokenPoI),
+            {ok, 400, #{<<"reason">> := <<"Invalid proof of inclusion">>}}
+                = get_channel_slash(maps:put(poi, EncBrokenPoI, Encoded))
+        end,
+        BrokenPoIs),
     ok.
 
 state_channels_settle(ChannelId, MinerPubkey) ->


### PR DESCRIPTION
PT [HTTP API shall not crash when PoI is broken](https://www.pivotaltracker.com/story/show/158691726)