### PR TITLE
Fix aest_names system tests suite

### DIFF
--- a/system_test/aest_names_SUITE.erl
+++ b/system_test/aest_names_SUITE.erl
@@ -103,8 +103,7 @@ test_name_registration(Cfg) ->
     EncMPubKey = aec_base58c:encode(account_pubkey, MPubKey),
     EncRPubKey = aec_base58c:encode(account_pubkey, RPubKey),
 
-    AsciiName = <<"richard.test">>,
-    Name = aens_utils:from_ascii(AsciiName),
+    Name = <<"richard.test">>,
     NameSalt = 36346245,
     EncNameId = aec_base58c:encode(name, aens_hash:name_hash(Name)),
 
@@ -192,8 +191,7 @@ test_name_transfer(Cfg) ->
     RPubKey2 = maps:get(pubkey, ?ROBERT),
     EncMPubKey = aec_base58c:encode(account_pubkey, MPubKey),
 
-    AsciiName = <<"richard.test">>,
-    Name = aens_utils:from_ascii(AsciiName),
+    Name = <<"richard.test">>,
     NameSalt = 36346245,
 
     %% Setup nodes


### PR DESCRIPTION
* Do not use nonexistent aens_utils:from_ascii/1 function

After the fix:
```
===> Running Common Test suites...
%%% aest_names_SUITE ==> test_name_registration: OK
%%% aest_names_SUITE ==> test_name_transfer: OK
All 2 tests passed.
```