### PR TITLE
Refactor aetx behaviour

### DIFF
--- a/apps/aechannel/src/aesc_close_mutual_tx.erl
+++ b/apps/aechannel/src/aesc_close_mutual_tx.erl
@@ -16,8 +16,8 @@
          ttl/1,
          nonce/1,
          origin/1,
-         check/5,
-         process/6,
+         check/3,
+         process/3,
          signers/2,
          version/0,
          serialization_template/1,
@@ -101,13 +101,12 @@ origin(#channel_close_mutual_tx{} = Tx) ->
 channel_pubkey(#channel_close_mutual_tx{channel_id = ChannelId}) ->
     aec_id:specialize(ChannelId, channel).
 
--spec check(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) ->
-        {ok, aec_trees:trees()} | {error, term()}.
+-spec check(tx(), aec_trees:trees(), aetx_env:env()) -> {ok, aec_trees:trees()} | {error, term()}.
 check(#channel_close_mutual_tx{initiator_amount_final = InitiatorAmount,
                                responder_amount_final = ResponderAmount,
                                fee                    = Fee,
                                nonce                  = Nonce} = Tx,
-      _Context, Trees, _Height, _ConsensusVersion) ->
+      Trees,_Env) ->
     ChannelPubKey = channel_pubkey(Tx),
     case aesc_state_tree:lookup(ChannelPubKey, aec_trees:channels(Trees)) of
         none ->
@@ -138,14 +137,13 @@ check(#channel_close_mutual_tx{initiator_amount_final = InitiatorAmount,
             end
     end.
 
--spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
-              non_neg_integer(), binary() | no_tx_hash) -> {ok, aec_trees:trees()}.
+-spec process(tx(), aec_trees:trees(), aetx_env:env()) -> {ok, aec_trees:trees()}.
 process(#channel_close_mutual_tx{initiator_amount_final = InitiatorAmount,
                                  responder_amount_final = ResponderAmount,
                                  ttl                    = _TTL,
                                  fee                    = _Fee,
                                  nonce                  = Nonce} = Tx,
-        _Context, Trees, _Height, _ConsensusVersion, _TxHash) ->
+        Trees,_Env) ->
     ChannelPubKey = channel_pubkey(Tx),
     AccountsTree0 = aec_trees:accounts(Trees),
     ChannelsTree0 = aec_trees:channels(Trees),

--- a/apps/aechannel/src/aesc_close_solo_tx.erl
+++ b/apps/aechannel/src/aesc_close_solo_tx.erl
@@ -16,8 +16,8 @@
          ttl/1,
          nonce/1,
          origin/1,
-         check/5,
-         process/6,
+         check/3,
+         process/3,
          signers/2,
          version/0,
          serialization_template/1,
@@ -101,12 +101,12 @@ channel_pubkey(#channel_close_solo_tx{channel_id = ChannelId}) ->
 from_pubkey(#channel_close_solo_tx{from_id = FromPubKey}) ->
     aec_id:specialize(FromPubKey, account).
 
--spec check(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) ->
-        {ok, aec_trees:trees()} | {error, term()}.
+-spec check(tx(), aec_trees:trees(), aetx_env:env()) -> {ok, aec_trees:trees()} | {error, term()}.
 check(#channel_close_solo_tx{payload    = Payload,
                              poi        = PoI,
                              fee        = Fee,
-                             nonce      = Nonce} = Tx, _Context, Trees, _Height, _ConsensusVersion) ->
+                             nonce      = Nonce} = Tx,
+      Trees,_Env) ->
     ChannelPubKey  = channel_pubkey(Tx),
     FromPubKey = from_pubkey(Tx),
     case aesc_utils:check_solo_close_payload(ChannelPubKey, FromPubKey, Nonce, Fee,
@@ -115,13 +115,13 @@ check(#channel_close_solo_tx{payload    = Payload,
         Err -> Err
     end.
 
--spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
-              non_neg_integer(), binary() | no_tx_hash) -> {ok, aec_trees:trees()}.
+-spec process(tx(), aec_trees:trees(), aetx_env:env()) -> {ok, aec_trees:trees()}.
 process(#channel_close_solo_tx{payload    = Payload,
                                poi        = PoI,
                                fee        = Fee,
-                               nonce      = Nonce} = Tx, _Context, Trees,
-        Height, _ConsensusVersion, _TxHash) ->
+                               nonce      = Nonce} = Tx,
+        Trees, Env) ->
+    Height         = aetx_env:height(Env),
     ChannelPubKey  = channel_pubkey(Tx),
     FromPubKey     = from_pubkey(Tx),
     aesc_utils:process_solo_close(ChannelPubKey, FromPubKey, Nonce, Fee,

--- a/apps/aechannel/src/aesc_create_tx.erl
+++ b/apps/aechannel/src/aesc_create_tx.erl
@@ -17,8 +17,8 @@
          ttl/1,
          nonce/1,
          origin/1,
-         check/5,
-         process/6,
+         check/3,
+         process/3,
          signers/2,
          version/0,
          serialization_template/1,
@@ -130,14 +130,14 @@ nonce(#channel_create_tx{nonce = Nonce}) ->
 origin(#channel_create_tx{} = Tx) ->
     initiator_pubkey(Tx).
 
--spec check(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) ->
-        {ok, aec_trees:trees()} | {error, term()}.
+-spec check(tx(), aec_trees:trees(), aetx_env:env()) -> {ok, aec_trees:trees()} | {error, term()}.
 check(#channel_create_tx{initiator_amount   = InitiatorAmount,
                          responder_amount   = ResponderAmount,
                          channel_reserve    = ChannelReserve,
                          nonce              = Nonce,
                          state_hash         = _StateHash,
-                         fee                = Fee} = Tx, _Context, Trees, _Height, _ConsensusVersion) ->
+                         fee                = Fee} = Tx,
+      Trees,_Env) ->
     InitiatorPubKey = initiator_pubkey(Tx),
     ResponderPubKey = responder_pubkey(Tx),
     Checks =
@@ -152,14 +152,13 @@ check(#channel_create_tx{initiator_amount   = InitiatorAmount,
             Error
     end.
 
--spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
-              non_neg_integer(), binary() | no_tx_hash) -> {ok, aec_trees:trees()}.
+-spec process(tx(), aec_trees:trees(), aetx_env:env()) -> {ok, aec_trees:trees()}.
 process(#channel_create_tx{initiator_amount   = InitiatorAmount,
                            responder_amount   = ResponderAmount,
                            fee                = Fee,
                            state_hash         = _StateHash,
-                           nonce              = Nonce} = CreateTx, _Context, Trees0, _Height,
-        _ConsensusVersion, _TxHash) ->
+                           nonce              = Nonce} = CreateTx,
+        Trees0,_Env) ->
     InitiatorPubKey = initiator_pubkey(CreateTx),
     ResponderPubKey = responder_pubkey(CreateTx),
 

--- a/apps/aechannel/src/aesc_deposit_tx.erl
+++ b/apps/aechannel/src/aesc_deposit_tx.erl
@@ -18,8 +18,8 @@
          nonce/1,
          origin/1,
          amount/1,
-         check/5,
-         process/6,
+         check/3,
+         process/3,
          signers/2,
          version/0,
          serialization_template/1,
