### PR TITLE
Add data/aecore/keys to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ swagger/swagger-codegen-cli-*.jar
 system_test/logs
 system_test/aest_hard_fork_SUITE_data/db
 docker/keys/*/sign_key*
+data/aecore/keys


### PR DESCRIPTION
When starting a node using `make console` it generates keypair in the directory `data/aecore/keys`. 