### PR TITLE
System test improvements

### DIFF
--- a/apps/aehttp/test/aehttp_client.erl
+++ b/apps/aehttp/test/aehttp_client.erl
@@ -14,10 +14,8 @@ request(OpId, Params, Cfg) ->
     BaseUrl = string:trim(proplists:get_value(Interface, Cfg), trailing, "/"),
     Path = endpoints:path(Method, OpId, Params),
     Query = endpoints:query(Method, OpId, Params),
-    {ok, ClientPid} = inets:start(httpc, [{profile, test_browser}], stand_alone),
-    Response = request(Method, BaseUrl, Path, Query, Params, [], [{timeout, 15000}], [], ClientPid, Cfg),
-    ok = gen_server:stop(ClientPid, normal, infinity),
-    Response.
+    {ok, _} = application:ensure_all_started(inets),
+    request(Method, BaseUrl, Path, Query, Params, [], [{timeout, 15000}], [], default, Cfg).
 
 request(get, BaseUrl, Path, Query, _Params, Headers, HttpOpts, Opts, Profile, Cfg) ->
     Url = binary_to_list(iolist_to_binary([BaseUrl, Path, Query])),

--- a/system_test/helpers/aest_nodes.erl
+++ b/system_test/helpers/aest_nodes.erl
@@ -40,6 +40,7 @@
 -export([get_block/2]).
 -export([get_top/1]).
 -export([get_mempool/1]).
+-export([get_account/2]).
 -export([post_spend_tx/5]).
 -export([post_create_state_channel_tx/4,
          post_close_mutual_state_channel_tx/5,
@@ -379,6 +380,10 @@ get_mempool(NodeName) ->
         {Mempool, undefined} -> Mempool
         %% nomatch if none of the two
     end.
+
+get_account(NodeName, PubKey) ->
+    Params = #{pubkey => aec_base58c:encode(account_pubkey, PubKey)},
+    verify(200, request(NodeName, 'GetAccountByPubkey', Params)).
 
 post_spend_tx(Node, From, To, Nonce, Map) ->
     #{ pubkey := SendPubKey, privkey := SendSecKey } = From,

--- a/system_test/helpers/aest_nodes_mgr.erl
+++ b/system_test/helpers/aest_nodes_mgr.erl
@@ -39,13 +39,9 @@
 
 %=== GENERIC API FUNCTIONS =====================================================
 
-start(Backends, EnvMap) ->
-    {ok, _} = application:ensure_all_started(hackney),
-    gen_server:start({local, ?SERVER}, ?MODULE, [Backends, EnvMap], []).
+start(Backends, EnvMap) -> start_proc(?FUNCTION_NAME, Backends, EnvMap).
 
-start_link(Backends, EnvMap) ->
-    {ok, _} = application:ensure_all_started(hackney),
-    gen_server:start_link({local, ?SERVER}, ?MODULE, [Backends, EnvMap], []).
+start_link(Backends, EnvMap) -> start_proc(?FUNCTION_NAME, Backends, EnvMap).
 
 stop() ->
     gen_server:stop(?SERVER).
@@ -178,6 +174,13 @@ code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
 
 %=== INTERNAL FUNCTIONS ========================================================
+
+start_proc(Func, Backends, EnvMap) ->
+    [{ok, _} = application:ensure_all_started(A) || A <- [
+        hackney,
+        yamerl
+    ]],
+    gen_server:Func({local, ?SERVER}, ?MODULE, [Backends, EnvMap], []).
 
 log(LogFun, Format, Params) when is_function(LogFun) ->
     LogFun(Format, Params);

--- a/system_test/helpers/aest_nodes_mgr.erl
+++ b/system_test/helpers/aest_nodes_mgr.erl
@@ -114,19 +114,19 @@ handle_call({setup_nodes, NodeSpecs}, _From, State) ->
 handle_call({get_node_pubkey, NodeName}, _From, State) ->
     {reply, mgr_get_node_pubkey(NodeName, State), State};
 handle_call({get_service_address, NodeName, Service}, _From, #{nodes := Nodes} = State) ->
-    #{NodeName := {Mod, NodeState}} = Nodes,
+    {Mod, NodeState} = maps:get(NodeName, Nodes),
     ServiceAddress = Mod:get_service_address(Service, NodeState),
     {reply, ServiceAddress, State};
 handle_call({get_internal_address, NodeName, Service}, _From, #{nodes := Nodes} = State) ->
-    #{NodeName := {Mod, NodeState}} = Nodes,
+    {Mod, NodeState} = maps:get(NodeName, Nodes),
     ServiceAddress = Mod:get_internal_address(Service, NodeState),
     {reply, ServiceAddress, State};
 handle_call({get_config, NodeName, Path}, _From, #{nodes := Nodes} = State) when is_list(Path) ->
-    #{NodeName := {_Mod, NodeState}} = Nodes,
+    {_Mod, NodeState} = maps:get(NodeName, Nodes),
     Config = maps:get(config, NodeState, []),
     {reply, config_find(Path, Config), State};
 handle_call({get_hostname, NodeName}, _From, #{nodes := Nodes} = State) ->
-    #{NodeName := {_Mod, _NodeState}} = Nodes,
+    {_Mod, _NodeState} = maps:get(NodeName, Nodes),
     %% for the moment only localhost supported
     {reply, "localhost", State};
 handle_call({start_node, NodeName}, _From, #{nodes := Nodes} = State) ->
@@ -134,12 +134,12 @@ handle_call({start_node, NodeName}, _From, #{nodes := Nodes} = State) ->
     NodeState2 = Mod:start_node(NodeState),
     {reply, ok, State#{nodes := Nodes#{NodeName := {Mod, NodeState2}}}};
 handle_call({stop_node, NodeName, Timeout}, _From, #{nodes := Nodes} =State) ->
-    #{NodeName := {Mod, NodeState}} = Nodes,
+    {Mod, NodeState} = maps:get(NodeName, Nodes),
     Opts = #{soft_timeout => Timeout},
     NodeState2 = Mod:stop_node(NodeState, Opts),
     {reply, ok, State#{nodes := Nodes#{NodeName := {Mod, NodeState2}}}};
 handle_call({kill_node, NodeName}, _From, #{nodes := Nodes} = State) ->
-    #{NodeName := {Mod, NodeState}} = Nodes,
+    {Mod, NodeState} = maps:get(NodeName, Nodes),
     NodeState2 = Mod:kill_node(NodeState),
     {reply, ok, State#{nodes := Nodes#{NodeName := {Mod, NodeState2}}}};
 handle_call({extract_archive, NodeName, Path, Archive}, _From, State) ->
@@ -214,7 +214,7 @@ mgr_cleanup(State) ->
 
 
 mgr_get_node_pubkey(NodeName, #{nodes := Nodes}) ->
-    #{NodeName := {Mod, NodeState}} = Nodes,
+    {Mod, NodeState} = maps:get(NodeName, Nodes),
     Mod:get_node_pubkey(NodeState).
 
 mgr_extract_archive(NodeName, Path, Archive, #{nodes := Nodes} = State) ->


### PR DESCRIPTION
This PR introduces the following improvements:
* It starts `yamerl` before running system tests, which is needed for parsing the node configuration
* It uses `maps:get/2` instead of pattern matching to get node instances, so that the user can see which node is missing in case of errors
* Raises proper exceptions on HTTP request from system tests instead of `badmatch` so they can be distinguished from bugs
* Adds a `get_account/2` utility function to return an account object given a public key
* Uses the default HTTPC profile so requests can be made in parallel (needed by load tests)
