### PR TITLE
PT 160993470 implement abort in Sophia

### DIFF
--- a/apps/aesophia/src/aeso_ast_infer_types.erl
+++ b/apps/aesophia/src/aeso_ast_infer_types.erl
@@ -104,6 +104,8 @@ global_env() ->
      %% State
      {"state", State},
      {"put",   Fun1(State, Unit)},
+     %% Abort
+     {"abort", Fun1(String, Unit)},
      %% Oracles
      {["Oracle", "register"],     Fun([Address, Signature, Fee, TTL], Oracle(Q, R))},
      {["Oracle", "query_fee"],    Fun([Oracle(Q, R)], Fee)},

--- a/apps/aesophia/test/contracts/abort_test.aes
+++ b/apps/aesophia/test/contracts/abort_test.aes
@@ -1,0 +1,16 @@
+// A simple test of the abort built-in function.
+
+contract AbortTest =
+
+  // This is still legal but will be stripped out.
+  private function abort(s : string) = 42
+
+  function do_abort_1(s : string) =
+    abort("42")
+
+  function do_abort_2(s : string) =
+    my_abort("42")
+
+  // This fail in the same way as the built-in abort.
+  private function my_abort(s : string) =
+    switch (0) 1 => ()

--- a/apps/aesophia/test/contracts/aeproof.aes
+++ b/apps/aesophia/test/contracts/aeproof.aes
@@ -141,5 +141,5 @@ contract AEProof =
     function getProofsByOwner(owner: address): array(uint) =
         Map.get(owner, state())
 
-    function require(x : bool) : unit = if(x) () else abort()
+    function require(x : bool) : unit = if(x) () else abort("false")
 

--- a/apps/aesophia/test/contracts/dutch_auction.aes
+++ b/apps/aesophia/test/contracts/dutch_auction.aes
@@ -15,9 +15,6 @@ contract DutchAuction =
     Chain.spend(to, amount)
     total - amount
 
-  private function abort(err : string) =
-    switch(0) 1 => ()
-
   private function require(b : bool, err : string) =
     if(!b) abort(err)
 

--- a/apps/aesophia/test/contracts/erc20_token.aes
+++ b/apps/aesophia/test/contracts/erc20_token.aes
@@ -76,9 +76,6 @@ contract ERC20Token =
     put( state{approval_log = e :: state.approval_log })
     e
 
-  private function abort(err : string) =
-    switch(0) 1 => ()
-
   private function require(b : bool, err : string) =
     if(!b) abort(err)
 

--- a/apps/aesophia/test/contracts/fundme.aes
+++ b/apps/aesophia/test/contracts/fundme.aes
@@ -12,9 +12,6 @@ contract FundMe =
                    deadline      : int,
                    goal          : int }
 
-  private function abort(err : string) =
-    switch(0) 1 => ()
-
   private function require(b : bool, err : string) =
     if(!b) abort(err)
 

--- a/apps/aesophia/test/contracts/multi_sig.aes
+++ b/apps/aesophia/test/contracts/multi_sig.aes
@@ -33,7 +33,7 @@ contract MultiSig =
 
     function lookup(map, key) =
       switch(Map.get(key, map))
-        None        => abort()
+        None        => abort("not found")
         Some(value) => value
 
     function revoke(operation : hash) =

--- a/apps/aesophia/test/contracts/oracles.aes
+++ b/apps/aesophia/test/contracts/oracles.aes
@@ -68,8 +68,5 @@ contract Oracles =
     Oracle.respond(o, q, sig, Answer(question, "magic", 1337))
     Oracle.get_answer(o, q)
 
-  private function abort(err : string) =
-    switch(0) 1 => ()
-
   private function require(b : bool, err : string) =
     if(!b) abort(err)

--- a/apps/aesophia/test/contracts/oracles_gas.aes
+++ b/apps/aesophia/test/contracts/oracles_gas.aes
@@ -23,6 +23,3 @@ contract OraclesGas =
 
   private function require(b : bool, err : string) =
     if(!b) abort(err)
-
-  private function abort(err : string) =
-    switch(0) 1 => ()

--- a/apps/aesophia/test/contracts/remote_oracles.aes
+++ b/apps/aesophia/test/contracts/remote_oracles.aes
@@ -99,8 +99,5 @@ contract RemoteOracles =
     qr   : int) =
     r.respond(o, q, sign, qr)
 
-  private function abort(err : string) =
-    switch(0) 1 => ()
-
   private function require(b : bool, err : string) =
     if(!b) abort(err)

--- a/apps/aesophia/test/contracts/variant_types.aes
+++ b/apps/aesophia/test/contracts/variant_types.aes
@@ -9,11 +9,7 @@ contract VariantTypes =
 
   function init() = Stopped
 
-  function abort() =
-    switch(true)
-      false => ()
-
-  function require(b) = if(!b) abort()
+  function require(b) = if(!b) abort("required")
 
   function start(bal : int) =
     switch(state)

--- a/apps/aesophia/test/contracts/voting.aes
+++ b/apps/aesophia/test/contracts/voting.aes
@@ -60,7 +60,7 @@ contract Voting =
     let voter = Map.find(delegateTo, state.voters)
     switch(voter.vote)
       Voted(vote)  => addVote(vote, weight)
-      Delegated(_) => abort()   // impossible
+      Delegated(_) => abort("impossible")   // impossible
       NotVoted     => voter{ weight = voter.weight + weight }
 
   function delegate(delegateTo: address) =
@@ -85,7 +85,7 @@ contract Voting =
   // const
   function winningProposal() : proposal =
     switch(state.proposals)
-      []      => abort()
+      []      => abort("none")
       p :: ps => winningProposal'(p, ps)
 
   // const


### PR DESCRIPTION
Implement the abort function as a built-in in Sophia. The compiler now generates a local abort function which will be called. Any user defined abort functions are removed.

This implements [PT-160993470](https://www.pivotaltracker.com/story/show/160993470).