### PR TITLE
Pt 159616844 local host failure

### DIFF
--- a/apps/aecore/test/aecore_suite_utils.erl
+++ b/apps/aecore/test/aecore_suite_utils.erl
@@ -691,13 +691,11 @@ delete_file(F) ->
             erlang:error(Other, [F])
     end.
 
-hostname() ->
-    {ok, H} = inet:gethostname(),
-    H.
-
+%% Use localhost here, because some systems have both 127.0.0.1 and 127.0.1.1
+%% defined, resulting in a conflict during testing
 peer_info(N) ->
     list_to_binary(["aenode://", aec_base58c:encode(peer_pubkey, pubkey(N)),
-                  "@", hostname(), ":", integer_to_list(port_number(N))]).
+                  "@localhost:", integer_to_list(port_number(N))]).
 
 port_number(dev1) -> 3015;
 port_number(dev2) -> 3025;

--- a/apps/aecore/test/aecore_sync_SUITE.erl
+++ b/apps/aecore/test/aecore_sync_SUITE.erl
@@ -441,7 +441,7 @@ mine_and_compare(N1, Config) ->
     AllNodes = [N || {_, N} <- ?config(nodes, Config)],
     PrevTop = rpc:call(N1, aec_chain, top_block, [], 5000),
     %% If there are txs in the mempool, there will be an additional micro block.
-    %% Micor blocks may result in micro forks, so we need to mine sufficiently many
+    %% Micro blocks may result in micro forks, so we need to mine sufficiently many
     %% blocks.
     %% Better to use: aecore_suite_utils:mine_blocks_until_txs_on_chain/3, but
     %% then we need to pass on the TxHashes... which this test structure does


### PR DESCRIPTION
In https://www.pivotaltracker.com/story/show/159616844 is was noticed that some linux systems have tho /etc/hosts entries 
127.0.0.1 localhost
127.0.1.1 [HOSTNAME]

Since we connect Erlang nodes over Noise using localhost, we get a mismatch with inet:gethostname() which will return the configured hostname. 
This seems purely a test issue and the change in the test configuration fixes this.

See https://www.debian.org/doc/manuals/debian-reference/ch05.en.html#_the_hostname_resolution for documentation on this weird 127.0.1.1