@@ -128,13 +128,13 @@ channel_id(#channel_deposit_tx{channel_id = ChannelId}) ->
 channel_pubkey(#channel_deposit_tx{channel_id = ChannelId}) ->
     aec_id:specialize(ChannelId, channel).
 
--spec check(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) ->
-        {ok, aec_trees:trees()} | {error, term()}.
+-spec check(tx(), aec_trees:trees(), aetx_env:env()) -> {ok, aec_trees:trees()} | {error, term()}.
 check(#channel_deposit_tx{amount     = Amount,
                           fee        = Fee,
                           state_hash  = _StateHash,
                           round       = Round,
-                          nonce      = Nonce} = Tx, _Context, Trees, _Height, _ConsensusVersion) ->
+                          nonce      = Nonce} = Tx,
+      Trees,_Env) ->
     ChannelPubKey = channel_pubkey(Tx),
     FromPubKey    = from_pubkey(Tx),
     Checks =
@@ -147,14 +147,13 @@ check(#channel_deposit_tx{amount     = Amount,
             Error
     end.
 
--spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
-              non_neg_integer(), binary() | no_tx_hash) -> {ok, aec_trees:trees()}.
+-spec process(tx(), aec_trees:trees(), aetx_env:env()) -> {ok, aec_trees:trees()}.
 process(#channel_deposit_tx{amount     = Amount,
                             fee        = Fee,
                             state_hash = StateHash,
                             round      = Round,
-                            nonce      = Nonce} = Tx, _Context, Trees,
-        _Height, _ConsensusVersion, _TxHash) ->
+                            nonce      = Nonce} = Tx,
+        Trees,_Env) ->
     ChannelPubKey = channel_pubkey(Tx),
     FromPubKey    = from_pubkey(Tx),
     AccountsTree0 = aec_trees:accounts(Trees),

--- a/apps/aechannel/src/aesc_offchain_tx.erl
+++ b/apps/aechannel/src/aesc_offchain_tx.erl
@@ -11,8 +11,8 @@
          ttl/1,
          nonce/1,
          origin/1,
-         check/5,
-         process/6,
+         check/3,
+         process/3,
          signers/2,
          version/0,
          serialization_template/1,
@@ -96,21 +96,18 @@ nonce(#channel_offchain_tx{round = N}) ->
 origin(#channel_offchain_tx{}) ->
     error(do_not_use).
 
--spec check(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) ->
-        {ok, aec_trees:trees()} | {error, term()}.
+-spec check(tx(), aec_trees:trees(), aetx_env:env()) -> {ok, aec_trees:trees()} | {error, term()}.
 check(#channel_offchain_tx{
          channel_id         = _ChannelId,
          updates            = _Updates,
          state_hash         = _State,
-         round              = _Round}, _Context, Trees, _Height,
-                                                _ConsensusVersion) ->
+         round              = _Round},
+      Trees,_Env) ->
     %% TODO: implement checks relevant to off-chain
     {ok, Trees}.
 
--spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
-              non_neg_integer(), binary() | no_tx_hash) -> {ok, aec_trees:trees()}.
-process(#channel_offchain_tx{}, _Context, _Trees, _Height, _ConsensusVersion,
-       _TxHash) ->
+-spec process(tx(), aec_trees:trees(), aetx_env:env()) -> {ok, aec_trees:trees()}.
+process(#channel_offchain_tx{},_Trees, #{}) ->
     error(off_chain_tx).
 
 -spec signers(tx(), aec_trees:trees()) -> {ok, list(aec_keys:pubkey())}.

--- a/apps/aechannel/src/aesc_settle_tx.erl
+++ b/apps/aechannel/src/aesc_settle_tx.erl
@@ -16,8 +16,8 @@
          ttl/1,
          nonce/1,
          origin/1,
-         check/5,
-         process/6,
+         check/3,
+         process/3,
          signers/2,
          version/0,
          serialization_template/1,
@@ -101,12 +101,13 @@ from_pubkey(#channel_settle_tx{from_id = FromId}) ->
 channel_pubkey(#channel_settle_tx{channel_id = ChannelId}) ->
     aec_id:specialize(ChannelId, channel).
 
--spec check(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) ->
-        {ok, aec_trees:trees()} | {error, term()}.
+-spec check(tx(), aec_trees:trees(), aetx_env:env()) -> {ok, aec_trees:trees()} | {error, term()}.
 check(#channel_settle_tx{initiator_amount_final = InitiatorAmount,
                          responder_amount_final = ResponderAmount,
                          fee                    = Fee,
-                         nonce                  = Nonce} = Tx, _Context, Trees, Height, _ConsensusVersion) ->
+                         nonce                  = Nonce} = Tx,
+      Trees, Env) ->
+    Height        = aetx_env:height(Env),
     ChannelPubKey = channel_pubkey(Tx),
     FromPubKey    = from_pubkey(Tx),
     Checks =
@@ -120,13 +121,12 @@ check(#channel_settle_tx{initiator_amount_final = InitiatorAmount,
             Error
     end.
 
--spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
-              non_neg_integer(), binary() | no_tx_hash) -> {ok, aec_trees:trees()}.
+-spec process(tx(), aec_trees:trees(), aetx_env:env()) -> {ok, aec_trees:trees()}.
 process(#channel_settle_tx{initiator_amount_final = InitiatorAmount,
                            responder_amount_final = ResponderAmount,
                            fee                    = Fee,
-                           nonce                  = Nonce} = Tx, _Context,
-        Trees, _Height, _ConsensusVersion, _TxHash) ->
+                           nonce                  = Nonce} = Tx,
+        Trees,_Env) ->
     ChannelPubKey = channel_pubkey(Tx),
     FromPubKey    = from_pubkey(Tx),
     AccountsTree0 = aec_trees:accounts(Trees),

--- a/apps/aechannel/src/aesc_slash_tx.erl
+++ b/apps/aechannel/src/aesc_slash_tx.erl
@@ -16,8 +16,8 @@
          ttl/1,
          nonce/1,
          origin/1,
-         check/5,
-         process/6,
+         check/3,
+         process/3,
          signers/2,
          version/0,
          serialization_template/1,
