### PR TITLE
PT-161409828 Add minimum height check for key blocks and generations in swagger

### DIFF
--- a/apps/aehttp/priv/swagger.json
+++ b/apps/aehttp/priv/swagger.json
@@ -210,7 +210,8 @@
           "in" : "path",
           "description" : "The height of the block",
           "required" : true,
-          "type" : "integer"
+          "type" : "integer",
+          "minimum" : 0
         } ],
         "responses" : {
           "200" : {
@@ -473,7 +474,8 @@
           "in" : "path",
           "description" : "The height of the generation",
           "required" : true,
-          "type" : "integer"
+          "type" : "integer",
+          "minimum" : 0
         } ],
         "responses" : {
           "200" : {

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -193,6 +193,7 @@ paths:
           description: 'The height of the block'
           required: true
           type : integer
+          minimum: 0
       responses:
         '200':
           description: 'Successful operation'
@@ -421,6 +422,7 @@ paths:
           description: 'The height of the generation'
           required: true
           type : integer
+          minimum: 0
       responses:
         '200':
           description: 'Successful operation'

--- a/docs/release-notes/next/PT-161409828.md
+++ b/docs/release-notes/next/PT-161409828.md
@@ -1,0 +1,1 @@
+* Improves the stability of the HTTP user API.


### PR DESCRIPTION
[PT-161409828](https://www.pivotaltracker.com/n/projects/2124891/stories/161409828)

Fixes `GET /key-blocks/height/-1` and `GET /generations/height/-1` crashes.