### PR TITLE
Don't change the timestamp of micro candidates

### DIFF
--- a/apps/aecore/src/aec_block_micro_candidate.erl
+++ b/apps/aecore/src/aec_block_micro_candidate.erl
@@ -141,7 +141,7 @@ determine_new_time(PrevBlock) ->
     case aec_blocks:type(PrevBlock) of
         key ->
             %% Just make sure we are progressing time.
-            max(aeu_time:now_in_msecs(), LastTime);
+            max(aeu_time:now_in_msecs(), LastTime + 1);
         micro ->
             %% Make sure to respect the micro block cycle.
             MicroBlockCycle = aec_governance:micro_block_cycle(),

--- a/apps/aecore/src/aec_block_micro_candidate.erl
+++ b/apps/aecore/src/aec_block_micro_candidate.erl
@@ -117,7 +117,9 @@ int_create_block(PrevBlockHash, PrevBlock, KeyBlock, Trees, Txs) ->
     Height = aec_blocks:height(KeyBlock),
     Version = aec_hard_forks:protocol_effective_at_height(Height),
 
-    Time = aeu_time:now_in_msecs(),
+    MicroBlockCycle = aec_governance:micro_block_cycle(),
+    LastTime = aec_blocks:time_in_msecs(PrevBlock),
+    Time = max(aeu_time:now_in_msecs(), MicroBlockCycle + LastTime),
 
     KeyHeader = aec_blocks:to_header(KeyBlock),
     Env = aetx_env:tx_env_from_key_header(KeyHeader, PrevKeyHash,
@@ -182,7 +184,7 @@ int_update(MaxGas, Block, Txs, BlockInfo) ->
             {ok, TxsRootHash} = aec_txs_trees:root_hash(TxsTree1),
             NewBlock = aec_blocks:update_micro_candidate(
                          Block, TxsRootHash, aec_trees:hash(Trees1),
-                         Txs0 ++ Txs1, aeu_time:now_in_msecs()),
+                         Txs0 ++ Txs1),
             NewBlockInfo = BlockInfo#{ trees => Trees1
                                      , txs_tree => TxsTree1 },
             {ok, NewBlock, NewBlockInfo}

--- a/apps/aecore/src/aec_blocks.erl
+++ b/apps/aecore/src/aec_blocks.erl
@@ -51,7 +51,7 @@
          txs/1,
          txs_hash/1,
          type/1,
-         update_micro_candidate/5,
+         update_micro_candidate/4,
          validate_key_block/1,
          validate_micro_block/1,
          version/1
@@ -321,11 +321,11 @@ txs_hash(Block) ->
     aec_headers:txs_hash(to_micro_header(Block)).
 
 -spec update_micro_candidate(micro_block(), txs_hash(), state_hash(),
-                             [aetx_sign:signed_tx()], non_neg_integer()
+                             [aetx_sign:signed_tx()]
                             ) -> micro_block().
-update_micro_candidate(#mic_block{} = Block, TxsRootHash, RootHash, Txs, TimeMSecs) ->
+update_micro_candidate(#mic_block{} = Block, TxsRootHash, RootHash, Txs) ->
     H = aec_headers:update_micro_candidate(to_micro_header(Block),
-                                           TxsRootHash, RootHash, TimeMSecs),
+                                           TxsRootHash, RootHash),
     Block#mic_block{ header = H
                    , txs    = Txs
                    }.

