### PR TITLE
wrap all the places where we sign transactions with network id

### DIFF
--- a/apps/aechannel/test/aesc_txs_SUITE.erl
+++ b/apps/aechannel/test/aesc_txs_SUITE.erl
@@ -2896,7 +2896,8 @@ fp_register_name(Cfg) ->
     SignContractAddress =
         fun(PubK, PrivK, ConId) ->
             BinToSign = <<PubK/binary, ConId/binary>>,
-            SigBin = <<Word1:256, Word2:256>> = enacl:sign_detached(BinToSign, PrivK),
+            SigBin = <<Word1:256, Word2:256>> =
+                enacl:sign_detached(aec_governance:add_network_id(BinToSign), PrivK),
             %_Sig = aeu_hex:hexstring_encode(aeso_data:to_binary({Word1, Word2}, 0))
             ?TEST_LOG("Signature binary ~p", [SigBin]),
             Word11 = integer_to_binary(Word1),

--- a/apps/aecontract/test/aecontract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_SUITE.erl
@@ -2275,7 +2275,8 @@ sophia_signatures_aens(_Cfg) ->
 
 sign(Material, KeyHolder) ->
     PrivKey  = aect_test_utils:priv_key(KeyHolder, state()),
-    <<Word1:256, Word2:256>> = enacl:sign_detached(Material, PrivKey),
+    MaterialForNetworkId = aec_governance:add_network_id(Material),
+    <<Word1:256, Word2:256>> = enacl:sign_detached(MaterialForNetworkId, PrivKey),
     {Word1, Word2}.
 
 %% Testing map functions and primitives

--- a/apps/aecore/src/aec_governance.erl
+++ b/apps/aecore/src/aec_governance.erl
@@ -23,7 +23,9 @@
          accepted_future_block_time_shift/0,
          fraud_report_reward/0,
          state_gas_cost_per_block/1,
-         primop_base_gas_cost/1]).
+         primop_base_gas_cost/1,
+         add_network_id/1,
+         get_network_id/0]).
 
 -export_type([protocols/0]).
 
@@ -35,6 +37,7 @@
         #{?PROTOCOL_VERSION => ?GENESIS_HEIGHT
          }).
 
+-define(NETWORK_ID, <<"ae_mainnet">>).
 -define(BLOCKS_TO_CHECK_DIFFICULTY_COUNT, 17).
 -define(TIMESTAMP_MEDIAN_BLOCKS, 11).
 -define(EXPECTED_BLOCK_MINE_RATE_MINUTES, 3).
@@ -204,3 +207,12 @@ name_registrars() ->
 
 fraud_report_reward() ->
     ?POF_REWARD.
+
+-spec add_network_id(binary()) -> binary().
+add_network_id(SerializedTransaction) ->
+    NetworkId = get_network_id(),
+    <<NetworkId/binary, SerializedTransaction/binary>>.
+
+get_network_id() ->
+    aeu_env:user_config_or_env([<<"fork_management">>, <<"network_id">>],
+                                aecore, network_id, ?NETWORK_ID).

--- a/apps/aecore/src/aec_keys.erl
+++ b/apps/aecore/src/aec_keys.erl
@@ -119,7 +119,8 @@ sign_micro_block(MicroBlock) ->
 sign_tx(Tx) ->
     %% Serialize first to maybe (hopefully) pass as reference.
     Bin = aetx:serialize_to_binary(Tx),
-    {ok, Signature} = gen_server:call(?MODULE, {sign, Bin}),
+    BinForNetwork = aec_governance:add_network_id(Bin),
+    {ok, Signature} = gen_server:call(?MODULE, {sign, BinForNetwork}),
     {ok, aetx_sign:new(Tx, [Signature])}.
 
 -spec pubkey() -> {ok, binary()} | {error, key_not_found}.

--- a/apps/aecore/src/aec_vm_chain.erl
+++ b/apps/aecore/src/aec_vm_chain.erl
@@ -381,7 +381,8 @@ check_name_signature(AKey, Hash, CKey, Signature) ->
 
 check_signature(AKey, AKey, _Binary, _Signature) -> ok;
 check_signature(AKey, _CKey, Binary, Signature) ->
