### PR TITLE
Pt 160548220 expired ttl crashes cowboy

### DIFF
--- a/apps/aecore/src/aec_tx_pool.erl
+++ b/apps/aecore/src/aec_tx_pool.erl
@@ -104,11 +104,11 @@ stop() ->
 
 %% INFO: Transaction from the same sender with the same nonce and fee
 %%       will be overwritten
--spec push(aetx_sign:signed_tx()) -> ok.
+-spec push(aetx_sign:signed_tx()) -> ok | {error, atom()}.
 push(Tx) ->
     push(Tx, tx_created).
 
--spec push(aetx_sign:signed_tx(), event()) -> ok.
+-spec push(aetx_sign:signed_tx(), event()) -> ok | {error, atom()}.
 push(Tx, Event) when ?PUSH_EVENT(Event) ->
     %% Verify that this is a signed transaction.
     try aetx_sign:tx(Tx)

--- a/apps/aehttp/src/aehttp_dispatch_ext.erl
+++ b/apps/aehttp/src/aehttp_dispatch_ext.erl
@@ -320,9 +320,13 @@ handle_request('PostTransaction', #{'Tx' := Tx}, _Context) ->
         {ok, TxDec} ->
             case deserialize_transaction(TxDec) of
                 {ok, SignedTx} ->
-                    ok = aec_tx_pool:push(SignedTx), %% TODO Add proper error handling
-                    Hash = aetx_sign:hash(SignedTx),
-                    {200, [], #{<<"tx_hash">> => aec_base58c:encode(tx_hash, Hash)}};
+                    case aec_tx_pool:push(SignedTx) of
+                        ok ->
+                            Hash = aetx_sign:hash(SignedTx),
+                            {200, [], #{<<"tx_hash">> => aec_base58c:encode(tx_hash, Hash)}};
+                        {error, _} ->
+                            {400, [], #{reason => <<"Invalid tx">>}}
+                    end; 
                 {error, broken_tx} ->
                     {400, [], #{reason => <<"Invalid tx">>}}
             end;


### PR DESCRIPTION
Sending an expired TTL or any other malformed info in a transaction could cause a 500 status code to be returned due to a crash in aehttp_dispatch_ext.