@@ -101,12 +101,13 @@ from_pubkey(#channel_slash_tx{from_id = FromId}) ->
 channel_pubkey(#channel_slash_tx{channel_id = ChannelId}) ->
     aec_id:specialize(ChannelId, channel).
 
--spec check(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) ->
-        {ok, aec_trees:trees()} | {error, term()}.
+-spec check(tx(), aec_trees:trees(), aetx_env:env()) -> {ok, aec_trees:trees()} | {error, term()}.
 check(#channel_slash_tx{payload    = Payload,
                         poi        = PoI,
                         fee        = Fee,
-                        nonce      = Nonce} = Tx, _Context, Trees, Height,  _ConsensusVersion) ->
+                        nonce      = Nonce} = Tx,
+      Trees, Env) ->
+    Height        = aetx_env:height(Env),
     ChannelPubKey = channel_pubkey(Tx),
     FromPubKey    = from_pubkey(Tx),
     case aesc_utils:check_slash_payload(ChannelPubKey, FromPubKey, Nonce, Fee,
@@ -115,13 +116,13 @@ check(#channel_slash_tx{payload    = Payload,
         Err -> Err
     end.
 
--spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
-              non_neg_integer(), binary() | no_tx_hash) -> {ok, aec_trees:trees()}.
+-spec process(tx(), aec_trees:trees(), aetx_env:env()) -> {ok, aec_trees:trees()}.
 process(#channel_slash_tx{payload    = Payload,
                           poi        = PoI,
                           fee        = Fee,
-                          nonce      = Nonce} = Tx, _Context, Trees, Height,
-        _ConsensusVersion, _TxHash) ->
+                          nonce      = Nonce} = Tx,
+        Trees, Env) ->
+    Height        = aetx_env:height(Env),
     ChannelPubKey = channel_pubkey(Tx),
     FromPubKey    = from_pubkey(Tx),
     aesc_utils:process_slash(ChannelPubKey, FromPubKey, Nonce, Fee,

--- a/apps/aechannel/src/aesc_snapshot_solo_tx.erl
+++ b/apps/aechannel/src/aesc_snapshot_solo_tx.erl
@@ -16,8 +16,8 @@
          ttl/1,
          nonce/1,
          origin/1,
-         check/5,
-         process/6,
+         check/3,
+         process/3,
          signers/2,
          version/0,
          serialization_template/1,
@@ -98,11 +98,11 @@ channel_pubkey(#channel_snapshot_solo_tx{channel_id = ChannelId}) ->
 from_pubkey(#channel_snapshot_solo_tx{from_id = FromId}) ->
     aec_id:specialize(FromId, account).
 
--spec check(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) ->
-        {ok, aec_trees:trees()} | {error, term()}.
+-spec check(tx(), aec_trees:trees(), aetx_env:env()) -> {ok, aec_trees:trees()} | {error, term()}.
 check(#channel_snapshot_solo_tx{payload    = Payload,
                                 fee        = Fee,
-                                nonce      = Nonce} = Tx, _Context, Trees, _Height, _ConsensusVersion) ->
+                                nonce      = Nonce} = Tx,
+      Trees, _Env) ->
     ChannelPubKey = channel_pubkey(Tx),
     FromPubKey    = from_pubkey(Tx),
     case aesc_utils:check_solo_snapshot_payload(ChannelPubKey, FromPubKey, Nonce, Fee,
@@ -111,12 +111,11 @@ check(#channel_snapshot_solo_tx{payload    = Payload,
         Err -> Err
     end.
 
--spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
-              non_neg_integer(), binary() | no_tx_hash) -> {ok, aec_trees:trees()}.
+-spec process(tx(), aec_trees:trees(), aetx_env:env()) -> {ok, aec_trees:trees()}.
 process(#channel_snapshot_solo_tx{payload    = Payload,
-                               fee        = Fee,
-                               nonce      = Nonce} = Tx, _Context, Trees,
-        _Height, _ConsensusVersion, _TxHash) ->
+                                  fee        = Fee,
+                                  nonce      = Nonce} = Tx,
+        Trees,_Env) ->
     ChannelPubKey = channel_pubkey(Tx),
     FromPubKey    = from_pubkey(Tx),
     aesc_utils:process_solo_snapshot(ChannelPubKey, FromPubKey, Nonce, Fee, Payload, Trees).

--- a/apps/aechannel/src/aesc_withdraw_tx.erl
+++ b/apps/aechannel/src/aesc_withdraw_tx.erl
@@ -18,8 +18,8 @@
          nonce/1,
          origin/1,
          amount/1,
-         check/5,
-         process/6,
+         check/3,
+         process/3,
          signers/2,
          version/0,
          serialization_template/1,
@@ -126,13 +126,13 @@ channel_id(#channel_withdraw_tx{channel_id = ChannelId}) ->
 amount(#channel_withdraw_tx{amount = Amt}) ->
     Amt.
 
--spec check(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) ->
-        {ok, aec_trees:trees()} | {error, term()}.
+-spec check(tx(), aec_trees:trees(), aetx_env:env()) -> {ok, aec_trees:trees()} | {error, term()}.
 check(#channel_withdraw_tx{amount       = Amount,
                            fee          = Fee,
                            state_hash   = _StateHash,
                            round        = Round,
-                           nonce        = Nonce} = Tx, _Context, Trees, _Height, _ConsensusVersion) ->
+                           nonce        = Nonce} = Tx,
+     Trees,_Env) ->
     ChannelPubKey = channel_pubkey(Tx),
     ToPubKey      = to_pubkey(Tx),
     Checks =
@@ -145,14 +145,13 @@ check(#channel_withdraw_tx{amount       = Amount,
             Error
     end.
 
--spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
-              non_neg_integer(), binary() | no_tx_hash) -> {ok, aec_trees:trees()}.
+-spec process(tx(), aec_trees:trees(), aetx_env:env()) -> {ok, aec_trees:trees()}.
 process(#channel_withdraw_tx{amount       = Amount,
                              fee          = Fee,
                              state_hash   = StateHash,
                              round        = Round,
-                             nonce        = Nonce} = Tx, _Context, Trees,
-        _Height, _ConsensusVersion, _TxHash) ->
+                             nonce        = Nonce} = Tx,
+        Trees,_Env) ->
     ChannelPubKey = channel_pubkey(Tx),
     ToPubKey      = to_pubkey(Tx),
     AccountsTree0 = aec_trees:accounts(Trees),

--- a/apps/aechannel/test/aesc_test_utils.erl
+++ b/apps/aechannel/test/aesc_test_utils.erl
@@ -171,9 +171,9 @@ set_channel(Channel, State) ->
 
 apply_on_trees_without_sigs_check([SignedTx], Trees, Height, ConsensusVersion) ->
     Tx = aetx_sign:tx(SignedTx),
-    {ok, Trees1} = aetx:check(Tx, Trees, Height, ConsensusVersion),
-    {ok, Trees2} = aetx:process_with_tx_hash(Tx, Trees1, Height, ConsensusVersion,
-                                             aetx_sign:hash(SignedTx)),
+    Env = aetx_env:tx_env(Height, ConsensusVersion, {value, SignedTx}),
+    {ok, Trees1} = aetx:check(Tx, Trees, Env),
+    {ok, Trees2} = aetx:process(Tx, Trees1, Env),
     {ok, [SignedTx], Trees2}.
 
 %%%===================================================================

--- a/apps/aecontract/test/aecontract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_SUITE.erl
@@ -197,25 +197,27 @@ create_contract_negative(_Cfg) ->
     Trees        = aect_test_utils:trees(S1),
     PrivKey      = aect_test_utils:priv_key(PubKey, S1),
     CurrHeight   = 1,
+    Env          = aetx_env:tx_env(CurrHeight, ?PROTOCOL_VERSION),
 
     %% Test creating a bogus account
     {BadPubKey, BadS} = aect_test_utils:setup_new_account(aect_test_utils:new_state()),
     BadPrivKey        = aect_test_utils:priv_key(BadPubKey, BadS),
     RTx1      = aect_test_utils:create_tx(BadPubKey, S1),
     {error, S1} = sign_and_apply_transaction(RTx1, BadPrivKey, S1),
-    {error, account_not_found} = aetx:check(RTx1, Trees, CurrHeight, ?PROTOCOL_VERSION),
+
+    {error, account_not_found} = aetx:check(RTx1, Trees, Env),
 
     %% Insufficient funds
     S2     = aect_test_utils:set_account_balance(PubKey, 0, S1),
     Trees2 = aect_test_utils:trees(S2),
     RTx2   = aect_test_utils:create_tx(PubKey, S2),
     {error, S2} = sign_and_apply_transaction(RTx2, PrivKey, S2),
