### PR TITLE
Cleanup test output and comment out unused test code

### DIFF
--- a/apps/aecore/test/aec_peers_pool_tests.erl
+++ b/apps/aecore/test/aec_peers_pool_tests.erl
@@ -1345,8 +1345,8 @@ validate_counters() ->
 
     Now1 = erlang:system_time(millisecond),
 
-    {Pool2, Now2, All2, Selected2} = lists:foldl(fun(K, {P, N, A, S}) ->
-        if (K rem 10000) =:= 0 -> io:format(user, "*", []); true -> ok end,
+    {Pool2, Now2, All2, Selected2} = 
+        lists:foldl(fun(_K, {P, N, A, S}) ->
             case {rand_int(1, 8), A, S} of
                 {1, _, _} ->
                     case random_select(P, N, both, undefined) of

--- a/apps/aecore/test/aec_peers_tests.erl
+++ b/apps/aecore/test/aec_peers_tests.erl
@@ -1189,9 +1189,9 @@ dump_messages(Acc) ->
         case Acc of
             [] -> ok;
             _ ->
-                io:format(user, "Message box:~n", []),
+                io:format("Message box:~n", []),
                 lists:foreach(fun(M) ->
-                    io:format(user, "    ~p~n", [M])
+                    io:format("    ~p~n", [M])
                 end, lists:reverse(Acc))
         end
     end.
@@ -1203,21 +1203,21 @@ setup_mock_getaddr() ->
 cleanup_mock_getaddr() ->
     catch meck:unload(inet).
 
-mock_interactive_getaddr() ->
-    Self = self(),
-    ok = meck:expect(inet, getaddr, fun(Hostname, _) ->
-        Ref = erlang:make_ref(),
-        Self ! {self(), Ref, {getaddr, Hostname}},
-        receive
-            {Ref, error} ->
-                throw(test_intervactive_call_error);
-            {Ref, {Delay, Result}} ->
-                timer:sleep(Delay),
-                Result
-        after 5000 ->
-            throw(test_intervactive_call_timeout)
-        end
-    end).
+%% mock_interactive_getaddr() ->
+%%     Self = self(),
+%%     ok = meck:expect(inet, getaddr, fun(Hostname, _) ->
+%%         Ref = erlang:make_ref(),
+%%         Self ! {self(), Ref, {getaddr, Hostname}},
+%%         receive
+%%             {Ref, error} ->
+%%                 throw(test_intervactive_call_error);
+%%             {Ref, {Delay, Result}} ->
+%%                 timer:sleep(Delay),
+%%                 Result
+%%         after 5000 ->
+%%             throw(test_intervactive_call_timeout)
+%%         end
+%%     end).
 
 mock_getaddr(Result) ->
     Self = self(),


### PR DESCRIPTION
In ticket https://www.pivotaltracker.com/story/show/160022359 sporadic eunit test failures were observed. Since then the aec_peers implementation has changed again.

Running Eunit tests 100 times did not show a single failure. Most likely this issue is resolved by the changes we made to aec_peers.

For the reviewer: please run the eunit tests in your local setup ` make eunit TEST=aec_peers_pool, aec_peers`