### PR TITLE
Avoid reading the contract twice in aect_call_tx:process

### DIFF
--- a/apps/aecontract/src/aect_call_tx.erl
+++ b/apps/aecontract/src/aect_call_tx.erl
@@ -224,6 +224,7 @@ run_contract(#contract_call_tx{ nonce  = _Nonce
     ContractsTree  = aec_trees:contracts(Trees),
     Contract       = aect_state_tree:get_contract(ContractPubkey, ContractsTree),
     Code           = aect_contracts:code(Contract),
+    Store          = aect_contracts:state(Contract),
     CallDef = #{ caller     => CallerPubkey
                , contract   => ContractPubkey
                , gas        => Gas
@@ -232,6 +233,7 @@ run_contract(#contract_call_tx{ nonce  = _Nonce
                , amount     => Amount
                , call_stack => CallStack
                , code       => Code
+               , store      => Store
                , call       => Call
                , trees      => Trees
                , tx_env     => Env

--- a/apps/aecontract/src/aect_create_tx.erl
+++ b/apps/aecontract/src/aect_create_tx.erl
@@ -306,11 +306,12 @@ run_contract(#contract_create_tx{ nonce      =_Nonce
                                 , gas_price  = GasPrice
                                 , call_data  = CallData
                                 } = Tx,
-             Call, Env, Trees,_Contract, ContractPubKey)->
+             Call, Env, Trees, Contract, ContractPubKey)->
     Caller = owner_pubkey(Tx),
     CallStack = [], %% TODO: should we have a call stack for create_tx also
                     %% when creating a contract in a contract.
 
+    Store     = aect_contracts:state(Contract),
     CallDef = #{ caller      => Caller
                , contract    => ContractPubKey
                , gas         => Gas
