### PR TITLE
PT-160237116 SC Chain watching

### DIFF
--- a/apps/aechannel/src/aesc_channels.erl
+++ b/apps/aechannel/src/aesc_channels.erl
@@ -40,6 +40,7 @@
          channel_reserve/1,
          state_hash/1,
          round/1,
+         lock_period/1,
          closes_at/1]).
 
 -compile({no_auto_import, [round/1]}).

--- a/apps/aechannel/src/aesc_codec.hrl
+++ b/apps/aechannel/src/aesc_codec.hrl
@@ -54,6 +54,7 @@
 -define(DISCONNECT, disconnect).
 -define(SIGNED, signed).
 -define(MIN_DEPTH_ACHIEVED, minimum_depth_achieved).
+-define(CHANNEL_CLOSING, channel_closing).
 
 %% Error codes
 -define(ERR_VALIDATION, 1).

--- a/apps/aechannel/src/aesc_fsm.erl
+++ b/apps/aechannel/src/aesc_fsm.erl
@@ -35,7 +35,8 @@
 -export([signing_response/3]).    %% (Fsm, Tag, Obj)
 
 %% Used by min-depth watcher
--export([minimum_depth_achieved/4]).  %% (Fsm, OnChainId, Type, TxHash)
+-export([minimum_depth_achieved/4,     %% (Fsm, OnChainId, Type, TxHash)
+         channel_closing_on_chain/2]). %% (Fsm, OnChainId)
 
 -export([init/1,
          callback_mode/0,
@@ -91,6 +92,30 @@
         ; R==upd_create_contract
         ; R==upd_call_contract).
 
+-define(KNOWN_MSG_TYPE(T), T =:= ?CH_OPEN
+                         ; T =:= ?CH_ACCEPT
+                         ; T =:= ?FND_CREATED
+                         ; T =:= ?FND_SIGNED
+                         ; T =:= ?FND_LOCKED
+                         ; T =:= ?UPDATE
+                         ; T =:= ?UPDATE_ACK
+                         ; T =:= ?UPDATE_ERR
+                         ; T =:= ?DEP_CREATED
+                         ; T =:= ?DEP_SIGNED
+                         ; T =:= ?DEP_LOCKED
+                         ; T =:= ?DEP_ERR
+                         ; T =:= ?WDRAW_CREATED
+                         ; T =:= ?WDRAW_SIGNED
+                         ; T =:= ?WDRAW_LOCKED
+                         ; T =:= ?WDRAW_ERR
+                         ; T =:= ?INBAND_MSG
+                         ; T =:= disconnect
+                         ; T =:= ?LEAVE
+                         ; T =:= ?LEAVE_ACK
+                         ; T =:= ?SHUTDOWN
+                         ; T =:= ?SHUTDOWN_ACK
+                         ; T =:= ?CH_REESTABL
+                         ; T =:= ?CH_REEST_ACK).
 
 -define(KEEP, 10).
 -record(w, { n = 0         :: non_neg_integer()
@@ -169,30 +194,7 @@ callback_mode() -> [state_functions, state_enter].
 %%   |                                                                          |
 %%   +--------------------------------------------------------------------------+
 
-message(Fsm, {T, _} = Msg) when T =:= ?CH_OPEN
-                              ; T =:= ?CH_ACCEPT
-                              ; T =:= ?FND_CREATED
-                              ; T =:= ?FND_SIGNED
-                              ; T =:= ?FND_LOCKED
-                              ; T =:= ?UPDATE
-                              ; T =:= ?UPDATE_ACK
-                              ; T =:= ?UPDATE_ERR
-                              ; T =:= ?DEP_CREATED
-                              ; T =:= ?DEP_SIGNED
-                              ; T =:= ?DEP_LOCKED
-                              ; T =:= ?DEP_ERR
-                              ; T =:= ?WDRAW_CREATED
-                              ; T =:= ?WDRAW_SIGNED
-                              ; T =:= ?WDRAW_LOCKED
-                              ; T =:= ?WDRAW_ERR
-                              ; T =:= ?INBAND_MSG
-                              ; T =:= disconnect
-                              ; T =:= ?LEAVE
-                              ; T =:= ?LEAVE_ACK
-                              ; T =:= ?SHUTDOWN
-                              ; T =:= ?SHUTDOWN_ACK
-                              ; T =:= ?CH_REESTABL
-                              ; T =:= ?CH_REEST_ACK ->
+message(Fsm, {T, _} = Msg) when ?KNOWN_MSG_TYPE(T) ->
     lager:debug("message(~p, ~p)", [Fsm, Msg]),
     gen_statem:cast(Fsm, Msg).
 
@@ -213,6 +215,9 @@ signing_response(Fsm, Tag, Obj) ->
 
 minimum_depth_achieved(Fsm, ChanId, Type, TxHash) ->
     gen_statem:cast(Fsm, {?MIN_DEPTH_ACHIEVED, ChanId, Type, TxHash}).
+
+channel_closing_on_chain(Fsm, ChanId) ->
+    gen_statem:cast(Fsm, {?CHANNEL_CLOSING, ChanId}).
 
 where(ChanId, Role) when Role == initiator; Role == responder ->
     gproc:where(gproc_name_by_role(ChanId, Role));
@@ -547,16 +552,8 @@ awaiting_open(cast, {?CH_OPEN, Msg}, #data{role = responder} = D) ->
         {error, _} = Error ->
             close(Error, D)
     end;
-awaiting_open(timeout, awaiting_open = T, D) ->
-    close({timeout, T}, D);
-awaiting_open(cast, {?DISCONNECT, _Msg}, D) ->
-    close(disconnect, D);
-awaiting_open(cast, {_, _} = Msg, D) ->
-    lager:debug("Wrong msg in awaiting_open: ~p", [Msg]),
-    %% should send an error msg
-    close(protocol_error, D);
-awaiting_open({call, From}, Req, D) ->
-    handle_call(awaiting_open, Req, From, D).
+awaiting_open(Type, Msg, D) ->
+    handle_common_event(Type, Msg, error_all, D).
 
 awaiting_reestablish(enter, _OldSt, _D) -> keep_state_and_data;
 awaiting_reestablish(cast, {?CH_REESTABL, Msg}, #data{role = responder} = D) ->
@@ -568,14 +565,8 @@ awaiting_reestablish(cast, {?CH_REESTABL, Msg}, #data{role = responder} = D) ->
         {error, _} = Error ->
             close(Error, D)
     end;
-awaiting_reestablish(timeout, awaiting_reestablish = T, D) ->
-    close({timeout, T}, D);
-awaiting_reestablish(cast, {?DISCONNECT, _Msg}, D) ->
-    close(disconnect, D);
-awaiting_reestablish(cast, {_, _} = Msg, D) ->
-    lager:debug("Wrong msg in awaiting_reestablish: ~p", [Msg]),
-    %% should send and error msg
-    close(protocol_error, D).
+awaiting_reestablish(Type, Msg, D) ->
+    handle_common_event(Type, Msg, error_all, D).
 
 initialized(enter, _OldSt, _D) -> keep_state_and_data;
 initialized(cast, {?CH_ACCEPT, Msg}, #data{role = initiator} = D) ->
@@ -589,12 +580,8 @@ initialized(cast, {?CH_ACCEPT, Msg}, #data{role = initiator} = D) ->
         {error, _} = Error ->
             close(Error, D)
     end;
-initialized(timeout, initialized = T, D) ->
-    close({timeout, T}, D);
-initialized(cast, {?DISCONNECT, _Msg}, D) ->
-    close(disconnect, D);
-initialized({call, From}, Req, D) ->
-    handle_call(initialized, Req, From, D).
+initialized(Type, Msg, D) ->
+    handle_common_event(Type, Msg, error_all, D).
 
 reestablish_init(enter, _OldSt, _D) -> keep_state_and_data;
 reestablish_init(cast, {?CH_REEST_ACK, Msg}, D) ->
@@ -605,12 +592,8 @@ reestablish_init(cast, {?CH_REEST_ACK, Msg}, D) ->
         {error, _} = Err ->
             close(Err, D)
     end;
-reestablish_init(timeout, reestablish_init = T, D) ->
-    close({timeout, T}, D);
-reestablish_init(cast, {?DISCONNECT, _Msg}, D) ->
-    close(disconnect, D);
-reestablish_init({call, From}, Req, D) ->
-    handle_call(reestablish_init, Req, From, D).
+reestablish_init(Type, Msg, D) ->
+    handle_common_event(Type, Msg, error_all, D).
 
 awaiting_signature(enter, _OldSt, _D) -> keep_state_and_data;
 awaiting_signature(cast, {Req, _} = Msg, #data{ongoing_update = true} = D)
@@ -694,13 +677,8 @@ awaiting_signature(cast, {?SIGNED, ?SHUTDOWN_ACK, SignedTx} = Msg,
     report(on_chain_tx, NewSignedTx, D1),
     close(close_mutual, D2);
 %% Other
-awaiting_signature(timeout, awaiting_signature = T, D) ->
-    close({timeout, T}, D);
-awaiting_signature(cast, {?DISCONNECT, _Msg}, D) ->
-    close(disconnect, D);
-awaiting_signature({call, From}, Req, D) ->
-    handle_call(awaiting_signature, Req, From, D).
-
+awaiting_signature(Type, Msg, D) ->
+    handle_common_event(Type, Msg, postpone, D).
 
 accepted(enter, _OldSt, _D) -> keep_state_and_data;
 accepted(cast, {?FND_CREATED, Msg}, #data{role = responder} = D) ->
@@ -714,13 +692,8 @@ accepted(cast, {?FND_CREATED, Msg}, #data{role = responder} = D) ->
         %% {error, _} = Error ->
         %%     close(Error, D)
     end;
-accepted(cast, {?DISCONNECT, _Msg}, D) ->
-    close(disconnect, D);
-accepted(timeout, accepted = T, D) ->
-    close({timeout, T}, D);
-accepted({call, From}, Req, D) ->
-    handle_call(accepted, Req, From, D).
-
+accepted(Type, Msg, D) ->
+    handle_common_event(Type, Msg, error, D).
 
 half_signed(enter, _OldSt, _D) -> keep_state_and_data;
 half_signed(cast, {?FND_SIGNED, Msg}, #data{role = initiator} = D) ->
@@ -736,12 +709,8 @@ half_signed(cast, {?FND_SIGNED, Msg}, #data{role = initiator} = D) ->
         %% {error, _} = Error ->
         %%     close(Error, D)
     end;
-half_signed(timeout, half_signed = T, D) ->
-    close({timeout, T}, D);
-half_signed(cast, {?DISCONNECT, _Msg}, D) ->
-    close(disconnect, D);
-half_signed({call, From}, Req, D) ->
-    handle_call(half_signed, Req, From, D).
+half_signed(Type, Msg, D) ->
+    handle_common_event(Type, Msg, error, D).
 
 dep_half_signed(enter, _OldSt, _D) -> keep_state_and_data;
 dep_half_signed(cast, {Req, _} = Msg, D) when ?UPDATE_CAST(Req) ->
@@ -770,12 +739,8 @@ dep_half_signed(cast, {?DEP_ERR, Msg}, D) ->
         {error, _} = Error ->
             close(Error, D)
     end;
-dep_half_signed(timeout, dep_half_signed = T, D) ->
-    close({timeout, T}, D);
-dep_half_signed(cast, {?DISCONNECT, _Msg}, D) ->
-    close(disconnect, D);
-dep_half_signed({call, From}, Req, D) ->
-    handle_call(dep_half_signed, Req, From, D).
+dep_half_signed(Type, Msg, D) ->
+    handle_common_event(Type, Msg, error, D).
 
 dep_signed(enter, _OldSt, _D) -> keep_state_and_data;
 dep_signed(cast, {?DEP_LOCKED, Msg}, #data{latest = {deposit, SignedTx}} = D) ->
@@ -790,10 +755,8 @@ dep_signed(timeout, dep_signed = T, D) ->
     close({timeout, T}, D);
 dep_signed(cast, {?SHUTDOWN, _Msg}, D) ->
     next_state(closing, D);
-dep_signed(cast, {?DISCONNECT, _Msg}, D) ->
-    next_state(disconnected, D);
-dep_signed({call, From}, Req, D) ->
-    handle_call(dep_signed, Req, From, D).
+dep_signed(Type, Msg, D) ->
+    handle_common_event(Type, Msg, error, D).
 
 deposit_locked_complete(SignedTx, #data{state = State, opts = Opts} = D) ->
     D1   = D#data{state = aesc_offchain_state:add_signed_tx(SignedTx, State, Opts)},
@@ -826,12 +789,8 @@ wdraw_half_signed(cast, {?WDRAW_ERR, Msg}, D) ->
         {error, _} = Error ->
             close(Error, D)
     end;
-wdraw_half_signed(timeout, wdraw_half_signed = T, D) ->
-    close({timeout, T}, D);
-wdraw_half_signed(cast, {?DISCONNECT, _Msg}, D) ->
-    close(disconnect, D);
-wdraw_half_signed({call, From}, Req, D) ->
-    handle_call(wdraw_half_signed, Req, From, D).
+wdraw_half_signed(Type, Msg, D) ->
+    handle_common_event(Type, Msg, error, D).
 
 %% Don't flag for update conflicts once we've pushed to the chain, and
 %% wait for confirmation; postpone instead.
@@ -845,14 +804,10 @@ wdraw_signed(cast, {?WDRAW_LOCKED, Msg}, #data{latest = {withdraw, SignedTx}} = 
         {error, _} = Error ->
             close(Error, D)
     end;
-wdraw_signed(timeout, wdraw_signed = T, D) ->
-    close({timeout, T}, D);
 wdraw_signed(cast, {?SHUTDOWN, _Msg}, D) ->
     next_state(closing, D);
-wdraw_signed(cast, {?DISCONNECT, _Msg}, D) ->
-    next_state(disconnected, D);
-wdraw_signed({call, From}, Req, D) ->
-    handle_call(wdraw_signed, Req, From, D).
+wdraw_signed(Type, Msg, D) ->
+    handle_common_event(Type, Msg, error, D).
 
 withdraw_locked_complete(SignedTx, #data{state = State, opts = Opts} = D) ->
     D1   = D#data{state = aesc_offchain_state:add_signed_tx(SignedTx, State, Opts)},
@@ -888,12 +843,8 @@ awaiting_locked(cast, {?DEP_LOCKED, _Msg}, D) ->
     postpone(D);
 awaiting_locked(cast, {?WDRAW_LOCKED, _Msg}, D) ->
     postpone(D);
-awaiting_locked(cast, {?DISCONNECT, _Msg}, D) ->
-    close(disconnect, D);
-awaiting_locked(timeout, awaiting_locked = T, D) ->
-    close({timeout, T}, D);
-awaiting_locked({call, From}, Req, D) ->
-    handle_call(awaiting_locked, Req, From, D).
+awaiting_locked(Type, Msg, D) ->
+    handle_common_event(Type, Msg, error, D).
 
 awaiting_initial_state(enter, _OldSt, _D) -> keep_state_and_data;
 awaiting_initial_state(cast, {?UPDATE, Msg}, #data{role = responder} = D) ->
@@ -909,16 +860,8 @@ awaiting_initial_state(cast, {?UPDATE, Msg}, #data{role = responder} = D) ->
             %% TODO: do we do a dispute challenge here?
             close(Error, D)
     end;
-awaiting_initial_state(cast, {?DISCONNECT, _Msg}, D) ->
-    close(disconnect, D);
-awaiting_initial_state(timeout, awaiting_initial_state = T, D) ->
-    close({timeout, T}, D);
-awaiting_initial_state({call, From}, Req, D) ->
-    handle_call(awaiting_initial_state, Req, From, D);
-awaiting_initial_state(Evt, Msg, D) ->
-    lager:debug("unexpected: awaiting_initial_state(~p, ~p, ~p)",
-                [Evt, Msg, D]),
-    close({unexpected, Msg}, D).
+awaiting_initial_state(Type, Msg, D) ->
+    handle_common_event(Type, Msg, error, D).
 
 awaiting_update_ack(enter, _OldSt, _D) -> keep_state_and_data;
 awaiting_update_ack(cast, {Req,_} = Msg, #data{} = D) when ?UPDATE_CAST(Req) ->
@@ -949,12 +892,10 @@ awaiting_update_ack(cast, {?UPDATE_ERR, Msg}, D) ->
         {error, _} = Error ->
             close(Error, D)
     end;
-awaiting_update_ack(cast, {?DISCONNECT, _Msg}, D) ->
-    close(disconnect, D);
-awaiting_update_ack(timeout, awaiting_update_ack = T, D) ->
-    close({timeout, T}, D);
 awaiting_update_ack({call, _}, _Req, D) ->
-    postpone(D).
+    postpone(D);
+awaiting_update_ack(Type, Msg, D) ->
+    handle_common_event(Type, Msg, postpone, D).
 
 awaiting_leave_ack(enter, _OldSt, _D) -> keep_state_and_data;
 awaiting_leave_ack(cast, {?LEAVE_ACK, Msg}, D) ->
@@ -979,10 +920,8 @@ awaiting_leave_ack(cast, {?LEAVE, Msg}, D) ->
         {error, _} = Err ->
             close(Err, D)
     end;
-awaiting_leave_ack(cast, _Msg, D) ->
-    postpone(D);
-awaiting_leave_ack({call, _From}, _Req, D) ->
-    postpone(D).
+awaiting_leave_ack(Type, Msg, D) ->
+    handle_common_event(Type, Msg, postpone, D).
 
 signed(enter, _OldSt, _D) -> keep_state_and_data;
 signed(cast, {?FND_LOCKED, Msg}, D) ->
@@ -993,15 +932,10 @@ signed(cast, {?FND_LOCKED, Msg}, D) ->
         {error, _} = Error ->
             close(Error, D)
     end;
-signed(timeout, signed = T, D) ->
-    close({timeout, T}, D);
 signed(cast, {?SHUTDOWN, _Msg}, D) ->
     next_state(closing, D);
-signed(cast, {?DISCONNECT, _Msg}, D) ->
-    next_state(disconnected, D);
-signed({call, From}, Req, D) ->
-    handle_call(signed, Req, From, D).
-
+signed(Type, Msg, D) ->
+    handle_common_event(Type, Msg, error, D).
 
 funding_locked_complete(D) ->
     D1   = D#data{state = aesc_offchain_state:add_signed_tx(D#data.create_tx,
@@ -1057,6 +991,9 @@ open(cast, {?INBAND_MSG, Msg}, D) ->
                    D
            end,
     keep_state(NewD);
+open(cast, {?SIGNED, _, _} = Msg, D) ->
+    lager:debug("Received signing reply in 'open' - ignore: ~p", [Msg]),
+    keep_state(log(ignore, ?SIGNED, Msg, D));
 open({call, From}, Request, D) ->
     handle_call(open, Request, From, D);
 open(cast, {?LEAVE, Msg}, D) ->
@@ -1078,15 +1015,8 @@ open(cast, {?SHUTDOWN, Msg}, D) ->
         {error, E} ->
             close({shutdown_error, E}, D)
     end;
-open(cast, {?DISCONNECT, _Msg}, D) ->
-    next_state(disconnected, D);
-open(cast, _Msg, D) ->
-    lager:error("Discarding cast in 'open' state: ~p", [_Msg]),
-    keep_state(D);
-open(info, Msg, D) ->
-    handle_info(Msg, D);
-open(timeout, open = T, D) ->
-    close({timeout, T}, D).
+open(Type, Msg, D) ->
+    handle_common_event(Type, Msg, discard, D).
 
 closing(enter, _OldSt, _D) -> keep_state_and_data;
 closing(cast, {?SHUTDOWN_ACK, Msg}, D) ->
@@ -1099,10 +1029,10 @@ closing(cast, {?SHUTDOWN_ACK, Msg}, D) ->
         {error, _} = Error ->
             close(Error, D)
     end;
-closing(cast, {?DISCONNECT, _Msg}, D) ->
-    next_state(disconnected, D);
 closing(cast, {closing_signed, _Msg}, D) ->  %% TODO: not using this, right?
-    close(closing_signed, D).
+    close(closing_signed, D);
+closing(Type, Msg, D) ->
+    handle_common_event(Type, Msg, error, D).
 
 disconnected(cast, {?CH_REESTABL, _Msg}, D) ->
     next_state(closing, D).
@@ -1301,7 +1231,49 @@ handle_call_(_St, _Req, From, D) ->
 
 handle_info(Msg, #data{cur_statem_state = St} = D) ->
     lager:debug("Discarding info in ~p state: ~p", [St, Msg]),
-    keep_state(D).
+    keep_state(log(drop, msg_type(Msg), Msg, D)).
+
+handle_common_event(E, Msg, M, #data{cur_statem_state = St} = D) ->
+    lager:debug("handle_common_event(~p, ~p, ~p, ~p, D)", [E, Msg, St, M]),
+    handle_common_event_(E, Msg, St, M, D).
+
+handle_common_event_(timeout, St = T, St, _, D) ->
+    close({timeout, T}, D);
+handle_common_event_(cast, {?DISCONNECT, _}, _St, _, D) ->
+    close(disconnect, D);
+handle_common_event_(cast, {?CHANNEL_CLOSING, ChanId} = Msg, _St, _,
+                     #data{on_chain_id = ChanId} = D) ->
+    lager:debug("got ~p", [Msg]),
+    close(channel_closing_on_chain, D);
+handle_common_event_({call, From}, Req, St, Mode, D) ->
+    case Mode of
+        postpone_all ->
+            postpone(D);
+        error_all ->
+            keep_state(D, [{reply, From, {error, not_ready}}]);
+        _ ->
+            handle_call(St, Req, From, D)
+    end;
+handle_common_event_(_Type, {_, _} = _Msg, _St, P, D) when P == postpone;
+                                                           P == postpone_all ->
+    postpone(D);
+handle_common_event_(info, Msg, _St, _P, D) ->
+    handle_info(Msg, D);
+handle_common_event_(Type, Msg, St, discard, D) ->
+    lager:error("Discarding ~p in '~p' state: ~p", [Type, St, Msg]),
+    keep_state(log(drop, msg_type(Msg), Msg, D));
+handle_common_event_(Type, Msg, St, error, D) ->
+    lager:debug("Wrong ~p in ~p: ~p", [Type, St, Msg]),
+    %% should send an error msg
+    close(protocol_error, D).
+
+msg_type(Msg) when is_tuple(Msg) ->
+    T = element(1, Msg),
+    if ?KNOWN_MSG_TYPE(T) -> T;
+       true -> unknown
+    end;
+msg_type(T) -> T.
+
 
 cur_channel_id(#data{channel_id = TChId,
                      on_chain_id = PChId}) ->
@@ -2176,12 +2148,13 @@ start_min_depth_watcher(Type, SignedTx,
     case {Type, Watcher0} of
         {funding, undefined} ->
             {ok, Watcher1} = aesc_fsm_min_depth_watcher:start_link(
-                               Type, TxHash, OnChainId, MinDepth),
+                               Type, TxHash, OnChainId, MinDepth, ?MODULE),
             evt({watcher, Watcher1}),
             {ok, D1#data{watcher = Watcher1,
                          latest = {watch, Type, TxHash, SignedTx}}};
         {_, Pid} when Pid =/= undefined ->  % assertion
-            ok = aesc_fsm_min_depth_watcher:watch(Pid, Type, TxHash, MinDepth),
+            ok = aesc_fsm_min_depth_watcher:watch(
+                   Pid, Type, TxHash, MinDepth, ?MODULE),
             {ok, D1#data{latest = {watch, Type, TxHash, SignedTx}}}
     end.
 

--- a/apps/aechannel/src/aesc_fsm.erl
+++ b/apps/aechannel/src/aesc_fsm.erl
@@ -1247,15 +1247,12 @@ handle_common_event_(cast, {?CHANNEL_CLOSING, ChanId} = Msg, _St, _,
     close(channel_closing_on_chain, D);
 handle_common_event_({call, From}, Req, St, Mode, D) ->
     case Mode of
-        postpone_all ->
-            postpone(D);
         error_all ->
             keep_state(D, [{reply, From, {error, not_ready}}]);
         _ ->
             handle_call(St, Req, From, D)
     end;
-handle_common_event_(_Type, {_, _} = _Msg, _St, P, D) when P == postpone;
-                                                           P == postpone_all ->
+handle_common_event_(_Type, {_, _} = _Msg, _St, P, D) when P == postpone ->
     postpone(D);
 handle_common_event_(info, Msg, _St, _P, D) ->
     handle_info(Msg, D);

--- a/apps/aechannel/src/aesc_fsm_min_depth_watcher.erl
+++ b/apps/aechannel/src/aesc_fsm_min_depth_watcher.erl
@@ -2,8 +2,8 @@
 -module(aesc_fsm_min_depth_watcher).
 -behaviour(gen_server).
 
--export([start_link/4,   %% (TxHash, ChanId, MinimumDepth)     -> {ok, Pid}
-         watch/4,        %% (WatcherPid, Type, TxHash, MinimumDepth) -> ok
+-export([start_link/5,   %% (TxHash, ChanId, MinimumDepth, Mod)   -> {ok, Pid}
+         watch/5,        %% (WatcherPid, Type, TxHash, MinimumDepth, Mod) -> ok
          watch_for_channel_close/3]).
 
 -export([init/1,
@@ -15,67 +15,78 @@
 
 -define(GEN_SERVER_OPTS, []).
 
+-record(st, { parent
+            , chan_id
+            , closing = false
+            , requests = [] }).
+
 watch_for_channel_close(ChanId, MinDepth, Mod) ->
-    gen_server:start_link(?MODULE, #{type         => close,
-                                     chan_id      => ChanId,
-                                     min_depth    => MinDepth,
-                                     parent       => self(),
-                                     callback_mod => Mod},
+    gen_server:start_link(?MODULE, #{parent  => self(),
+                                     chan_id => ChanId,
+                                     requests =>
+                                         [#{mode         => close,
+                                            min_depth    => MinDepth,
+                                            type         => close,
+                                            parent       => self(),
+                                            callback_mod => Mod}]},
                           ?GEN_SERVER_OPTS).
 
-start_link(Type, TxHash, ChanId, MinDepth) ->
-    gen_server:start_link(?MODULE, #{tx_hash   => TxHash,
-                                     chan_id   => ChanId,
-                                     type      => Type,
-                                     parent    => self(),
-                                     min_depth => MinDepth},
+start_link(Type, TxHash, ChanId, MinDepth, Mod) ->
+    gen_server:start_link(?MODULE, #{parent   => self(),
+                                     chan_id  => ChanId,
+                                     requests =>
+                                         [#{mode         => tx_hash,
+                                            tx_hash      => TxHash,
+                                            type         => Type,
+                                            parent       => self(),
+                                            callback_mod => Mod,
+                                            min_depth    => MinDepth},
+                                          #{mode         => watch,
+                                            parent       => self(),
+                                            callback_mod => Mod}]},
                           ?GEN_SERVER_OPTS).
 
-watch(Watcher, Type, TxHash, MinDepth) ->
-    gen_server:call(Watcher, {watch, Type, TxHash, MinDepth}).
+watch(Watcher, Type, TxHash, MinDepth, Mod) ->
+    gen_server:call(Watcher, #{mode         => tx_hash,
+                               type         => Type,
+                               tx_hash      => TxHash,
+                               min_depth    => MinDepth,
+                               callback_mod => Mod,
+                               parent       => self()}).
 
-init(#{parent := Parent} = Arg) ->
+init(#{parent := Parent, chan_id := ChanId, requests := Reqs}) ->
     lager:debug("started min_depth watcher for ~p", [Parent]),
     erlang:monitor(process, Parent),
     true = aec_events:subscribe(top_changed),
     lager:debug("subscribed to top_changed", []),
     self() ! check_status,
-    {ok, Arg}.
+    {ok, #st{parent = Parent, chan_id = ChanId, requests = Reqs}}.
 
-handle_info({gproc_ps_event, top_changed, _},
-            #{type := close, closes_at := H, min_depth := Min} = St) ->
-    case determine_depth_(H, Min) of
-        true ->
-            #{callback_mod := Mod, parent := Parent, chan_id := ChanId} = St,
-            case Mod:minimum_depth_achieved(
-                   Parent, ChanId, close, undefined) of
-                ok ->
-                    {noreply, St}
-                %% stop ->
-                %%     {stop, normal, St}
-            end;
-        _ ->
-            {noreply, St}
-    end;
-handle_info({gproc_ps_event, top_changed, _}, St) ->
-    check_status(St);
-handle_info({'DOWN', _, process, Parent, _}, #{parent := Parent} = St) ->
+handle_info({gproc_ps_event, top_changed, _}, #st{} = St) ->
+    {noreply, check_status(St)};
+handle_info({'DOWN', _, process, Parent, _}, #st{parent = Parent} = St) ->
     {stop, normal, St};
 handle_info(check_status, St) ->
-    check_status(St);
+    {noreply, check_status(St)};
 handle_info(_Msg, St) ->
     lager:debug("got unknown Msg: ~p", [_Msg]),
     {noreply, St}.
 
-handle_call({watch, Type, TxHash, MinDepth}, From, #{tx_hash := TxHash0} = St) ->
-    case TxHash0 of
-        undefined ->
+handle_call(#{mode := _, callback_mod := _, parent := _} = Req, From,
+            #st{requests = Reqs} = St) ->
+    case maps:find(tx_hash, Req) of
+        {ok, TxHash} ->
+            case [true || #{tx_hash := TH} <- Reqs,
+                          TH =:= TxHash] of
+                [] ->
+                    gen_server:reply(From, ok),
+                    {noreply, check_status(St#st{requests = Reqs ++ [Req]})};
+                [_|_] ->
+                    {reply, {error, {already_watching, TxHash}}, St}
+            end;
+        error ->
             gen_server:reply(From, ok),
-            check_status(St#{tx_hash => TxHash,
-                             type    => Type,
-                             min_depth => MinDepth});
-        Existing ->
-            {reply, {error, {already_watching, Existing}}, St}
+            {noreply, check_status(St#st{requests = [Req|Reqs]})}
     end;
 handle_call(_Req, _From, St) ->
     {reply, {error, unknown_request}, St}.
@@ -89,73 +100,151 @@ terminate(_Reason, _St) ->
 code_change(_FromVsn, St, _Extra) ->
     {ok, St}.
 
-check_status(#{type := close, chan_id := ChId, parent := Parent} = St) ->
-    lager:debug("check_status(type = close, parent = ~p)", [Parent]),
-    TopHeight = top_height(),
-    St1 =
-        case aec_chain:get_channel(ChId) of
-            {ok, Ch} ->
-                case aesc_channels:is_active(Ch) of
-                    true ->
-                        St;
-                    false ->
-                        St#{closes_at => aesc_channels:closes_at(Ch)}
-                end;
-            {error, _} ->
-                %% Set closing time to current top height, wait for min_depth
-                St#{closes_at => TopHeight}
-        end,
-    {noreply, St1};
-check_status(#{tx_hash := undefined} = St) ->
-    watch_for_chain_transaction(St);
-check_status(#{parent := Parent, chan_id := ChanId,
-               tx_hash := TxHash, type := Type, min_depth := MinDepth} = St) ->
-    lager:debug("check_status(~p)", [Parent]),
-    case min_depth_achieved(TxHash, MinDepth) of
+check_status(#st{requests = Reqs} = St) ->
+    check_status(Reqs, St, #{}, []).
+
+check_status([Req|Reqs], St, Cache, Acc) ->
+    case check_status_(Req, St, Cache) of
+        {done, #{} = Cache1} ->
+            check_status(Reqs, St, Cache1, Acc);
+        {done, #st{} = St1, #{} = Cache1} ->
+            check_status(Reqs, St1, Cache1, Acc);
+        {#{} = Req1, Cache1} ->
+            check_status(Reqs, St, Cache1, [Req1|Acc])
+    end;
+check_status([], St, _, Acc) ->
+    St#st{requests = lists:reverse(Acc)}.
+
+check_status_(#{mode := close, closes_at := H, min_depth := Min} = R,
+              #st{chan_id = ChId}, Cache) ->
+    {HasDepth, Cache1} = determine_depth_(H, Min, Cache),
+    case HasDepth of
         true ->
+            #{callback_mod := Mod, parent := Parent} = R,
+            Mod:minimum_depth_achieved(Parent, ChId, close, undefined),
+            {done, Cache1};
+        _ ->
+            {R, Cache1}
+    end;
+check_status_(#{mode := close, parent := Parent} = R, #st{chan_id = ChId}, C) ->
+    lager:debug("check_status(type = close, parent = ~p)", [Parent]),
+    {TopHeight, C1} = top_height(C),
+    {Status, C2} = channel_status(ChId, C1),
+    case Status of
+        #{ is_active := true } ->
+            {R, C2};
+        #{ closes_at := ClosesAt } ->
+            {R#{ closes_at => ClosesAt }, C2};
+        undefined ->
+            %% Set closing time to current top height, wait for min_depth
+            {R#{ closes_at => TopHeight }, C2}
+    end;
+check_status_(#{mode := watch} = R, St, C) ->
+    watch_for_channel_closing(R, St, C);
+check_status_(#{mode := tx_hash, tx_hash := TxHash, parent := Parent,
+                type := Type, min_depth := MinDepth} = R,
+              #st{chan_id = ChanId}, C) ->
+    lager:debug("check_status(tx_hash = ~p, parent = ~p)", [TxHash, Parent]),
+    case min_depth_achieved(TxHash, MinDepth, C) of
+        {true, C1} ->
             lager:debug("min_depth achieved", []),
-            case aesc_fsm:minimum_depth_achieved(
+            #{ callback_mod := Mod } = R,
+            case Mod:minimum_depth_achieved(
                    Parent, ChanId, Type, TxHash) of
                 ok ->
-                    {noreply, St#{funding_locked => true,
-                                  type    => undefined,
-                                  tx_hash => undefined}}
+                    {done, C1}
                 %% stop ->
                 %%     {stop, normal, St}
             end;
-        _ ->
+        {_, C1} ->
             lager:debug("min_depth not yet achieved", []),
-            {noreply, St}
+            {R, C1}
     end.
 
-watch_for_chain_transaction(St) ->
-    lager:debug("watch_for_chain_transaction(~p)", [St]),
-    {noreply, St}.
+watch_for_channel_closing(#{callback_mod := Mod, parent := Parent},
+                          #st{closing = true, chan_id = ChanId}, C) ->
+    Mod:channel_closing_on_chain(Parent, ChanId),
+    {done, C};
+watch_for_channel_closing(#{check_at_height := _} = R, St, C) ->
+    {CurHeight, C1} = top_height(C),
+    watch_for_channel_closing(CurHeight, R, St, C1);
+watch_for_channel_closing(R, St, C) ->
+    {CurHeight, C1} = top_height(C),
+    watch_for_channel_closing(
+      CurHeight, R#{check_at_height => CurHeight}, St, C1).
 
-min_depth_achieved(TxHash, MinDepth) ->
-    case aec_chain:find_tx_with_location(TxHash) of
-        none ->
-            lager:debug("couldn't find tx hash", []),
-            undefined;
-        {mempool, _} ->
-            lager:debug("tx still in mempool", []),
-            undefined;
-        {BlockHash, _} ->
-            lager:debug("tx in Block ~p", [BlockHash]),
-            determine_depth(BlockHash, MinDepth)
+watch_for_channel_closing(CurHeight, #{check_at_height := H} = R,
+                          #st{chan_id = ChanId} = St, C)
+  when CurHeight >= H ->
+    {Status, C1} = channel_status(ChanId, C),
+    case Status of
+        #{is_active := true, lock_period := LP} ->
+            NextHeight = CurHeight + erlang:min(1, LP div 2),
+            {R#{check_at_height => NextHeight}, C1};
+        #{is_active := false} ->
+            #{callback_mod := Mod, parent := Parent} = R,
+            Mod:channel_closing_on_chain(Parent, ChanId),
+            {done, St#st{closing = true}, C1};
+        undefined ->
+            {R, C1}
+    end;
+watch_for_channel_closing(_, R, _, C) ->
+    {R, C}.
+
+
+channel_status(ChId, C) ->
+    channel_status(maps:find({status, ChId}, C), ChId, C).
+
+channel_status({ok, S}, _, C) -> {S, C};
+channel_status(error, ChId, C) ->
+    St = case aec_chain:get_channel(ChId) of
+             {ok, Ch} ->
+                 #{ is_active   => aesc_channels:is_active(Ch)
+                  , lock_period => aesc_channels:lock_period(Ch)
+                  , closes_at   => aesc_channels:closes_at(Ch) };
+             _ ->
+                 undefined
+         end,
+    {St, C#{ {status, ChId} => St }}.
+
+min_depth_achieved(TxHash, MinDepth, C) ->
+    {L, C1} = tx_location(TxHash, C),
+    case L of
+        undefined ->
+            {undefined, C1};
+        _ ->
+            determine_depth(L, MinDepth, C1)
     end.
 
-determine_depth(BHash, MinDepth) ->
-    case aec_chain:get_header(BHash) of
-        {ok, Hdr} ->
-            Height = aec_headers:height(Hdr),
-            lager:debug("tx at height ~p", [Height]),
-            determine_depth_(Height, MinDepth);
-        error ->
-            undefined
+tx_location(TxHash, C) ->
+    tx_location(maps:find({location,TxHash}, C), TxHash, C).
+
+tx_location({ok, L}, _, C) -> {L, C};
+tx_location(error, TxHash, C) ->
+    L = case aec_chain:find_tx_with_location(TxHash) of
+            none ->
+                lager:debug("couldn't find tx hash", []),
+                undefined;
+            {mempool, _} ->
+                lager:debug("tx still in mempool", []),
+                undefined;
+            {BlockHash, _} ->
+                lager:debug("tx in Block ~p", [BlockHash]),
+                BlockHash
+        end,
+    {L, C#{ {location, TxHash} => L }}.
+
+determine_depth(BHash, MinDepth, C) ->
+    {H, C1} = height(BHash, C),
+    case H of
+        undefined ->
+            {undefined, C1};
+        _ ->
+            determine_depth_(H, MinDepth, C1)
     end.
 
-top_height() ->
+top_height(#{top_height := H} = C) -> {H, C};
+top_height(C) ->
     TopHeight = case aec_chain:top_header() of
                     undefined ->
                         undefined;
@@ -163,13 +252,27 @@ top_height() ->
                         aec_headers:height(TopHdr)
                 end,
     lager:debug("top height = ~p", [TopHeight]),
-    TopHeight.
+    {TopHeight, C#{ top_height => TopHeight }}.
 
-determine_depth_(Height, MinDepth) ->
-    case top_height() of
-        undefined ->
-            undefined;
-        TopHeight ->
-            (TopHeight - Height) >= MinDepth
+height(BHash, C) ->
+    height(maps:find({height, BHash}, C), BHash, C).
+
+height({ok, H}, _BHash, C) -> {H, C};
+height(error, BHash, C) ->
+    Height = case aec_chain:get_header(BHash) of
+                 {ok, Hdr} ->
+                     H = aec_headers:height(Hdr),
+                     lager:debug("tx at height ~p", [H]),
+                     H;
+                 error ->
+                     undefined
+             end,
+    {Height, C#{ {height, BHash} => Height }}.
+
+determine_depth_(Height, MinDepth, C) ->
+    case top_height(C) of
+        {undefined, _} = Res -> Res;
+        {TopHeight, C1} ->
+            {(TopHeight - Height) >= MinDepth, C1}
     end.
 

--- a/apps/aechannel/src/aesc_fsm_min_depth_watcher.erl
+++ b/apps/aechannel/src/aesc_fsm_min_depth_watcher.erl
@@ -105,11 +105,11 @@ check_status(#st{requests = Reqs} = St) ->
 
 check_status([Req|Reqs], St, Cache, Acc) ->
     case check_status_(Req, St, Cache) of
-        {done, #{} = Cache1} ->
+        {done, Cache1} when is_map(Cache1) ->
             check_status(Reqs, St, Cache1, Acc);
-        {done, #st{} = St1, #{} = Cache1} ->
+        {done, #st{} = St1, Cache1} when is_map(Cache1) ->
             check_status(Reqs, St1, Cache1, Acc);
-        {#{} = Req1, Cache1} ->
+        {Req1, Cache1} when is_map(Req1) ->
             check_status(Reqs, St, Cache1, [Req1|Acc])
     end;
 check_status([], St, _, Acc) ->
@@ -149,13 +149,8 @@ check_status_(#{mode := tx_hash, tx_hash := TxHash, parent := Parent,
         {true, C1} ->
             lager:debug("min_depth achieved", []),
             #{ callback_mod := Mod } = R,
-            case Mod:minimum_depth_achieved(
-                   Parent, ChanId, Type, TxHash) of
-                ok ->
-                    {done, C1}
-                %% stop ->
-                %%     {stop, normal, St}
-            end;
+            Mod:minimum_depth_achieved(Parent, ChanId, Type, TxHash),
+            {done, C1};
         {_, C1} ->
             lager:debug("min_depth not yet achieved", []),
             {R, C1}

--- a/docs/release-notes/next/PT-160237116.md
+++ b/docs/release-notes/next/PT-160237116.md
@@ -1,0 +1,2 @@
+* The state channel fsm will now terminate if it detects that someone is
+  trying to close the channel on-chain.


### PR DESCRIPTION
See [PT #160237116](https://www.pivotaltracker.com/story/show/160237116)

The chain watcher detects if the channel object enters `closing` status, and informs the fsm, which terminates.

Also includes refactoring of the fsm's handling of general events, which was inconsistently implemented.