### PR TITLE
Option pattern compiler bug

### DIFF
--- a/apps/aecontract/test/aecontract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_SUITE.erl
@@ -1952,7 +1952,10 @@ sophia_maps(_Cfg) ->
                                 {fromlist_s, StrMap, MapS}] ] ++
         []),
 
-    _ = [ Result = Call(Fn, Type, Args) || {Fn, Type, Args, Result} <- Calls ],
+    _ = [ begin
+            io:format("Applying ~p.\nArgs = ~p\nType = ~p\nExpected = ~p\n", [Fn, Args, Type, Result]),
+            Result = Call(Fn, Type, Args)
+          end || {Fn, Type, Args, Result} <- Calls ],
 
     %% to_list (not tolist_state)
     _ = [ {Xs, Xs} = {lists:keysort(1, Call(Fn, Type, Map)), maps:to_list(Map)}

--- a/apps/aehttp/test/aehttp_contracts_SUITE.erl
+++ b/apps/aehttp/test/aehttp_contracts_SUITE.erl
@@ -738,29 +738,29 @@ maps_contract(Config) ->
     {IL1Value,_} = call_compute_func(NodeName, CPubkey, CPrivkey,
                                      EncodedMapsPubkey,
                                      <<"lookup_state_i">>, <<"(3)">>),
-    #{<<"type">> := <<"option">>,
-      <<"value">> := #{<<"value">> := [#{<<"value">> := 5},
-                                       #{<<"value">> := 6}]}} =
+    #{<<"type">> := <<"variant">>,
+      <<"value">> := [1, #{<<"value">> := [#{<<"value">> := 5},
+                                           #{<<"value">> := 6}]}]} =
         decode_data(<<"option((int, int))">>, IL1Value),
     {IL2Value,_} = call_compute_func(NodeName, CPubkey, CPrivkey,
                                      EncodedMapsPubkey,
                                      <<"lookup_state_i">>, <<"(10)">>),
-    #{<<"type">> := <<"option">>,
-      <<"value">> := <<"None">>} =
+    #{<<"type">> := <<"variant">>,
+      <<"value">> := [0]} =
         decode_data(<<"option((int, int))">>, IL2Value),
 
     {SL1Value,_} = call_compute_func(NodeName, CPubkey, CPrivkey,
                                      EncodedMapsPubkey,
                                      <<"lookup_state_s">>, <<"(\"three\")">>),
-    #{<<"type">> := <<"option">>,
-      <<"value">> := #{<<"value">> := [#{<<"value">> := 5},
-                                       #{<<"value">> := 6}]}} =
+    #{<<"type">> := <<"variant">>,
+      <<"value">> := [1, #{<<"value">> := [#{<<"value">> := 5},
+                                           #{<<"value">> := 6}]}]} =
         decode_data(<<"option((int, int))">>, SL1Value),
     {SL2Value,_} = call_compute_func(NodeName, CPubkey, CPrivkey,
                                      EncodedMapsPubkey,
                                      <<"lookup_state_s">>, <<"(\"ten\")">>),
-    #{<<"type">> := <<"option">>,
-      <<"value">> := <<"None">>} =
+    #{<<"type">> := <<"variant">>,
+      <<"value">> := [0]} =
         decode_data(<<"option((int, int))">>, SL2Value),
 
     %% Map.delete

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -902,10 +902,10 @@ test_decode_sophia_data2(_Config) ->
                           , #{ <<"type">> := <<"list">>
                              , <<"value">> :=
                                    [_,_,_]}
-                          , #{ <<"type">> := <<"option">>
+                          , #{ <<"type">> := <<"variant">>
                              , <<"value">> :=
-                                   #{ <<"type">> := <<"word">>
-                                    , <<"value">> := 1}}]}
+                                   [1, #{ <<"type">> := <<"word">>
+                                        , <<"value">> := 1 }]} ]}
                   ]
            }
      } = Decoded,

--- a/apps/aesophia/src/aeso_icode.erl
+++ b/apps/aesophia/src/aeso_icode.erl
@@ -9,7 +9,7 @@
 %%%-------------------------------------------------------------------
 -module(aeso_icode).
 
--export([new/1, pp/1, set_name/2, set_functions/2, map_typerep/2, get_constructor_tag/2]).
+-export([new/1, pp/1, set_name/2, set_functions/2, map_typerep/2, option_typerep/1, get_constructor_tag/2]).
 -export_type([icode/0]).
 
 -include("aeso_icode.hrl").
@@ -61,17 +61,22 @@ builtin_types() ->
      , "oracle"       => fun([_, _]) -> word end
      , "oracle_query" => fun([_, _]) -> word end
      , "list"         => fun([A]) -> {list, A} end
-     , "option"       => fun([A]) -> {option, A} end
+     , "option"       => fun([A]) -> {variant, [[], [A]]} end
      , "map"          => fun([K, V]) -> map_typerep(K, V) end
      , ["Chain", "ttl"] => fun([]) -> {variant, [[word], [word]]} end
      }.
 
 builtin_constructors() ->
     #{ "RelativeTTL" => 0
-     , "FixedTTL"    => 1 }.
+     , "FixedTTL"    => 1
+     , "None"        => 0
+     , "Some"        => 1 }.
 
 map_typerep(K, V) ->
     {list, {tuple, [K, V]}}.  %% Lists of key-value pairs for now
+
+option_typerep(A) ->
+    {variant, [[], [A]]}.
 
 new_env() ->
     [].

--- a/apps/aesophia/src/aeso_icode.hrl
+++ b/apps/aesophia/src/aeso_icode.hrl
@@ -5,7 +5,6 @@
 -define(TYPEREP_STRING_TAG, 1).
 -define(TYPEREP_LIST_TAG,   2).
 -define(TYPEREP_TUPLE_TAG,  3).
--define(TYPEREP_OPTION_TAG, 4).
 -define(TYPEREP_VARIANT_TAG, 5).
 
 -record(arg, {name::string(), type::?Type()}).

--- a/apps/aesophia/test/aeso_abi_tests.erl
+++ b/apps/aesophia/test/aeso_abi_tests.erl
@@ -62,7 +62,7 @@ encode_decode_sophia_test() ->
     1 = encode_decode_sophia_string("true"),
     0 = encode_decode_sophia_string("false"),
     <<"Hello">> = encode_decode_sophia_string("\"Hello\""),
-    {<<"Hello">>, [1,2,3], {some, 1}} =
+    {<<"Hello">>, [1,2,3], {variant, 1, [1]}} =
         encode_decode_sophia_string(
           "(\"Hello\", [1,2,3], Some(true))"),
     ok.

--- a/apps/aesophia/test/contracts/complex_types.aes
+++ b/apps/aesophia/test/contracts/complex_types.aes
@@ -78,8 +78,8 @@ contract ComplexTypes =
       None :: ys => None
       Some(x) :: ys =>
         switch(all_some(ys))
-          None     => None
           Some(xs) => Some(x :: xs)
+          None     => None
 
   function remote_all_some(xs : list(option(int))) : option(list(int)) =
     state.worker.all_some(gas = 10000, xs)


### PR DESCRIPTION
Compilation of option type patterns were buggy (h/t @velzevur). Fixed by removing special handling of option types in the compiler. They are now defined as (a builtin) `datatype option('a) = None | Some('a)`.
