### PR TITLE
The `aec_tx_pool:size()` function must also include the 'visited' set

### DIFF
--- a/apps/aecore/src/aec_tx_pool.erl
+++ b/apps/aecore/src/aec_tx_pool.erl
@@ -215,7 +215,11 @@ new_sync_top_target(NewSyncTop) ->
 
 -spec size() -> non_neg_integer() | undefined.
 size() ->
-    ets:info(?MEMPOOL, size) + ets:info(?MEMPOOL_VISITED, size).
+    ensure_num(ets:info(?MEMPOOL, size))
+        + ensure_num(ets:info(?MEMPOOL_VISITED, size)).
+
+ensure_num(undefined) -> 0;
+ensure_num(N) when is_integer(N) -> N.
 
 pool_db() -> ?MEMPOOL.
 pool_db_visited() -> ?MEMPOOL_VISITED.

--- a/apps/aecore/src/aec_tx_pool.erl
+++ b/apps/aecore/src/aec_tx_pool.erl
@@ -215,7 +215,7 @@ new_sync_top_target(NewSyncTop) ->
 
 -spec size() -> non_neg_integer() | undefined.
 size() ->
-    ets:info(?MEMPOOL, size).
+    ets:info(?MEMPOOL, size) + ets:info(?MEMPOOL_VISITED, size).
 
 pool_db() -> ?MEMPOOL.
 pool_db_visited() -> ?MEMPOOL_VISITED.

--- a/apps/aecore/src/aec_tx_pool_metrics_probe.erl
+++ b/apps/aecore/src/aec_tx_pool_metrics_probe.erl
@@ -102,7 +102,4 @@ sample_(_, Acc) ->
     Acc.
 
 pending_txs() ->
-    case aec_tx_pool:size() of
-        S when is_integer(S), S >= 0 -> S;
-        undefined -> 0
-    end.
+    aec_tx_pool:size().

--- a/apps/aecore/test/aec_tx_pool_tests.erl
+++ b/apps/aecore/test/aec_tx_pool_tests.erl
@@ -223,14 +223,17 @@ tx_pool_test_() ->
                ?assertEqual(ok, aec_tx_pool:push(STx1)),
                ?assertEqual([], aec_tx_pool:peek_visited()),
                [{PK, Nonce1, _}] = aec_tx_pool:peek_nonces(),
+               Size = aec_tx_pool:size(),
                ?assertEqual({ok, [STx1]},
                             aec_tx_pool:get_candidate(MaxGas, TopBlockHash)),
                ?assertEqual([STx1], aec_tx_pool:peek_visited()),
                ?assertEqual([], aec_tx_pool:peek_db()),
+               ?assertEqual(Size, aec_tx_pool:size()),
                %% a 'key' top_change should restore visited to the mempool
                aec_tx_pool:top_change(key, TopBlockHash, TopBlockHash),
                ?assertEqual([], aec_tx_pool:peek_visited()),
-               ?assertEqual([STx1], aec_tx_pool:peek_db())
+               ?assertEqual([STx1], aec_tx_pool:peek_db()),
+               ?assertEqual(Size, aec_tx_pool:size())
        end},
       {"Ensure candidate ordering",
        fun() ->

--- a/apps/aehttp/src/aehttp_dispatch_ext.erl
+++ b/apps/aehttp/src/aehttp_dispatch_ext.erl
@@ -550,11 +550,7 @@ handle_request_('GetStatus', _Params, _Context) ->
     NodeVersion = aeu_info:get_version(),
     NodeRevision = aeu_info:get_revision(),
     PeerCount = length(aec_peers:get_random(all)),
-    PendingTxsCount =
-        case aec_tx_pool:size() of
-            N when N =/= undefined -> N;
-            undefined -> 0
-        end,
+    PendingTxsCount = aec_tx_pool:size(),
     {200, [],
      #{<<"genesis_key_block_hash">>     => aec_base58c:encode(key_block_hash, GenesisBlockHash),
        <<"solutions">>                  => Solutions,


### PR DESCRIPTION
Amended test case to verify that this didn't happen, then fixed it.

See [PT #161504220](https://www.pivotaltracker.com/story/show/161504220)