### PR TITLE
Compile test contract cli

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -327,6 +327,8 @@ internal-clean: $$(KIND)
 internal-distclean: $$(KIND)
 	@rm -rf ./_build/$(KIND)
 
+compile-aes:
+	( cd apps/aesophia && make compile_test_aes CONTRACT=$(CONTRACT) ; )
 
 .PHONY: \
 	all console \
@@ -344,4 +346,5 @@ internal-distclean: $$(KIND)
 	clean distclean \
 	swagger swagger-docs swagger-check swagger-version-check \
 	rebar-lock-check \
+	compile-aes\
 	python-env python-ws-test python-uats python-single-uat python-release-test

--- a/apps/aesophia/Makefile
+++ b/apps/aesophia/Makefile
@@ -1,0 +1,2 @@
+compile_test_aes:
+	( cd scripts && ./compile_test_contract $(CONTRACT) ../../../_build/default/lib/aesophia/ebin/ ;)

--- a/apps/aesophia/Makefile
+++ b/apps/aesophia/Makefile
@@ -1,2 +1,2 @@
 compile_test_aes:
-	( cd scripts && ./compile_test_contract $(CONTRACT) ../../../_build/default/lib/aesophia/ebin/ ;)
+	( cd scripts && ./compile_test_contract $(CONTRACT) ../../../_build/default/lib/ ;)

--- a/apps/aesophia/scripts/compile_test_contract
+++ b/apps/aesophia/scripts/compile_test_contract
@@ -1,6 +1,6 @@
 #!/usr/bin/env escript
 %% -*- erlang -*-
-%%! -smp enable -sname complile_test_contract -mnesia debug verbose
+%%! -smp enable -sname compile_test_contract -mnesia debug verbose
 
 main([TestName, EbinDir]) ->
     code:add_patha(lists:concat([EbinDir, "/aesophia/ebin/"])),
@@ -13,6 +13,7 @@ main([TestName, EbinDir]) ->
             io:format("Compiling contract ~s~s.aes\n\n", [TestDir, TestName]),
             aeso_compiler:from_string(C, []);
         {error, enoent} ->
-            io:format("Contract ~s.aes not found in ~s\n", [TestName, TestDir])
+            io:format("Contract ~s.aes not found in ~s\n", [TestName, TestDir]),
+            halt(127)
     end.
 

--- a/apps/aesophia/scripts/compile_test_contract
+++ b/apps/aesophia/scripts/compile_test_contract
@@ -1,0 +1,17 @@
+#!/usr/bin/env escript
+%% -*- erlang -*-
+%%! -smp enable -sname complile_test_contract -mnesia debug verbose
+
+main([TestName, Ebin]) ->
+    code:add_patha(Ebin),
+    TestDir = "../test/contracts/",
+    case file:read_file(lists:concat([TestDir,
+                                      TestName, ".aes"])) of
+        {ok, Bin} ->
+            C = binary_to_list(Bin),
+            io:format("Compiling contract ~s~s.aes\n\n", [TestDir, TestName]),
+            aeso_compiler:from_string(C, []);
+        {error, enoent} ->
+            io:format("Contract ~s.aes not found in ~s\n", [TestName, TestDir])
+    end.
+

--- a/apps/aesophia/scripts/compile_test_contract
+++ b/apps/aesophia/scripts/compile_test_contract
@@ -2,8 +2,9 @@
 %% -*- erlang -*-
 %%! -smp enable -sname complile_test_contract -mnesia debug verbose
 
-main([TestName, Ebin]) ->
-    code:add_patha(Ebin),
+main([TestName, EbinDir]) ->
+    code:add_patha(lists:concat([EbinDir, "/aesophia/ebin/"])),
+    code:add_patha(lists:concat([EbinDir, "/aebytecode/ebin/"])),
     TestDir = "../test/contracts/",
     case file:read_file(lists:concat([TestDir,
                                       TestName, ".aes"])) of