--- a/apps/aecore/src/aec_conductor.erl
+++ b/apps/aecore/src/aec_conductor.erl
@@ -727,8 +727,7 @@ start_micro_signing(#state{consensus = #consensus{leader = true},
             State;
         false ->
             epoch_mining:info("Signing microblock"),
-            AdjMicroBlock = aec_blocks:set_time_in_msecs(MicroBlock, aeu_time:now_in_msecs()),
-            {ok, SignedMicroBlock} = aec_keys:sign_micro_block(AdjMicroBlock),
+            {ok, SignedMicroBlock} = aec_keys:sign_micro_block(MicroBlock),
             State1 = State#state{micro_block_candidate = undefined},
             case handle_signed_block(SignedMicroBlock, State1) of
                 {ok, State2} ->

--- a/apps/aecore/src/aec_headers.erl
+++ b/apps/aecore/src/aec_headers.erl
@@ -52,7 +52,7 @@
          time_in_secs/1,
          txs_hash/1,
          type/1,
-         update_micro_candidate/4,
+         update_micro_candidate/3,
          validate_key_block_header/1,
          validate_micro_block_header/1,
          version/1
@@ -309,12 +309,11 @@ time_in_msecs(#mic_header{time = T}) -> T.
 set_time_in_msecs(#key_header{} = H, Time) -> H#key_header{time = Time};
 set_time_in_msecs(#mic_header{} = H, Time) -> H#mic_header{time = Time}.
 
--spec update_micro_candidate(micro_header(), txs_hash(), state_hash(),
-                             non_neg_integer()) -> micro_header().
-update_micro_candidate(#mic_header{} = H, TxsRootHash, RootHash, TimeMSecs) ->
+-spec update_micro_candidate(micro_header(), txs_hash(), state_hash()) ->
+                                    micro_header().
+update_micro_candidate(#mic_header{} = H, TxsRootHash, RootHash) ->
     H#mic_header{txs_hash = TxsRootHash,
-                 root_hash = RootHash,
-                 time = TimeMSecs
+                 root_hash = RootHash
                 }.
 
 %%%===================================================================

--- a/apps/aecore/test/aec_blocks_tests.erl
+++ b/apps/aecore/test/aec_blocks_tests.erl
@@ -92,8 +92,7 @@ validate_test_malformed_txs_root_hash() ->
     Block = aec_blocks:update_micro_candidate(
               RawBlock, MalformedTxsRootHash,
               aec_blocks:root_hash(RawBlock),
-              [SignedSpend],
-              aec_blocks:time_in_msecs(RawBlock)),
+              [SignedSpend]),
     ?assertEqual({error, {block, malformed_txs_hash}},
                  ?TEST_MODULE:validate_micro_block(Block)).
 
@@ -105,8 +104,7 @@ validate_test_pass_validation_no_txs() ->
     Block = aec_blocks:update_micro_candidate(
               RawBlock, TxsRootHash,
               aec_blocks:root_hash(RawBlock),
-              [],
-              aec_blocks:time_in_msecs(RawBlock)),
+              []),
     ?assertEqual(ok, ?TEST_MODULE:validate_micro_block(Block)).
 
 validate_test_pass_validation() ->
@@ -124,8 +122,7 @@ validate_test_pass_validation() ->
     Block = aec_blocks:update_micro_candidate(
               RawBlock, TxsRootHash,
               aec_blocks:root_hash(RawBlock),
-              Txs,
-              aec_blocks:time_in_msecs(RawBlock)),
+              Txs),
 
     ?assertEqual(ok, ?TEST_MODULE:validate_micro_block(Block)).
 

--- a/apps/aehttp/test/aehttp_contracts_SUITE.erl
+++ b/apps/aehttp/test/aehttp_contracts_SUITE.erl
@@ -982,13 +982,13 @@ environment_contract(Config) ->
     #{<<"value">> := CoinBase} = decode_data(<<"address">>, CoinBaseValue),
     ct:pal("CoinBase ~p\n", [CoinBase]),
 
-    %% Block timestamp. TODO: currently this does not work.
-    %% ct:pal("Calling timestamp\n"),
-    %% {TimeStampValue,_} = call_compute_func(NodeName, CPubkey, CPrivkey,
-    %%                                        EncodedContractPubkey,
-    %%                                        <<"timestamp">>, <<"()">>),
-    %% #{<<"value">> := TimeStamp} = decode_data(<<"int">>, TimeStampValue),
-    %% ct:pal("Timestamp ~p\n", [TimeStamp]),
+    %% Block timestamp.
+    ct:pal("Calling timestamp\n"),
+    {TimeStampValue,_} = call_compute_func(NodeName, CPubkey, CPrivkey,
+                                           EncodedContractPubkey,
+                                           <<"timestamp">>, <<"()">>),
+    #{<<"value">> := TimeStamp} = decode_data(<<"int">>, TimeStampValue),
+    ct:pal("Timestamp ~p\n", [TimeStamp]),
 
     %% Block height.
     ct:pal("Calling block_height\n"),


### PR DESCRIPTION
Since contract calls in the transactions might already have used the
timestamp of the block, the timestamp cannot be adjusted after
transactions have been applied.

Part of (but not completely solving)
https://www.pivotaltracker.com/story/show/160681645

EDIT:
New ticket for this PR https://www.pivotaltracker.com/story/show/160790442