### PR TITLE
Unlink the worker before killing it

### DIFF
--- a/apps/aecore/src/aec_tx_pool_sync.erl
+++ b/apps/aecore/src/aec_tx_pool_sync.erl
@@ -379,6 +379,7 @@ do_local_action(#sync{ id = Ref }, Action, ActionFun, Timeout) ->
     Pid ! {go, SendRef}.
 
 kill_local_action(Worker, Ref, Action) ->
+    unlink(Worker),
     erlang:exit(Worker, kill),
     %% Flush any late arriving result
     receive {local_action, Ref, _, Action, _} -> ok


### PR DESCRIPTION
Quickfix... after the weekend we need to think of trap-exit is a good thing to add.

The workes should go down with the pool server that spawns them. But if other processes are linked to this pool server, then we change the bahviour if we stay alive when they go down.
