### PR TITLE
If we generate a 500-599 response, we don't want to validate it

### DIFF
--- a/apps/aehttp/src/aehttp_api_validate.erl
+++ b/apps/aehttp/src/aehttp_api_validate.erl
@@ -29,6 +29,8 @@ validator(Json) ->
     Validator :: jesse_state:state()
     ) -> ok | no_return().
 
+response(OperationId, Method0, Code, Response, Validator) when Code >= 500 andalso Code < 600 ->
+    ok;
 response(OperationId, Method0, Code, Response, Validator) ->
     Method = to_method(Method0),
     #{responses := Resps} = maps:get(Method, endpoints:operation(OperationId)),


### PR DESCRIPTION
These response codes are not specified and if we happen to generate them, then we don't need to validate them.