@@ -319,6 +320,7 @@ run_contract(#contract_create_tx{ nonce      =_Nonce
                , amount      => 0 %% Initial call takes no amount
                , call_stack  => CallStack
                , code        => Code
+               , store       => Store
                , call        => Call
                , trees       => Trees
                , tx_env      => Env

--- a/apps/aecontract/src/aect_dispatch.erl
+++ b/apps/aecontract/src/aect_dispatch.erl
@@ -75,6 +75,7 @@ run_common(#{  amount      := Value
              , call_stack  := CallStack
              , caller      := <<CallerAddr:?PUB_SIZE/unit:8>>
              , code        := Code
+             , store       := Store
              , contract    := <<Address:?PUB_SIZE/unit:8>>
              , gas         := Gas
              , gas_price   := GasPrice
@@ -93,6 +94,7 @@ run_common(#{  amount      := Value
             chainAPI          => aec_vm_chain,
             vm_version        => VMVersion},
     Exec = #{code       => Code,
+             store      => Store,
              address    => Address,
              caller     => CallerAddr,
              data       => CallData,

--- a/apps/aecontract/src/aect_evm.erl
+++ b/apps/aecontract/src/aect_evm.erl
@@ -8,7 +8,7 @@
 -module(aect_evm).
 
 -export([ simple_call_common/3
-        , call_common/6
+        , call_common/7
         , encode_call_data/3
         , execute_call/2
         ]).
@@ -29,20 +29,22 @@ simple_call_common(Code, CallData, VMVersion) ->
     Owner          = <<123456:32/unit:8>>,
     Deposit        = 0,
     Contract       = aect_contracts:new(Owner, 1, VMVersion, Code, Deposit),
+    Store          = aect_contracts:state(Contract),
     ContractKey    = aect_contracts:pubkey(Contract),
     Trees1         = aect_utils:insert_contract_in_trees(Contract, Trees),
-    call_common(CallData, ContractKey, Code, TxEnv, Trees1, VMVersion).
+    call_common(CallData, ContractKey, Code, Store, TxEnv, Trees1, VMVersion).
 
--spec call_common(binary(), binary(), binary(), aetx_env:env(),
+-spec call_common(binary(), binary(), binary(), aect_contracts:store(), aetx_env:env(),
                   aec_trees:trees(), VMVersion :: integer()) ->
                      {ok, binary()} | {error, binary()}.
-call_common(CallData, ContractKey, Code, TxEnv, Trees, VMVersion) ->
+call_common(CallData, ContractKey, Code, Store, TxEnv, Trees, VMVersion) ->
     <<Address:256>> = ContractKey,
     GasLimit = aec_governance:block_gas_limit(),
     Amount = 0,
     ChainState = aec_vm_chain:new_state(Trees, TxEnv, ContractKey),
     <<BeneficiaryInt:?BENEFICIARY_PUB_BYTES/unit:8>> = aetx_env:beneficiary(TxEnv),
     Spec = #{ code => Code
+            , store => Store
             , address => Address
             , caller => 0
             , data => CallData
@@ -70,6 +72,7 @@ call_common(CallData, ContractKey, Code, TxEnv, Trees, VMVersion) ->
 
 -spec execute_call(map(), boolean()) -> {ok, map()} | {error, term()}.
 execute_call(#{ code := Code
+              , store := Store
               , address := Address
               , caller := Caller
               , data := CallData
@@ -89,6 +92,7 @@ execute_call(#{ code := Code
     %% TODO: Handle Contract In State.
     Spec =
         #{ exec => #{ code => Code
+                    , store => Store
                     , address => Address
                     , caller => Caller
                     , data => CallData

--- a/apps/aecontract/src/aect_sophia.erl
+++ b/apps/aecontract/src/aect_sophia.erl
@@ -55,13 +55,14 @@ on_chain_call(ContractKey, Function, Argument) ->
     ContractsTree  = aec_trees:contracts(Trees),
     Contract       = aect_state_tree:get_contract(ContractKey, ContractsTree),
     SerializedCode = aect_contracts:code(Contract),
+    Store          = aect_contracts:state(Contract),
     %% TODO: Check the type info before calling?
     #{ byte_code := Code} = aeso_compiler:deserialize(SerializedCode),
     case create_call(Code, Function, Argument) of
         {error, E} -> {error, E};
         CallData ->
             VMVersion   = ?AEVM_01_Sophia_01,
-            aect_evm:call_common(CallData, ContractKey, Code,
+            aect_evm:call_common(CallData, ContractKey, Code, Store,
                                  TxEnv, Trees, VMVersion)
     end.
 

--- a/apps/aevm/src/aevm_eeevm_state.erl
+++ b/apps/aevm/src/aevm_eeevm_state.erl
@@ -131,7 +131,7 @@ init(#{ env  := Env
     init_vm(State,
             maps:get(code, Exec),
             maps:get(mem, Exec, #{mem_size => 0}),
-            ChainAPI:get_store(ChainState)).
+            maps:get(store, Exec)).
 
 
 init_vm(State, Code, Mem, Store) ->

--- a/test/aebytecode_aevm_SUITE.erl
+++ b/test/aebytecode_aevm_SUITE.erl
@@ -26,6 +26,7 @@ execute_identy_fun_from_file(_Cfg) ->
         aevm_eeevm:eval(
           aevm_eeevm_state:init(
             #{ exec => #{ code => Code,
+                          store => #{},
                           address => 90120,
                           caller => 0,
                           data => <<0:256, 42:256>>,

--- a/test/contract_solidity_bytecode_aevm_SUITE.erl
+++ b/test/contract_solidity_bytecode_aevm_SUITE.erl
@@ -41,7 +41,7 @@ execute_identity_fun_from_solidity_binary(_Cfg) ->
     Code = aeu_hex:hexstring_decode(id_bytecode()),
     Env  = initial_state(#{101 => Code}),
     NewCode = successful_call_(101, word, main, <<42>>, Env),
-    {ok, <<42:256>>, _, _} =  execute_call(101, <<26,148,216,62,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 42>>, Env#{ 101 => NewCode}, #{}),
+    {ok, <<42:256>>, _, _} =  execute_call(101, <<26,148,216,62,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 42>>, Env#{101 => NewCode}, #{}),
     ok.
 
 
@@ -160,6 +160,7 @@ execute_call(Contract, CallData, ChainState, Options) ->
     Res = aect_evm:execute_call(
           maps:merge(
           #{ code              => Code,
+             store             => #{},
              address           => Contract,
              caller            => 0,
              data              => CallData,

--- a/test/contract_sophia_bytecode_aevm_SUITE.erl
+++ b/test/contract_sophia_bytecode_aevm_SUITE.erl
@@ -71,6 +71,7 @@ execute_call(Contract, CallData, ChainState, Options) ->
     Res = aect_evm:execute_call(
           maps:merge(
           #{ code              => Code,
+             store             => get_store(ChainState1),
              address           => Contract,
              caller            => 0,
              data              => CallData,

--- a/test/sophia_bytecode_aevm_SUITE.erl
+++ b/test/sophia_bytecode_aevm_SUITE.erl
@@ -10,7 +10,7 @@
 -export(
    [
      execute_identity_fun_from_bytecode/1
-     , execute_identity_fun_from_sophia_file/1
+   , execute_identity_fun_from_sophia_file/1
    ]).
 
 -include("apps/aecontract/src/aecontract.hrl").
@@ -36,6 +36,7 @@ execute_identity_fun_from_sophia_file(_Cfg) ->
         aevm_eeevm:eval(
           aevm_eeevm_state:init(
             #{ exec => #{ code => Code,
+                          store => #{},
                           address => 91210,
                           caller => 0,
                           data => CallData,
@@ -80,6 +81,7 @@ execute_identity_fun_from_bytecode(_Cfg) ->
         aevm_eeevm:eval(
           aevm_eeevm_state:init(
             #{ exec => #{ code => Code,
+                          store => #{},
                           address => 91210,
                           caller => 0,
                           data => <<32:256, 96:256, 42:256, 0:256>>,


### PR DESCRIPTION
We already have laid our hands on the contract state/store - save it in the passed data structure...