### PR TITLE
Add some test explicitly testing state handling

### DIFF
--- a/apps/aesophia/test/contracts/remote_state.aes
+++ b/apps/aesophia/test/contracts/remote_state.aes
@@ -1,0 +1,12 @@
+contract RemoteState =
+  record rstate = { i : int, s : string, m : map(int, int) }
+
+  function get(s : rstate) = s
+  function get_i(s : rstate) = s.i
+  function get_s(s : rstate) = s.s
+  function get_m(s : rstate) = s.m
+
+  function fun_update_i(s : rstate, ni) = s{ i = ni }
+  function fun_update_s(s : rstate, ns) = s{ s = ns }
+  function fun_update_m(s : rstate, nm) = s{ m = nm }
+

--- a/apps/aesophia/test/contracts/remote_state.aes
+++ b/apps/aesophia/test/contracts/remote_state.aes
@@ -1,6 +1,8 @@
 contract RemoteState =
   record rstate = { i : int, s : string, m : map(int, int) }
 
+  function look_at(s : rstate) = ()
+
   function get(s : rstate) = s
   function get_i(s : rstate) = s.i
   function get_s(s : rstate) = s.s
@@ -9,4 +11,5 @@ contract RemoteState =
   function fun_update_i(s : rstate, ni) = s{ i = ni }
   function fun_update_s(s : rstate, ns) = s{ s = ns }
   function fun_update_m(s : rstate, nm) = s{ m = nm }
+  function fun_update_mk(s : rstate, k, v) = s{ m = s.m{[k] = v} }
 

--- a/apps/aesophia/test/contracts/state_handling.aes
+++ b/apps/aesophia/test/contracts/state_handling.aes
@@ -1,0 +1,50 @@
+contract Remote =
+  function get : (state) => state
+  function get_i : (state) => int
+  function get_s : (state) => string
+  function get_m : (state) => map(int, int)
+
+  function fun_update_i : (state, int)           => state
+  function fun_update_s : (state, string)        => state
+  function fun_update_m : (state, map(int, int)) => state
+
+contract StateHandling =
+  record state = { i : int, s : string, m : map(int, int) }
+
+  function init(r : Remote, i : int) =
+    let state0 = { i = 0, s = "undefined", m = {} }
+    r.fun_update_i(state0, i)
+
+  function read() = state
+  function read_i() = state.i
+  function read_s() = state.s
+  function read_m() = state.m
+
+  function update(new_state : state) = put(new_state)
+  function update_i(new_i) = put(state{ i = new_i })
+  function update_s(new_s) = put(state{ s = new_s })
+  function update_m(new_m) = put(state{ m = new_m })
+
+  function pass(r : Remote) = r.get(state)
+  function pass_i(r : Remote) = r.get_i(state)
+  function pass_s(r : Remote) = r.get_s(state)
+  function pass_m(r : Remote) = r.get_m(state)
+
+  function pass_update_i(r : Remote, i) = r.fun_update_i(state, i)
+  function pass_update_s(r : Remote, s) = r.fun_update_s(state, s)
+  function pass_update_m(r : Remote, m) = r.fun_update_m(state, m)
+
+  function remote_update_i(r : Remote, i) = put(r.fun_update_i(state, i))
+  function remote_update_s(r : Remote, s) = put(r.fun_update_s(state, s))
+  function remote_update_m(r : Remote, m) = put(r.fun_update_m(state, m))
+
+  // remote called
+  function get(s : state) = s
+  function get_i(s : state) = s.i
+  function get_s(s : state) = s.s
+  function get_m(s : state) = s.m
+
+  function fun_update_i(st, ni) = st{ i = ni }
+  function fun_update_s(st, ns) = st{ s = ns }
+  function fun_update_m(st, nm) = st{ m = nm }
+

--- a/apps/aesophia/test/contracts/state_handling.aes
+++ b/apps/aesophia/test/contracts/state_handling.aes
@@ -1,12 +1,14 @@
 contract Remote =
+  function look_at : (state) => ()
   function get : (state) => state
   function get_i : (state) => int
   function get_s : (state) => string
   function get_m : (state) => map(int, int)
 
-  function fun_update_i : (state, int)           => state
-  function fun_update_s : (state, string)        => state
-  function fun_update_m : (state, map(int, int)) => state
+  function fun_update_i  : (state, int)           => state
+  function fun_update_s  : (state, string)        => state
+  function fun_update_m  : (state, map(int, int)) => state
+  function fun_update_mk : (state, int, int)      => state
 
 contract StateHandling =
   record state = { i : int, s : string, m : map(int, int) }
@@ -25,6 +27,9 @@ contract StateHandling =
   function update_s(new_s) = put(state{ s = new_s })
   function update_m(new_m) = put(state{ m = new_m })
 
+  function pass_it(r : Remote) = r.look_at(state)
+  function nop(r : Remote) = put(state{ i = state.i })
+
   function pass(r : Remote) = r.get(state)
   function pass_i(r : Remote) = r.get_i(state)
   function pass_s(r : Remote) = r.get_s(state)
@@ -34,11 +39,14 @@ contract StateHandling =
   function pass_update_s(r : Remote, s) = r.fun_update_s(state, s)
   function pass_update_m(r : Remote, m) = r.fun_update_m(state, m)
 
-  function remote_update_i(r : Remote, i) = put(r.fun_update_i(state, i))
-  function remote_update_s(r : Remote, s) = put(r.fun_update_s(state, s))
-  function remote_update_m(r : Remote, m) = put(r.fun_update_m(state, m))
+  function remote_update_i (r : Remote, i)    = put(r.fun_update_i(state, i))
+  function remote_update_s (r : Remote, s)    = put(r.fun_update_s(state, s))
+  function remote_update_m (r : Remote, m)    = put(r.fun_update_m(state, m))
+  function remote_update_mk(r : Remote, k, v) = put(r.fun_update_mk(state, k, v))
 
   // remote called
+  function look_at(s : state) = ()
+
   function get(s : state) = s
   function get_i(s : state) = s.i
   function get_s(s : state) = s.s
@@ -47,4 +55,5 @@ contract StateHandling =
   function fun_update_i(st, ni) = st{ i = ni }
   function fun_update_s(st, ns) = st{ s = ns }
   function fun_update_m(st, nm) = st{ m = nm }
+  function fun_update_mk(st, k, v) = st{ m = st.m{[k] = v} }
 


### PR DESCRIPTION
Test that a called contract can read and update its own state.
Test that you can pass your state as an argument to another contract. (This is possibly very expensive - good implementation might be needed.)
Test that another contract can update the state and return it.
Test that the callers state is not changed by an updated state in a called contract. (This should not be possible with current implementation but we want a test to make sure future implementations doesnt change this.)
Test that the caller can receive an updated version of its state and choose to update its own state

+ testing remote call inside initialization call of contract create transaction