### PR TITLE
Keep CP in argument for more efficient execution.

### DIFF
--- a/apps/aevm/src/aevm_eeevm_state.erl
+++ b/apps/aevm/src/aevm_eeevm_state.erl
@@ -28,6 +28,7 @@
         , data/1
         , difficulty/1
         , do_return/3
+        , do_trace/1
         , extcode/2
         , extcode/4
         , extcodesize/2


### PR DESCRIPTION
Tried several different speedups of the VM (module merging with igor, inling, and native code compilation) but just keeping the PC/CP in a register/argument gave most bang for the buck.