### PR TITLE
PT-160887405 Remove unsupported `oneof` from swagger spec

### DIFF
--- a/apps/aehttp/priv/swagger.json
+++ b/apps/aehttp/priv/swagger.json
@@ -58,7 +58,10 @@
         "parameters" : [ ],
         "responses" : {
           "200" : {
-            "description" : "Successful operation"
+            "description" : "Successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/KeyBlockOrMicroBlockHeader"
+            }
           },
           "404" : {
             "description" : "Block not found",
@@ -2138,10 +2141,49 @@
         "pof_hash" : "pof_hash",
         "prev_hash" : null,
         "prev_key_hash" : null,
-        "time" : 6,
-        "version" : 1,
-        "hash" : { },
-        "height" : 0
+        "time" : 7,
+        "version" : 9,
+        "hash" : null,
+        "height" : 2
+      }
+    },
+    "KeyBlockOrMicroBlockHeader" : {
+      "type" : "object",
+      "properties" : {
+        "key_block" : {
+          "$ref" : "#/definitions/KeyBlock"
+        },
+        "micro_block" : {
+          "$ref" : "#/definitions/MicroBlockHeader"
+        }
+      },
+      "example" : {
+        "micro_block" : {
+          "txs_hash" : null,
+          "state_hash" : null,
+          "signature" : null,
+          "pof_hash" : "pof_hash",
+          "prev_hash" : null,
+          "prev_key_hash" : null,
+          "time" : 7,
+          "version" : 9,
+          "hash" : null,
+          "height" : 2
+        },
+        "key_block" : {
+          "beneficiary" : null,
+          "state_hash" : null,
+          "prev_hash" : null,
+          "pow" : "",
+          "prev_key_hash" : null,
+          "time" : 5,
+          "nonce" : 1,
+          "version" : 5,
+          "hash" : { },
+          "miner" : null,
+          "height" : 0,
+          "target" : 6
+        }
       }
     },
     "GenericTxs" : {

--- a/apps/aehttp/test/aehttp_contracts_SUITE.erl
+++ b/apps/aehttp/test/aehttp_contracts_SUITE.erl
@@ -245,7 +245,7 @@ spending_2(Config) ->
     BBal1 = get_balance(BPubkey),
     ct:pal("Balances 1: ~p, ~p\n", [ABal1,BBal1]),
 
-    {ok,200,#{<<"height">> := Height}} = get_top(),
+    {ok,200,#{<<"key_block">> := #{<<"height">> := Height}}} = get_top(),
     ct:pal("Height ~p\n", [Height]),
 
     %% Transfer money from Alice to Bert, but more than Alice has.

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -54,9 +54,8 @@ paths:
       responses:
         '200':
           description: 'Successful operation'
-          oneOf:
-            - $ref: '#/definitions/KeyBlock'
-            - $ref: '#/definitions/MicroBlockHeader'
+          schema:
+            $ref: '#/definitions/KeyBlockOrMicroBlockHeader'
         '404':
           description: 'Block not found'
           schema:
@@ -1819,6 +1818,13 @@ definitions:
       - signature
       - time
       - version
+  KeyBlockOrMicroBlockHeader:
+    type: object
+    properties:
+      key_block:
+        $ref: '#/definitions/KeyBlock'
+      micro_block:
+        $ref: '#/definitions/MicroBlockHeader'
   GenericTxs:
     type: object
     properties:

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -1,5 +1,4 @@
 swagger: '2.0'
-openapi: '3.0.0'
 info:
   description: 'This is the [Aeternity](https://www.aeternity.com/) Epoch API.'
   version: 0.24.0

--- a/docs/operation.md
+++ b/docs/operation.md
@@ -79,16 +79,16 @@ Verify that the height is the same; it may take a few minutes for your node to c
 ### Verify that node mines on same chain as the testnet
 
 After the node is successfully connected to the testnet, you could verify that it is mining on the same chain as the rest of the network.
-You can validate it observing the `hash` of the `/top` of the remote nodes:
+You can validate it observing the `hash` of the `/blocks/top` of the remote nodes:
 ```bash
 $ curl http://52.10.46.160:3013/v2/blocks/top
-{"hash":"bh$2UWBL9BciGC1w2FUukJZinchGRrCuwEuFTkcVvpZcfcpjiAbUy","height":...}
+{"key_block":{"hash":"kh_2UWBL9BciGC1w2FUukJZinchGRrCuwEuFTkcVvpZcfcpjiAbUy","height":...}}
 ```
 
 This is the hash of the block being at the top of the chain of the node and it should be same as the hash in `prev_hash` of the block you're currently mining:
 ```bash
 $ curl http://127.0.0.1:3013/v2/key-blocks/pending
-{...,"height":... ,"prev_hash":"bh$2UWBL9BciGC1w2FUukJZinchGRrCuwEuFTkcVvpZcfcpjiAbUy", ...}
+{"key_block":{...,"height":... ,"prev_hash":"kh_2UWBL9BciGC1w2FUukJZinchGRrCuwEuFTkcVvpZcfcpjiAbUy", ...}}
 ```
-Height would be +1 of what is in the `/top` of the remote node but this is not
+Height would be +1 of what is in the `/blocks/top` of the remote node but this is not
 as strong guarantee as the `prev_hash`.

--- a/docs/release-notes/next/PT-160887405.md
+++ b/docs/release-notes/next/PT-160887405.md
@@ -1,0 +1,1 @@
+* Changes /blocks/top endpoint, the returned value is more explicit about the block type.


### PR DESCRIPTION
[PT-160887405](https://www.pivotaltracker.com/n/projects/2124891/stories/160887405)

This PR changes the HTTP API of `GetTopBlock`.

- [x] system tests
- [x] docs in epoch repo, release notes
- [x] docs in protocol repo - no changes necessary