-    {error, insufficient_funds} = aetx:check(RTx2, Trees2, CurrHeight, ?PROTOCOL_VERSION),
+    {error, insufficient_funds} = aetx:check(RTx2, Trees2, Env),
 
     %% Test too high account nonce
     RTx3 = aect_test_utils:create_tx(PubKey, #{nonce => 0}, S1),
     {error, S1} = sign_and_apply_transaction(RTx3, PrivKey, S1),
-    {error, account_nonce_too_high} = aetx:check(RTx3, Trees, CurrHeight, ?PROTOCOL_VERSION),
+    {error, account_nonce_too_high} = aetx:check(RTx3, Trees, Env),
 
     ok.
 
@@ -371,7 +373,8 @@ call_contract_negative_insufficient_funds(_Cfg) ->
                                        amount    => Value,
                                        fee       => Fee}, S),
     {error, _} = sign_and_apply_transaction(CallTx, aect_test_utils:priv_key(Acc1, S), S),
-    {error, insufficient_funds} = aetx:check(CallTx, aect_test_utils:trees(S), _CurrHeight = 1, ?PROTOCOL_VERSION),
+    Env = aetx_env:tx_env(_Height = 1, ?PROTOCOL_VERSION),
+    {error, insufficient_funds} = aetx:check(CallTx, aect_test_utils:trees(S), Env),
     ok.
 
 call_contract_negative(_Cfg) ->

--- a/apps/aecore/src/aec_vm_chain.erl
+++ b/apps/aecore/src/aec_vm_chain.erl
@@ -419,10 +419,10 @@ do_set_store(Store, PubKey, Trees) ->
 
 apply_transaction(Tx, #state{ trees = Trees, height = Height } = State) ->
     ConsensusVersion = aec_hard_forks:protocol_effective_at_height(Height),
-    case aetx:check_from_contract(Tx, Trees, Height, ConsensusVersion) of
+    Env = aetx_env:contract_env(Height, ConsensusVersion),
+    case aetx:check(Tx, Trees, Env) of
         {ok, Trees1} ->
-            {ok, Trees2} =
-                aetx:process_from_contract(Tx, Trees1, Height, ConsensusVersion),
+            {ok, Trees2} = aetx:process(Tx, Trees1, Env),
             State1 = State#state{ trees = Trees2 },
             {ok, State1};
         {error, _} = E -> E

--- a/apps/aens/src/aens_claim_tx.erl
+++ b/apps/aens/src/aens_claim_tx.erl
@@ -17,8 +17,8 @@
          ttl/1,
          nonce/1,
          origin/1,
-         check/5,
-         process/6,
+         check/3,
+         process/3,
          signers/2,
          version/0,
          serialization_template/1,
@@ -95,12 +95,13 @@ nonce(#ns_claim_tx{nonce = Nonce}) ->
 origin(#ns_claim_tx{} = Tx) ->
     account_pubkey(Tx).
 
--spec check(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) ->
-        {ok, aec_trees:trees()} | {error, term()}.
+-spec check(tx(), aec_trees:trees(), aetx_env:env()) -> {ok, aec_trees:trees()} | {error, term()}.
 check(#ns_claim_tx{nonce     = Nonce,
                    name      = Name,
                    name_salt = NameSalt,
-                   fee       = Fee} = Tx, _Context, Trees, Height, _ConsensusVersion) ->
+                   fee       = Fee} = Tx,
+      Trees, Env) ->
+    Height = aetx_env:height(Env),
     AccountPubKey = account_pubkey(Tx),
     case aens_utils:to_ascii(Name) of
         {ok, NameAscii} ->
@@ -122,13 +123,13 @@ check(#ns_claim_tx{nonce     = Nonce,
             {error, Reason}
     end.
 
--spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
-              non_neg_integer(), binary() | no_tx_hash) -> {ok, aec_trees:trees()}.
+-spec process(tx(), aec_trees:trees(), aetx_env:env()) -> {ok, aec_trees:trees()}.
 process(#ns_claim_tx{nonce     = Nonce,
                      name      = PlainName,
                      name_salt = NameSalt,
                      fee       = Fee} = ClaimTx,
-        _Context, Trees0, Height, _ConsensusVersion, _TxHash) ->
+        Trees0, Env) ->
+    Height = aetx_env:height(Env),
     AccountPubKey = account_pubkey(ClaimTx),
     AccountsTree0 = aec_trees:accounts(Trees0),
     NSTree0 = aec_trees:ns(Trees0),

--- a/apps/aens/src/aens_preclaim_tx.erl
+++ b/apps/aens/src/aens_preclaim_tx.erl
@@ -17,8 +17,8 @@
          ttl/1,
          nonce/1,
          origin/1,
-         check/5,
-         process/6,
+         check/3,
+         process/3,
          signers/2,
          version/0,
          serialization_template/1,
@@ -94,10 +94,10 @@ nonce(#ns_preclaim_tx{nonce = Nonce}) ->
 origin(#ns_preclaim_tx{} = Tx) ->
     account_pubkey(Tx).
 
--spec check(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) ->
-        {ok, aec_trees:trees()} | {error, term()}.
+-spec check(tx(), aec_trees:trees(), aetx_env:env()) -> {ok, aec_trees:trees()} | {error, term()}.
 check(#ns_preclaim_tx{nonce = Nonce,
-                      fee   = Fee} = Tx, _Context, Trees, _Height, _ConsensusVersion) ->
+                      fee   = Fee} = Tx,
+      Trees,_Env) ->
     AccountPubKey  = account_pubkey(Tx),
     CommitmentHash = commitment_hash(Tx),
 
@@ -110,10 +110,10 @@ check(#ns_preclaim_tx{nonce = Nonce,
         {error, Reason} -> {error, Reason}
     end.
 
--spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
-              non_neg_integer(), binary() | no_tx_hash) -> {ok, aec_trees:trees()}.
+-spec process(tx(), aec_trees:trees(), aetx_env:env()) -> {ok, aec_trees:trees()}.
 process(#ns_preclaim_tx{fee = Fee, nonce = Nonce} = PreclaimTx,
-        _Context, Trees0, Height, _ConsensusVersion, _TxHash) ->
+        Trees0, Env) ->
+    Height = aetx_env:height(Env),
     AccountPubKey = account_pubkey(PreclaimTx),
     AccountsTree0 = aec_trees:accounts(Trees0),
     NSTree0 = aec_trees:ns(Trees0),

--- a/apps/aens/src/aens_revoke_tx.erl
+++ b/apps/aens/src/aens_revoke_tx.erl
@@ -16,8 +16,8 @@
          ttl/1,
          nonce/1,
          origin/1,
-         check/5,
-         process/6,
+         check/3,
+         process/3,
          signers/2,
          version/0,
          serialization_template/1,
@@ -87,10 +87,10 @@ nonce(#ns_revoke_tx{nonce = Nonce}) ->
 origin(#ns_revoke_tx{} = Tx) ->
     account_pubkey(Tx).
 
--spec check(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) ->
-        {ok, aec_trees:trees()} | {error, term()}.
+-spec check(tx(), aec_trees:trees(), aetx_env:env()) -> {ok, aec_trees:trees()} | {error, term()}.
 check(#ns_revoke_tx{nonce = Nonce,
-                    fee   = Fee} = Tx, _Context, Trees, _Height, _ConsensusVersion) ->
+                    fee   = Fee} = Tx,
+      Trees,_Env) ->
     AccountPubKey = account_pubkey(Tx),
     NameHash = name_hash(Tx),
 
