### PR TITLE
Pt 160920700 Improve stability of post tx

### DIFF
--- a/py/tests/integration/common.py
+++ b/py/tests/integration/common.py
@@ -208,6 +208,14 @@ def genesis_hash(api):
 def wait_until_height(api, height):
     wait(lambda: api.get_current_key_block().height >= height, timeout_seconds=120, sleep_seconds=0.25)
 
+def ensure_transaction_posted(ext_api, signed_tx):
+    tx_object = Tx(tx=signed_tx)
+    tx_hash = ext_api.post_transaction(tx_object).tx_hash
+    top = ext_api.get_current_key_block()
+    wait_until_height(ext_api, top.height + 1)
+    wait(lambda: ext_api.get_transaction_by_hash(tx_hash).block_hash != 'none',
+         timeout_seconds=20, sleep_seconds=0.25)
+
 def get_account_balance(api, pub_key):
     return _balance_from_get_account(lambda: api.get_account_by_pubkey(pub_key), pub_key)
 

--- a/py/tests/integration/test_spend_tx.py
+++ b/py/tests/integration/test_spend_tx.py
@@ -34,6 +34,7 @@ def test_not_enough_tokens():
     bob_private_key = keys.new_private()
     bob_public_key = keys.public_key(bob_private_key)
     bob_address = keys.address(bob_public_key)
+    bob = {'privk': bob_private_key, 'enc_pubk': bob_address}
 
     # initial balances - amounts that the miner should send them
     alice_init_balance = test_settings["send_tokens"]["alice"]
@@ -42,7 +43,6 @@ def test_not_enough_tokens():
     # populate accounts with tokens, and validate balances
     common.send_tokens_to_unchanging_user_and_wait_balance(beneficiary, alice_address, alice_init_balance, 1, ext_api, int_api)
     common.send_tokens_to_unchanging_user_and_wait_balance(beneficiary, bob_address, bob_init_balance, 1, ext_api, int_api)
-    common.wait_until_height(ext_api, ext_api.get_current_key_block().height + 3)
     alice_balance0 = common.get_account_balance(ext_api, alice_address)
     bob_balance0 = common.get_account_balance(ext_api, bob_address)
     print("Alice balance is " + str(alice_balance0))
@@ -54,8 +54,7 @@ def test_not_enough_tokens():
     spend_tx_fee = test_settings["spend_tx"]["fee"]
     few_tokens_to_send = test_settings["spend_tx"]["small_amount"]
     print("Bob is about to send " + str(few_tokens_to_send) + " to Alice")
-    send_tokens_to_unchanging_user(bob_private_key, bob_address, alice_address, few_tokens_to_send, spend_tx_fee, ext_api, int_api)
-    common.wait_until_height(ext_api, ext_api.get_current_key_block().height + 3)
+    common.send_tokens_to_unchanging_user_and_wait_balance(bob, alice_address, few_tokens_to_send, spend_tx_fee, ext_api, int_api)
     alice_balance1 = common.get_account_balance(ext_api, pub_key=alice_address)
     bob_balance1 = common.get_account_balance(ext_api, pub_key=bob_address)
     print("Alice balance is " + str(alice_balance1))
@@ -66,7 +65,7 @@ def test_not_enough_tokens():
     # check that Bob is unable to send less tokens than he has
     many_tokens_to_send = test_settings["spend_tx"]["large_amount"]
     print("Bob is about to send " + str(many_tokens_to_send) + " to Alice")
-    send_tokens_to_unchanging_user(bob_private_key, bob_address, alice_address, many_tokens_to_send, spend_tx_fee, ext_api, int_api)
+    common.send_tokens_to_unchanging_user(bob, alice_address, many_tokens_to_send, spend_tx_fee, ext_api, int_api)
     common.wait_until_height(ext_api, ext_api.get_current_key_block().height + 3)
     alice_balance2 = common.get_account_balance(ext_api, pub_key=alice_address)
     bob_balance2 = common.get_account_balance(ext_api, pub_key=bob_address)