### PR DESCRIPTION
Make target for compilation of contracts. A prerequisite is a compiled node.
#### Usage
```
make compile-aes CONTRACT=<contract name>
```
where the `contract name` is the name (without extension) of a contract that is peresent in `apps/aesophia/test/contracts/`

#### Successful
Contract `aens.aes` is compilable so:
```
$ make compile-aes CONTRACT=aens
( cd apps/aesophia && make compile_test_aes CONTRACT=aens ; )
make[1]: Entering directory '/home/vlz/projects/aeternity/epoch/apps/aesophia'
( cd scripts && ./compile_test_contract aens ../../../_build/default/lib/ ;)
Compiling contract ../test/contracts/aens.aes

Dependency sorted types:
  []
Dependency sorted functions:
  [{acyclic,"transfer"},
   {acyclic,"revoke"},
   {acyclic,"resolve_word"},
   {acyclic,"resolve_string"},
   {acyclic,"preclaim"},
   {acyclic,"claim"}]
Inferred transfer : (address, address, hash, signature) => ()
Inferred revoke : (address, hash, signature) => ()
Inferred resolve_word : (string, string) => option(address)
Inferred resolve_string : (string, string) => option(string)
Inferred preclaim : (address, hash, signature) => ()
Inferred claim : (address, string, int, signature) => ()
make[1]: Leaving directory '/home/vlz/projects/aeternity/epoch/apps/aesophia'
```

#### Unsuccessful
Contract `voting.aes` is not compilable so:
```
$ make compile-aes CONTRACT=voting
( cd apps/aesophia && make compile_test_aes CONTRACT=voting ; )
make[1]: Entering directory '/home/vlz/projects/aeternity/epoch/apps/aesophia'
( cd scripts && ./compile_test_contract voting ../../../_build/default/lib/ ;)
Compiling contract ../test/contracts/voting.aes

escript: exception error: no function clause matching 
                 aeso_ast_infer_types:'-infer_contract/2-fun-0-'({type_decl,
                                                                  [{line,4},
                                                                   {col,3}],
                                                                  {id,
                                                                   [{line,4},
                                                                    {col,8}],
                                                                   "state"},
                                                                  []}) (/home/vlz/projects/aeternity/epoch/_build/default/lib/aesophia/src/aeso_ast_infer_types.erl, line 174)
  in function  aeso_ast_infer_types:'-infer_contract/2-lc$^1/1-0-'/3 (/home/vlz/projects/aeternity/epoch/_build/default/lib/aesophia/src/aeso_ast_infer_types.erl, line 178)
  in call from aeso_ast_infer_types:infer_contract/2 (/home/vlz/projects/aeternity/epoch/_build/default/lib/aesophia/src/aeso_ast_infer_types.erl, line 179)
  in call from aeso_ast_infer_types:infer_contract_top/2 (/home/vlz/projects/aeternity/epoch/_build/default/lib/aesophia/src/aeso_ast_infer_types.erl, line 155)
  in call from aeso_ast_infer_types:infer/2 (/home/vlz/projects/aeternity/epoch/_build/default/lib/aesophia/src/aeso_ast_infer_types.erl, line 146)
  in call from aeso_ast_to_icode:convert/2 (/home/vlz/projects/aeternity/epoch/_build/default/lib/aesophia/src/aeso_ast_to_icode.erl, line 20)
  in call from aeso_compiler:from_string/2 (/home/vlz/projects/aeternity/epoch/_build/default/lib/aesophia/src/aeso_compiler.erl, line 38)
Makefile:2: recipe for target 'compile_test_aes' failed
make[1]: *** [compile_test_aes] Error 127
make[1]: Leaving directory '/home/vlz/projects/aeternity/epoch/apps/aesophia'
Makefile:331: recipe for target 'compile-aes' failed
make: *** [compile-aes] Error 2
```