@@ -103,10 +103,10 @@ check(#ns_revoke_tx{nonce = Nonce,
         {error, Reason} -> {error, Reason}
     end.
 
--spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
-              non_neg_integer(), binary() | no_tx_hash) -> {ok, aec_trees:trees()}.
+-spec process(tx(), aec_trees:trees(), aetx_env:env()) -> {ok, aec_trees:trees()}.
 process(#ns_revoke_tx{fee = Fee, nonce = Nonce} = Tx,
-        _Context, Trees0, Height, _ConsensusVersion, _TxHash) ->
+        Trees0, Env) ->
+    Height = aetx_env:height(Env),
     AccountPubKey = account_pubkey(Tx),
     NameHash = name_hash(Tx),
     AccountsTree0 = aec_trees:accounts(Trees0),

--- a/apps/aens/src/aens_transfer_tx.erl
+++ b/apps/aens/src/aens_transfer_tx.erl
@@ -17,8 +17,8 @@
          ttl/1,
          nonce/1,
          origin/1,
-         check/5,
-         process/6,
+         check/3,
+         process/3,
          signers/2,
          version/0,
          serialization_template/1,
@@ -106,10 +106,10 @@ account_pubkey(#ns_transfer_tx{account_id = AccountId}) ->
 name_hash(#ns_transfer_tx{name_id = NameId}) ->
     aec_id:specialize(NameId, name).
 
--spec check(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) ->
-        {ok, aec_trees:trees()} | {error, term()}.
+-spec check(tx(), aec_trees:trees(), aetx_env:env()) -> {ok, aec_trees:trees()} | {error, term()}.
 check(#ns_transfer_tx{nonce = Nonce,
-                      fee   = Fee} = Tx, _Context, Trees, _Height, _ConsensusVersion) ->
+                      fee   = Fee} = Tx,
+      Trees,_Env) ->
     AccountPubKey = account_pubkey(Tx),
     NameHash = name_hash(Tx),
 
@@ -124,10 +124,9 @@ check(#ns_transfer_tx{nonce = Nonce,
         {error, Reason} -> {error, Reason}
     end.
 
--spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
-              non_neg_integer(), binary() | no_tx_hash) -> {ok, aec_trees:trees()}.
+-spec process(tx(), aec_trees:trees(), aetx_env:env()) -> {ok, aec_trees:trees()}.
 process(#ns_transfer_tx{fee = Fee, nonce = Nonce} = TransferTx,
-        _Context, Trees0, _Height, _ConsensusVersion, _TxHash) ->
+        Trees0,_Env) ->
     NameHash = name_hash(TransferTx),
     AccountPubKey = account_pubkey(TransferTx),
     AccountsTree0 = aec_trees:accounts(Trees0),

--- a/apps/aens/src/aens_update_tx.erl
+++ b/apps/aens/src/aens_update_tx.erl
@@ -17,8 +17,8 @@
          ttl/1,
          nonce/1,
          origin/1,
-         check/5,
-         process/6,
+         check/3,
+         process/3,
          signers/2,
          version/0,
          serialization_template/1,
@@ -103,11 +103,11 @@ nonce(#ns_update_tx{nonce = Nonce}) ->
 origin(#ns_update_tx{} = Tx) ->
     account_pubkey(Tx).
 
--spec check(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) ->
-        {ok, aec_trees:trees()} | {error, term()}.
+-spec check(tx(), aec_trees:trees(), aetx_env:env()) -> {ok, aec_trees:trees()} | {error, term()}.
 check(#ns_update_tx{nonce    = Nonce,
                     fee      = Fee,
-                    name_ttl = TTL} = Tx, _Context, Trees, _Height, _ConsensusVersion) ->
+                    name_ttl = TTL} = Tx,
+      Trees,_Env) ->
     AccountPubKey = account_pubkey(Tx),
     NameHash = name_hash(Tx),
 
@@ -121,10 +121,10 @@ check(#ns_update_tx{nonce    = Nonce,
         {error, Reason} -> {error, Reason}
     end.
 
--spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
-              non_neg_integer(), binary() | no_tx_hash) -> {ok, aec_trees:trees()}.
+-spec process(tx(), aec_trees:trees(), aetx_env:env()) -> {ok, aec_trees:trees()}.
 process(#ns_update_tx{nonce = Nonce, fee = Fee} = UpdateTx,
-        _Context, Trees0, Height, _ConsensusVersion, _TxHash) ->
+        Trees0, Env) ->
+    Height = aetx_env:height(Env),
     AccountPubKey = account_pubkey(UpdateTx),
     NameHash = name_hash(UpdateTx),
     AccountsTree0 = aec_trees:accounts(Trees0),

--- a/apps/aens/test/aens_SUITE.erl
+++ b/apps/aens/test/aens_SUITE.erl
@@ -98,6 +98,8 @@ preclaim_negative(Cfg) ->
     {PubKey, S1} = aens_test_utils:setup_new_account(aens_test_utils:new_state()),
     Trees = aens_test_utils:trees(S1),
     Height = 1,
+    Env = aetx_env:tx_env(Height, ?PROTOCOL_VERSION),
+
     {ok, NameAscii} = aens_utils:to_ascii(<<"詹姆斯詹姆斯.test"/utf8>>),
     CHash = aens_hash:commitment_hash(NameAscii, 123),
 
@@ -105,22 +107,19 @@ preclaim_negative(Cfg) ->
     BadPubKey = <<42:32/unit:8>>,
     TxSpec1 = aens_test_utils:preclaim_tx_spec(BadPubKey, CHash, S1),
     {ok, Tx1} = aens_preclaim_tx:new(TxSpec1),
-    {error, account_not_found} =
-        aetx:check(Tx1, Trees, Height, ?PROTOCOL_VERSION),
+    {error, account_not_found} = aetx:check(Tx1, Trees, Env),
 
     %% Insufficient funds
     S2 = aens_test_utils:set_account_balance(PubKey, 0, S1),
     Trees2 = aens_test_utils:trees(S2),
     TxSpec2 = aens_test_utils:preclaim_tx_spec(PubKey, CHash, S1),
     {ok, Tx2} = aens_preclaim_tx:new(TxSpec2),
