### PR TITLE
PT-161093359 Size gas in primops

### DIFF
--- a/apps/aechannel/src/aesc_utils.erl
+++ b/apps/aechannel/src/aesc_utils.erl
@@ -270,7 +270,7 @@ check_force_progress_(PayloadHash, PayloadRound,
               end
           end,
           fun() -> check_root_hash_of_trees(PayloadHash, OffChainTrees) end,
-          fun() -> % check produced tree has the same root hash as the poi 
+          fun() -> % check produced tree has the same root hash as the poi
               ContractPubkey = aesc_offchain_update:extract_contract_pubkey(Update),
               aeu_validation:run([
                   fun() ->
@@ -523,7 +523,7 @@ process_force_progress(Tx, OffChainTrees, TxHash, Height, Trees, Env) ->
     Accs = aec_trees:accounts(NewOffChainTrees),
     GetBalance =
         fun(Pubkey) ->
-            Acc = aec_accounts_trees:get(Pubkey, Accs), 
+            Acc = aec_accounts_trees:get(Pubkey, Accs),
             aec_accounts:balance(Acc)
         end,
 
@@ -613,8 +613,8 @@ spend(From, Amount, Nonce, Trees) ->
                           aec_trees:trees()) -> aec_trees:trees().
 consume_gas_and_fee(Update, Call, Fee, From, Nonce, Trees) ->
     {_Amount, GasPrice, _GasLimit} = aesc_offchain_update:extract_amounts(Update),
-    GasCost = aect_call:gas_used(Call) * GasPrice,
-    spend(From, GasCost + Fee, Nonce, Trees).
+    UsedAmount = aect_call:gas_used(Call) * GasPrice,
+    spend(From, UsedAmount + Fee, Nonce, Trees).
 
 set_channel(Channel, Trees) ->
     ChannelsTree0 = aec_trees:channels(Trees),

--- a/apps/aecontract/src/aect_call_tx.erl
+++ b/apps/aecontract/src/aect_call_tx.erl
@@ -120,7 +120,7 @@ origin(#contract_call_tx{} = Tx) ->
 call_id(#contract_call_tx{} = Tx) ->
     aect_call:id(caller_pubkey(Tx), nonce(Tx), contract_pubkey(Tx)).
 
-%% CallerAccount should exist, and have enough funds for the fee + gas cost
+%% CallerAccount should exist, and have enough funds for the fee + gas
 %% Contract should exist and its vm_version should match the one in the call.
 -spec check(tx(), aec_trees:trees(), aetx_env:env()) -> {ok, aec_trees:trees()} | {error, term()}.
 check(#contract_call_tx{nonce = Nonce,

--- a/apps/aecontract/src/aect_create_tx.erl
+++ b/apps/aecontract/src/aect_create_tx.erl
@@ -265,8 +265,8 @@ process(#contract_create_tx{owner_id   = OwnerId,
             %% Spend gas + fee
             %% (The VM will decide how much gas is used: 0, some, all.)
             Trees5 = aect_utils:insert_call_in_trees(CallRes, Trees0),
-            GasCost = aect_call:gas_used(CallRes) * GasPrice,
-            Trees6 = spend(OwnerPubKey, ContractPubKey, 0, Fee+GasCost, Nonce,
+            UsedAmount = aect_call:gas_used(CallRes) * GasPrice,
+            Trees6 = spend(OwnerPubKey, ContractPubKey, 0, Fee + UsedAmount, Nonce,
                            Trees5, Env),
             {ok, Trees6}
     end.

--- a/apps/aecontract/test/aecontract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_SUITE.erl
@@ -2158,7 +2158,7 @@ sophia_oracles_gas_ttl__measure_gas_used(Sc, Height, Gas) ->
 %% Test that gas charged by oracle primop depends on TTL of state object.
 %% Test approach: run primop with low and high TTLs, then compare consumed gas. This proves that TTL-related gas computation kicks in without relying on absolute minimum value of gas used.
 sophia_oracles_gas_ttl__oracle_registration(_Cfg) ->
-    {Part, Whole} = aec_governance:state_gas_cost_per_block(oracle_registration),
+    {Part, Whole} = aec_governance:state_gas_per_block(oracle_registration),
     ?assertMatch(X when X > 0, Whole), %% Hardcoded expectation on governance - for test readability.
     ?assertMatch(X when X > 0, Part), %% Hardcoded expectation on governance - for test readability.
     MM = fun(H, Ttl, Gas) ->
@@ -2196,7 +2196,7 @@ sophia_oracles_gas_ttl__oracle_registration(_Cfg) ->
     ok.
 
 sophia_oracles_gas_ttl__oracle_extension(_Cfg) ->
-    {Part, Whole} = aec_governance:state_gas_cost_per_block(oracle_extension),
+    {Part, Whole} = aec_governance:state_gas_per_block(oracle_extension),
     ?assertMatch(X when X > 0, Whole), %% Hardcoded expectation on governance - for test readability.
     ?assertMatch(X when X > 0, Part), %% Hardcoded expectation on governance - for test readability.
     MM = fun(H, Ttl, Gas) ->
@@ -2228,7 +2228,7 @@ sophia_oracles_gas_ttl__oracle_extension(_Cfg) ->
     ok.
 
 sophia_oracles_gas_ttl__query(_Cfg) ->
-    {Part, Whole} = aec_governance:state_gas_cost_per_block(oracle_query),
+    {Part, Whole} = aec_governance:state_gas_per_block(oracle_query),
     ?assertMatch(X when X > 0, Whole), %% Hardcoded expectation on governance - for test readability.
     ?assertMatch(X when X > 0, Part), %% Hardcoded expectation on governance - for test readability.
     MM = fun(H, Ttl, Gas) ->
@@ -2266,7 +2266,7 @@ sophia_oracles_gas_ttl__query(_Cfg) ->
     ok.
 
 sophia_oracles_gas_ttl__response(_Cfg) ->
-    {Part, Whole} = aec_governance:state_gas_cost_per_block(oracle_response),
+    {Part, Whole} = aec_governance:state_gas_per_block(oracle_response),
     ?assertMatch(X when X > 0, Whole), %% Hardcoded expectation on governance - for test readability.
     ?assertMatch(X when X > 0, Part), %% Hardcoded expectation on governance - for test readability.
     MM = fun(H, Ttl, Gas) ->

--- a/apps/aecontract/test/aecontract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_SUITE.erl
@@ -2176,9 +2176,13 @@ sophia_oracles_gas_ttl__oracle_registration(_Cfg) ->
     %% Smoke test.
     ?assertMatch({{}, _}, Rel(H, 1)),
     G = fun({{}=_Result, GasUsed}) -> GasUsed end,
-    %% TTL increases gas used.
-    ?assertEqual(Part + G(Rel(H, 1        )), G(Rel(H, 1 +   Whole))),
-    ?assertEqual(Part + G(Rel(H, 1 + Whole)), G(Rel(H, 1 + 2*Whole))),
+    %% This test uses 2 different TTLs that have the same number of digits.
+    %% Since there is a primop in the contract call and the primop includes
+    %% the TTL, the serialized tx representing the primop has the same size
+    %% for TTLs with the same number of digits. Different numbers of digits
+    %% would not work as there would be different size gas for the primop.
+    ?assertEqual(Part + G(Rel(H, 1 +   Whole)), G(Rel(H, 1 + 2*Whole))),
+    ?assertEqual(Part + G(Rel(H, 1 + 2*Whole)), G(Rel(H, 1 + 3*Whole))),
     %% Gas used for absolute TTL is same(ish) as relative.
     Abs = fun(He, Ttl) -> M(He, ?CHAIN_ABSOLUTE_TTL_MEMORY_ENCODING(Ttl)) end,
     RelGas = G(Rel(H, 1 + Whole)),
@@ -2215,8 +2219,8 @@ sophia_oracles_gas_ttl__oracle_extension(_Cfg) ->
     ?assertMatch({{}, _}, Rel(H, 1)),
     G = fun({{}=_Result, GasUsed}) -> GasUsed end,
     %% TTL increases gas used.
-    ?assertEqual(Part + G(Rel(H, 1        )), G(Rel(H, 1 +   Whole))),
-    ?assertEqual(Part + G(Rel(H, 1 + Whole)), G(Rel(H, 1 + 2*Whole))),
+    ?assertEqual(Part + G(Rel(H, 1 +   Whole)), G(Rel(H, 1 + 2*Whole))),
+    ?assertEqual(Part + G(Rel(H, 1 + 2*Whole)), G(Rel(H, 1 + 3*Whole))),
     %% Enough gas for base cost though not enough for all TTL causes out-of-gas.
     ?assertMatch(
        {{error, <<"out_of_gas">>}, _},
@@ -2247,8 +2251,8 @@ sophia_oracles_gas_ttl__query(_Cfg) ->
     ?assertMatch({{}, _}, Rel(H, 1)),
     G = fun({{}=_Result, GasUsed}) -> GasUsed end,
     %% TTL increases gas used.
-    ?assertEqual(Part + G(Rel(H, 1        )), G(Rel(H, 1 +   Whole))),
-    ?assertEqual(Part + G(Rel(H, 1 + Whole)), G(Rel(H, 1 + 2*Whole))),
+    ?assertEqual(Part + G(Rel(H, 1 +   Whole)), G(Rel(H, 1 + 2*Whole))),
+    ?assertEqual(Part + G(Rel(H, 1 + 2*Whole)), G(Rel(H, 1 + 3*Whole))),
     %% Gas used for absolute TTL is same(ish) as relative.
     Abs = fun(He, Ttl) -> M(He, ?CHAIN_ABSOLUTE_TTL_MEMORY_ENCODING(Ttl)) end,
     RelGas = G(Rel(H, 1 + Whole)),
@@ -2285,8 +2289,8 @@ sophia_oracles_gas_ttl__response(_Cfg) ->
     ?assertMatch({{}, _}, Rel(H, 1)),
     G = fun({{}=_Result, GasUsed}) -> GasUsed end,
     %% TTL increases gas used.
-    ?assertEqual(Part + G(Rel(H, 1        )), G(Rel(H, 1 +   Whole))),
-    ?assertEqual(Part + G(Rel(H, 1 + Whole)), G(Rel(H, 1 + 2*Whole))),
+    ?assertEqual(Part + G(Rel(H, 1 +   Whole)), G(Rel(H, 1 + 2*Whole))),
+    ?assertEqual(Part + G(Rel(H, 1 + 2*Whole)), G(Rel(H, 1 + 3*Whole))),
     %% Enough gas for base cost though not enough for all TTL causes out-of-gas.
     ?assertMatch(
        {{error, <<"out_of_gas">>}, _},

--- a/apps/aecore/src/aec_governance.erl
+++ b/apps/aecore/src/aec_governance.erl
@@ -22,8 +22,8 @@
          micro_block_cycle/0,
          accepted_future_block_time_shift/0,
          fraud_report_reward/0,
-         state_gas_cost_per_block/1,
-         primop_base_gas_cost/1,
+         state_gas_per_block/1,
+         primop_base_gas/1,
          add_network_id/1,
          get_network_id/0]).
 
@@ -56,7 +56,7 @@
 
 -define(ACCEPTED_FUTURE_BLOCK_TIME_SHIFT, (?EXPECTED_BLOCK_MINE_RATE_MINUTES * 3 * 60 * 1000)). %% 9 min
 
--define(ORACLE_STATE_GAS_COST_PER_YEAR, 32000). %% 32000 as `?GCREATE` in `aevm_gas.hrl` i.e. an oracle-related state object costs per year as much as it costs to indefinitely create an account.
+-define(ORACLE_STATE_GAS_PER_YEAR, 32000). %% 32000 as `?GCREATE` in `aevm_gas.hrl` i.e. an oracle-related state object costs per year as much as it costs to indefinitely create an account.
 
 %% Maps consensus protocol version to minimum height at which such
 %% version is effective.  The height must be strictly increasing with
@@ -116,10 +116,10 @@ tx_base_gas(oracle_extend_tx) -> ?TX_BASE_GAS;
 tx_base_gas(oracle_query_tx) -> ?TX_BASE_GAS;
 tx_base_gas(oracle_register_tx) -> ?TX_BASE_GAS;
 tx_base_gas(oracle_response_tx) -> ?TX_BASE_GAS;
-tx_base_gas(_) -> 
+tx_base_gas(_) ->
     %% never accept unknown transaction types
     block_gas_limit().
- 
+
 byte_gas() ->
     ?BYTE_GAS.
 
@@ -148,41 +148,41 @@ micro_block_cycle() ->
 accepted_future_block_time_shift() ->
     ?ACCEPTED_FUTURE_BLOCK_TIME_SHIFT.
 
-%% Reoccurring gas cost, meant to be paid up front.
+%% Reoccurring gas, meant to be paid up front.
 %%
 %% Expressed as a fraction because otherwise it would become too large
 %% when multiplied by the number of key blocks.
--spec state_gas_cost_per_block(atom()) -> {Part::pos_integer(), Whole::pos_integer()}.
-state_gas_cost_per_block(oracle_registration) -> {?ORACLE_STATE_GAS_COST_PER_YEAR, ?EXPECTED_BLOCKS_IN_A_YEAR_FLOOR};
-state_gas_cost_per_block(oracle_extension)    -> state_gas_cost_per_block(oracle_registration);
-state_gas_cost_per_block(oracle_query)        -> state_gas_cost_per_block(oracle_registration);
-state_gas_cost_per_block(oracle_response)     -> state_gas_cost_per_block(oracle_registration).
+-spec state_gas_per_block(atom()) -> {Part::pos_integer(), Whole::pos_integer()}.
+state_gas_per_block(oracle_registration) -> {?ORACLE_STATE_GAS_PER_YEAR, ?EXPECTED_BLOCKS_IN_A_YEAR_FLOOR};
+state_gas_per_block(oracle_extension)    -> state_gas_per_block(oracle_registration);
+state_gas_per_block(oracle_query)        -> state_gas_per_block(oracle_registration);
+state_gas_per_block(oracle_response)     -> state_gas_per_block(oracle_registration).
 
 %% As primops are not meant to be called from contract call
 %% transactions, calling a primop costs (apart from the fees for the
 %% calling contract create transaction or contract call transaction)
-%% at least the gas cost of the call instruction (e.g. `CALL`) used
+%% at least the gas of the call instruction (e.g. `CALL`) used
 %% for calling the primop.
-primop_base_gas_cost(?PRIM_CALL_SPEND              ) -> 0;
-primop_base_gas_cost(?PRIM_CALL_ORACLE_REGISTER    ) -> 0;
-primop_base_gas_cost(?PRIM_CALL_ORACLE_QUERY       ) -> 0;
-primop_base_gas_cost(?PRIM_CALL_ORACLE_RESPOND     ) -> 0;
-primop_base_gas_cost(?PRIM_CALL_ORACLE_EXTEND      ) -> 0;
-primop_base_gas_cost(?PRIM_CALL_ORACLE_GET_ANSWER  ) -> 0;
-primop_base_gas_cost(?PRIM_CALL_ORACLE_GET_QUESTION) -> 0;
-primop_base_gas_cost(?PRIM_CALL_ORACLE_QUERY_FEE   ) -> 0;
-primop_base_gas_cost(?PRIM_CALL_AENS_RESOLVE       ) -> 0;
-primop_base_gas_cost(?PRIM_CALL_AENS_PRECLAIM      ) -> 0;
-primop_base_gas_cost(?PRIM_CALL_AENS_CLAIM         ) -> 0;
-primop_base_gas_cost(?PRIM_CALL_AENS_UPDATE        ) -> 0;
-primop_base_gas_cost(?PRIM_CALL_AENS_TRANSFER      ) -> 0;
-primop_base_gas_cost(?PRIM_CALL_AENS_REVOKE        ) -> 0;
-primop_base_gas_cost(?PRIM_CALL_MAP_EMPTY          ) -> 0;
-primop_base_gas_cost(?PRIM_CALL_MAP_GET            ) -> 0;
-primop_base_gas_cost(?PRIM_CALL_MAP_PUT            ) -> 0;
-primop_base_gas_cost(?PRIM_CALL_MAP_DELETE         ) -> 0;
-primop_base_gas_cost(?PRIM_CALL_MAP_SIZE           ) -> 0;
-primop_base_gas_cost(?PRIM_CALL_MAP_TOLIST         ) -> 0.
+primop_base_gas(?PRIM_CALL_SPEND              ) -> 0;
+primop_base_gas(?PRIM_CALL_ORACLE_REGISTER    ) -> 0;
+primop_base_gas(?PRIM_CALL_ORACLE_QUERY       ) -> 0;
+primop_base_gas(?PRIM_CALL_ORACLE_RESPOND     ) -> 0;
+primop_base_gas(?PRIM_CALL_ORACLE_EXTEND      ) -> 0;
+primop_base_gas(?PRIM_CALL_ORACLE_GET_ANSWER  ) -> 0;
+primop_base_gas(?PRIM_CALL_ORACLE_GET_QUESTION) -> 0;
+primop_base_gas(?PRIM_CALL_ORACLE_QUERY_FEE   ) -> 0;
+primop_base_gas(?PRIM_CALL_AENS_RESOLVE       ) -> 0;
+primop_base_gas(?PRIM_CALL_AENS_PRECLAIM      ) -> 0;
+primop_base_gas(?PRIM_CALL_AENS_CLAIM         ) -> 0;
+primop_base_gas(?PRIM_CALL_AENS_UPDATE        ) -> 0;
+primop_base_gas(?PRIM_CALL_AENS_TRANSFER      ) -> 0;
+primop_base_gas(?PRIM_CALL_AENS_REVOKE        ) -> 0;
+primop_base_gas(?PRIM_CALL_MAP_EMPTY          ) -> 0;
+primop_base_gas(?PRIM_CALL_MAP_GET            ) -> 0;
+primop_base_gas(?PRIM_CALL_MAP_PUT            ) -> 0;
+primop_base_gas(?PRIM_CALL_MAP_DELETE         ) -> 0;
+primop_base_gas(?PRIM_CALL_MAP_SIZE           ) -> 0;
+primop_base_gas(?PRIM_CALL_MAP_TOLIST         ) -> 0.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Naming system variables

--- a/apps/aecore/src/aec_governance_utils.erl
+++ b/apps/aecore/src/aec_governance_utils.erl
@@ -1,9 +1,9 @@
 -module(aec_governance_utils).
 
 %% API
--export([state_gas_cost/2]).
+-export([state_gas/2]).
 
-state_gas_cost(_CostPerKeyBlock = {Part, Whole}, NKeyBlocks)
+state_gas(_GasPerKeyBlock = {Part, Whole}, NKeyBlocks)
   when is_integer(Whole), Whole > 0,
        is_integer(Part), Part >= 0,
        is_integer(NKeyBlocks), NKeyBlocks >= 0 ->

--- a/apps/aecore/src/aec_spend_tx.erl
+++ b/apps/aecore/src/aec_spend_tx.erl
@@ -15,6 +15,7 @@
          sender_id/1,
          sender_pubkey/1,
          recipient_id/1,
+         amount/1,
          check/3,
          process/3,
          signers/2,
@@ -119,6 +120,10 @@ sender_pubkey(#spend_tx{sender_id = SenderId}) ->
 -spec recipient_id(tx()) -> aec_id:id().
 recipient_id(#spend_tx{recipient_id = RecipientId}) ->
     RecipientId.
+
+-spec amount(tx()) -> non_neg_integer().
+amount(#spend_tx{amount = Amount}) ->
+    Amount.
 
 resolve_recipient_pubkey(Tx, Trees) ->
     case resolve_recipient(Tx, Trees) of

--- a/apps/aehttp/test/aehttp_contracts_SUITE.erl
+++ b/apps/aehttp/test/aehttp_contracts_SUITE.erl
@@ -266,8 +266,8 @@ simple_storage_contract(Config) ->
                  priv_key := BPriv}} = proplists:get_value(accounts, Config),
 
     %% Make sure accounts have enough tokens.
-    _ABal0 = ensure_balance(APub, 100000),
-    _BBal0 = ensure_balance(BPub, 100000),
+    _ABal0 = ensure_balance(APub, 200000),
+    _BBal0 = ensure_balance(BPub, 200000),
     {ok,[_]} = aecore_suite_utils:mine_key_blocks(Node, 1),
 
     %% Compile test contract "simple_storage.aes"
@@ -1264,7 +1264,7 @@ contract_create_compute_tx(Pubkey, Privkey, Code, InitArgument, CallerSet) ->
                               vm_version => 1,  %?AEVM_01_Sophia_01
                               deposit => 2,
                               amount => 0,      %Initial balance
-                              gas => 20000,     %May need a lot of gas
+                              gas => 100000,     %May need a lot of gas
                               gas_price => 1,
                               fee => 1,
                               nonce => Nonce,
@@ -1289,7 +1289,7 @@ contract_call_compute_tx(Pubkey, Privkey, Nonce, EncodedContractPubkey,
                               contract_id => EncodedContractPubkey,
                               vm_version => 1,  %?AEVM_01_Sophia_01
                               amount => 0,
-                              gas => 50000,     %May need a lot of gas
+                              gas => 100000,     %May need a lot of gas
                               gas_price => 1,
                               fee => 1,
                               nonce => Nonce,

--- a/apps/aens/src/aens_revoke_tx.erl
+++ b/apps/aens/src/aens_revoke_tx.erl
@@ -26,6 +26,10 @@
          for_client/1
         ]).
 
+-export([account_id/1,
+         name_id/1
+        ]).
+
 %%%===================================================================
 %%% Types
 %%%===================================================================
@@ -82,6 +86,14 @@ ttl(#ns_revoke_tx{ttl = TTL}) ->
 -spec nonce(tx()) -> non_neg_integer().
 nonce(#ns_revoke_tx{nonce = Nonce}) ->
     Nonce.
+
+-spec account_id(tx()) -> aec_id:id().
+account_id(#ns_revoke_tx{account_id = AccountId}) ->
+    AccountId.
+
+-spec name_id(tx()) -> aec_id:id().
+name_id(#ns_revoke_tx{name_id = NameId}) ->
+    NameId.
 
 -spec origin(tx()) -> aec_keys:pubkey().
 origin(#ns_revoke_tx{} = Tx) ->

--- a/apps/aens/src/aens_transfer_tx.erl
+++ b/apps/aens/src/aens_transfer_tx.erl
@@ -27,6 +27,10 @@
          for_client/1
         ]).
 
+-export([account_id/1,
+         name_id/1
+        ]).
+
 %% Getters
 -ifdef(TEST).
 -export([recipient_pubkey/1]).
@@ -215,6 +219,14 @@ for_client(#ns_transfer_tx{account_id   = AccountId,
 recipient_pubkey(#ns_transfer_tx{recipient_id = RecipientId}) ->
     aec_id:specialize(RecipientId, account).
 -endif.
+
+-spec account_id(tx()) -> aec_id:id().
+account_id(#ns_transfer_tx{account_id = AccountId}) ->
+    AccountId.
+
+-spec name_id(tx()) -> aec_id:id().
+name_id(#ns_transfer_tx{name_id = NameId}) ->
+    NameId.
 
 %%%===================================================================
 %%% Internal functions

--- a/apps/aeoracle/src/aeo_oracles.erl
+++ b/apps/aeoracle/src/aeo_oracles.erl
@@ -38,10 +38,10 @@
 -type fixed_ttl()    :: {block, aec_blocks:height()}.
 -type ttl()          :: relative_ttl() | fixed_ttl().
 
--type type_format()  :: binary(). %% Utf8 encoded string
+-type type_format()  :: term().  %% TODO: Fix format types.
 
 -type query()    :: binary().             %% Don't use native types for queries
--type response() :: binary(). %% Don't use native types for responses
+-type response() :: term().      %% TODO: Fix response type.
 
 -record(oracle, { id              :: aec_id:id()
                 , query_format    :: type_format()

--- a/apps/aeoracle/src/aeo_register_tx.erl
+++ b/apps/aeoracle/src/aeo_register_tx.erl
@@ -179,11 +179,12 @@ serialize(#oracle_register_tx{account_id      = AccountId,
                   ?ttl_delta_atom -> ?ttl_delta_int;
                   ?ttl_block_atom -> ?ttl_block_int
               end,
+
     {version(),
     [ {account_id, AccountId}
     , {nonce, Nonce}
-    , {query_format, QueryFormat}
-    , {response_format, ResponseFormat}
+    , {query_format, format_to_binary(QueryFormat)}
+    , {response_format, format_to_binary(ResponseFormat)}
     , {query_fee, QueryFee}
     , {ttl_type, TTLType}
     , {ttl_value, TTLValue}
@@ -257,3 +258,9 @@ ensure_not_oracle(PubKey, Trees) ->
         {value, _Oracle} -> {error, account_is_already_an_oracle};
         none             -> ok
     end.
+
+format_to_binary(Format) when is_atom(Format) ->
+    atom_to_binary(Format, utf8);
+format_to_binary(Format) ->
+    Format.
+

--- a/apps/aeoracle/src/aeo_response_tx.erl
+++ b/apps/aeoracle/src/aeo_response_tx.erl
@@ -184,7 +184,7 @@ serialize(#oracle_response_tx{oracle_id    = OracleId,
     [ {oracle_id, OracleId}
     , {nonce, Nonce}
     , {query_id, QueryId}
-    , {response, Response}
+    , {response, response_to_binary(Response)}
     , {response_ttl_type, ?ttl_delta_int}
     , {response_ttl_value, ResponseTTLValue}
     , {fee, Fee}
@@ -265,3 +265,11 @@ check_oracle(OraclePubKey, Trees) ->
         {value, _Oracle} -> ok;
         none -> {error, oracle_does_not_exist}
     end.
+
+response_to_binary(Response) when is_atom(Response) ->
+    atom_to_binary(Response, utf8);
+response_to_binary(Response) when is_integer(Response) ->
+    list_to_binary(integer_to_list(Response));
+response_to_binary(Response) ->
+    Response.
+

--- a/apps/aetx/src/aetx.erl
+++ b/apps/aetx/src/aetx.erl
@@ -15,6 +15,7 @@
         , gas/1
         , gas_price/1
         , ttl/1
+        , size/1
         , new/2
         , nonce/1
         , origin/1
@@ -205,6 +206,10 @@ ttl(#aetx{ cb = CB, tx = Tx }) ->
         0 -> max_ttl;
         N -> N
     end.
+
+-spec size(Tx :: tx()) -> pos_integer().
+size(#aetx{ size = Size }) ->
+    Size.
 
 %%%===================================================================
 %%% Checking transactions

--- a/apps/aevm/src/aevm_ae_primops.erl
+++ b/apps/aevm/src/aevm_ae_primops.erl
@@ -8,7 +8,7 @@
 %%%-------------------------------------------------------------------
 
 -module(aevm_ae_primops).
--export([call/3, is_local_primop/1]).
+-export([call/4, is_local_primop/1]).
 
 -include_lib("aebytecode/include/aeb_opcodes.hrl").
 -include("aevm_ae_primops.hrl").
@@ -26,7 +26,7 @@
 -define(TEST_LOG(Format, Data), ok).
 -endif.
 
--spec call(Value::non_neg_integer(), Data::binary(), StateIn) ->
+-spec call(Gas::non_neg_integer(), Value::non_neg_integer(), Data::binary(), StateIn) ->
                   {ok, ReturnValue, GasSpent::non_neg_integer(), StateOut} |
                   {error, Reason} when
       StateIn :: State,
@@ -38,18 +38,17 @@
       OogResource :: any(),
       OogGas :: pos_integer().
 %% Wrapper function for logging error in tests.
-call(Value, Data, State) ->
-    case call_(Value, Data, State) of
+call(Gas, Value, Data, State) ->
+    case call_(Gas, Value, Data, State) of
         {ok, _, _, _} = Ok ->
             Ok;
         {error, _} = Err ->
-            ?TEST_LOG("Primop call error ~p~n~p:~p(~p, ~p, State)",
-                      [Err, ?MODULE, ?FUNCTION_NAME, Value, Data]),
+            ?TEST_LOG("Primop call error ~p~n~p:~p(~p, ~p, ~p, State)",
+                      [Err, ?MODULE, ?FUNCTION_NAME, Gas, Value, Data]),
             Err
     end.
 
-call_(Value, Data, StateIn) ->
-    Gas = aevm_eeevm_state:gas(StateIn),
+call_(Gas, Value, Data, StateIn) ->
     try
         PrimOp = get_primop(Data),
         BaseGas = aec_governance:primop_base_gas(PrimOp),

--- a/apps/aevm/src/aevm_ae_primops.erl
+++ b/apps/aevm/src/aevm_ae_primops.erl
@@ -113,13 +113,14 @@ is_local_primop(Data) ->
 %% Basic account operations.
 %% ------------------------------------------------------------------
 
-spend_call(Value, Data, State) ->
+spend_call(Value, Data, #chain{api = API, state = State} = Chain) ->
     [Recipient] = get_args([word], Data),
     %% TODO: This assumes that we are spending to an account
     RecipientId = aec_id:create(account, <<Recipient:256>>),
-    Callback = fun(API, ChainState) ->
-                       API:spend(RecipientId, Value, ChainState) end,
-    no_dynamic_gas(fun() -> cast_chain(Callback, State) end).
+    {ok, Tx} = API:spend_tx(RecipientId, Value, State),
+    Callback = fun(ChainAPI, ChainState) ->
+                       ChainAPI:spend(Tx, ChainState) end,
+    no_dynamic_gas(fun() -> cast_chain(Callback, Chain) end).
 
 %% ------------------------------------------------------------------
 %% Oracle operations.
@@ -176,87 +177,99 @@ oracle_ttl_t() ->
 sign_t() ->
     {tuple, [word, word]}.
 
-oracle_call_register(_Value, Data, State) ->
+oracle_call_register(_Value, Data, #chain{api = API, state = State} = Chain) ->
     ArgumentTypes = [word, sign_t(), word, oracle_ttl_t(), typerep, typerep],
-    [Acct, Sign0, QFee, TTL, QType, RType] = get_args(ArgumentTypes, Data),
-    case chain_ttl_delta(TTL, State) of
+    [Acct, Sign0, QFee, TTL, QFormat, RFormat] = get_args(ArgumentTypes, Data),
+    %% The aeo_register_tx expects the formats to be binary, althought, atoms are provided.
+    %% This should be solved in a different ticket.
+    case chain_ttl_delta(TTL, Chain) of
         {error, _} = Err -> Err;
         {ok, DeltaTTL = {delta, _}} ->
+            {ok, Tx} = API:oracle_register_tx(<<Acct:256>>, QFee, TTL, QFormat, RFormat, State),
             Callback =
-                fun(API, ChainState) ->
-                    case API:oracle_register(<<Acct:256>>, to_sign(Sign0), QFee, TTL, QType, RType, ChainState) of
+                fun(ChainAPI, ChainState) ->
+                    case ChainAPI:oracle_register(Tx, to_sign(Sign0), ChainState) of
                         {ok, <<OKey:256>>, ChainState1} -> {ok, OKey, ChainState1};
                         {error, _} = Err                -> Err
                     end
                 end,
-            DynGas = state_gas(oracle_registration, DeltaTTL),
-            ?TEST_LOG("~s computed gas cost ~p from relative TTL ~p", [?FUNCTION_NAME, DynGas, DeltaTTL]),
-            {ok, DynGas, fun() -> call_chain(Callback, State) end}
+            SizeGas = size_gas(Tx),
+            StateGas = state_gas(oracle_registration, DeltaTTL),
+            DynGas = SizeGas + StateGas,
+            ?TEST_LOG("~s computed gas ~p - size gas: ~p, state gas: ~p (relative TTL: ~p)",
+                        [?FUNCTION_NAME, DynGas, SizeGas, StateGas, DeltaTTL]),
+            {ok, DynGas, fun() -> call_chain(Callback, Chain) end}
     end.
 
-oracle_call_query(Value, Data, State) ->
+oracle_call_query(Value, Data, #chain{api = API, state = State} = Chain) ->
     [Oracle]  = get_args([word], Data),  %% We need the oracle address before we can decode the query
-    OracleKey = <<Oracle:256>>,
-    case call_chain1(fun(API, ChainState) -> API:oracle_query_format(OracleKey, ChainState) end, State) of
-        {ok, QueryType} ->
-            ArgumentTypes = [word, QueryType, oracle_ttl_t(), oracle_ttl_t()],
-            [_Oracle, Q, QTTL, RTTL] = get_args(ArgumentTypes, Data),
-            case chain_ttl_delta(QTTL, State) of
+    case API:oracle_query_format(<<Oracle:256>>, State) of
+        {ok, QFormat} ->
+            ArgumentTypes = [word, QFormat, oracle_ttl_t(), oracle_ttl_t()],
+            [Oracle, Q, QTTL, RTTL] = get_args(ArgumentTypes, Data),
+            case chain_ttl_delta(QTTL, Chain) of
                 {error, _} = Err -> Err;
                 {ok, DeltaQTTL = {delta, _}} ->
+                    {ok, Tx} = API:oracle_query_tx(<<Oracle:256>>, Q, _QFee=Value, QTTL, RTTL, State),
                     Callback =
-                        fun(API, ChainState) ->
-                            case API:oracle_query(OracleKey, Q, _QFee=Value, QTTL, RTTL, ChainState) of
+                        fun(ChainAPI, ChainState) ->
+                            case ChainAPI:oracle_query(Tx, ChainState) of
                                 {ok, <<QKey:256>>, ChainState1} -> {ok, QKey, ChainState1};
                                 {error, _} = Err                -> Err
                             end
                         end,
-                    DynGas = state_gas(oracle_query, DeltaQTTL),
-                    ?TEST_LOG("~s computed gas cost ~p from relative TTL ~p", [?FUNCTION_NAME, DynGas, DeltaQTTL]),
-                    {ok, DynGas, fun() -> call_chain(Callback, State) end}
+                    SizeGas = size_gas(Tx),
+                    StateGas = state_gas(oracle_query, DeltaQTTL),
+                    DynGas = SizeGas + StateGas,
+                    ?TEST_LOG("~s computed gas ~p - size gas: ~p, state gas: ~p (relative TTL: ~p)",
+                                [?FUNCTION_NAME, DynGas, SizeGas, StateGas, DeltaQTTL]),
+                    {ok, DynGas, fun() -> call_chain(Callback, Chain) end}
             end;
         {error, _} = Err -> Err
     end.
 
-oracle_call_respond(_Value, Data, State) ->
-    [Oracle, Query] = get_args([word, word], Data),
+oracle_call_respond(_Value, Data, #chain{api = API, state = State} = Chain) ->
+    [Oracle, QueryId] = get_args([word, word], Data),
     OracleKey = <<Oracle:256>>,
-    QueryKey = <<Query:256>>,
-    case call_chain1(fun(API, ChainState) -> API:oracle_query_response_ttl(OracleKey, QueryKey, ChainState) end, State) of
+    QueryKey = <<QueryId:256>>,
+    case API:oracle_query_response_ttl(OracleKey, QueryKey, State) of
         {error, _} = Err -> Err;
         {ok, RTTL} ->
-            case chain_ttl_delta(RTTL, State) of
+            case chain_ttl_delta(RTTL, Chain) of
                 {error, _} = Err -> Err;
                 {ok, DeltaRTTL = {delta, _}} ->
-                    Callback2 =
-                        fun() ->
-                            case call_chain1(fun(API, ChainState) ->
-                                API:oracle_response_format(OracleKey, ChainState) end, State) of
-                                {ok, RType} ->
-                                    ArgumentTypes = [word, word, sign_t(), RType],
-                                    [_, _, Sign0, R] = get_args(ArgumentTypes, Data),
-                                    Callback = fun(API, ChainState) ->
-                                        API:oracle_respond(OracleKey, QueryKey, to_sign(Sign0), R, DeltaRTTL, ChainState) end,
-                                    cast_chain(Callback, State);
-                                {error, _} = Err -> Err
-                            end
-                        end,
-                    DynGas = state_gas(oracle_response, DeltaRTTL),
-                    ?TEST_LOG("~s computed gas cost ~p from relative TTL ~p", [?FUNCTION_NAME, DynGas, DeltaRTTL]),
-                    {ok, DynGas, Callback2}
+                    case API:oracle_response_format(OracleKey, State) of
+                        {error, _} = Err -> Err;
+                        {ok, RFormat} ->
+                            ArgumentTypes = [word, word, sign_t(), RFormat],
+                            [_, _, Sign0, R] = get_args(ArgumentTypes, Data),
+                            {ok, Tx} = API:oracle_respond_tx(OracleKey, QueryKey, R, DeltaRTTL, State),
+                            SizeGas = size_gas(Tx),
+                            StateGas = state_gas(oracle_response, DeltaRTTL),
+                            DynGas = SizeGas + StateGas,
+                            ?TEST_LOG("~s computed gas ~p - size gas: ~p, state gas: ~p (relative TTL: ~p)",
+                                      [?FUNCTION_NAME, DynGas, SizeGas, StateGas, DeltaRTTL]),
+                            Callback = fun(ChainAPI, ChainState) ->
+                                ChainAPI:oracle_respond(Tx, to_sign(Sign0), ChainState) end,
+                            {ok, DynGas, fun() -> cast_chain(Callback, Chain) end}
+                    end
             end
     end.
 
-oracle_call_extend(_Value, Data, State) ->
+oracle_call_extend(_Value, Data, #chain{api = API, state = State} = Chain) ->
     ArgumentTypes = [word, sign_t(), oracle_ttl_t()],
     [Oracle, Sign0, TTL] = get_args(ArgumentTypes, Data),
-    case chain_ttl_delta(TTL, State) of
+    case chain_ttl_delta(TTL, Chain) of
         {error, _} = Err -> Err;
         {ok, DeltaTTL = {delta, _}} ->
-            Callback = fun(API, ChainState) -> API:oracle_extend(<<Oracle:256>>, to_sign(Sign0), TTL, ChainState) end,
-            DynGas = state_gas(oracle_extension, DeltaTTL),
-            ?TEST_LOG("~s computed gas cost ~p from relative TTL ~p", [?FUNCTION_NAME, DynGas, DeltaTTL]),
-            {ok, DynGas, fun() -> cast_chain(Callback, State) end}
+            {ok, Tx} = API:oracle_extend_tx(<<Oracle:256>>, TTL, State),
+            Callback = fun(ChainAPI, ChainState) ->
+                               ChainAPI:oracle_extend(Tx, to_sign(Sign0), ChainState)
+                       end,
+            StateGas = state_gas(oracle_extension, DeltaTTL),
+            ?TEST_LOG("~s computed gas ~p - state gas: ~p (relative TTL: ~p)",
+                        [?FUNCTION_NAME, StateGas, StateGas, DeltaTTL]),
+            {ok, StateGas, fun() -> cast_chain(Callback, Chain) end}
     end.
 
 
@@ -297,30 +310,36 @@ aens_call(?PRIM_CALL_AENS_REVOKE, _Value, Data, State) ->
 aens_call(PrimOp, _, _, _) ->
     {error, {illegal_aens_primop_call, PrimOp}}.
 
-aens_call_resolve(Data, State) ->
+aens_call_resolve(Data, Chain) ->
     [Name, Key, Type] = get_args([string, string, typerep], Data),
-    Callback = fun(API, ChainState) -> API:aens_resolve(Name, Key, Type, ChainState) end,
-    no_dynamic_gas(fun() -> query_chain(Callback, State) end).
+    Callback = fun(ChainAPI, ChainState) -> ChainAPI:aens_resolve(Name, Key, Type, ChainState) end,
+    no_dynamic_gas(fun() -> query_chain(Callback, Chain) end).
 
-aens_call_preclaim(Data, State) ->
+aens_call_preclaim(Data, #chain{api = API, state = State} = Chain) ->
     [Addr, CHash, Sign0] = get_args([word, word, sign_t()], Data),
-    Callback = fun(API, ChainState) -> API:aens_preclaim(<<Addr:256>>, <<CHash:256>>, to_sign(Sign0), ChainState) end,
-    no_dynamic_gas(fun() -> cast_chain(Callback, State) end).
+    {ok, Tx} = API:aens_preclaim_tx(<<Addr:256>>, <<CHash:256>>, State),
+    SizeGas = size_gas(Tx),
+    Callback = fun(ChainAPI, ChainState) -> ChainAPI:aens_preclaim(Tx, to_sign(Sign0), ChainState) end,
+    {ok, SizeGas, fun() -> cast_chain(Callback, Chain) end}.
 
-aens_call_claim(Data, State) ->
+aens_call_claim(Data, #chain{api = API, state = State} = Chain) ->
     [Addr, Name, Salt, Sign0] = get_args([word, string, word, sign_t()], Data),
-    Callback = fun(API, ChainState) -> API:aens_claim(<<Addr:256>>, Name, Salt, to_sign(Sign0), ChainState) end,
-    no_dynamic_gas(fun() -> cast_chain(Callback, State) end).
+    {ok, Tx} = API:aens_claim_tx(<<Addr:256>>, Name, Salt, State),
+    SizeGas = size_gas(Tx),
+    Callback = fun(ChainAPI, ChainState) -> ChainAPI:aens_claim(Tx, to_sign(Sign0), ChainState) end,
+    {ok, SizeGas, fun() -> cast_chain(Callback, Chain) end}.
 
-aens_call_transfer(Data, State) ->
+aens_call_transfer(Data, #chain{api = API, state = State} = Chain) ->
     [From, To, Hash, Sign0] = get_args([word, word, word, sign_t()], Data),
-    Callback = fun(API, ChainState) -> API:aens_transfer(<<From:256>>, <<To:256>>, <<Hash:256>>, to_sign(Sign0), ChainState) end,
-    no_dynamic_gas(fun() -> cast_chain(Callback, State) end).
+    {ok, Tx} = API:aens_transfer_tx(<<From:256>>, <<To:256>>, <<Hash:256>>, State),
+    Callback = fun(ChainAPI, ChainState) -> ChainAPI:aens_transfer(Tx, to_sign(Sign0), ChainState) end,
+    no_dynamic_gas(fun() -> cast_chain(Callback, Chain) end).
 
-aens_call_revoke(Data, State) ->
+aens_call_revoke(Data, #chain{api = API, state = State} = Chain) ->
     [Addr, Hash, Sign0] = get_args([word, word, sign_t()], Data),
-    Callback = fun(API, ChainState) -> API:aens_revoke(<<Addr:256>>, <<Hash:256>>, to_sign(Sign0), ChainState) end,
-    no_dynamic_gas(fun() -> cast_chain(Callback, State) end).
+    {ok, Tx} = API:aens_revoke_tx(<<Addr:256>>, <<Hash:256>>, State),
+    Callback = fun(ChainAPI, ChainState) -> ChainAPI:aens_revoke(Tx, to_sign(Sign0), ChainState) end,
+    no_dynamic_gas(fun() -> cast_chain(Callback, Chain) end).
 
 %% ------------------------------------------------------------------
 %% Map operations.
@@ -438,8 +457,8 @@ get_args(Types, Data) ->                %% First component is the typerep
 no_dynamic_gas(Cb) when is_function(Cb, 0) ->
     {ok, _DynGas=0, Cb}.
 
-chain_ttl_delta(TTL, State) ->
-    ChainHeight = call_chain1(fun(API, ChainState) -> API:get_height(ChainState) end, State),
+chain_ttl_delta(TTL, #chain{api = API, state = State}) ->
+    ChainHeight = API:get_height(State),
     ttl_delta(ChainHeight, TTL).
 
 ttl_delta(_, {delta, D}) when
@@ -455,6 +474,9 @@ ttl_delta(CurrHeight, {block, H}) when
         false ->
             {error, too_low_abs_ttl}
     end.
+
+size_gas(Tx) ->
+    aetx:size(Tx) * aec_governance:byte_gas().
 
 state_gas(Tag, {delta, TTL}) ->
     aec_governance_utils:state_gas(

--- a/apps/aevm/src/aevm_ae_primops.hrl
+++ b/apps/aevm/src/aevm_ae_primops.hrl
@@ -1,1 +1,1 @@
--define(AEVM_PRIMOP_ERR_REASON_OOG(Resource, Cost, State), {out_of_gas, {{primop, Resource}, Cost}, State}).
+-define(AEVM_PRIMOP_ERR_REASON_OOG(Resource, Gas, State), {out_of_gas, {{primop, Resource}, Gas}, State}).

--- a/apps/aevm/src/aevm_chain_api.erl
+++ b/apps/aevm/src/aevm_chain_api.erl
@@ -37,10 +37,14 @@
 
 %% -- Accounts --
 
+-callback spend_tx(Recipient :: aec_id:id(),
+                   Amount :: non_neg_integer(),
+                   State :: chain_state()) ->
+    {ok, aetx:tx()}.
+
 %% Execute a spend transaction from the contract account.
--callback spend(Recipient :: aec_id:id(),
-                Amount    :: non_neg_integer(),
-                State     :: chain_state()) -> {ok, chain_state()} | {error, term()}.
+-callback spend(Tx :: aetx:tx(), State :: chain_state()) ->
+    {ok, chain_state()} | {error, term()}.
 
 %% Get the current balance of an account.
 -callback get_balance(Account :: pubkey(), State :: chain_state()) ->
@@ -48,35 +52,50 @@
 
 %% -- Oracles --
 
--callback oracle_register(Account :: pubkey(),
-                          Sign :: binary(),
-                          QueryFee :: non_neg_integer(),
-                          TTL :: aeo_oracles:ttl(),
-                          DecodedQType :: aeso_sophia:type(),
-                          DecodedRType :: aeso_sophia:type(),
-                          ChainState :: chain_state()) ->
+-callback oracle_register_tx(Account :: pubkey(),
+                            QueryFee :: non_neg_integer(),
+                            TTL :: aeo_oracles:ttl(),
+                            DecodedQType :: aeso_sophia:type(),
+                            DecodedRType :: aeso_sophia:type(),
+                            ChainState :: chain_state()) ->
+    {ok, aetx:tx()}.
+
+-callback oracle_register(Tx :: aetx:tx(),
+                          Signature :: binary(),
+                          State :: chain_state()) ->
     {ok, OracleKey :: pubkey(), chain_state()} | {error, term()}.
 
--callback oracle_query(Oracle :: pubkey(),
-                       Query :: term(),
-                       Value :: non_neg_integer(),
-                       QueryTTL :: aeo_oracles:ttl(),
-                       ResponseTTL :: aeo_oracles:ttl(),
-                       ChainState :: chain_state()) ->
+-callback oracle_query_tx(Oracle :: pubkey(),
+                          Query :: term(),
+                          Value :: non_neg_integer(),
+                          QueryTTL :: aeo_oracles:ttl(),
+                          ResponseTTL :: aeo_oracles:ttl(),
+                          ChainState :: chain_state()) ->
+    {ok, aetx:tx()}.
+
+-callback oracle_query(Tx :: aetx:tx(), State :: chain_state()) ->
     {ok, QueryId :: pubkey(), chain_state()} | {error, term()}.
 
--callback oracle_respond(Oracle :: pubkey(),
-                         Query :: pubkey(),
-                         Sign :: binary(),
-                         Response :: term(),
-                         ResponseTTL :: aeo_oracles:ttl(),
-                         ChainState :: chain_state()) ->
+-callback oracle_respond_tx(Oracle :: pubkey(),
+                            Query :: pubkey(),
+                            Response :: term(),
+                            ResponseTTL :: aeo_oracles:ttl(),
+                            ChainState :: chain_state()) ->
+    {ok, aetx:tx()}.
+
+-callback oracle_respond(Tx :: aetx:tx(),
+                         Signature :: binary(),
+                         State :: chain_state()) ->
     {ok, chain_state()} | {error, term()}.
 
--callback oracle_extend(Oracle :: pubkey(),
-                        Sign :: binary(),
-                        TTL :: aeo_oracles:ttl(),
-                        ChainState :: chain_state()) ->
+-callback oracle_extend_tx(Oracle :: pubkey(),
+                           TTL :: aeo_oracles:ttl(),
+                           ChainState :: chain_state()) ->
+    {ok, aetx:tx()}.
+
+-callback oracle_extend(Tx :: aetx:tx(),
+                        Signature :: binary(),
+                        State :: chain_state()) ->
     {ok, chain_state()} | {error, term()}.
 
 -callback oracle_get_answer(Oracle :: pubkey(),
@@ -121,39 +140,55 @@
                        ChainState :: chain_state()) ->
     {ok, none | {some, term()}} | {error, term()}.
 
--callback aens_preclaim(Addr  :: pubkey(),
-                        CHash :: binary(),
-                        Sign  :: binary(),
+-callback aens_preclaim_tx(Addr :: pubkey(),
+                           CHash :: binary(),
+                           ChainState :: chain_state()) ->
+    {ok, aetx:tx()}.
+
+-callback aens_preclaim(Tx :: aetx:tx(),
+                        Signature :: binary(),
+                        State :: chain_state()) ->
+    {ok, chain_state()} | {error, term()}.
+
+-callback aens_claim_tx(Addr :: pubkey(),
+                        Name :: binary(),
+                        Salt :: integer(),
                         ChainState :: chain_state()) ->
+    {ok, aetx:tx()}.
+
+-callback aens_claim(Tx :: aetx:tx(),
+                     Signature :: binary(),
+                     State :: chain_state()) ->
     {ok, chain_state()} | {error, term()}.
 
--callback aens_claim(Addr  :: pubkey(),
-                     Name  :: binary(),
-                     Salt  :: integer(),
-                     Sign  :: binary(),
-                     ChainState :: chain_state()) ->
+-callback aens_transfer_tx(FromAddr :: pubkey(),
+                           ToAddr :: pubkey(),
+                           Hash :: binary(),
+                           ChainState :: chain_state()) ->
+    {ok, aetx:tx()}.
+
+-callback aens_transfer(Tx :: aetx:tx(),
+                        Signature :: binary(),
+                        State :: chain_state()) ->
     {ok, chain_state()} | {error, term()}.
 
--callback aens_transfer(FromAddr   :: pubkey(),
-                        ToAddr     :: pubkey(),
-                        Hash       :: binary(),
-                        Sign       :: binary(),
-                        ChainState :: chain_state()) ->
-    {ok, chain_state()} | {error, term()}.
+-callback aens_revoke_tx(Addr :: pubkey(),
+                         Hash :: binary(),
+                         ChainState :: chain_state()) ->
+    {ok, aetx:tx()}.
 
--callback aens_revoke(Addr       :: pubkey(),
-                      Hash       :: binary(),
-                      Sign       :: binary(),
-                      ChainState :: chain_state()) ->
+-callback aens_revoke(Tx :: aetx:tx(),
+                      Signature :: binary(),
+                      State :: chain_state()) ->
     {ok, chain_state()} | {error, term()}.
 
 %% Make a call to another contract.
--callback call_contract(Contract  :: pubkey(),
-                        Gas       :: non_neg_integer(),
-                        Value     :: non_neg_integer(),
-                        CallData  :: binary(),
+-callback call_contract(Contract :: pubkey(),
+                        Gas :: non_neg_integer(),
+                        Value :: non_neg_integer(),
+                        CallData :: binary(),
                         CallStack :: [non_neg_integer()],
-                        State     :: chain_state()) ->
+                        State :: chain_state()) ->
                     {ok, call_result(), chain_state()} | {error, term()}.
 
 -callback get_store(chain_state()) -> store().

--- a/apps/aevm/src/aevm_eeevm_state.erl
+++ b/apps/aevm/src/aevm_eeevm_state.erl
@@ -363,7 +363,7 @@ write_heap_value(HeapValue, State) ->
 call_contract(Caller, Target, CallGas, Value, Data, State) ->
     case vm_version(State) of
         ?AEVM_01_Sophia_01 when Target == ?PRIM_CALLS_CONTRACT ->
-            Res = aevm_ae_primops:call(Value, Data, State),
+            Res = aevm_ae_primops:call(CallGas, Value, Data, State),
             Res;
         _ ->
             CallStack  = [Caller | call_stack(State)],

--- a/apps/aevm/src/aevm_gas.erl
+++ b/apps/aevm/src/aevm_gas.erl
@@ -1,17 +1,18 @@
 %%%-------------------------------------------------------------------
 %%% @copyright (C) 2017, Aeternity Anstalt
 %%% @doc
-%%%     Calculate gas cost of operations
+%%%     Calculate gas of operations
 %%% @end
 %%% Created : 2 Oct 2017
 %%%-------------------------------------------------------------------
 
 -module(aevm_gas).
 
--export([ op_cost/2
-        , mem_cost/1
-        , mem_cost/2
+-export([ op_gas/2
+        , mem_gas/1
+        , mem_gas/2
         ]).
+
 -export([ call_cap/2
         ]).
 
@@ -23,54 +24,54 @@
 %% API
 %%====================================================================
 
-%% NOTE: This is just purely the op cost, not including memory cost
-op_cost(Op, State) ->
-    try aevm_opcodes:op_base_cost(Op) + op_dynamic_cost(Op, State)
+%% NOTE: This is just purely the op gas, not including memory gas
+op_gas(Op, State) ->
+    try aevm_opcodes:op_base_gas(Op) + op_dynamic_gas(Op, State)
     catch error:{badarg, _, _} -> State %% TODO: This is not right
     end.
 
-%% NOTE: This is just purely the mem cost, not including op cost
-mem_cost(State1, State2) ->
+%% NOTE: This is just purely the mem gas, not including op gas
+mem_gas(State1, State2) ->
     Size1 = aevm_eeevm_memory:size_in_words(State1),
     case aevm_eeevm_memory:size_in_words(State2) of
         Size1 -> 0;
-        Size2 -> mem_cost(Size2) - mem_cost(Size1)
+        Size2 -> mem_gas(Size2) - mem_gas(Size1)
     end.
 
-mem_cost(Size) ->
+mem_gas(Size) ->
     Size * ?GMEMORY + round(math:floor((Size * Size) / 512)).
 
 call_cap(?CALL, State) ->
-    {CGascap, _} = call_dynamic_cost_components(State),
+    {CGascap, _} = call_dynamic_gas_components(State),
     CGascap;
 call_cap(?CALLCODE, State) ->
-    {CGascap, _} = call_dynamic_cost_components(State),
+    {CGascap, _} = call_dynamic_gas_components(State),
     CGascap;
 call_cap(?DELEGATECALL, State) -> %% TODO This is a placeholder.
-    {CGascap, _} = call_dynamic_cost_components(State),
+    {CGascap, _} = call_dynamic_gas_components(State),
     CGascap.
 
-op_dynamic_cost(?CALL, State) ->
-    call_dynamic_cost(State);
-op_dynamic_cost(?DELEGATECALL, State) ->
-    call_dynamic_cost(State);
-op_dynamic_cost(?CALLCODE, State) ->
-    call_dynamic_cost(State);
-op_dynamic_cost(?CALLDATACOPY, State) ->
+op_dynamic_gas(?CALL, State) ->
+    call_dynamic_gas(State);
+op_dynamic_gas(?DELEGATECALL, State) ->
+    call_dynamic_gas(State);
+op_dynamic_gas(?CALLCODE, State) ->
+    call_dynamic_gas(State);
+op_dynamic_gas(?CALLDATACOPY, State) ->
     ?GCOPY * round(ceil(peek(2, State)/32));
-op_dynamic_cost(?CODECOPY, State) ->
+op_dynamic_gas(?CODECOPY, State) ->
     ?GCOPY * round(ceil(peek(2, State)/32));
-op_dynamic_cost(?EXTCODECOPY, State) ->
+op_dynamic_gas(?EXTCODECOPY, State) ->
     ?GCOPY * round(ceil(peek(3, State)/32));
-op_dynamic_cost(?LOG0, State) -> ?GLOGDATA * peek(1, State);
-op_dynamic_cost(?LOG1, State) -> ?GLOGDATA * peek(1, State);
-op_dynamic_cost(?LOG2, State) -> ?GLOGDATA * peek(1, State);
-op_dynamic_cost(?LOG3, State) -> ?GLOGDATA * peek(1, State);
-op_dynamic_cost(?LOG4, State) -> ?GLOGDATA * peek(1, State);
-op_dynamic_cost(?SHA3, State) ->
+op_dynamic_gas(?LOG0, State) -> ?GLOGDATA * peek(1, State);
+op_dynamic_gas(?LOG1, State) -> ?GLOGDATA * peek(1, State);
+op_dynamic_gas(?LOG2, State) -> ?GLOGDATA * peek(1, State);
+op_dynamic_gas(?LOG3, State) -> ?GLOGDATA * peek(1, State);
+op_dynamic_gas(?LOG4, State) -> ?GLOGDATA * peek(1, State);
+op_dynamic_gas(?SHA3, State) ->
     Us1 = peek(1, State),
     ?GSHA3WORD * round(ceil(Us1/32));
-op_dynamic_cost(?SSTORE, State) ->
+op_dynamic_gas(?SSTORE, State) ->
     Us0 = peek(0, State),
     Us1 = peek(1, State),
     Old = aevm_eeevm_store:load(Us0, State),
@@ -78,23 +79,23 @@ op_dynamic_cost(?SSTORE, State) ->
         true  -> ?GSSET;   %% Additional storage is needed
         false -> ?GSRESET  %% Resetting a new value in the store.
     end;
-op_dynamic_cost(?EXP, State) ->
+op_dynamic_gas(?EXP, State) ->
     case peek(1, State) of
         0 -> 0;
         Us1 -> ?GEXPBYTE * (1 + floor_log_256(Us1))
     end;
-op_dynamic_cost(_Op,_State) ->
+op_dynamic_gas(_Op,_State) ->
     0.
 
 %%====================================================================
 %% Internal functions
 %%====================================================================
 
-call_dynamic_cost(State) ->
-    {CGascap, CExtra} = call_dynamic_cost_components(State),
+call_dynamic_gas(State) ->
+    {CGascap, CExtra} = call_dynamic_gas_components(State),
     CGascap + CExtra.
 
-call_dynamic_cost_components(State) ->
+call_dynamic_gas_components(State) ->
     Gas = aevm_eeevm_state:gas(State),
     Us0 = peek(0, State),
     %%Us1 = peek(1, State), %% TODO: Needed for CNEW.

--- a/apps/aevm/src/aevm_opcodes.erl
+++ b/apps/aevm/src/aevm_opcodes.erl
@@ -8,7 +8,7 @@
 
 -module(aevm_opcodes).
 
--export([ op_base_cost/1
+-export([ op_base_gas/1
         , op_name/1
         ]).
 
@@ -21,9 +21,9 @@
 op_name(OP) -> element(1, opcode(OP)).
 %% op_pop(OP) -> element(2, opcode(OP)).
 %% op_push(OP) -> element(3, opcode(OP)).
-op_base_cost(OP) -> element(4, opcode(OP)).
+op_base_gas(OP) -> element(4, opcode(OP)).
 
-%% @doc Opcodes defined as {OPCODE, POPPED, PUSHED, BASE_GAS_COST}
+%% @doc Opcodes defined as {OPCODE, POPPED, PUSHED, BASE_GAS}
 
 opcode(?STOP)           -> {aeb_opcodes:mnemonic(?STOP)           ,  0,  0, ?GZERO};
 opcode(?ADD)            -> {aeb_opcodes:mnemonic(?ADD)            ,  2,  1, ?GVERYLOW};

--- a/apps/aevm/test/aevm_eeevm_tests.erl
+++ b/apps/aevm/test/aevm_eeevm_tests.erl
@@ -15,7 +15,7 @@
 %% For VMTests
 %%  "Because the data of the blockchain is not given,
 %%   the opcode BLOCKHASH could not return the hashes
-%%   of the corresponding blocks. Therefore we define the hash of 
+%%   of the corresponding blocks. Therefore we define the hash of
 %%   block number n to be SHA3-256("n")."
 %% Indicated by the option blockhash->sha3
 extra_opts(Name) ->

--- a/docs/release-notes/next/PT-161093359.md
+++ b/docs/release-notes/next/PT-161093359.md
@@ -1,0 +1,1 @@
+* Increases the gas of the VM primitive operations that create or extend objects on the state trees, approximating that to a component proportional to the serialized equivalent transaction. This affects consensus.

--- a/docs/release-notes/next/PT-161340434.md
+++ b/docs/release-notes/next/PT-161340434.md
@@ -1,0 +1,1 @@
+* Fixes gas available to VM primops contract to be the same as for other contracts. This affects consensus.

--- a/test/aevm_chain_SUITE.erl
+++ b/test/aevm_chain_SUITE.erl
@@ -111,13 +111,14 @@ spend(_Cfg) ->
     AccBal1  = aec_vm_chain:get_balance(Acc, S),
     Bal1     = aec_vm_chain:get_balance(Contract1, S),
     Amount   = 50,
-    {ok, S1} = aec_vm_chain:spend(AccId, Amount, S),
+    {ok, T1} = aec_vm_chain:spend_tx(AccId, Amount, S),
+    {ok, S1} = aec_vm_chain:spend(T1, S),
     Bal2     = aec_vm_chain:get_balance(Contract1, S1),
     Bal2     = Bal1 - Amount,
     AccBal2  = aec_vm_chain:get_balance(Acc, S1),
     AccBal2  = AccBal1 + Amount,
-    {error, insufficient_funds}
-             = aec_vm_chain:spend(AccId, 1000000, S1),
+    {ok, T2} = aec_vm_chain:spend_tx(AccId, 1000000, S1),
+    {error, insufficient_funds} = aec_vm_chain:spend(T2, S1),
     ok.
 
 %%%===================================================================

--- a/test/contract_sophia_bytecode_aevm_SUITE.erl
+++ b/test/contract_sophia_bytecode_aevm_SUITE.erl
@@ -27,10 +27,27 @@
    ]).
 
 %% chain API exports
--export([ get_height/1, spend/3, get_balance/2, call_contract/6, get_store/1, set_store/2,
-          oracle_register/7, oracle_query/6, oracle_query_format/2, oracle_response_format/2,
-          oracle_respond/6, oracle_get_answer/3,
-          oracle_query_fee/2, oracle_query_response_ttl/3, oracle_get_question/3, oracle_extend/4]).
+-export([ get_height/1,
+          spend_tx/3,
+          spend/2,
+          get_balance/2,
+          call_contract/6,
+          get_store/1,
+          set_store/2,
+          oracle_register_tx/6,
+          oracle_register/3,
+          oracle_query_tx/6,
+          oracle_query/2,
+          oracle_query_format/2,
+          oracle_response_format/2,
+          oracle_respond_tx/5,
+          oracle_respond/3,
+          oracle_get_answer/3,
+          oracle_query_fee/2,
+          oracle_query_response_ttl/3,
+          oracle_get_question/3,
+          oracle_extend_tx/3,
+          oracle_extend/3]).
 
 -include("apps/aecontract/src/aecontract.hrl").
 -include_lib("common_test/include/ct.hrl").
@@ -75,13 +92,13 @@ execute_call(Contract, CallData, ChainState, Options) ->
              address           => Contract,
              caller            => 0,
              data              => CallData,
-             gas               => 1000000,
+             gas               => 1500000,
              gasPrice          => 1,
              origin            => 0,
              value             => 0,
              currentCoinbase   => 0,
              currentDifficulty => 0,
-             currentGasLimit   => 1000000,
+             currentGasLimit   => 2000000,
              currentNumber     => 0,
              currentTimestamp  => 0,
              chainState        => ChainState1,
@@ -441,16 +458,33 @@ initial_state(Contracts, Accounts) ->
 get_height(#{ environment := #{ currentNumber := Height } }) ->
     Height.
 
-spend(_To, Amount, _) when Amount < 0 ->
+spend_tx(_To, Amount, _) when Amount < 0 ->
     {error, negative_spend};
-spend(ToId, Amount, S = #{ running := From, accounts := Accounts }) ->
-    <<To:256>> = aec_id:specialize(ToId, account),
-    Balance = get_balance(<<From:256>>, S),
+spend_tx(ToId, Amount, State = #{running := From}) ->
+    Balance = get_balance(<<From:256>>, State),
     case Amount =< Balance of
-        true -> {ok, S#{ accounts := Accounts#{ From => Balance            - Amount,
-                                                To   => get_balance(<<To:256>>, S) + Amount } }};
-        false -> {error, insufficient_funds}
+        true ->
+            Spec =
+                #{sender_id    => aec_id:create(account, <<From:256>>),
+                  recipient_id => ToId,
+                  amount       => Amount,
+                  fee          => 0,
+                  nonce        => 1,
+                  payload      => <<>>},
+            aec_spend_tx:new(Spec);
+        false ->
+            {error, insufficient_funds}
     end.
+
+spend(Tx, State = #{accounts := Accounts}) ->
+    {aec_spend_tx, STx} = aetx:specialize_callback(Tx),
+    <<To:256>> = aec_id:specialize(aec_spend_tx:recipient_id(STx), account),
+    <<From:256>> = aec_id:specialize(aec_spend_tx:sender_id(STx), account),
+    Amount = aec_spend_tx:amount(STx),
+    FromBalance = get_balance(<<From:256>>, State),
+    ToBalance = get_balance(<<To:256>>, State),
+    {ok, State#{accounts := Accounts#{From => FromBalance - Amount,
+                                      To   => ToBalance + Amount}}}.
 
 get_balance(<<Account:256>>, #{ accounts := Accounts }) ->
     maps:get(Account, Accounts, 0).
@@ -483,60 +517,130 @@ call_contract(<<Contract:256>>, _Gas, Value, CallData, _, S = #{running := Calle
             {error, {no_such_contract, Contract}}
     end.
 
-oracle_register(PubKey = <<Account:256>>, Sign, QueryFee, TTL, QueryFormat, ResponseFormat, State) ->
-    io:format("oracle_register(~p, ~p, ~p, ~p, ~p, ~p)\n", [Account, Sign, QueryFee, TTL, QueryFormat, ResponseFormat]),
+oracle_register_tx(PubKey = <<Account:256>>, QueryFee, TTL, QFormat, RFormat, _State) ->
+    io:format("oracle_register(~p, ~p, ~p, ~p, ~p)\n", [Account, QueryFee, TTL, QFormat, RFormat]),
+    Spec =
+        #{account_id      => aec_id:create(account, PubKey),
+          nonce           => 1,
+          query_format    => QFormat,
+          response_format => RFormat,
+          query_fee       => QueryFee,
+          oracle_ttl      => TTL,
+          ttl             => 0,
+          fee             => 0},
+    aeo_register_tx:new(Spec).
+
+oracle_register(Tx, Signature, State) ->
+    {aeo_register_tx, OTx} = aetx:specialize_callback(Tx),
+    <<PubKey:256>> = aeo_register_tx:account_pubkey(OTx),
     Oracles = maps:get(oracles, State, #{}),
-    State1 = State#{ oracles => Oracles#{ Account =>
-                        #{sign            => Sign,
-                          nonce           => 1,
-                          query_fee       => QueryFee,
-                          query_format    => QueryFormat,
-                          response_format => ResponseFormat,
-                          ttl             => TTL} } },
-    {ok, PubKey, State1}.
+    State1 =
+        State#{
+          oracles =>
+            Oracles#{
+              PubKey =>
+                #{sign            => Signature,
+                  nonce           => aeo_register_tx:nonce(OTx),
+                  query_fee       => aeo_register_tx:query_fee(OTx),
+                  query_format    => aeo_register_tx:query_format(OTx),
+                  response_format => aeo_register_tx:response_format(OTx),
+                  ttl             => aeo_register_tx:ttl(OTx)}}},
+    {ok, <<PubKey:256>>, State1}.
 
-oracle_query(<<Oracle:256>>, Q, Value, QTTL, RTTL, State) ->
+oracle_query_tx(OracleKey = <<Oracle:256>>, Q, Value, QTTL, RTTL, _State) ->
     io:format("oracle_query(~p, ~p, ~p, ~p, ~p)\n", [Oracle, Q, Value, QTTL, RTTL]),
-    QueryKey = <<QueryId:256>> = crypto:hash(sha256, term_to_binary(make_ref())),
-    Queries = maps:get(oracle_queries, State, #{}),
-    State1  = State#{ oracle_queries =>
-                Queries#{ QueryId =>
-                    #{oracle => Oracle,
-                      query  => Q,
-                      q_ttl  => QTTL,
-                      r_ttl  => RTTL} } },
-    {ok, QueryKey, State1}.
+    Spec =
+        #{sender_id     => aec_id:create(account, OracleKey),
+          nonce         => 1,
+          oracle_id     => aec_id:create(oracle, OracleKey),
+          query         => Q,
+          query_fee     => 0,
+          query_ttl     => QTTL,
+          response_ttl  => RTTL,
+          fee           => 0,
+          ttl           => 0
+         },
+    aeo_query_tx:new(Spec).
 
-oracle_respond(<<_Oracle:256>>, <<Query:256>>, Sign, R, _RTTL, State) ->
-    io:format("oracle_respond(~p, ~p, ~p)\n", [Query, Sign, R]),
+oracle_query(Tx, State) ->
+    {aeo_query_tx, OTx} = aetx:specialize_callback(Tx),
+    <<Oracle:256>> = aec_id:specialize(aeo_query_tx:sender_id(OTx), account),
+    <<QueryId:256>> = aeo_query_tx:query_id(OTx),
+    Q = aeo_query_tx:query(OTx),
+    QTTL = aeo_query_tx:query_ttl(OTx),
+    RTTL = aeo_query_tx:response_ttl(OTx),
+    Queries = maps:get(oracle_queries, State, #{}),
+    State1 =
+        State#{
+          oracle_queries =>
+            Queries#{
+              QueryId =>
+                #{oracle => Oracle,
+                  query  => Q,
+                  q_ttl  => QTTL,
+                  r_ttl  => RTTL}}},
+    {ok, <<QueryId:256>>, State1}.
+
+oracle_respond_tx(OracleKey, QueryIdKey = <<QueryId:256>>, R, RTTL, _State) ->
+    io:format("oracle_respond(~p, ~p)\n", [QueryId, R]),
+    Spec =
+        #{oracle_id    => aec_id:create(oracle, OracleKey),
+          nonce        => 1,
+          query_id     => QueryIdKey,
+          response     => R,
+          response_ttl => RTTL,
+          fee          => 0,
+          ttl          => 0 %% Not used
+         },
+    aeo_response_tx:new(Spec).
+
+oracle_respond(Tx, _Signature, State) ->
+    {aeo_response_tx, OTx} = aetx:specialize_callback(Tx),
+    <<QueryId:256>> = aeo_response_tx:query_id(OTx),
+    R = aeo_response_tx:response(OTx),
     case maps:get(oracle_queries, State, #{}) of
-        #{Query := Q} = Queries ->
-            State1 = State#{ oracle_queries := Queries#{ Query := Q#{ answer => {some, R} } } },
+        #{QueryId := Q} = Queries ->
+            State1 =
+                State#{
+                  oracle_queries := Queries#{QueryId := Q#{answer => {some, R}}}},
             {ok, State1};
-        _ -> {error, {no_such_query, Query}}
+        _ -> {error, {no_such_query, QueryId}}
     end.
 
-oracle_extend(<<Oracle:256>>,_Sign, TTL, State) ->
-    io:format("oracle_extend(~p, ~p, ~p)\n", [Oracle,_Sign, TTL]),
+oracle_extend_tx(OracleKey = <<Oracle:256>>, OTTL, _State) ->
+    io:format("oracle_extend(~p, ~p)\n", [Oracle, OTTL]),
+    Spec =
+        #{oracle_id  => aec_id:create(oracle, OracleKey),
+          nonce      => 1,
+          oracle_ttl => OTTL,
+          fee        => 0,
+          ttl        => 0 %% Not used
+         },
+    aeo_extend_tx:new(Spec).
+
+oracle_extend(Tx, _Signature, State) ->
+    {aeo_extend_tx, OTx} = aetx:specialize_callback(Tx),
+    <<Oracle:256>> = aec_id:specialize(aeo_extend_tx:oracle_id(OTx), oracle),
+    OTTL = aeo_extend_tx:oracle_ttl(OTx),
     case maps:get(oracles, State, #{}) of
         #{Oracle := O} = Oracles ->
-            State1 = State#{ oracles := Oracles#{ Oracle := O#{ ttl => TTL } } },
+            State1 = State#{oracles := Oracles#{Oracle := O#{ttl => OTTL}}},
             {ok, State1};
         _ -> foo= Oracle, {error, {no_such_oracle, Oracle}}
     end.
 
-oracle_get_answer(<<_Oracle:256>>, <<Query:256>>, State) ->
+oracle_get_answer(<<_Oracle:256>>, <<QueryId:256>>, State) ->
     case maps:get(oracle_queries, State, #{}) of
-        #{Query := Q} ->
+        #{QueryId := Q} ->
             Answer = maps:get(answer, Q, none),
             io:format("oracle_get_answer() -> ~p\n", [Answer]),
             {ok, Answer};
         _ -> {ok, none}
     end.
 
-oracle_get_question(<<_Oracle:256>>, <<Query:256>>, State) ->
+oracle_get_question(<<_Oracle:256>>, <<QueryId:256>>, State) ->
     case maps:get(oracle_queries, State, #{}) of
-        #{Query := Q} ->
+        #{QueryId := Q} ->
             Question = maps:get(query, Q, none),
             io:format("oracle_get_question() -> ~p\n", [Question]),
             {ok, Question};
@@ -545,25 +649,25 @@ oracle_get_question(<<_Oracle:256>>, <<Query:256>>, State) ->
 
 oracle_query_fee(<<Oracle:256>>, State) ->
     case maps:get(oracles, State, []) of
-        #{ Oracle := #{query_fee := Fee} } -> {ok, Fee};
+        #{Oracle := #{query_fee := Fee}} -> {ok, Fee};
         _ -> {error, {no_such_oracle, Oracle}}
     end.
 
-oracle_query_response_ttl(<<Oracle:256>>, <<Query:256>>, State) ->
+oracle_query_response_ttl(<<_Oracle:256>>, <<QueryId:256>>, State) ->
     case maps:get(oracle_queries, State, #{}) of
-        #{Query := Q} -> {ok, maps:get(r_ttl, Q)};
+        #{QueryId := Q} -> {ok, maps:get(r_ttl, Q)};
         _ -> {error, no_such_oracle_query}
     end.
 
 oracle_query_format(<<Oracle:256>>, State) ->
     case maps:get(oracles, State, []) of
-        #{ Oracle := #{query_format := Format} } -> {ok, Format};
+        #{Oracle := #{query_format := Format}} -> {ok, Format};
         _ -> {error, {no_such_oracle, Oracle}}
     end.
 
 oracle_response_format(<<Oracle:256>>, State) ->
     case maps:get(oracles, State, #{}) of
-        #{ Oracle := #{response_format := Format} } -> {ok, Format};
+        #{Oracle := #{response_format := Format}} -> {ok, Format};
         _ -> {error, {no_such_oracle, Oracle}}
     end.
 


### PR DESCRIPTION
[PT-161093359](https://www.pivotaltracker.com/n/projects/2124891/stories/161093359)
[PT-161340434](https://www.pivotaltracker.com/n/projects/2124891/stories/161340434) - Also included in this PR.

This PR adds size gas to the primops. Before, the primops had only state gas (computed from TTL). The primops have higher gas now, it's sum of the state gas and size gas. Size gas is computed from a related serialized transaction.

The protocol PR will follow.

TODO:

- [x] decide how to compute size gas - `aetx:size(Tx) * aec_governance:byte_gas()` should be good enough basic solution
- [x] add release note
