### PR TITLE
PT-160256699 Add gas_price/1 to all txs

### DIFF
--- a/apps/aechannel/src/aesc_close_mutual_tx.erl
+++ b/apps/aechannel/src/aesc_close_mutual_tx.erl
@@ -13,6 +13,7 @@
          type/0,
          fee/1,
          gas/1,
+         gas_price/1,
          ttl/1,
          nonce/1,
          origin/1,
@@ -80,6 +81,10 @@ fee(#channel_close_mutual_tx{fee = Fee}) ->
 -spec gas(tx()) -> non_neg_integer().
 gas(#channel_close_mutual_tx{}) ->
     aec_governance:tx_gas().
+
+-spec gas_price(tx()) -> non_neg_integer().
+gas_price(#channel_close_mutual_tx{}) ->
+    aec_governance:tx_gas_price().
 
 -spec ttl(tx()) -> aetx:tx_ttl().
 ttl(#channel_close_mutual_tx{ttl = Ttl}) ->

--- a/apps/aechannel/src/aesc_close_solo_tx.erl
+++ b/apps/aechannel/src/aesc_close_solo_tx.erl
@@ -13,6 +13,7 @@
          type/0,
          fee/1,
          gas/1,
+         gas_price/1,
          ttl/1,
          nonce/1,
          origin/1,
@@ -82,6 +83,10 @@ fee(#channel_close_solo_tx{fee = Fee}) ->
 -spec gas(tx()) -> non_neg_integer().
 gas(#channel_close_solo_tx{}) ->
     aec_governance:tx_gas().
+
+-spec gas_price(tx()) -> non_neg_integer().
+gas_price(#channel_close_solo_tx{}) ->
+    aec_governance:tx_gas_price().
 
 -spec ttl(tx()) -> aetx:tx_ttl().
 ttl(#channel_close_solo_tx{ttl = TTL}) ->

--- a/apps/aechannel/src/aesc_create_tx.erl
+++ b/apps/aechannel/src/aesc_create_tx.erl
@@ -14,6 +14,7 @@
          type/0,
          fee/1,
          gas/1,
+         gas_price/1,
          ttl/1,
          nonce/1,
          origin/1,
@@ -117,6 +118,10 @@ fee(#channel_create_tx{fee = Fee}) ->
 -spec gas(tx()) -> non_neg_integer().
 gas(#channel_create_tx{}) ->
     aec_governance:tx_gas().
+
+-spec gas_price(tx()) -> non_neg_integer().
+gas_price(#channel_create_tx{}) ->
+    aec_governance:tx_gas_price().
 
 -spec ttl(tx()) -> aetx:tx_ttl().
 ttl(#channel_create_tx{ttl = TTL}) ->

--- a/apps/aechannel/src/aesc_deposit_tx.erl
+++ b/apps/aechannel/src/aesc_deposit_tx.erl
@@ -14,6 +14,7 @@
          type/0,
          fee/1,
          gas/1,
+         gas_price/1,
          ttl/1,
          nonce/1,
          origin/1,
@@ -100,6 +101,10 @@ fee(#channel_deposit_tx{fee = Fee}) ->
 -spec gas(tx()) -> non_neg_integer().
 gas(#channel_deposit_tx{}) ->
     aec_governance:tx_gas().
+
+-spec gas_price(tx()) -> non_neg_integer().
+gas_price(#channel_deposit_tx{}) ->
+    aec_governance:tx_gas_price().
 
 -spec ttl(tx()) -> aetx:tx_ttl().
 ttl(#channel_deposit_tx{ttl = TTL}) ->

--- a/apps/aechannel/src/aesc_force_progress_tx.erl
+++ b/apps/aechannel/src/aesc_force_progress_tx.erl
@@ -14,6 +14,7 @@
          type/0,
          fee/1,
          gas/1,
+         gas_price/1,
          ttl/1,
          nonce/1,
          origin/1,
@@ -109,6 +110,10 @@ fee(#channel_force_progress_tx{fee = Fee}) ->
 -spec gas(tx()) -> non_neg_integer().
 gas(#channel_force_progress_tx{}) ->
     aec_governance:tx_gas().
+
+-spec gas_price(tx()) -> non_neg_integer().
+gas_price(#channel_force_progress_tx{}) ->
+    aec_governance:tx_gas_price().
 
 -spec ttl(tx()) -> aetx:tx_ttl().
 ttl(#channel_force_progress_tx{ttl = TTL}) ->

--- a/apps/aechannel/src/aesc_offchain_tx.erl
+++ b/apps/aechannel/src/aesc_offchain_tx.erl
@@ -8,6 +8,7 @@
          type/0,
          fee/1,
          gas/1,
+         gas_price/1,
          ttl/1,
          nonce/1,
          origin/1,
@@ -80,6 +81,11 @@ fee(#channel_offchain_tx{}) ->
 
 -spec gas(tx()) -> non_neg_integer().
 gas(#channel_offchain_tx{}) ->
+    %% This tx should never hit the mempool or any block
+    0.
+
+-spec gas_price(tx()) -> non_neg_integer().
+gas_price(#channel_offchain_tx{}) ->
     %% This tx should never hit the mempool or any block
     0.
 

--- a/apps/aechannel/src/aesc_settle_tx.erl
+++ b/apps/aechannel/src/aesc_settle_tx.erl
@@ -13,6 +13,7 @@
          type/0,
          fee/1,
          gas/1,
+         gas_price/1,
          ttl/1,
          nonce/1,
          origin/1,
@@ -82,6 +83,10 @@ fee(#channel_settle_tx{fee = Fee}) ->
 -spec gas(tx()) -> non_neg_integer().
 gas(#channel_settle_tx{}) ->
     aec_governance:tx_gas().
+
+-spec gas_price(tx()) -> non_neg_integer().
+gas_price(#channel_settle_tx{}) ->
+    aec_governance:tx_gas_price().
 
 -spec ttl(tx()) -> aetx:tx_ttl().
 ttl(#channel_settle_tx{ttl = TTL}) ->

--- a/apps/aechannel/src/aesc_slash_tx.erl
+++ b/apps/aechannel/src/aesc_slash_tx.erl
@@ -13,6 +13,7 @@
          type/0,
          fee/1,
          gas/1,
+         gas_price/1,
          ttl/1,
          nonce/1,
          origin/1,
@@ -82,6 +83,10 @@ fee(#channel_slash_tx{fee = Fee}) ->
 -spec gas(tx()) -> non_neg_integer().
 gas(#channel_slash_tx{}) ->
     aec_governance:tx_gas().
+
+-spec gas_price(tx()) -> non_neg_integer().
+gas_price(#channel_slash_tx{}) ->
+    aec_governance:tx_gas_price().
 
 -spec ttl(tx()) -> aetx:tx_ttl().
 ttl(#channel_slash_tx{ttl = TTL}) ->

--- a/apps/aechannel/src/aesc_snapshot_solo_tx.erl
+++ b/apps/aechannel/src/aesc_snapshot_solo_tx.erl
@@ -13,6 +13,7 @@
          type/0,
          fee/1,
          gas/1,
+         gas_price/1,
          ttl/1,
          nonce/1,
          origin/1,
@@ -79,6 +80,10 @@ fee(#channel_snapshot_solo_tx{fee = Fee}) ->
 -spec gas(tx()) -> non_neg_integer().
 gas(#channel_snapshot_solo_tx{}) ->
     aec_governance:tx_gas().
+
+-spec gas_price(tx()) -> non_neg_integer().
+gas_price(#channel_snapshot_solo_tx{}) ->
+    aec_governance:tx_gas_price().
 
 -spec ttl(tx()) -> aetx:tx_ttl().
 ttl(#channel_snapshot_solo_tx{ttl = TTL}) ->

--- a/apps/aechannel/src/aesc_withdraw_tx.erl
+++ b/apps/aechannel/src/aesc_withdraw_tx.erl
@@ -14,6 +14,7 @@
          type/0,
          fee/1,
          gas/1,
+         gas_price/1,
          ttl/1,
          nonce/1,
          origin/1,
@@ -98,6 +99,10 @@ fee(#channel_withdraw_tx{fee = Fee}) ->
 -spec gas(tx()) -> non_neg_integer().
 gas(#channel_withdraw_tx{}) ->
     aec_governance:tx_gas().
+
+-spec gas_price(tx()) -> non_neg_integer().
+gas_price(#channel_withdraw_tx{}) ->
+    aec_governance:tx_gas_price().
 
 -spec ttl(tx()) -> aetx:tx_ttl().
 ttl(#channel_withdraw_tx{ttl = TTL}) ->

--- a/apps/aecore/src/aec_governance.erl
+++ b/apps/aecore/src/aec_governance.erl
@@ -9,6 +9,7 @@
          block_mine_reward/0,
          block_gas_limit/0,
          tx_gas/0,
+         tx_gas_price/0,
          beneficiary_reward_delay/0,
          minimum_tx_fee/0,
          minimum_gas_price/0,
@@ -45,6 +46,8 @@
 -define(BLOCK_GAS_LIMIT, 1600000).
 %% Taken from Ethereum - a simple tx to send Eth is about 21000 gas.
 -define(TX_GAS, 21000).
+%% TODO: this will be removed, gas price will be set by the tx sender.
+-define(TX_GAS_PRICE, 1000000000).
 -define(POF_REWARD       , 500000000000000000). %% (?BLOCK_MINE_REWARD / 100) * 5
 -define(BENEFICIARY_REWARD_DELAY, 180). %% in key blocks / generations
 -define(MICRO_BLOCK_CYCLE, 3000). %% in msecs
@@ -92,6 +95,9 @@ block_gas_limit() ->
 
 tx_gas() ->
     ?TX_GAS.
+
+tx_gas_price() ->
+    ?TX_GAS_PRICE.
 
 minimum_tx_fee() ->
     1.

--- a/apps/aecore/src/aec_spend_tx.erl
+++ b/apps/aecore/src/aec_spend_tx.erl
@@ -9,6 +9,7 @@
          type/0,
          fee/1,
          gas/1,
+         gas_price/1,
          ttl/1,
          nonce/1,
          origin/1,
@@ -95,6 +96,10 @@ fee(#spend_tx{fee = F}) ->
 -spec gas(tx()) -> non_neg_integer().
 gas(#spend_tx{}) ->
     aec_governance:tx_gas().
+
+-spec gas_price(tx()) -> non_neg_integer().
+gas_price(#spend_tx{}) ->
+    aec_governance:tx_gas_price().
 
 -spec ttl(tx()) -> aetx:tx_ttl().
 ttl(#spend_tx{ttl = TTL}) ->

--- a/apps/aecore/test/aec_tx_pool_tests.erl
+++ b/apps/aecore/test/aec_tx_pool_tests.erl
@@ -186,8 +186,8 @@ tx_pool_test_() ->
                    , a_signed_tx        (        PK1, me,       3,     3)
                    , a_signed_tx        (        PK2, me,       2,     5)
                    , a_signed_tx        (        PK2, me,       1,     6)
-                   , signed_ct_create_tx(        PK4,           1,     1,_GasPrice=1)
-                   , signed_ct_call_tx  (        PK4,           2,     4,          9)
+                   , signed_ct_create_tx(        PK4,           1,     1,_GasPrice=1100000000)
+                   , signed_ct_call_tx  (        PK4,           2,     4,          9000000000)
                    , signed_ct_call_tx  (        PK4,           3,     7,          0)
                    ],
 
@@ -230,17 +230,17 @@ tx_pool_test_() ->
                ?assertEqual({ok, [STx3, STx2]}, aec_tx_pool:get_candidate(MaxGas, aec_chain:top_block_hash())),
 
                %% Replace same nonce with same fee but positive gas price (gas price of transaction without gas price is considered zero)
-               STx4 = signed_ct_create_tx(PK, Nonce2=2, Fee2=5,_GasPrice4=1),
+               STx4 = signed_ct_create_tx(PK, Nonce2=2, Fee2=5,_GasPrice4=1100000000),
                ?assertEqual(ok, aec_tx_pool:push(STx4)),
                ?assertEqual({ok, [STx3, STx4]}, aec_tx_pool:get_candidate(MaxGas, aec_chain:top_block_hash())),
 
                %% Replace same nonce with same fee but higher gas price
-               STx5 = signed_ct_create_tx(PK, Nonce2=2, Fee2=5, 2),
+               STx5 = signed_ct_create_tx(PK, Nonce2=2, Fee2=5, 2000000000),
                ?assertEqual(ok, aec_tx_pool:push(STx5)),
                ?assertEqual({ok, [STx3, STx5]}, aec_tx_pool:get_candidate(MaxGas, aec_chain:top_block_hash())),
 
                %% Order by nonce even if fee and gas price are higher
-               STx6 = signed_ct_call_tx(PK, _Nonce6=3,_Fee6=9,_GasPrice6=9),
+               STx6 = signed_ct_call_tx(PK, _Nonce6=3,_Fee6=9,_GasPrice6=9000000000),
                ?assertEqual(ok, aec_tx_pool:push(STx6)),
                ?assertEqual({ok, [STx3, STx5, STx6]}, aec_tx_pool:get_candidate(MaxGas, aec_chain:top_block_hash())),
 

--- a/apps/aens/src/aens_claim_tx.erl
+++ b/apps/aens/src/aens_claim_tx.erl
@@ -14,6 +14,7 @@
          type/0,
          fee/1,
          gas/1,
+         gas_price/1,
          ttl/1,
          nonce/1,
          origin/1,
@@ -82,6 +83,10 @@ fee(#ns_claim_tx{fee = Fee}) ->
 -spec gas(tx()) -> non_neg_integer().
 gas(#ns_claim_tx{}) ->
     aec_governance:tx_gas().
+
+-spec gas_price(tx()) -> non_neg_integer().
+gas_price(#ns_claim_tx{}) ->
+    aec_governance:tx_gas_price().
 
 -spec ttl(tx()) -> aetx:tx_ttl().
 ttl(#ns_claim_tx{ttl = TTL}) ->

--- a/apps/aens/src/aens_preclaim_tx.erl
+++ b/apps/aens/src/aens_preclaim_tx.erl
@@ -14,6 +14,7 @@
          type/0,
          fee/1,
          gas/1,
+         gas_price/1,
          ttl/1,
          nonce/1,
          origin/1,
@@ -81,6 +82,10 @@ fee(#ns_preclaim_tx{fee = Fee}) ->
 -spec gas(tx()) -> non_neg_integer().
 gas(#ns_preclaim_tx{}) ->
     aec_governance:tx_gas().
+
+-spec gas_price(tx()) -> non_neg_integer().
+gas_price(#ns_preclaim_tx{}) ->
+    aec_governance:tx_gas_price().
 
 -spec ttl(tx()) -> aetx:tx_ttl().
 ttl(#ns_preclaim_tx{ttl = TTL}) ->

--- a/apps/aens/src/aens_revoke_tx.erl
+++ b/apps/aens/src/aens_revoke_tx.erl
@@ -13,6 +13,7 @@
          type/0,
          fee/1,
          gas/1,
+         gas_price/1,
          ttl/1,
          nonce/1,
          origin/1,
@@ -74,6 +75,10 @@ fee(#ns_revoke_tx{fee = Fee}) ->
 -spec gas(tx()) -> non_neg_integer().
 gas(#ns_revoke_tx{}) ->
     aec_governance:tx_gas().
+
+-spec gas_price(tx()) -> non_neg_integer().
+gas_price(#ns_revoke_tx{}) ->
+    aec_governance:tx_gas_price().
 
 -spec ttl(tx()) -> aetx:tx_ttl().
 ttl(#ns_revoke_tx{ttl = TTL}) ->

--- a/apps/aens/src/aens_transfer_tx.erl
+++ b/apps/aens/src/aens_transfer_tx.erl
@@ -14,6 +14,7 @@
          type/0,
          fee/1,
          gas/1,
+         gas_price/1,
          ttl/1,
          nonce/1,
          origin/1,
@@ -87,6 +88,10 @@ fee(#ns_transfer_tx{fee = Fee}) ->
 -spec gas(tx()) -> non_neg_integer().
 gas(#ns_transfer_tx{}) ->
     aec_governance:tx_gas().
+
+-spec gas_price(tx()) -> non_neg_integer().
+gas_price(#ns_transfer_tx{}) ->
+    aec_governance:tx_gas_price().
 
 -spec ttl(tx()) -> aetx:tx_ttl().
 ttl(#ns_transfer_tx{ttl = TTL}) ->

--- a/apps/aens/src/aens_update_tx.erl
+++ b/apps/aens/src/aens_update_tx.erl
@@ -14,6 +14,7 @@
          type/0,
          fee/1,
          gas/1,
+         gas_price/1,
          ttl/1,
          nonce/1,
          origin/1,
@@ -90,6 +91,10 @@ fee(#ns_update_tx{fee = Fee}) ->
 -spec gas(tx()) -> non_neg_integer().
 gas(#ns_update_tx{}) ->
     aec_governance:tx_gas().
+
+-spec gas_price(tx()) -> non_neg_integer().
+gas_price(#ns_update_tx{}) ->
+    aec_governance:tx_gas_price().
 
 -spec ttl(tx()) -> aetx:tx_ttl().
 ttl(#ns_update_tx{ttl = TTL}) ->

--- a/apps/aeoracle/src/aeo_extend_tx.erl
+++ b/apps/aeoracle/src/aeo_extend_tx.erl
@@ -15,6 +15,7 @@
          type/0,
          fee/1,
          gas/1,
+         gas_price/1,
          ttl/1,
          nonce/1,
          origin/1,
@@ -67,6 +68,10 @@ fee(#oracle_extend_tx{fee = Fee}) ->
 -spec gas(tx()) -> non_neg_integer().
 gas(#oracle_extend_tx{}) ->
     aec_governance:tx_gas().
+
+-spec gas_price(tx()) -> non_neg_integer().
+gas_price(#oracle_extend_tx{}) ->
+    aec_governance:tx_gas_price().
 
 -spec ttl(tx()) -> aetx:tx_ttl().
 ttl(#oracle_extend_tx{ttl = TTL}) ->

--- a/apps/aeoracle/src/aeo_query_tx.erl
+++ b/apps/aeoracle/src/aeo_query_tx.erl
@@ -15,6 +15,7 @@
          type/0,
          fee/1,
          gas/1,
+         gas_price/1,
          ttl/1,
          nonce/1,
          origin/1,
@@ -128,6 +129,10 @@ fee(#oracle_query_tx{fee = F}) ->
 -spec gas(tx()) -> non_neg_integer().
 gas(#oracle_query_tx{}) ->
     aec_governance:tx_gas().
+
+-spec gas_price(tx()) -> non_neg_integer().
+gas_price(#oracle_query_tx{}) ->
+    aec_governance:tx_gas_price().
 
 -spec ttl(tx()) -> aetx:tx_ttl().
 ttl(#oracle_query_tx{ttl = TTL}) ->

--- a/apps/aeoracle/src/aeo_register_tx.erl
+++ b/apps/aeoracle/src/aeo_register_tx.erl
@@ -15,6 +15,7 @@
          type/0,
          fee/1,
          gas/1,
+         gas_price/1,
          ttl/1,
          nonce/1,
          origin/1,
@@ -85,6 +86,10 @@ fee(#oracle_register_tx{fee = Fee}) ->
 -spec gas(tx()) -> non_neg_integer().
 gas(#oracle_register_tx{}) ->
     aec_governance:tx_gas().
+
+-spec gas_price(tx()) -> non_neg_integer().
+gas_price(#oracle_register_tx{}) ->
+    aec_governance:tx_gas_price().
 
 -spec ttl(tx()) -> aetx:tx_ttl().
 ttl(#oracle_register_tx{ttl = TTL}) ->

--- a/apps/aeoracle/src/aeo_response_tx.erl
+++ b/apps/aeoracle/src/aeo_response_tx.erl
@@ -15,6 +15,7 @@
          type/0,
          fee/1,
          gas/1,
+         gas_price/1,
          ttl/1,
          nonce/1,
          origin/1,
@@ -93,6 +94,10 @@ fee(#oracle_response_tx{fee = F}) ->
 -spec gas(tx()) -> non_neg_integer().
 gas(#oracle_response_tx{}) ->
     aec_governance:tx_gas().
+
+-spec gas_price(tx()) -> non_neg_integer().
+gas_price(#oracle_response_tx{}) ->
+    aec_governance:tx_gas_price().
 
 -spec ttl(tx()) -> aetx:tx_ttl().
 ttl(#oracle_response_tx{ttl = TTL}) ->

--- a/apps/aetx/src/aetx.erl
+++ b/apps/aetx/src/aetx.erl
@@ -13,7 +13,7 @@
         , deserialize_from_binary/1
         , fee/1
         , gas/1
-        , lookup_gas_price/1
+        , gas_price/1
         , ttl/1
         , is_tx_type/1
         , new/2
@@ -149,9 +149,6 @@
 -callback for_client(Tx :: tx_instance()) ->
     map().
 
--optional_callbacks([gas_price/1]).
-
-
 %%%===================================================================
 %%% Getters and setters
 %%%===================================================================
@@ -176,14 +173,9 @@ fee(#aetx{ cb = CB, tx = Tx }) ->
 gas(#aetx{ cb = CB, tx = Tx }) ->
     CB:gas(Tx).
 
--spec lookup_gas_price(Tx :: tx()) -> none | {value, GasPrice} when
-      GasPrice :: aect_contracts:amount().
-lookup_gas_price(#aetx{ cb = aect_create_tx, tx = Tx }) ->
-    {value, aect_create_tx:gas_price(Tx)};
-lookup_gas_price(#aetx{ cb = aect_call_tx, tx = Tx }) ->
-    {value, aect_call_tx:gas_price(Tx)};
-lookup_gas_price(#aetx{}) ->
-    none.
+-spec gas_price(Tx :: tx()) -> GasPrice :: non_neg_integer().
+gas_price(#aetx{ cb = CB, tx = Tx }) ->
+    CB:gas_price(Tx).
 
 -spec nonce(Tx :: tx()) -> Nonce :: non_neg_integer().
 nonce(#aetx{ cb = CB, tx = Tx }) ->


### PR DESCRIPTION
This is a preparatory PR for [PT-160256699](https://www.pivotaltracker.com/n/projects/2124891/stories/160256699).

It adds `gas_price/1` to all txs and a fixed gas price to governance (this will change in future PRs). All txs have a fixed gas price except for contract create and contract call txs.