-    {error, insufficient_funds} =
-        aetx:check(Tx2, Trees2, Height, ?PROTOCOL_VERSION),
+    {error, insufficient_funds} = aetx:check(Tx2, Trees2, Env),
 
     %% Test too high account nonce
     TxSpec3 = aens_test_utils:preclaim_tx_spec(PubKey, CHash, #{nonce => 0}, S1),
     {ok, Tx3} = aens_preclaim_tx:new(TxSpec3),
-    {error, account_nonce_too_high} =
-        aetx:check(Tx3, Trees, Height, ?PROTOCOL_VERSION),
+    {error, account_nonce_too_high} = aetx:check(Tx3, Trees, Env),
 
     %% Test commitment already present
     {PubKey2, Name, NameSalt, S3} = preclaim(Cfg),
@@ -129,8 +128,7 @@ preclaim_negative(Cfg) ->
     Trees3 = aens_test_utils:trees(S3),
     TxSpec4 = aens_test_utils:preclaim_tx_spec(PubKey2, CHash2, S3),
     {ok, Tx4} = aens_preclaim_tx:new(TxSpec4),
-    {error, commitment_already_present}
-        = aetx:check(Tx4, Trees3, Height, ?PROTOCOL_VERSION),
+    {error, commitment_already_present} = aetx:check(Tx4, Trees3, Env),
     ok.
 
 %%%===================================================================
@@ -173,53 +171,47 @@ claim_negative(Cfg) ->
     {PubKey, Name, NameSalt, S1} = preclaim(Cfg),
     Trees = aens_test_utils:trees(S1),
     Height = ?PRE_CLAIM_HEIGHT,
+    Env = aetx_env:tx_env(Height, ?PROTOCOL_VERSION),
 
     %% Test commitment delta too small
     TxSpec = aens_test_utils:claim_tx_spec(PubKey, Name, NameSalt, S1),
     {ok, Tx0} = aens_claim_tx:new(TxSpec),
-    {error, commitment_delta_too_small} =
-        aetx:check(Tx0, Trees, Height, ?PROTOCOL_VERSION),
+    {error, commitment_delta_too_small} = aetx:check(Tx0, Trees, Env),
 
     %% Test bad account key
     BadPubKey = <<42:32/unit:8>>,
     TxSpec1 = aens_test_utils:claim_tx_spec(BadPubKey, Name, NameSalt, S1),
     {ok, Tx1} = aens_claim_tx:new(TxSpec1),
-    {error, account_not_found} =
-        aetx:check(Tx1, Trees, Height, ?PROTOCOL_VERSION),
+    {error, account_not_found} = aetx:check(Tx1, Trees, Env),
 
     %% Insufficient funds
     S2 = aens_test_utils:set_account_balance(PubKey, 0, S1),
     Trees2 = aens_test_utils:trees(S2),
     TxSpec2 = aens_test_utils:claim_tx_spec(PubKey, Name, NameSalt, S1),
     {ok, Tx2} = aens_claim_tx:new(TxSpec2),
-    {error, insufficient_funds} =
-        aetx:check(Tx2, Trees2, Height, ?PROTOCOL_VERSION),
+    {error, insufficient_funds} = aetx:check(Tx2, Trees2, Env),
 
     %% Test too high account nonce
     TxSpec3 = aens_test_utils:claim_tx_spec(PubKey, Name, NameSalt, #{nonce => 0}, S1),
     {ok, Tx3} = aens_claim_tx:new(TxSpec3),
-    {error, account_nonce_too_high} =
-        aetx:check(Tx3, Trees, Height, ?PROTOCOL_VERSION),
+    {error, account_nonce_too_high} = aetx:check(Tx3, Trees, Env),
 
     %% Test commitment not found
     TxSpec4 = aens_test_utils:claim_tx_spec(PubKey, Name, NameSalt + 1, S1),
     {ok, Tx4} = aens_claim_tx:new(TxSpec4),
-    {error, name_not_preclaimed} =
-        aetx:check(Tx4, Trees, Height, ?PROTOCOL_VERSION),
+    {error, name_not_preclaimed} = aetx:check(Tx4, Trees, Env),
 
     %% Test commitment not owned
     {PubKey2, S3} = aens_test_utils:setup_new_account(S1),
     Trees3 = aens_test_utils:trees(S3),
     TxSpec5 = aens_test_utils:claim_tx_spec(PubKey2, Name, NameSalt, S3),
     {ok, Tx5} = aens_claim_tx:new(TxSpec5),
-    {error, commitment_not_owned} =
-        aetx:check(Tx5, Trees3, Height, ?PROTOCOL_VERSION),
+    {error, commitment_not_owned} = aetx:check(Tx5, Trees3, Env),
 
     %% Test bad name
     TxSpec6 = aens_test_utils:claim_tx_spec(PubKey, <<"abcdefghi">>, NameSalt, S1),
     {ok, Tx6} = aens_claim_tx:new(TxSpec6),
-    {error, no_registrar} =
-        aetx:check(Tx6, Trees, Height, ?PROTOCOL_VERSION),
+    {error, no_registrar} = aetx:check(Tx6, Trees, Env),
     ok.
 
 claim_race_negative(_Cfg) ->
@@ -234,7 +226,8 @@ claim_race_negative(_Cfg) ->
     %% Test bad account key
     TxSpec1 = aens_test_utils:claim_tx_spec(PubKey2, Name2, NameSalt2, S2),
     {ok, Tx1} = aens_claim_tx:new(TxSpec1),
-    {error, name_already_taken} = aetx:check(Tx1, Trees, Height, ?PROTOCOL_VERSION).
+    Env = aetx_env:tx_env(Height, ?PROTOCOL_VERSION),
+    {error, name_already_taken} = aetx:check(Tx1, Trees, Env).
 
 %%%===================================================================
 %%% Update
@@ -272,56 +265,50 @@ update_negative(Cfg) ->
     {PubKey, NHash, S1} = claim(Cfg),
     Trees = aens_test_utils:trees(S1),
     Height = ?PRE_CLAIM_HEIGHT + 1,
+    Env = aetx_env:tx_env(Height, ?PROTOCOL_VERSION),
 
     %% Test TX TTL too low
     MaxTTL = aec_governance:name_claim_max_expiration(),
     TxSpec0 = aens_test_utils:update_tx_spec(PubKey, NHash, #{ttl => Height - 1}, S1),
     {ok, Tx0} = aens_update_tx:new(TxSpec0),
-    {error, ttl_expired} =
-        aetx:check(Tx0, Trees, Height, ?PROTOCOL_VERSION),
+    {error, ttl_expired} = aetx:check(Tx0, Trees, Env),
 
     %% Test name TTL too high
     MaxTTL = aec_governance:name_claim_max_expiration(),
     TxSpec1 = aens_test_utils:update_tx_spec(PubKey, NHash, #{name_ttl => MaxTTL + 1}, S1),
     {ok, Tx1} = aens_update_tx:new(TxSpec1),
-    {error, ttl_too_high} =
-        aetx:check(Tx1, Trees, Height, ?PROTOCOL_VERSION),
+    {error, ttl_too_high} = aetx:check(Tx1, Trees, Env),
 
     %% Test bad account key
     BadPubKey = <<42:32/unit:8>>,
     TxSpec2 = aens_test_utils:update_tx_spec(BadPubKey, NHash, S1),
     {ok, Tx2} = aens_update_tx:new(TxSpec2),
-    {error, account_not_found} =
-        aetx:check(Tx2, Trees, Height, ?PROTOCOL_VERSION),
+    {error, account_not_found} = aetx:check(Tx2, Trees, Env),
 
     %% Insufficient funds
     S2 = aens_test_utils:set_account_balance(PubKey, 0, S1),
     Trees2 = aens_test_utils:trees(S2),
     TxSpec3 = aens_test_utils:update_tx_spec(PubKey, NHash, S1),
     {ok, Tx3} = aens_update_tx:new(TxSpec3),
-    {error, insufficient_funds} =
-        aetx:check(Tx3, Trees2, Height, ?PROTOCOL_VERSION),
+    {error, insufficient_funds} = aetx:check(Tx3, Trees2, Env),
 
     %% Test too high account nonce
     TxSpec4 = aens_test_utils:update_tx_spec(PubKey, NHash, #{nonce => 0}, S1),
     {ok, Tx4} = aens_update_tx:new(TxSpec4),
-    {error, account_nonce_too_high} =
-        aetx:check(Tx4, Trees, Height, ?PROTOCOL_VERSION),
+    {error, account_nonce_too_high} = aetx:check(Tx4, Trees, Env),
 
     %% Test name not present
     {ok, NHash2} = aens:get_name_hash(<<"othername.test">>),
     TxSpec5 = aens_test_utils:update_tx_spec(PubKey, NHash2, S1),
     {ok, Tx5} = aens_update_tx:new(TxSpec5),
-    {error, name_does_not_exist} =
-        aetx:check(Tx5, Trees, Height, ?PROTOCOL_VERSION),
+    {error, name_does_not_exist} = aetx:check(Tx5, Trees, Env),
 
     %% Test name not owned
     {PubKey2, S3} = aens_test_utils:setup_new_account(S1),
     Trees3 = aens_test_utils:trees(S3),
     TxSpec6 = aens_test_utils:update_tx_spec(PubKey2, NHash, S3),
     {ok, Tx6} = aens_update_tx:new(TxSpec6),
-    {error, name_not_owned} =
-        aetx:check(Tx6, Trees3, Height, ?PROTOCOL_VERSION),
+    {error, name_not_owned} = aetx:check(Tx6, Trees3, Env),
 
     %% Test name revoked
     {value, N} = aens_state_tree:lookup_name(NHash, aec_trees:ns(Trees)),
@@ -330,7 +317,7 @@ update_negative(Cfg) ->
     TxSpec7 = aens_test_utils:update_tx_spec(PubKey, NHash, S4),
     {ok, Tx7} = aens_update_tx:new(TxSpec7),
     {error, name_revoked} =
-        aetx:check(Tx7, aens_test_utils:trees(S4), Height, ?PROTOCOL_VERSION),
+        aetx:check(Tx7, aens_test_utils:trees(S4), Env),
     ok.
 
 %%%===================================================================
@@ -367,42 +354,38 @@ transfer_negative(Cfg) ->
     {PubKey, NHash, S1} = claim(Cfg),
     Trees = aens_test_utils:trees(S1),
     Height = ?PRE_CLAIM_HEIGHT+1,
+    Env = aetx_env:tx_env(Height, ?PROTOCOL_VERSION),
 
     %% Test bad account key
     BadPubKey = <<42:32/unit:8>>,
     TxSpec1 = aens_test_utils:transfer_tx_spec(BadPubKey, NHash, PubKey, S1),
     {ok, Tx1} = aens_transfer_tx:new(TxSpec1),
-    {error, account_not_found} =
-        aetx:check(Tx1, Trees, Height, ?PROTOCOL_VERSION),
+    {error, account_not_found} = aetx:check(Tx1, Trees, Env),
 
     %% Insufficient funds
     S2 = aens_test_utils:set_account_balance(PubKey, 0, S1),
     Trees2 = aens_test_utils:trees(S2),
     TxSpec2 = aens_test_utils:transfer_tx_spec(PubKey, NHash, PubKey, S1),
     {ok, Tx2} = aens_transfer_tx:new(TxSpec2),
-    {error, insufficient_funds} =
-        aetx:check(Tx2, Trees2, Height, ?PROTOCOL_VERSION),
+    {error, insufficient_funds} = aetx:check(Tx2, Trees2, Env),
 
     %% Test too high account nonce
     TxSpec3 = aens_test_utils:transfer_tx_spec(PubKey, NHash, PubKey, #{nonce => 0}, S1),
     {ok, Tx3} = aens_transfer_tx:new(TxSpec3),
-    {error, account_nonce_too_high} =
-        aetx:check(Tx3, Trees, Height, ?PROTOCOL_VERSION),
+    {error, account_nonce_too_high} = aetx:check(Tx3, Trees, Env),
 
     %% Test name not present
     {ok, NHash2} = aens:get_name_hash(<<"othername.test">>),
     TxSpec4 = aens_test_utils:transfer_tx_spec(PubKey, NHash2, PubKey, S1),
     {ok, Tx4} = aens_transfer_tx:new(TxSpec4),
-    {error, name_does_not_exist} =
-        aetx:check(Tx4, Trees, Height, ?PROTOCOL_VERSION),
+    {error, name_does_not_exist} = aetx:check(Tx4, Trees, Env),
 
     %% Test name not owned
     {PubKey2, S3} = aens_test_utils:setup_new_account(S1),
     Trees3 = aens_test_utils:trees(S3),
     TxSpec5 = aens_test_utils:transfer_tx_spec(PubKey2, NHash, PubKey, S3),
     {ok, Tx5} = aens_transfer_tx:new(TxSpec5),
-    {error, name_not_owned} =
-        aetx:check(Tx5, Trees3, Height, ?PROTOCOL_VERSION),
+    {error, name_not_owned} = aetx:check(Tx5, Trees3, Env),
 
     %% Test name revoked
     {value, N} = aens_state_tree:lookup_name(NHash, aec_trees:ns(Trees)),
@@ -411,7 +394,7 @@ transfer_negative(Cfg) ->
     TxSpec6 = aens_test_utils:transfer_tx_spec(PubKey, NHash, PubKey, S4),
     {ok, Tx6} = aens_transfer_tx:new(TxSpec6),
     {error, name_revoked} =
-        aetx:check(Tx6, aens_test_utils:trees(S4), Height, ?PROTOCOL_VERSION),
+        aetx:check(Tx6, aens_test_utils:trees(S4), Env),
     ok.
 
 %%%===================================================================
@@ -445,42 +428,38 @@ revoke_negative(Cfg) ->
     {PubKey, NHash, S1} = claim(Cfg),
     Trees = aens_test_utils:trees(S1),
     Height = ?PRE_CLAIM_HEIGHT+1,
+    Env = aetx_env:tx_env(Height, ?PROTOCOL_VERSION),
 
     %% Test bad account key
     BadPubKey = <<42:32/unit:8>>,
     TxSpec1 = aens_test_utils:revoke_tx_spec(BadPubKey, NHash, S1),
     {ok, Tx1} = aens_revoke_tx:new(TxSpec1),
-    {error, account_not_found} =
-        aetx:check(Tx1, Trees, Height, ?PROTOCOL_VERSION),
+    {error, account_not_found} = aetx:check(Tx1, Trees, Env),
 
     %% Insufficient funds
     S2 = aens_test_utils:set_account_balance(PubKey, 0, S1),
     Trees2 = aens_test_utils:trees(S2),
     TxSpec2 = aens_test_utils:revoke_tx_spec(PubKey, NHash, S1),
     {ok, Tx2} = aens_revoke_tx:new(TxSpec2),
-    {error, insufficient_funds} =
-        aetx:check(Tx2, Trees2, Height, ?PROTOCOL_VERSION),
+    {error, insufficient_funds} = aetx:check(Tx2, Trees2, Env),
 
     %% Test too high account nonce
     TxSpec3 = aens_test_utils:revoke_tx_spec(PubKey, NHash, #{nonce => 0}, S1),
     {ok, Tx3} = aens_revoke_tx:new(TxSpec3),
-    {error, account_nonce_too_high} =
-        aetx:check(Tx3, Trees, Height, ?PROTOCOL_VERSION),
+    {error, account_nonce_too_high} = aetx:check(Tx3, Trees, Env),
 
     %% Test name not present
     {ok, NHash2} = aens:get_name_hash(<<"othername.test">>),
     TxSpec4 = aens_test_utils:revoke_tx_spec(PubKey, NHash2, S1),
     {ok, Tx4} = aens_revoke_tx:new(TxSpec4),
-    {error, name_does_not_exist} =
-        aetx:check(Tx4, Trees, Height, ?PROTOCOL_VERSION),
+    {error, name_does_not_exist} = aetx:check(Tx4, Trees, Env),
 
     %% Test name not owned
     {PubKey2, S3} = aens_test_utils:setup_new_account(S1),
     Trees3 = aens_test_utils:trees(S3),
     TxSpec5 = aens_test_utils:revoke_tx_spec(PubKey2, NHash, S3),
     {ok, Tx5} = aens_revoke_tx:new(TxSpec5),
-    {error, name_not_owned} =
-        aetx:check(Tx5, Trees3, Height, ?PROTOCOL_VERSION),
+    {error, name_not_owned} = aetx:check(Tx5, Trees3, Env),
 
     %% Test name already revoked
     {value, N} = aens_state_tree:lookup_name(NHash, aec_trees:ns(Trees)),
@@ -489,7 +468,7 @@ revoke_negative(Cfg) ->
     TxSpec6 = aens_test_utils:revoke_tx_spec(PubKey, NHash, S4),
     {ok, Tx6} = aens_revoke_tx:new(TxSpec6),
     {error, name_revoked} =
-        aetx:check(Tx6, aens_test_utils:trees(S4), Height, ?PROTOCOL_VERSION),
+        aetx:check(Tx6, aens_test_utils:trees(S4), Env),
     ok.
 
 %%%===================================================================

--- a/apps/aeoracle/src/aeo_response_tx.erl
+++ b/apps/aeoracle/src/aeo_response_tx.erl
@@ -18,8 +18,8 @@
          ttl/1,
          nonce/1,
          origin/1,
-         check/5,
-         process/6,
+         check/3,
+         process/3,
          signers/2,
          version/0,
          serialization_template/1,
@@ -108,10 +108,11 @@ origin(#oracle_response_tx{} = Tx) ->
 
 %% Oracle should exist, and have enough funds for the fee.
 %% QueryId id should match oracle.
--spec check(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(), non_neg_integer()) ->
+-spec check(tx(), aec_trees:trees(), aetx_env:env()) ->
         {ok, aec_trees:trees()} | {error, term()}.
 check(#oracle_response_tx{nonce = Nonce, query_id = QueryId, fee = Fee} = Tx,
-      Context, Trees, Height, _ConsensusVersion) ->
+      Trees, Env) ->
+    Height = aetx_env:height(Env),
     OraclePubKey = oracle_pubkey(Tx),
     case fetch_query(OraclePubKey, QueryId, Trees) of
         {value, I} ->
@@ -120,7 +121,7 @@ check(#oracle_response_tx{nonce = Nonce, query_id = QueryId, fee = Fee} = Tx,
             Checks =
                 [fun() -> check_oracle(OraclePubKey, Trees) end,
                  fun() -> check_query(OraclePubKey, I) end |
-                 case Context of
+                 case aetx_env:context(Env) of
                      aetx_contract -> []; %% TODO: Handle fees from contracts right.
                      aetx_transaction ->
                          [fun() -> aetx_utils:check_account(OraclePubKey, Trees,
@@ -139,11 +140,11 @@ check(#oracle_response_tx{nonce = Nonce, query_id = QueryId, fee = Fee} = Tx,
 signers(#oracle_response_tx{} = Tx, _) ->
     {ok, [oracle_pubkey(Tx)]}.
 
--spec process(tx(), aetx:tx_context(), aec_trees:trees(), aec_blocks:height(),
-              non_neg_integer(), binary() | no_tx_hash) -> {ok, aec_trees:trees()}.
-process(#oracle_response_tx{nonce = Nonce, query_id = QueryId, response = Response,
-                            fee = Fee} = Tx,
-        _Context, Trees0, Height, _ConsensusVersion, _TxHash) ->
+-spec process(tx(), aec_trees:trees(), aetx_env:env()) -> {ok, aec_trees:trees()}.
+process(#oracle_response_tx{nonce = Nonce, query_id = QueryId,
+                            response = Response, fee = Fee} = Tx,
+        Trees0, Env) ->
+    Height = aetx_env:height(Env),
     OraclePubKey  = oracle_pubkey(Tx),
     AccountsTree0 = aec_trees:accounts(Trees0),
     OraclesTree0  = aec_trees:oracles(Trees0),

--- a/apps/aetx/src/aetx_env.erl
+++ b/apps/aetx/src/aetx_env.erl
@@ -1,0 +1,116 @@
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2018, Aeternity Anstalt
+%%%-------------------------------------------------------------------
+%%% @doc
+%%% ADT containing a check/process environment for transactions
+%%% @end
+%%%-------------------------------------------------------------------
+
+-module(aetx_env).
+
+%% Constructors
+-export([ tx_env/2
+        , tx_env/3
+        , contract_env/2
+        ]).
+
+%% Getters
+-export([ consensus_version/1
+        , context/1
+        , height/1
+        , signed_tx/1
+        ]).
+
+%% Setters
+-export([ set_consensus_version/2
+        , set_context/2
+        , set_height/2
+        , set_signed_tx/2
+        ]).
+
+
+%%%===================================================================
+%%% Types
+%%%===================================================================
+
+%% Where does this transaction come from? Is it a top level transaction
+%% or was it created by a smart contract. In the latter case the fee
+%% logic is different.
+-type context() :: 'aetx_transaction' | 'aetx_contract'.
+-type wrapped_tx() :: {'value', aetx_sign:signed_tx()} | 'none'.
+
+-record(env, { consensus_version :: non_neg_integer()
+             , context           :: context()
+             , height            :: aec_blocks:height()
+             , signed_tx         :: wrapped_tx()
+             }).
+
+-opaque env() :: #env{}.
+
+-export_type([ env/0
+             , context/0
+             , wrapped_tx/0
+             ]).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+-spec contract_env(aec_blocks:height(), non_neg_integer()) -> env().
+contract_env(Height, ConsensusVersion) ->
+    #env{ consensus_version = ConsensusVersion
+        , context = aetx_contract
+        , height  = Height
+        , signed_tx = none
+     }.
+
+-spec tx_env(aec_blocks:height(), non_neg_integer()) -> env().
+tx_env(Height, ConsensusVersion) ->
+    #env{ consensus_version = ConsensusVersion
+        , context = aetx_transaction
+        , height  = Height
+        , signed_tx = none
+        }.
+
+-spec tx_env(aec_blocks:height(), non_neg_integer(),
+             {'value', aetx_sign:signed_tx()}) -> env().
+tx_env(Height, ConsensusVersion, {value, _} = STx) ->
+    #env{ consensus_version = ConsensusVersion
+        , context = aetx_transaction
+        , height  = Height
+        , signed_tx = STx
+        }.
+
+%%%===================================================================
+%%% Getters and setters
+
+-spec consensus_version(env()) -> non_neg_integer().
+consensus_version(#env{consensus_version = X}) -> X.
+
+-spec set_consensus_version(env(), non_neg_integer()) -> env().
+set_consensus_version(Env, X) -> Env#env{consensus_version = X}.
+
+%%------
+
+-spec context(env()) -> context().
+context(#env{context = X}) -> X.
+
+-spec set_context(env(), context()) -> env().
+set_context(Env, X) -> Env#env{context = X}.
+
+%%------
+
+-spec height(env()) -> aec_blocks:height().
+height(#env{height = X}) -> X.
+
+-spec set_height(env(), aec_blocks:height()) -> env().
+set_height(Env, X) -> Env#env{height = X}.
+
+%%------
+
+-spec signed_tx(env()) -> wrapped_tx().
+signed_tx(#env{signed_tx = X}) -> X.
+
+-spec set_signed_tx(env(), wrapped_tx()) -> env().
+set_signed_tx(Env, {value, _} = X) -> Env#env{signed_tx = X};
+set_signed_tx(Env, none) ->  Env#env{signed_tx = none}.


### PR DESCRIPTION
In context of https://www.pivotaltracker.com/story/show/160281213

Make an process/check environment for the transaction behavior to facilitate further adds of necessary environment information (e.g., for contracts: Beneficiary, timestamp).

As a side effect, avoid calculating the tx hash for all transactions, since it is only needed for forcing progress.