@@ -89,6 +88,7 @@ def test_send_by_name():
     alice_private_key = keys.new_private()
     alice_public_key = keys.public_key(alice_private_key)
     alice_address = keys.address(alice_public_key)
+    alice = {'privk': alice_private_key, 'enc_pubk': alice_address}
 
     bob_private_key = keys.new_private()
     bob_public_key = keys.public_key(bob_private_key)
@@ -121,8 +121,8 @@ def test_send_by_name():
 
     tokens_to_send = test_settings["spend_tx"]["amount"]
     print("Alice is about to send " + str(tokens_to_send) + " to " + bob_name)
-    send_tokens_to_name(bob_name, tokens_to_send, alice_address, alice_private_key, int_api, ext_api)
-    common.wait_until_height(ext_api, ext_api.get_current_key_block().height + 3)
+    resolved_address = get_address_by_name(bob_name, ext_api)
+    common.send_tokens_to_unchanging_user_and_wait_balance(alice, resolved_address, tokens_to_send, 1, ext_api, int_api)
 
     # validate balances
     alice_balance2 = common.get_account_balance(ext_api, alice_address)
@@ -187,13 +187,8 @@ def register_name(name, address, external_api, internal_api, private_key):
     assert_equals('account_pubkey', received_pointers.key)
     assert_equals(address, received_pointers.id)
 
-def send_tokens_to_name(name, tokens, sender_address, private_key, internal_api, external_api):
-    name_entry = external_api.get_name_entry_by_name(name)
+def get_address_by_name(name, ext_api):
+    name_entry = ext_api.get_name_entry_by_name(name)
     resolved_address = name_entry.pointers[0].id
     print("Name " + name + " resolved to address " + resolved_address)
-    send_tokens_to_unchanging_user(private_key, sender_address, resolved_address, tokens, 1, external_api, internal_api)
-
-def send_tokens_to_unchanging_user(sender_priv_key, sender_enc_pub_key, address, tokens, fee, external_api, internal_api):
-    sender = {'privk': sender_priv_key,
-              'enc_pubk': sender_enc_pub_key}
-    common.send_tokens_to_unchanging_user(sender, address, tokens, fee, external_api, internal_api)
+    return resolved_address

--- a/py/tests/integration/test_spend_tx.py
+++ b/py/tests/integration/test_spend_tx.py
@@ -154,10 +154,7 @@ def register_name(name, address, external_api, internal_api, private_key):
         internal_api.post_name_preclaim(\
             NamePreclaimTx(commitment_id=commitment_id, fee=1, ttl=100, account_id=address)).tx)
     signed_preclaim = keys.sign_encode_tx(unsigned_preclaim, private_key)
-
-    external_api.post_transaction(Tx(tx=signed_preclaim))
-    top = external_api.get_current_key_block()
-    common.wait_until_height(external_api, top.height + 3)
+    common.ensure_transaction_posted(external_api, signed_preclaim)
 
     # claim
     encoded_name = common.encode_name(name)
@@ -165,10 +162,7 @@ def register_name(name, address, external_api, internal_api, private_key):
         internal_api.post_name_claim(\
             NameClaimTx(name=encoded_name, name_salt=salt, fee=1, ttl=100, account_id=address)).tx)
     signed_claim = keys.sign_encode_tx(unsigned_claim, private_key)
-
-    external_api.post_transaction(Tx(tx=signed_claim))
-    top = external_api.get_current_key_block()
-    common.wait_until_height(external_api, top.height + 3)
+    common.ensure_transaction_posted(external_api, signed_claim)
     name_entry0 = external_api.get_name_entry_by_name(name)
 
     # set pointers
@@ -178,10 +172,7 @@ def register_name(name, address, external_api, internal_api, private_key):
             NameUpdateTx(name_id=name_entry0.id, name_ttl=6000, client_ttl=50,\
                 pointers=pointers, fee=1, ttl=100, account_id=address)).tx)
     signed_update = keys.sign_encode_tx(unsigned_update, private_key)