-    case enacl:sign_verify_detached(Signature, Binary, AKey) of
+    BinaryForNetwork = aec_governance:add_network_id(Binary),
+    case enacl:sign_verify_detached(Signature, BinaryForNetwork, AKey) of
        {ok, _}    -> ok;
        {error, _} -> {error, signature_check_failed}
     end.

--- a/apps/aecore/test/aec_test_utils.erl
+++ b/apps/aecore/test/aec_test_utils.erl
@@ -430,11 +430,12 @@ sign_tx(Tx, PrivKey) when is_binary(PrivKey) ->
     sign_tx(Tx, [PrivKey]);
 sign_tx(Tx, PrivKeys) when is_list(PrivKeys) ->
     Bin = aetx:serialize_to_binary(Tx),
+    BinForNetwork = aec_governance:add_network_id(Bin),
     case lists:filter(fun(PrivKey) -> not (?VALID_PRIVK(PrivKey)) end, PrivKeys) of
         [_|_]=BrokenKeys -> erlang:error({invalid_priv_key, BrokenKeys});
         [] -> pass
     end,
-    Signatures = [ enacl:sign_detached(Bin, PrivKey) || PrivKey <- PrivKeys ],
+    Signatures = [ enacl:sign_detached(BinForNetwork, PrivKey) || PrivKey <- PrivKeys ],
     aetx_sign:new(Tx, Signatures).
 
 signed_spend_tx(ArgsMap) ->

--- a/apps/aetx/src/aetx_sign.erl
+++ b/apps/aetx/src/aetx_sign.erl
@@ -104,7 +104,8 @@ verify_one_pubkey(Sigs, PubKey, Bin) ->
     verify_one_pubkey(Sigs, PubKey, Bin, []).
 
 verify_one_pubkey([Sig|Left], PubKey, Bin, Acc) when ?VALID_PUBK(PubKey) ->
-    case enacl:sign_verify_detached(Sig, Bin, PubKey) of
+    BinForNetwork = aec_governance:add_network_id(Bin),
+    case enacl:sign_verify_detached(Sig, BinForNetwork, PubKey) of
         {ok, _}    -> {ok, Acc ++ Left};
         {error, _} -> verify_one_pubkey(Left, PubKey, Bin, [Sig|Acc])
     end;

--- a/apps/aeutils/priv/epoch_config_schema.json
+++ b/apps/aeutils/priv/epoch_config_schema.json
@@ -711,6 +711,16 @@
                     }
                 }
             }
+        },
+        "fork_management" : {
+            "type"    : "object",
+            "additionalProperties" : false,
+            "properties" : {
+                "network_id" : {
+                    "description" :
+                    "Identification of the network in case of hard forks.",
+                    "type" : "string"}
+            }
         }
     }
 }

--- a/apps/aeutils/test/data/epoch_full.yaml
+++ b/apps/aeutils/test/data/epoch_full.yaml
@@ -149,3 +149,6 @@ metrics:
           actions: log
         - name: "ae.epoch.aecore.**"
           actions: log,send
+
+fork_management:
+    network_id: "ae_mainnet"

--- a/docs/release-notes/next/PT-159946514-replay-attacks
+++ b/docs/release-notes/next/PT-159946514-replay-attacks
@@ -1,0 +1,1 @@
+* Avoid replay attacks by naming networks (forks) with network_id and including them in transaction signature

--- a/py/tests/integration/keys.py
+++ b/py/tests/integration/keys.py
@@ -18,13 +18,13 @@ def sign(message, private_key):
     return private_key.sign(message).signature
 
 def sign_encode_tx(packed_tx, private_key):
-    signature = sign(packed_tx, private_key)
+    signature = sign("ae_mainnet" + packed_tx, private_key)
     signed_encoded = common.encode_signed_tx(packed_tx, [bytearray(signature)])
     return signed_encoded
 
 def sign_verify_encode_tx(packed_tx, private_key, public_key):
-    signature = sign(packed_tx, private_key)
-    assert verify(signature, packed_tx, public_key)
+    signature = sign("ae_mainnet" + packed_tx, private_key)
+    assert verify(signature, "ae_mainnet" + packed_tx, public_key)
     signed_encoded = common.encode_signed_tx(packed_tx, [bytearray(signature)])
     return signed_encoded
 


### PR DESCRIPTION
All serialized transactions are prefixed with "ae_mainnet" binary.
It is default in governance and it is configurable via epoch config.


TODO:
- documentation