### PR TITLE
Correct TTL in oracle tests following Chain.ttl type

### DIFF
--- a/apps/aecontract/test/aecontract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_SUITE.erl
@@ -82,6 +82,8 @@
 -define(MINER_PUBKEY, <<12345:?MINER_PUB_BYTES/unit:8>>).
 -define(BENEFICIARY_PUBKEY, <<12345:?BENEFICIARY_PUB_BYTES/unit:8>>).
 
+-define(CHAIN_RELATIVE_TTL_MEMORY_ENCODING(X), {variant, 0, [X]}).
+-define(CHAIN_ABSOLUTE_TTL_MEMORY_ENCODING(X), {variant, 1, [X]}).
 
 %%%===================================================================
 %%% Common test framework
@@ -743,8 +745,8 @@ sophia_typed_calls(_Cfg) ->
 %%  - Failing calls
 sophia_oracles(_Cfg) ->
     state(aect_test_utils:new_state()),
-    RelativeTTL       = fun(Delta)  -> {variant, 0, [Delta]} end,
-    FixedTTL          = fun(Height) -> {variant, 1, [Height]} end,
+    RelativeTTL       = fun(Delta)  -> ?CHAIN_RELATIVE_TTL_MEMORY_ENCODING(Delta) end,
+    FixedTTL          = fun(Height) -> ?CHAIN_ABSOLUTE_TTL_MEMORY_ENCODING(Height) end,
     Acc               = ?call(new_account, 1000000),
     Ct = <<CtId:256>> = ?call(create_contract, Acc, oracles, {}, #{amount => 100000}),
     QueryFee          = 100,
@@ -790,8 +792,8 @@ ttl_height(_, {block, H}) -> H.
 
 %% Run a single transaction from an Oracle TTL scenario and check the results.
 step_ttl(St = #{ account := Acc, contract := Ct }, Height, Cmd) ->
-    Enc = fun({delta, D}) -> {variant, 0, [D]};
-             ({block, H}) -> {variant, 1, [H]} end,
+    Enc = fun({delta, D}) -> ?CHAIN_RELATIVE_TTL_MEMORY_ENCODING(D);
+             ({block, H}) -> ?CHAIN_ABSOLUTE_TTL_MEMORY_ENCODING(H) end,
     QFee = 10,
     Error = {error, <<"out_of_gas">>},
     io:format("-- At height ~p --\nState ~p\nTransaction: ~p\n", [Height, St, Cmd]),

--- a/apps/aecontract/test/aecontract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_SUITE.erl
@@ -977,14 +977,14 @@ oracle_init_from_remote_contract(OperatorAcc, InitialOracleContractBalance, S) -
 
 oracle_register_from_contract(OperatorAcc, OCt, OCt, Opts, TxOpts, S) ->
     QueryFee = maps:get(qfee, Opts),
-    OTtl = maps:get(ottl, Opts, 15),
+    OTtl = ?CHAIN_RELATIVE_TTL_MEMORY_ENCODING(maps:get(ottl, Opts, 15)),
     <<OCtId:256>> = OCt,
     {OCtId, S1} = call_contract(OperatorAcc, OCt, registerOracle, word, {OCt, 0, QueryFee, OTtl}, TxOpts, S),
     {ok, S1}.
 
 oracle_register_from_remote_contract(OperatorAcc, RCt, OCt, Opts, TxOpts, S) ->
     QueryFee = maps:get(qfee, Opts),
-    OTtl = maps:get(ottl, Opts, 15),
+    OTtl = ?CHAIN_RELATIVE_TTL_MEMORY_ENCODING(maps:get(ottl, Opts, 15)),
     <<OCtId:256>> = OCt,
     {OCtId, S1} = call_contract(OperatorAcc, RCt, callRegisterOracle, word, {OCt, OCt, 0, QueryFee, OTtl}, TxOpts, S),
     {ok, S1}.
@@ -997,8 +997,8 @@ oracle_query_from_contract_(Fun, UserAcc, OCt, OCt, Opts, TxOpts, S) ->
     QueryFee = maps:get(qfee, Opts),
     Question = maps:get(question, Opts, <<"why?">>),
     ?assertMatch(_ when is_binary(Question), Question),
-    QTtl = maps:get(qttl, Opts, 5),
-    RTtl = maps:get(rttl, Opts, 5),
+    QTtl = ?CHAIN_RELATIVE_TTL_MEMORY_ENCODING(maps:get(qttl, Opts, 5)),
+    RTtl = ?CHAIN_RELATIVE_TTL_MEMORY_ENCODING(maps:get(rttl, Opts, 5)),
     call_contract(UserAcc, OCt, Fun, word, {OCt, Question, QueryFee, QTtl, RTtl}, TxOpts, S).
 
 oracle_query_from_remote_contract(UserAcc, RCt, OCt, Opts, TxOpts, S) ->
@@ -1010,8 +1010,8 @@ oracle_query_from_remote_contract_(Fun, UserAcc, RCt, OCt, Opts, TxOpts, S) ->
 oracle_query_from_remote_contract_(Fun, UserAcc, RCt, OCt, OAcc, Opts, TxOpts, S) ->
     QueryFee = maps:get(qfee, Opts),
     Question = maps:get(question, Opts, <<"why?">>),
-    QTtl = maps:get(qttl, Opts, 5),
-    RTtl = maps:get(rttl, Opts, 5),
+    QTtl = ?CHAIN_RELATIVE_TTL_MEMORY_ENCODING(maps:get(qttl, Opts, 5)),
+    RTtl = ?CHAIN_RELATIVE_TTL_MEMORY_ENCODING(maps:get(rttl, Opts, 5)),
     Value = case maps:find(remote_value, Opts) of
                 {ok, V} -> V;
                 error -> maps:get(amount, TxOpts)


### PR DESCRIPTION
Delivers https://www.pivotaltracker.com/story/show/160562273

(Preparatory for [gas fees in oracle primops](https://www.pivotaltracker.com/story/show/159686884).)