-
-    external_api.post_transaction(Tx(tx=signed_update))
-    top = external_api.get_current_key_block()
-    common.wait_until_height(external_api, top.height + 3)
+    common.ensure_transaction_posted(external_api, signed_update)
     name_entry = external_api.get_name_entry_by_name(name)
     received_pointers = name_entry.pointers[0]
     assert_equals('account_pubkey', received_pointers.key)

--- a/py/tests/integration/test_unsigned_tx.py
+++ b/py/tests/integration/test_unsigned_tx.py
@@ -69,7 +69,7 @@ def test_contract_create():
     print("Signed transaction " + signed)
 
     alice_balance0 = common.get_account_balance(external_api, alice_address)
-    ensure_transaction_posted(external_api, signed)
+    common.ensure_transaction_posted(external_api, signed)
     alice_balance = common.get_account_balance(external_api, alice_address)
 
     assert_equals(alice_balance0,
@@ -104,7 +104,7 @@ def test_contract_call():
     signed = keys.sign_verify_encode_tx(unsigned_tx, private_key, public_key)
 
     alice_balance0 = common.get_account_balance(external_api, alice_address)
-    ensure_transaction_posted(external_api, signed)
+    common.ensure_transaction_posted(external_api, signed)
     alice_balance = common.get_account_balance(external_api, pub_key=alice_address)
 
     # assert contract created:
@@ -143,7 +143,7 @@ def test_contract_call():
 
     print("Signed transaction: " + signed_call)
     alice_balance0 = common.get_account_balance(external_api, alice_address)
-    ensure_transaction_posted(external_api, signed_call)
+    common.ensure_transaction_posted(external_api, signed_call)
     alice_balance = common.get_account_balance(external_api, alice_address)
 
     # The call runs out of gas and all gas is consumed
@@ -176,7 +176,7 @@ def test_contract_on_chain_call_off_chain():
     unsigned_tx = common.base58_decode(encoded_tx)
 
     signed = keys.sign_verify_encode_tx(unsigned_tx, private_key, public_key)
-    ensure_transaction_posted(external_api, signed)
+    common.ensure_transaction_posted(external_api, signed)
 
     call_contract = test_settings["contract_call"]
     call_input = ContractCallInput("sophia-address", encoded_contract_id,\
@@ -237,7 +237,7 @@ def test_spend():
     signed = keys.sign_verify_encode_tx(unsigned_tx, private_key, public_key)
 
     # Alice posts spend tx
-    ensure_transaction_posted(external_api, signed)
+    common.ensure_transaction_posted(external_api, signed)
 
     # Check that Alice was debited and Bob was credited
     alice_balance = common.get_account_balance(external_api, alice_address)
@@ -265,15 +265,6 @@ def send_tokens_to_user(beneficiary, user, test_settings, external_api, internal
                                                                   test_settings[user]["fee"],
                                                                   external_api,
                                                                   internal_api)
-
-def ensure_transaction_posted(api, signed_tx):
-    tx_object = Tx(tx=signed_tx)
-    tx_hash = api.post_transaction(tx_object).tx_hash
-    top = api.get_current_key_block()
-    common.wait_until_height(api, top.height + 1)
-    wait(lambda: api.get_transaction_by_hash(tx_hash).block_hash != 'none',
-         timeout_seconds=20, sleep_seconds=0.25)
-
 
 def get_unsigned_contract_create(owner_id, contract, external_api, internal_api):
     bytecode = read_id_contract(internal_api)


### PR DESCRIPTION
Introduce `ensure_transaction_posted` helper function. After posting signed transaction it waits for:
- new keyblock to avoid micro forks)
- tx on chain
---
I removed redundant `common.wait_until_height` calls in spend_tx suite, `common.send_tokens_to_unchanging_user_and_wait_balance` is doing the job