### PR TITLE
Add system tests for mempool cleanup of invalid transactions

### DIFF
--- a/system_test/aest_mempool_SUITE.erl
+++ b/system_test/aest_mempool_SUITE.erl
@@ -1,0 +1,196 @@
+-module(aest_mempool_SUITE).
+
+%=== EXPORTS ===================================================================
+
+% Common Test exports
+-export([all/0]).
+-export([init_per_suite/1]).
+-export([init_per_testcase/2]).
+-export([end_per_testcase/2]).
+-export([end_per_suite/1]).
+
+% Test cases
+-export([
+    test_mempool_ttl_cleanup/1,
+    test_mempool_bad_nonce_cleanup/1
+]).
+
+-import(aest_nodes, [
+    setup_nodes/2,
+    start_node/2,
+    wait_for_value/4,
+    wait_for_startup/3,
+    post_spend_tx/5
+]).
+
+%=== INCLUDES ==================================================================
+
+-include_lib("eunit/include/eunit.hrl").
+
+%=== MACROS ====================================================================
+
+-define(MINING_TIMEOUT,   3000).
+
+-define(MIKE, #{
+    pubkey => <<200,171,93,11,3,93,177,65,197,27,123,127,177,165,
+                190,211,20,112,79,108,85,78,88,181,26,207,191,211,
+                40,225,138,154>>,
+    privkey => <<237,12,20,128,115,166,32,106,220,142,111,97,141,104,201,130,56,
+                 100,64,142,139,163,87,166,185,94,4,159,217,243,160,169,200,171,
+                 93,11,3,93,177,65,197,27,123,127,177,165,190,211,20,112,79,108,
+                 85,78,88,181,26,207,191,211,40,225,138,154>>
+}).
+
+-define(ALICE, #{
+    pubkey => <<177,181,119,188,211,39,203,57,229,94,108,2,107,214, 167,74,27,
+                53,222,108,6,80,196,174,81,239,171,117,158,65,91,102>>,
+    privkey => <<145,69,14,254,5,22,194,68,118,57,0,134,66,96,8,20,124,253,238,
+                 207,230,147,95,173,161,192,86,195,165,186,115,251,177,181,119,
+                 188,211,39,203,57,229,94,108,2,107,214,167,74,27,53,222,108,6,
+                 80,196,174,81,239,171,117,158,65,91,102>>
+}).
+
+-define(BOB, #{
+    pubkey => <<103,28,85,70,70,73,69,117,178,180,148,246,81,104,
+                33,113,6,99,216,72,147,205,210,210,54,3,122,84,195,
+                62,238,132>>,
+    privkey => <<59,130,10,50,47,94,36,188,50,163,253,39,81,120,89,219,72,88,68,
+                 154,183,225,78,92,9,216,215,59,108,82,203,25,103,28,85,70,70,
+                 73,69,117,178,180,148,246,81,104,33,113,6,99,216,72,147,205,
+                 210,210,54,3,122,84,195,62,238,132>>
+}).
+
+-define(NODE1, #{
+    name    => node1,
+    peers   => [],
+    backend => aest_docker,
+    source  => {pull, "aeternity/epoch:local"}
+}).
+
+-define(NODE2, #{
+    name    => node2,
+    peers   => [node1],
+    backend => aest_docker,
+    source  => {pull, "aeternity/epoch:local"}
+}).
+
+%=== COMMON TEST FUNCTIONS =====================================================
+
+all() -> [
+    test_mempool_ttl_cleanup,
+    test_mempool_bad_nonce_cleanup
+].
+
+init_per_suite(Config) ->
+    [
+        {node_startup_time, 20000}, %% Time may take to get the node to respond to http
+        {node_shutdown_time, 20000} %% Time it may take to stop node cleanly
+    | Config].
+
+init_per_testcase(_TC, Config) ->
+    aest_nodes:ct_setup(Config).
+
+end_per_testcase(_TC, Config) ->
+    aest_nodes:ct_cleanup(Config).
+
+end_per_suite(_Config) -> ok.
+
+%=== TEST CASES ================================================================
+
+test_mempool_ttl_cleanup(Cfg) ->
+    %% Setup nodes
+    MikePubKey = maps:get(pubkey, ?MIKE),
+    EncMikePubkey = aec_base58c:encode(account_pubkey, MikePubKey),
+    NodeConfig = #{ beneficiary => EncMikePubkey },
+    NodeNames = [node1, node2],
+    setup([?NODE1, ?NODE2], NodeConfig, Cfg),
+    start_node(node1, Cfg),
+    start_node(node2, Cfg),
+    wait_for_startup(NodeNames, 1, Cfg),
+
+    %% Give tokens away
+    #{ tx_hash := PostTxHash1 } = post_spend_tx(node1, ?MIKE, ?ALICE, 1, #{amount => 200}),
+    #{ tx_hash := PostTxHash2 } = post_spend_tx(node1, ?MIKE, ?BOB, 2, #{amount => 200}),
+    aest_nodes:wait_for_value({txs_on_chain, [PostTxHash1, PostTxHash2]}, NodeNames, 10000, []),
+
+    %% Create a channel
+    #{tx_hash := CreateHash, channel_id := ChannelId} =
+        aest_nodes:post_create_state_channel_tx(node1, ?BOB, ?ALICE, #{ nonce => 1 }),
+    aest_nodes:wait_for_value({txs_on_chain, [CreateHash]}, [node1], 10000, []),
+
+    %% Send multiple deposit transaction with the same round
+    #{tx_hash := DepositHash1} =
+        aest_nodes:post_deposit_state_channel_tx(node1, ?BOB, ?ALICE, ChannelId,
+            #{ nonce => 2, amount => 10, round => 1, ttl => 20 }),
+    #{tx_hash := DepositHash2} =
+        aest_nodes:post_deposit_state_channel_tx(node1, ?BOB, ?ALICE, ChannelId,
+            #{ nonce => 3, amount => 11, round => 1, ttl => 20 }),
+    #{tx_hash := DepositHash3} =
+        aest_nodes:post_deposit_state_channel_tx(node1, ?BOB, ?ALICE, ChannelId,
+            #{ nonce => 4, amount => 12, round => 1, ttl => 20 }),
+    #{tx_hash := DepositHash4} =
+        aest_nodes:post_deposit_state_channel_tx(node1, ?BOB, ?ALICE, ChannelId,
+            #{ nonce => 5, amount => 13, round => 1, ttl => 20 }),
+
+    %% Check the first one got on the chain
+    aest_nodes:wait_for_value({txs_on_chain, [DepositHash1]},
+                              [node1, node2], {blocks_delta, 2}, []),
+
+    %% Check the others are dropped
+    aest_nodes:wait_for_value({txs_all_dropped, [DepositHash2, DepositHash3, DepositHash4]},
+                              [node1, node2], {blocks_delta, 21}, []),
+
+    ok.
+
+test_mempool_bad_nonce_cleanup(Cfg) ->
+    %% Setup nodes
+    MikePubKey = maps:get(pubkey, ?MIKE),
+    EncMikePubkey = aec_base58c:encode(account_pubkey, MikePubKey),
+    NodeConfig = #{ beneficiary => EncMikePubkey },
+    NodeNames = [node1, node2],
+    setup([?NODE1, ?NODE2], NodeConfig, Cfg),
+    start_node(node1, Cfg),
+    start_node(node2, Cfg),
+    wait_for_startup(NodeNames, 1, Cfg),
+
+    %% Give tokens away
+    #{ tx_hash := PostTxHash1 } = post_spend_tx(node1, ?MIKE, ?ALICE, 1, #{amount => 200}),
+    #{ tx_hash := PostTxHash2 } = post_spend_tx(node1, ?MIKE, ?BOB, 2, #{amount => 200}),
+    aest_nodes:wait_for_value({txs_on_chain, [PostTxHash1, PostTxHash2]}, NodeNames, 10000, []),
+
+    %% Create a channel
+    #{tx_hash := CreateHash, channel_id := ChannelId} =
+        aest_nodes:post_create_state_channel_tx(node1, ?BOB, ?ALICE, #{ nonce => 1 }),
+    aest_nodes:wait_for_value({txs_on_chain, [CreateHash]}, [node1], 10000, []),
+
+    %% Post deposit transactions on node1 (mining node)
+    #{tx_hash := DepositHash1} =
+        aest_nodes:post_deposit_state_channel_tx(node1, ?BOB, ?ALICE, ChannelId,
+            #{ nonce => 2, amount => 10, round => 1, ttl => 200 }),
+    #{tx_hash := DepositHash2} =
+        aest_nodes:post_deposit_state_channel_tx(node1, ?BOB, ?ALICE, ChannelId,
+            #{ nonce => 3, amount => 11, round => 2, ttl => 200 }),
+
+    %% Post deposit transactions on node2 with already used nounce
+    #{tx_hash := DepositHash3} =
+        aest_nodes:post_deposit_state_channel_tx(node2, ?BOB, ?ALICE, ChannelId,
+            #{ nonce => 3, amount => 13, round => 3, ttl => 200 }),
+    #{tx_hash := DepositHash4} =
+        aest_nodes:post_deposit_state_channel_tx(node2, ?BOB, ?ALICE, ChannelId,
+            #{ nonce => 4, amount => 14, round => 4, ttl => 200 }),
+
+    %% check the deposit with correct nonce got on chain
+    aest_nodes:wait_for_value({txs_on_chain, [DepositHash1, DepositHash4]},
+                              [node1, node2], {blocks_delta, 5}, []),
+
+    %% Check the one of the transaction with duplicated nonce is dropped
+    %% before its TTL expires
+    aest_nodes:wait_for_value({txs_any_dropped, [DepositHash2, DepositHash3]},
+                              [node1, node2], {blocks_delta, 10}, []),
+
+    ok.
+
+%=== INTERNAL FUNCTIONS ========================================================
+
+setup(NodeSpecs, Config, Cfg) ->
+    setup_nodes([maps:put(config, Config, N) || N <- NodeSpecs], Cfg).

--- a/system_test/aest_mempool_SUITE_data/epoch.yaml.mustache
+++ b/system_test/aest_mempool_SUITE_data/epoch.yaml.mustache
@@ -1,0 +1,38 @@
+{{#epoch_config}}
+---
+peers: {{^peers}}[]{{/peers}}
+{{#peers}}
+    - {{peer}}
+{{/peers}}
+
+sync:
+    port: {{services.sync.port}}
+    ping_interval: 5000
+    single_outbound_per_group: false
+
+mempool:
+    invalid_tx_ttl: 3
+
+http:
+    external:
+        port: {{services.ext_http.port}}
+
+keys:
+    password: {{key_password}}
+    dir: ./keys
+
+chain:
+    persist: true
+
+mining:
+    beneficiary: {{config.beneficiary}}
+    beneficiary_reward_delay: 2
+    autostart: true
+    micro_block_cycle: 100
+    expected_mine_rate: 1000
+    cuckoo:
+        miner:
+            executable: mean16s-generic
+            extra_args: ""
+            node_bits: 16
+{{/epoch_config}}


### PR DESCRIPTION
Add block-based expiration to wait_for_value.
I had a hard time making these tests reliable. As they are now they passed more than 30 times on my machine without error.