### PR TITLE
Improve tests w.r.t intermittent test failures

### DIFF
--- a/apps/aecore/test/aecore_sync_SUITE.erl
+++ b/apps/aecore/test/aecore_sync_SUITE.erl
@@ -117,6 +117,9 @@ init_per_suite(Config) ->
         <<"sync">> => #{
             <<"single_outbound_per_group">> => false
         },
+        <<"mempool">> => #{
+            <<"tx_ttl">> => 100
+        },
         <<"mining">> => #{
             <<"micro_block_cycle">> => 100
         }

--- a/system_test/aest_peers_SUITE.erl
+++ b/system_test/aest_peers_SUITE.erl
@@ -137,8 +137,8 @@ test_inbound_limitation(Cfg) ->
     start_node(node3, Cfg),
     wait_for_internal_api([node3], StartupTimeout),
 
-    T1 = erlang:system_time(millisecond),
     wait_for_value({height, Length + 1}, [node1, node2, node3], ?MINING_TIMEOUT * Length, Cfg),
+    T1 = erlang:system_time(millisecond),
 
     try_until(T1 + 3 * ping_interval(),
             fun() ->
@@ -159,8 +159,8 @@ test_inbound_limitation(Cfg) ->
     wait_for_value({height, 0}, [node4], StartupTimeout, Cfg),
     wait_for_internal_api([node4], StartupTimeout),
 
-    T2 = erlang:system_time(millisecond),
     wait_for_value({height, Length * 2 + 1}, [node1, node2, node3, node4], ?MINING_TIMEOUT * Length, Cfg),
+    T2 = erlang:system_time(millisecond),
 
     try_until(T2 + 3 * ping_interval(),
             fun() ->


### PR DESCRIPTION
One fix in aest_peers_SUITE: Give the nodes a fair chance to sync before checking for "syncedness"

and one in aecore_sync_SUITE: Don't have txs being garbage collected when checking that all nodes agree on the TX Pool.