### PR TITLE
Only allow forward generation on chain

### DIFF
--- a/apps/aecore/src/aec_peer_connection.erl
+++ b/apps/aecore/src/aec_peer_connection.erl
@@ -833,10 +833,10 @@ handle_get_generation(S, Msg) ->
     Forward = maps:get(forward, Msg),
     Response =
         case do_get_generation(maps:get(hash, Msg), Forward) of
-            {ok, KeyBlock, MicroBlocks} ->
-                SerKeyBlock = serialize_key_block(KeyBlock),
-                SerMicroBlocks = [ serialize_micro_block(B) || B <- MicroBlocks ],
-                {ok, #{key_block => SerKeyBlock, micro_blocks => SerMicroBlocks, forward => Forward }};
+            {ok, #{ key_block := KB, micro_blocks := MBs }} ->
+                SerKB = serialize_key_block(KB),
+                SerMBs = [ serialize_micro_block(B) || B <- MBs ],
+                {ok, #{key_block => SerKB, micro_blocks => SerMBs, forward => Forward }};
             error ->
                 {error, block_not_found}
         end,
@@ -844,9 +844,9 @@ handle_get_generation(S, Msg) ->
     S.
 
 do_get_generation(Hash, true) ->
-    aec_chain:get_generation(Hash);
+    aec_chain:get_generation_by_hash(Hash, forward);
 do_get_generation(Hash, false) ->
-    aec_chain:get_prev_generation(Hash).
+    aec_chain:get_generation_by_hash(Hash, backward).
 
 handle_get_generation_rsp(S, {get_generation, From, _TRef}, Msg) ->
     SerKeyBlock = maps:get(key_block, Msg),

--- a/apps/aecore/src/aec_sync.erl
+++ b/apps/aecore/src/aec_sync.erl
@@ -784,9 +784,9 @@ has_generation(KeyBlockHash) ->
     %% We are looking for the generation backwards from this Hash
     %% Possibly optimize by implementing aec_chain:has_generation operating on
     %% headers only
-    case aec_chain:get_prev_generation(KeyBlockHash) of
-        {ok, _KeyBlock, _MicroBlocks} -> true;
-        error                         -> false
+    case aec_chain:get_generation_by_hash(KeyBlockHash, backward) of
+        {ok, _Generation} -> true;
+        error             -> false
     end.
 
 header_hash(Block) ->

--- a/apps/aecore/test/aecore_suite_utils.erl
+++ b/apps/aecore/test/aecore_suite_utils.erl
@@ -249,9 +249,9 @@ mine_blocks_until_txs_on_chain_loop(Node, TxHashes, Max, Acc) ->
 
 txs_not_on_chain(Node, Block, TxHashes) ->
     {ok, BlockHash} = aec_blocks:hash_internal_representation(Block),
-    case rpc:call(Node, aec_chain, get_prev_generation, [BlockHash]) of
+    case rpc:call(Node, aec_chain, get_generation_by_hash, [BlockHash, backward]) of
         error -> TxHashes;
-        {ok, Block, MicroBlocks} -> txs_not_in_generation(MicroBlocks, TxHashes)
+        {ok, #{micro_blocks := MBs }} -> txs_not_in_generation(MBs, TxHashes)
     end.
 
 txs_not_in_generation([], TxHashes) -> TxHashes;


### PR DESCRIPTION
Make the call to `get_generation_by_hash` fail if the hash is not on the longest chain - and make this an explicit error in HTTP response.

Also make sure we can validate forward-generations at GenesisHeight.