### PR TITLE
Revert a line in release notes for v21

### DIFF
--- a/docs/release-notes/RELEASE-NOTES-0.21.0.md
+++ b/docs/release-notes/RELEASE-NOTES-0.21.0.md
@@ -10,8 +10,6 @@ It:
 * Fixes miner fee reward calculations, was too generous before. This impacts consensus.
 * Modifies the minimum static component of the fee of oracle transactions to `1` - as for all other transactions. This impacts consensus.
 * Increases beneficiary reward delay to 180 key blocks / generations. This impacts consensus.
-* Adds on-chain forcing of progress for channel off-chain contracts. This
-  impacts consesus.
 * Fixed sporadically seen timeout errors in sync when inet:getaddr took too much time to resolve
 * Detects more possible race conditions in state channel updates, thereby also making it possible to "softly reject" an update, by requesting a competing update in response to a signing request. This should be seen as a temporary measure until support for rejecting a signing request is implemented.
 * Changes the serialization format of micro headers to include the signature. This changes both what is signed by the miner, and how the block hash for micro blocks is computed. This affects consensus.


### PR DESCRIPTION
PT [Revert a line in v21 release notes](https://www.pivotaltracker.com/story/show/160281380)

In order to get the forcing of progress in ASAP, we've merged it without updating the release notes for version 21. It will be part of v 22 so this line
```
Adds on-chain forcing of progress for channel off-chain contracts. This
  impacts consesus.
```

is not suitable in `RELEASE-NOTES-0.21.0.md`