### PR TITLE
tests for json-rpc and legacy ws wc API

### DIFF
--- a/apps/aechannel/src/aesc_fsm.erl
+++ b/apps/aechannel/src/aesc_fsm.erl
@@ -435,21 +435,20 @@ init(#{opts := Opts0} = Arg) ->
     case Role of
         initiator ->
             if Reestablish ->
-                    {ok, reestablish_init, send_reestablish_msg(Data),
-                    [timer_for_state(reestablish_init, Data)]};
+                    ok_next(reestablish_init, send_reestablish_msg(Data));
               true ->
-                    {ok, initialized, send_open_msg(Data),
-                    [timer_for_state(initialized, Data)]}
+                    ok_next(initialized, send_open_msg(Data))
             end;
         responder ->
             if Reestablish ->
-                    {ok, awaiting_reestablish, Data,
-                    [timer_for_state(awaiting_reestablish, Data)]};
+                    ok_next(awaiting_reestablish, Data);
               true ->
-                    {ok, awaiting_open, Data,
-                    [timer_for_state(awaiting_open, Data)]}
+                    ok_next(awaiting_open, Data)
             end
     end.
+
+ok_next(Next, Data) ->
+    {ok, Next, cur_st(Next, Data), [timer_for_state(Next, Data)]}.
 
 check_opts([H|T], Opts) ->
     check_opts(T, H(Opts));

--- a/docs/release-notes/next/PT-159426861-json-rpc.md
+++ b/docs/release-notes/next/PT-159426861-json-rpc.md
@@ -1,0 +1,1 @@
+* Added JSON-RPC support in the state channel WebSocket API. The previous API remains supported for now. Support for JSON-RPC request batches implemented but not yet tested.


### PR DESCRIPTION
See [PT #161117807](https://www.pivotaltracker.com/story/show/161117807)

* Same tests are run for both legacy and json-rpc API, staying as close as possible to the old test suite code.
* Support for JSON-RPC request batches implemented, but not yet tested (requires changes to `aehttp_ws_test_utils.erl`)
* A separate `protocol` PR will be prepared with examples.