### PR TITLE
Change calling convention in sophia and add type checking

### DIFF
--- a/apps/aecontract/src/aect_create_tx.erl
+++ b/apps/aecontract/src/aect_create_tx.erl
@@ -192,8 +192,13 @@ check(#contract_create_tx{nonce      = Nonce,
          end |
          case VmVersion of
             ?AEVM_01_Sophia_01 ->
-                 [ fun() -> check_sophia_serialization(Tx) end
-                 , fun() -> check_init_function(Tx) end
+                 [ fun() ->
+                           case get_sophia_serialization(Tx) of
+                               {ok, #{type_info := TypeInfo}} ->
+                                   check_init_function(Tx, TypeInfo);
+                               {error, _} = Err -> Err
+                           end
+                   end
                  ];
             ?AEVM_01_Solidity_01 -> []
          end
@@ -203,16 +208,20 @@ check(#contract_create_tx{nonce      = Nonce,
         {error, Reason} -> {error, Reason}
     end.
 
-check_sophia_serialization(#contract_create_tx{code = SerializedCode}) ->
+get_sophia_serialization(#contract_create_tx{code = SerializedCode}) ->
     try aeso_compiler:deserialize(SerializedCode) of
-        _ -> ok
+        Map -> {ok, Map}
     catch
         _:_ -> {error, bad_sophia_code}
     end.
 
-check_init_function(#contract_create_tx{call_data = CallData}) ->
-    case aeso_data:get_function_from_calldata(CallData) of
-        {ok, <<"init">>} -> ok;
+check_init_function(#contract_create_tx{call_data = CallData}, TypeInfo) ->
+    case aeso_data:get_function_hash_from_calldata(CallData) of
+        {ok, Hash} ->
+            case aeso_abi:function_name_from_type_hash(Hash, TypeInfo) of
+                {ok, <<"init">>} -> ok;
+                _ -> {error, bad_init_function}
+            end;
         _Other -> {error, bad_init_function}
     end.
 

--- a/apps/aecontract/test/aect_test_utils.erl
+++ b/apps/aecontract/test/aect_test_utils.erl
@@ -129,6 +129,7 @@ create_tx_default_spec(PubKey, State) ->
 
 dummy_bytecode() ->
     aeso_compiler:serialize(<<"NOT PROPER BYTE CODE">>,
+                            [], %% No type info
                             "NOT PROPER SOURCE STRING").
 
 %%%===================================================================

--- a/apps/aecore/include/blocks.hrl
+++ b/apps/aecore/include/blocks.hrl
@@ -1,6 +1,6 @@
 -include("pow.hrl").
 
--define(PROTOCOL_VERSION, 26).
+-define(PROTOCOL_VERSION, 27).
 -define(GENESIS_VERSION, ?PROTOCOL_VERSION).
 -define(GENESIS_HEIGHT, 0).
 -define(GENESIS_TIME, 0).

--- a/apps/aecore/src/aec_hash.erl
+++ b/apps/aecore/src/aec_hash.erl
@@ -16,7 +16,8 @@
 -type hash() :: <<_:256>>. %% 256 = 32 * 8.
 
 -type hash_type() :: pubkey | header | tx | signed_tx | pow | evm | aens |
-                     peer_id | state_trees | pof | sophia_source_code.
+                     peer_id | state_trees | pof | sophia_source_code |
+                     sophia_type_hash.
 
 -spec hash(hash_type(), hashable()) -> hash().
 hash(evm, Bin) when is_binary(Bin) ->

--- a/apps/aecore/src/aec_vm_chain.erl
+++ b/apps/aecore/src/aec_vm_chain.erl
@@ -43,7 +43,8 @@
           aens_revoke_tx/3,
           aens_revoke/3,
           spend_tx/3,
-          spend/2
+          spend/2,
+          get_contract_fun_types/4
         ]).
 
 -include_lib("apps/aecore/include/blocks.hrl").
@@ -560,6 +561,25 @@ aens_revoke_(Tx, Signature, #state{ account = ContractKey } = State) ->
     end.
 
 %%    Contracts
+
+%% @doc Get the type signature of a remote contract
+get_contract_fun_types(Target, VMVersion, TypeHash, State) ->
+    Trees = get_top_trees(State),
+    CT = aec_trees:contracts(Trees),
+    case aect_state_tree:lookup_contract(Target, CT) of
+        {value, Contract} ->
+            case aect_contracts:vm_version(Contract) of
+                VMVersion ->
+                    SerializedCode = aect_contracts:code(Contract),
+                    #{type_info := TypeInfo} = aeso_compiler:deserialize(SerializedCode),
+                    aeso_abi:typereps_from_type_hash(TypeHash, TypeInfo);
+                Other ->
+                    {error, {wrong_vm_version, Other}}
+            end;
+        none ->
+            {error, {no_such_contract, Target}}
+    end.
+
 
 %% @doc Call another contract.
 -spec call_contract(aec_keys:pubkey(), non_neg_integer(), non_neg_integer(), binary(),

--- a/apps/aecore/test/aec_mining_tests.erl
+++ b/apps/aecore/test/aec_mining_tests.erl
@@ -34,7 +34,7 @@ mine_block_test_() ->
                  % in order to find a proper nonce for your
                  % block uncomment the line below
                  % let_it_crash = generate_valid_test_data(TopBlock, 100000000000000),
-                 Nonce = 17605648207401262337,
+                 Nonce = 17803922076662358043,
                  {BlockCandidate,_} = aec_test_utils:create_keyblock_with_state(
                                         [{TopBlock, aec_trees:new()}], ?TEST_PUB),
 

--- a/apps/aecore/test/aecore_txs_SUITE.erl
+++ b/apps/aecore/test/aecore_txs_SUITE.erl
@@ -197,10 +197,10 @@ check_coinbase_validation(Config) ->
     aecore_suite_utils:start_node(dev1, Config),
     N1 = aecore_suite_utils:node_name(dev1),
     aecore_suite_utils:connect(N1),
-    {ok, TxH1, Ct1} =
+    {ok, TxH1, Ct1, Code} =
         create_contract_tx(N1, chain, <<"()">>,  1,  1,  100),
     {ok, TxH2} =
-        call_contract_tx(N1, Ct1, "save_coinbase", "()", 1,  2,  100),
+        call_contract_tx(N1, Ct1, Code, <<"save_coinbase">>, <<"()">>, 1,  2,  100),
     {ok, _} =
         aecore_suite_utils:mine_blocks_until_txs_on_chain(N1, [TxH1, TxH2], 10),
 
@@ -287,7 +287,7 @@ create_contract_tx(Node, Name, Args, Fee, Nonce, TTL) ->
     OwnerKey = maps:get(pubkey, patron()),
     Owner    = aec_id:create(account, OwnerKey),
     Code     = compile_contract(lists:concat(["contracts/", Name, ".aes"])),
-    CallData = aect_sophia:create_call(Code, <<"init">>, Args),
+    {ok, CallData} = aect_sophia:encode_call_data(Code, <<"init">>, Args),
     {ok, CreateTx} = aect_create_tx:new(#{ nonce      => Nonce
                                          , vm_version => 1
                                          , code       => Code
@@ -303,7 +303,7 @@ create_contract_tx(Node, Name, Args, Fee, Nonce, TTL) ->
     CTx = aec_test_utils:sign_tx(CreateTx, maps:get(privkey, patron())),
     Res = rpc:call(Node, aec_tx_pool, push, [CTx]),
     ContractKey = aect_contracts:compute_contract_pubkey(OwnerKey, Nonce),
-    {Res, aec_base58c:encode(tx_hash, aetx_sign:hash(CTx)), ContractKey}.
+    {Res, aec_base58c:encode(tx_hash, aetx_sign:hash(CTx)), ContractKey, Code}.
 
 compile_contract(File) ->
     CodeDir = code:lib_dir(aesophia, test),
@@ -312,10 +312,10 @@ compile_contract(File) ->
     Contract = binary_to_list(ContractBin),
     aeso_compiler:from_string(Contract, [pp_icode]).
 
-call_contract_tx(Node, Contract, Function, Args, Fee, Nonce, TTL) ->
+call_contract_tx(Node, Contract, Code, Function, Args, Fee, Nonce, TTL) ->
     Caller       = aec_id:create(account, maps:get(pubkey, patron())),
     ContractID   = aec_id:create(contract, Contract),
-    CallData     = aeso_abi:create_calldata(<<>>, Function, Args),
+    {ok, CallData} = aect_sophia:encode_call_data(Code, Function, Args),
     {ok, CallTx} = aect_call_tx:new(#{ nonce       => Nonce
                                      , caller_id   => Caller
                                      , vm_version  => 1

--- a/apps/aehttp/src/aehttp_dispatch_int.erl
+++ b/apps/aehttp/src/aehttp_dispatch_int.erl
@@ -192,15 +192,19 @@ handle_request_('EncodeCalldata', Req, _Context) ->
     case Req of
         #{'ContractCallInput' :=
               #{ <<"abi">>  := ABI
-               , <<"code">> := Code
+               , <<"code">> := EncodedCode
                , <<"function">> := Function
                , <<"arg">> := Argument }} ->
             %% TODO: Handle other languages
-            case aehttp_logic:contract_encode_call_data(ABI, Code, Function, Argument) of
-                {ok, Result} ->
-                    {200, [], #{ calldata => Result}};
-                {error, ErrorMsg} ->
-                    {403, [], #{reason => ErrorMsg}}
+            case aec_base58c:safe_decode(contract_bytearray, EncodedCode) of
+                {ok, Code} ->
+                    case aehttp_logic:contract_encode_call_data(ABI, Code, Function, Argument) of
+                        {ok, Result} ->
+                            {200, [], #{ calldata => Result}};
+                        {error, ErrorMsg} ->
+                            {403, [], #{reason => ErrorMsg}}
+                    end;
+                {error, _} -> {403, [], #{reason => <<"Bad request">>}}
             end;
         _ -> {403, [], #{reason => <<"Bad request">>}}
     end;

--- a/apps/aesophia/src/aeso_abi.erl
+++ b/apps/aesophia/src/aeso_abi.erl
@@ -10,37 +10,193 @@
 -module(aeso_abi).
 -define(HASH_SIZE, 32).
 
--export([create_calldata/3, get_type/1]).
+-export([ create_calldata/3
+        , check_calldata/2
+        , function_type_info/3
+        , function_type_hash/3
+        , arg_typerep_from_function/2
+        , type_hash_from_function_name/2
+        , typereps_from_type_hash/2
+        , function_name_from_type_hash/2
+        ]).
 
+-ifdef(TEST).
+-export([ ast_to_erlang/1]).
+-endif.
+
+-type function_name() :: binary(). %% String
+-type typerep() :: aeso_sophia:type().
+-type function_type_info() :: { FunctionHash :: aec_hash:hash()
+                              , FunctionName :: function_name()
+                              , ArgType      :: aeso_sophia:heap() %% binary typerep
+                              , OutType      :: aeso_sophia:heap() %% binary typerep
+                              }.
+-type type_info() :: [function_type_info()].
+
+-ifdef(COMMON_TEST).
+-define(TEST_LOG(Format, Data),
+        try ct:log(Format, Data)
+        catch
+            %% Enable setting up node with "test" rebar profile.
+            error:undef -> ok
+        end).
+-define(DEBUG_LOG(Format, Data), begin lager:debug(Format, Data), ?TEST_LOG(Format, Data) end).
+-else.
+-define(TEST_LOG(Format, Data), ok).
+-define(DEBUG_LOG(Format, Data), lager:debug(Format, Data)).
+-endif.
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+%%%===================================================================
+%%% Handle calldata
 
 -spec create_calldata(binary(), string(), string()) ->
-                             aeso_sophia:heap()
+                             {ok, aeso_sophia:heap(), aeso_sophia:type()}
                                  | {error, argument_syntax_error}.
-create_calldata(Contract, Function, Argument) ->
-    %% TODO: check that function exists in contract.
-    FunctionHandle = encode_function(Contract, Function),
+
+create_calldata(ContractCode, Function, Argument) ->
     case aeso_constants:string(Argument) of
         {ok, {tuple, _, _} = Tuple} ->
-            encode_call(FunctionHandle, Tuple);
+            encode_call(ContractCode, Function, Tuple);
         {ok, {unit, _} = Tuple} ->
-            encode_call(FunctionHandle, Tuple);
+            encode_call(ContractCode, Function, Tuple);
         {ok, ParsedArgument} ->
             %% The Sophia compiler does not parse a singleton tuple (42) as a tuple,
             %% Wrap it in a tuple.
-            encode_call(FunctionHandle, {tuple, [], [ParsedArgument]});
+            encode_call(ContractCode, Function, {tuple, [], [ParsedArgument]});
         {error, _} ->
             {error, argument_syntax_error}
     end.
 
 %% Call takes one arument.
 %% Use a tuple to pass multiple arguments.
-encode_call(FunctionHandle, ArgumentAst) ->
+encode_call(ContractCode, Function, ArgumentAst) ->
     Argument = ast_to_erlang(ArgumentAst),
-    Call = list_to_tuple([FunctionHandle, Argument]),
-    ArgumentType = get_type(Argument),
-    %% TODO: Once we have types in metadata we shouldn't include it in the calldata
-    Data = aeso_data:to_binary({{tuple, [string, ArgumentType]}, Call}),
-    Data.
+    try aeso_compiler:deserialize(ContractCode) of
+        #{type_info := TypeInfo} ->
+            FunBin = list_to_binary(Function),
+            case type_hash_from_function_name(FunBin, TypeInfo) of
+                {ok, <<TypeHashInt:256>>} ->
+                    Data = aeso_data:to_binary({TypeHashInt, Argument}),
+                    case check_calldata(Data, TypeInfo) of
+                        {ok, CallDataType, OutType} ->
+                            {ok, Data, CallDataType, OutType};
+                        {error,_What} = Err ->
+                            Err
+                    end;
+                {error, _} = Err ->
+                    Err
+            end
+    catch _:_ -> {error, bad_contract_code}
+    end.
+
+-spec check_calldata(aeso_sophia:heap(), type_info()) ->
+                        {'ok', typerep()} | {'error', atom()}.
+check_calldata(CallData, TypeInfo) ->
+    %% The first element of the CallData should be the function name
+    case aeso_data:get_function_hash_from_calldata(CallData) of
+        {ok, Hash} ->
+            case typereps_from_type_hash(Hash, TypeInfo) of
+                {ok, ArgType, OutType} ->
+                    ?TEST_LOG("Found ~p for ~p", [ArgType, Hash]),
+                    try aeso_data:from_binary({tuple, [word, ArgType]}, CallData) of
+                        {ok, _Something} ->
+                            ?TEST_LOG("Whole call data: ~p\n", [_Something]),
+                            {ok, {tuple, [word, ArgType]}, OutType};
+                        {error, _} ->
+                            {error, bad_call_data}
+                    catch
+                        _T:_E ->
+                            ?TEST_LOG("Error parsing call data: ~p", [{_T, _E}]),
+                            {error, bad_call_data}
+                    end;
+                {error, _} ->
+                    ?TEST_LOG("Unknown function hash ~p", [Hash]),
+                    {error, unknown_function}
+            end;
+        {error, _What} ->
+            ?TEST_LOG("Bad call data ~p", [_What]),
+            {error, bad_call_data}
+    end.
+
+%%%===================================================================
+%%% Handle type info from contract meta data
+
+-spec function_type_info(function_name(), [typerep()], typerep()) ->
+                            function_type_info().
+function_type_info(Name, Args, OutType) ->
+    ArgType = {tuple, [T || {_, T} <- Args]},
+    { function_type_hash(Name, ArgType, OutType)
+    , Name
+    , aeso_data:to_binary(ArgType)
+    , aeso_data:to_binary(OutType)
+    }.
+
+-spec function_type_hash(function_name(), typerep(), typerep()) ->
+                            aec_hash:hash().
+function_type_hash(Name, ArgType, OutType) ->
+    aec_hash:hash(sophia_type_hash,
+                  iolist_to_binary([ Name
+                                   , aeso_data:to_binary(ArgType)
+                                   , aeso_data:to_binary(OutType)
+                                   ])).
+
+
+-spec arg_typerep_from_function(function_name(), type_info()) ->
+           {'ok', typerep()} | {'error', 'bad_type_data' | 'unknown_function'}.
+arg_typerep_from_function(Function, TypeInfo) ->
+    case lists:keyfind(Function, 2, TypeInfo) of
+        {_TypeHash, Function, ArgTypeBin,_OutTypeBin} ->
+            case aeso_data:from_binary(typerep, ArgTypeBin) of
+                {ok, ArgType} -> {ok, ArgType};
+                {error,_} -> {error, bad_type_data}
+            end;
+        false ->
+            {error, unknown_function}
+    end.
+
+-spec typereps_from_type_hash(aec_hash:hash(), type_info()) ->
+           {'ok', typerep()} | {'error', 'bad_type_data' | 'unknown_function'}.
+typereps_from_type_hash(TypeHash, TypeInfo) ->
+    case lists:keyfind(TypeHash, 1, TypeInfo) of
+        {TypeHash,_Function, ArgTypeBin, OutTypeBin} ->
+            case {aeso_data:from_binary(typerep, ArgTypeBin),
+                  aeso_data:from_binary(typerep, OutTypeBin)} of
+                {{ok, ArgType}, {ok, OutType}} -> {ok, ArgType, OutType};
+                {_, _} -> {error, bad_type_data}
+            end;
+        false ->
+            {error, unknown_function}
+    end.
+
+-spec function_name_from_type_hash(aec_hash:hash(), type_info()) ->
+                                          {'ok', function_name()}
+                                        | {'error', 'unknown_function'}.
+function_name_from_type_hash(TypeHash, TypeInfo) ->
+    case lists:keyfind(TypeHash, 1, TypeInfo) of
+        {TypeHash, Function,_ArgTypeBin,_OutTypeBin} ->
+            {ok, Function};
+        false ->
+            {error, unknown_function}
+    end.
+
+-spec type_hash_from_function_name(function_name(), type_info()) ->
+                                          {'ok', aec_hash:hash()}
+                                        | {'error', 'unknown_function'}.
+type_hash_from_function_name(Name, TypeInfo) ->
+    case lists:keyfind(Name, 2, TypeInfo) of
+        {TypeHash, Name,_ArgTypeBin,_OutTypeBin} ->
+            {ok, TypeHash};
+        false ->
+            {error, unknown_function}
+    end.
+
+%%%===================================================================
+%%% Test API
+%%%===================================================================
 
 ast_to_erlang({int, _, N}) -> N;
 ast_to_erlang({bool, _, true}) -> 1;
@@ -56,33 +212,3 @@ ast_to_erlang({list, _, Elems}) ->
 ast_to_erlang({map, _, Elems}) ->
     maps:from_list([ {ast_to_erlang(element(1, Elem)), ast_to_erlang(element(2, Elem))}
                         || Elem <- Elems ]).
-
-encode_function(_Contract, Function) ->
-     << <<X>> || X <- Function>>.
-
-get_type(N) when is_integer(N) -> word;
-get_type(S) when is_binary(S)  -> string;
-get_type(word)                 -> typerep;
-get_type(string)               -> typerep;
-get_type({list, _})            -> typerep;
-get_type({tuple, _})           -> typerep;
-get_type({variant, _})         -> typerep;
-get_type({map, _, _})          -> typerep;
-get_type(none)                 -> option_t(word);
-get_type({some, X})            -> option_t(get_type(X));
-get_type([])                   -> {list, word};
-get_type([H | _])              -> {list, get_type(H)};
-get_type(M) when is_map(M) ->
-    {KeyT, ValT} =
-        case maps:to_list(M) of
-            [] -> {word, word};
-            [{K, V} | _] -> {get_type(K), get_type(V)}
-        end,
-    {map, KeyT, ValT};
-get_type({variant, Tag, Args}) ->
-    {variant, lists:duplicate(Tag, []) ++ [lists:map(fun get_type/1, Args)]};
-get_type(T) when is_tuple(T) ->
-    {tuple, [ get_type(X) || X <- tuple_to_list(T) ]}.
-
-option_t(T) -> {variant, [[], [T]]}.
-

--- a/apps/aesophia/src/aeso_ast.erl
+++ b/apps/aesophia/src/aeso_ast.erl
@@ -3,6 +3,7 @@
 -export([int/2,
          line/1,
          pp/1,
+         pp_typed/1,
          symbol/2,
          symbol_name/1
         ]).
@@ -18,4 +19,9 @@ symbol_name({symbol, _, Name}) -> Name.
 pp(Ast) ->
     %% TODO: Actually do *Pretty* printing.
     io:format("~p~n", [Ast]).
+
+pp_typed(TypedAst) ->
+    String = prettypr:format(aeso_pretty:decls(TypedAst, [show_generated])),
+    %%io:format("Typed tree:\n~p\n",[TypedAst]),
+    io:format("Type info:\n~s\n",[String]).
 

--- a/apps/aesophia/src/aeso_ast_to_icode.erl
+++ b/apps/aesophia/src/aeso_ast_to_icode.erl
@@ -10,16 +10,13 @@
 -module(aeso_ast_to_icode).
 
 -export([ast_typerep/1, type_value/1,
-         convert/2]).
+         convert_typed/2]).
 
 -include_lib("aebytecode/include/aeb_opcodes.hrl").
 -include("aeso_icode.hrl").
 
--spec convert(aeso_syntax:ast(), list()) -> aeso_icode:icode().
-convert(Tree, Options) ->
-    TypedTree = aeso_ast_infer_types:infer(Tree),
-    [io:format("Typed tree:\n~s\n",[prettypr:format(aeso_pretty:decls(TypedTree, [show_generated]))]) || lists:member(pp_typed,Options)],
-    %% [io:format("Typed tree:\n~p\n",[TypedTree]) || lists:member(pp_typed,Options)],
+-spec convert_typed(aeso_syntax:ast(), list()) -> aeso_icode:icode().
+convert_typed(TypedTree, Options) ->
     code(TypedTree, aeso_icode:new(Options)).
 
 code([{contract, _Attribs, {con, _, Name}, Code}|Rest], Icode) ->
@@ -347,14 +344,17 @@ ast_body({app, _, {typed, _, {proj, _, {typed, _, Addr, {con, _, Contract}}, {id
     ArgType = ast_typerep({tuple_t, [], ArgsT}),
     Gas    = proplists:get_value("gas",   ArgOpts ++ Defaults),
     Value  = proplists:get_value("value", ArgOpts ++ Defaults),
-    Fun    = ast_body({string, [], list_to_binary(FunName)}, Icode),
+    OutType = ast_typerep(OutT, Icode),
+    <<TypeHash:256>> = aeso_abi:function_type_hash(FunName, ArgType, OutType),
+    %% The function is represented by its type hash (which includes the name)
+    Fun    = #integer{value = TypeHash},
     #prim_call_contract{
         address  = ast_body(Addr, Icode),
         gas      = Gas,
         value    = Value,
         arg      = #tuple{cpts = [Fun, #tuple{ cpts = ArgsI }]},
-        arg_type = {tuple, [string, ArgType]},
-        out_type = ast_typerep(OutT, Icode) };
+        type_hash= #integer{value = TypeHash}
+      };
 ast_body({proj, _, {typed, _, _, {con, _, Contract}}, {id, _, FunName}}, _Icode) ->
     error({underapplied_contract_call, string:join([Contract, FunName], ".")});
 
@@ -524,12 +524,15 @@ is_monomorphic(_) -> true.
 
 %% Implemented as a contract call to the contract with address 0.
 prim_call(Prim, Amount, Args, ArgTypes, OutType) ->
+    PrimBin = binary:encode_unsigned(Prim),
+    ArgType = {tuple, ArgTypes},
+    <<TypeHash:256>> = aeso_abi:function_type_hash(PrimBin, ArgType, OutType),
     #prim_call_contract{ gas      = prim_gas_left,
                          address  = #integer{ value = ?PRIM_CALLS_CONTRACT },
                          value    = Amount,
-                         arg      = #tuple{cpts = [#integer{ value = Prim } | Args]},
-                         arg_type = {tuple, [word | ArgTypes]},
-                         out_type = OutType }.
+                         arg      = #tuple{cpts = [#integer{ value = Prim }| Args]},
+                         type_hash= #integer{value = TypeHash}
+                       }.
 
 make_type_def(Args, Def, Icode = #{ type_vars := TypeEnv }) ->
     TVars = [ X || {tvar, _, X} <- Args ],

--- a/apps/aesophia/src/aeso_compiler.erl
+++ b/apps/aesophia/src/aeso_compiler.erl
@@ -19,7 +19,7 @@
 
 -ifdef(TEST).
 
--export([ serialize/2
+-export([ serialize/3
         ]).
 
 -endif.
@@ -59,20 +59,23 @@ from_string(ContractString, Options) ->
     Ast = parse(ContractString, Options),
     ok = pp_sophia_code(Ast, Options),
     ok = pp_ast(Ast, Options),
-    ICode = to_icode(Ast, Options),
+    TypedAst = aeso_ast_infer_types:infer(Ast),
+    ok = pp_typed_ast(TypedAst, Options),
+    ICode = to_icode(TypedAst, Options),
+    TypeInfo = extract_type_info(ICode),
     ok = pp_icode(ICode, Options),
     Assembler =  assemble(ICode, Options),
     ok = pp_assembler(Assembler, Options),
     ByteCodeList = to_bytecode(Assembler, Options),
     ByteCode = << << B:8 >> || B <- ByteCodeList >>,
     ok = pp_bytecode(ByteCode, Options),
-    serialize(ByteCode, ContractString).
+    serialize(ByteCode, TypeInfo, ContractString).
 
 parse(C,_Options) ->
     parse_string(C).
 
-to_icode(Ast, Options) ->
-    aeso_ast_to_icode:convert(Ast, Options).
+to_icode(TypedAst, Options) ->
+    aeso_ast_to_icode:convert_typed(TypedAst, Options).
 
 assemble(Icode, Options) ->
     aeso_icode_to_asm:convert(Icode, Options).
@@ -84,12 +87,19 @@ to_bytecode([Op|Rest], Options) ->
     [aeb_opcodes:m_to_op(Op)|to_bytecode(Rest, Options)];
 to_bytecode([], _) -> [].
 
+extract_type_info(#{functions := Functions} =_Icode) ->
+    TypeInfo = [aeso_abi:function_type_info(list_to_binary(Name), Args, TypeRep)
+                || {Name, Attrs, Args,_Body, TypeRep} <- Functions,
+                   not is_tuple(Name),
+                   not lists:member(private, Attrs)
+               ],
+    lists:sort(TypeInfo).
 
-serialize(ByteCode, ContractString) ->
+serialize(ByteCode, TypeInfo, ContractString) ->
     ContractBin = list_to_binary(ContractString),
     Version = version(),
     Fields = [ {source_hash, aec_hash:hash(sophia_source_code, ContractBin)}
-             , {type_info, []} %% TODO: This
+             , {type_info, TypeInfo}
              , {byte_code, ByteCode}
              ],
     aec_object_serialization:serialize(compiler_sophia,
@@ -117,7 +127,7 @@ deserialize(Binary) ->
 
 serialization_template(?COMPILER_VERSION) ->
     [ {source_hash, binary}
-    , {type_info, [binary]}
+    , {type_info, [{binary, binary, binary, binary}]} %% {type hash, name, arg type, out type}
     , {byte_code, binary}].
 
 
@@ -125,6 +135,7 @@ pp_sophia_code(C, Opts)->  pp(C, Opts, pp_sophia_code, fun(Code) ->
                                 io:format("~s\n", [prettypr:format(aeso_pretty:decls(Code))])
                             end).
 pp_ast(C, Opts)      ->  pp(C, Opts, pp_ast, fun aeso_ast:pp/1).
+pp_typed_ast(C, Opts)->  pp(C, Opts, pp_typed, fun aeso_ast:pp_typed/1).
 pp_icode(C, Opts)    ->  pp(C, Opts, pp_icode, fun aeso_icode:pp/1).
 pp_assembler(C, Opts)->  pp(C, Opts, pp_assembler, fun aeb_asm:pp/1).
 pp_bytecode(C, Opts) ->  pp(C, Opts, pp_bytecode, fun aeb_disassemble:pp/1).

--- a/apps/aesophia/src/aeso_icode.hrl
+++ b/apps/aesophia/src/aeso_icode.hrl
@@ -8,6 +8,7 @@
 -define(TYPEREP_VARIANT_TAG, 4).
 -define(TYPEREP_TYPEREP_TAG, 5).
 -define(TYPEREP_MAP_TAG,     6).
+-define(TYPEREP_FUN_TAG,     7).
 
 -record(arg, {name::string(), type::?Type()}).
 
@@ -26,8 +27,8 @@
     , address  :: expr()
     , value    :: expr()
     , arg      :: expr()
-    , arg_type :: ?Type()
-    , out_type :: ?Type() }).
+    , type_hash:: expr()
+    }).
 
 -record(prim_balance,    { address :: expr() }).
 -record(prim_block_hash, { height :: expr() }).

--- a/apps/aesophia/test/aeso_abi_tests.erl
+++ b/apps/aesophia/test/aeso_abi_tests.erl
@@ -4,8 +4,7 @@
 
 encode_call_with_integer_test() ->
     Words = fun aeso_test_utils:dump_words/1,
-    Expected = Words(aeso_data:to_binary({{tuple, [string, {tuple, [word]}]}, {<<"main">>, {42}}})),
-    Expected = Words(aeso_abi:create_calldata("", "main", "(42)")).
+    Expected = Words(aeso_data:to_binary({{tuple, [string, {tuple, [word]}]}, {<<"main">>, {42}}})).
 
 -define(SANDBOX(Code), sandbox(fun() -> Code end)).
 
@@ -73,20 +72,14 @@ encode_decode_sophia_string(String) ->
     io:format("AstType ~p~n", [AstType]),
     {ok, Type} = aeso_data:sophia_type_to_typerep(AstType),
     io:format("Type ~p~n", [Type]),
-    Data = aeso_abi:create_calldata(<<>>, "foo", String),
-    io:format("Data ~p~n", [Data]),
-    case Type of
-        {tuple, _} ->
-            {_, {<<"foo">>, R}} = decode({tuple, [typerep, {tuple, [string, Type]}]}, Data),
-            R;
-        _ ->
-            {_, {<<"foo">>, {R}}} = decode({tuple, [typerep, {tuple, [string, {tuple, [Type]}]}]}, Data),
-            R
-    end.
-
+    {ok, Ast} = aeso_constants:string(String),
+    ErlangString = aeso_abi:ast_to_erlang(Ast),
+    io:format("ErlangString ~p~n", [ErlangString]),
+    decode(Type, encode(ErlangString)).
 
 encode_decode(T, D) ->
-    D = decode(T, encode(D)).
+    ?assertEqual(D, decode(T, encode(D))),
+    D.
 
 encode(D) ->
     aeso_data:to_binary(D).

--- a/apps/aesophia/test/contracts/init_error.aes
+++ b/apps/aesophia/test/contracts/init_error.aes
@@ -1,0 +1,9 @@
+contract Remote =
+  function missing : (int) => int
+
+contract Init_error =
+
+  record state = {value : int}
+
+  function init(r : Remote, x : int) =
+    {value = r.missing(x)}

--- a/apps/aesophia/test/contracts/oracles.aes
+++ b/apps/aesophia/test/contracts/oracles.aes
@@ -39,6 +39,16 @@ contract Oracles =
                        rttl : ttl) : query_id =
     Oracle.query(o, q, qfee, qttl, rttl)
 
+  // Do not use in production!
+  function unsafeCreateQueryThenErr(o    : oracle_id,
+                       q    : query_t,
+                       qfee : fee,
+                       qttl : ttl,
+                       rttl : ttl) : query_id =
+    let res = Oracle.query(o, q, qfee, qttl, rttl)
+    require(qfee >= 100000000000000000, "causing a late error")
+    res
+
   function extendOracle(o    : oracle_id,
                         ttl  : ttl) : () =
     Oracle.extend(o, ttl)

--- a/apps/aesophia/test/contracts/remote_type_check.aes
+++ b/apps/aesophia/test/contracts/remote_type_check.aes
@@ -1,0 +1,22 @@
+contract Remote =
+  function id : ('a) => 'a
+  function missing : ('a) => 'a
+  function wrong_type : (string) => string
+
+contract Main =
+
+  function id(x : int) =
+    x
+
+  function wrong_type(x : int) =
+    x
+
+  function remote_id(r : Remote, x) =
+    r.id(x)
+
+  function remote_missing(r : Remote, x) =
+    r.missing(x)
+
+  function remote_wrong_type(r : Remote, x) =
+    r.wrong_type(x)
+

--- a/apps/aeutils/test/data/epoch_full.yaml
+++ b/apps/aeutils/test/data/epoch_full.yaml
@@ -102,7 +102,7 @@ chain:
     db_path: .
     # Hard forks
     hard_forks:
-      "26": 0
+      "27": 0
 
 mining:
     # Start mining automatically.

--- a/docs/release-notes/PT-160256544-check-types
+++ b/docs/release-notes/PT-160256544-check-types
@@ -1,0 +1,2 @@
+* Change calling convention in sophia and add type checking of remote calls. This makes the byte code smaller, the memory usage smaller, the contract calls more type safe. This affects consensus.
+

--- a/py/tests/integration/common.py
+++ b/py/tests/integration/common.py
@@ -116,7 +116,7 @@ def make_no_mining_user_config(root_dir, file_name):
 ---
 chain:
     hard_forks:
-        "26": 0
+        "27": 0
 
 mining:
     autostart: false
@@ -137,7 +137,7 @@ def make_mining_user_config(root_dir, key_dir, beneficiary, file_name):
 ---
 chain:
     hard_forks:
-        "26": 0
+        "27": 0
 keys:
     dir: "{}"
 

--- a/py/tests/integration/setup.yaml
+++ b/py/tests/integration/setup.yaml
@@ -115,7 +115,7 @@ tests: # test specific settings
         deposit: 2
         amount: 1
         gas: 75000
-        gas_used: 482
+        gas_used: 178
         gas_price: 1
         fee: 11
         function: "init"
@@ -132,7 +132,6 @@ tests: # test specific settings
         fee: 1
         amount: 10
         gas: 5500
-        gas_used: 305
         gas_price: 1
         data:
           function: main

--- a/py/tests/integration/test_use_cases.py
+++ b/py/tests/integration/test_use_cases.py
@@ -304,7 +304,7 @@ keys:
 
 chain:
     hard_forks:
-        "26": 0
+        "27": 0
 
 mining:
     autostart: true
@@ -334,7 +334,7 @@ keys:
 
 chain:
     hard_forks:
-        "26": 0
+        "27": 0
 
 mining:
     autostart: false

--- a/test/aevm_chain_SUITE.erl
+++ b/test/aevm_chain_SUITE.erl
@@ -67,7 +67,7 @@ setup_chain() ->
 create_contract(Owner, S) ->
     OwnerPrivKey = aect_test_utils:priv_key(Owner, S),
     IdContract   = aect_test_utils:compile_contract("contracts/identity.aes"),
-    CallData     = aeso_abi:create_calldata(IdContract, "init", "42"),
+    {ok, CallData} = aect_sophia:encode_call_data(IdContract, <<"init">>, <<"()">>),
 
     Overrides    = #{ code => IdContract
                     , call_data => CallData
@@ -90,7 +90,8 @@ sign_and_apply_transaction(Tx, PrivKey, S1) ->
 
 call_data(Arg) ->
     Code = aect_test_utils:compile_contract("contracts/identity.aes"),
-    aect_sophia:create_call(Code, <<"main">>, Arg).
+    {ok, CallData} = aect_sophia:encode_call_data(Code, <<"main">>, Arg),
+    CallData.
 
 %%%===================================================================
 %%% Height tests

--- a/test/contract_sophia_bytecode_aevm_SUITE.erl
+++ b/test/contract_sophia_bytecode_aevm_SUITE.erl
@@ -432,7 +432,7 @@ oracles(_Cfg) ->
     ChainEnv = #{ currentNumber => 20 },
     Env0 = initial_state(#{ environment => ChainEnv }, #{101 => QFee}),
     Env1 = create_contract(101, Code, "()", Env0),
-    {101, Env2} = successful_call(101, word, registerOracle, "(101, (0, 0), "++ integer_to_list(QFee) ++", (0, 10))", Env1),
+    {101, Env2} = successful_call(101, word, registerOracle, "(101, "++ integer_to_list(QFee) ++", (0, 10))", Env1),
     {Q, Env3}   = successful_call(101, word, createQuery, "(101, \"why?\", "++ integer_to_list(QFee) ++", (0, 10), (0, 11))", Env2, #{value => QFee}),
     QArg        = integer_to_list(Q),
     OandQArg    = "(101, "++ QArg ++")",

--- a/test/contract_sophia_bytecode_aevm_SUITE.erl
+++ b/test/contract_sophia_bytecode_aevm_SUITE.erl
@@ -31,6 +31,7 @@
           spend_tx/3,
           spend/2,
           get_balance/2,
+          get_contract_fun_types/4,
           call_contract/6,
           get_store/1,
           set_store/2,
@@ -82,16 +83,28 @@ compile_contract(Name) ->
 execute_call(Contract, CallData, ChainState, Options) ->
     #{Contract := SerializedCode} = ChainState,
     ChainState1 = ChainState#{ running => Contract },
-    Trace = false,
     %% TODO: Check the type info before calling?
-    #{ byte_code := Code} = aeso_compiler:deserialize(SerializedCode),
+    #{ byte_code := Code,
+       type_info := TypeInfo
+     } = aeso_compiler:deserialize(SerializedCode),
+    case aeso_abi:check_calldata(CallData, TypeInfo) of
+        {ok, CallDataType, OutType} ->
+            execute_call_1(Contract, CallData, CallDataType, OutType, Code, ChainState1, Options);
+        {error, _} = Err ->
+            Err
+    end.
+
+execute_call_1(Contract, CallData, CallDataType, OutType, Code, ChainState, Options) ->
+    Trace = false,
     Res = aect_evm:execute_call(
           maps:merge(
           #{ code              => Code,
-             store             => get_store(ChainState1),
+             store             => get_store(ChainState),
              address           => Contract,
              caller            => 0,
              data              => CallData,
+             call_data_type    => CallDataType,
+             out_type          => OutType,
              gas               => 1500000,
              gasPrice          => 1,
              origin            => 0,
@@ -101,7 +114,7 @@ execute_call(Contract, CallData, ChainState, Options) ->
              currentGasLimit   => 2000000,
              currentNumber     => 0,
              currentTimestamp  => 0,
-             chainState        => ChainState1,
+             chainState        => ChainState,
              chainAPI          => ?MODULE,
              vm_version        => ?AEVM_01_Sophia_01}, Options),
           Trace),
@@ -114,9 +127,9 @@ execute_call(Contract, CallData, ChainState, Options) ->
 
 make_call(Contract, Fun, Args, Env, Options) ->
     #{ Contract := Code } = Env,
-    CallData = aect_sophia:create_call(Code,
-                    list_to_binary(atom_to_list(Fun)),
-                    list_to_binary(Args)),
+    {ok, CallData} = aect_sophia:encode_call_data(Code,
+                                                  atom_to_binary(Fun, utf8),
+                                                  list_to_binary(Args)),
     execute_call(Contract, CallData, Env, Options).
 
 create_contract(Address, Code, Args, Env) ->
@@ -419,7 +432,7 @@ oracles(_Cfg) ->
     ChainEnv = #{ currentNumber => 20 },
     Env0 = initial_state(#{ environment => ChainEnv }, #{101 => QFee}),
     Env1 = create_contract(101, Code, "()", Env0),
-    {101, Env2} = successful_call(101, word, registerOracle, "(101, "++ integer_to_list(QFee) ++", (0, 10))", Env1),
+    {101, Env2} = successful_call(101, word, registerOracle, "(101, (0, 0), "++ integer_to_list(QFee) ++", (0, 10))", Env1),
     {Q, Env3}   = successful_call(101, word, createQuery, "(101, \"why?\", "++ integer_to_list(QFee) ++", (0, 10), (0, 11))", Env2, #{value => QFee}),
     QArg        = integer_to_list(Q),
     OandQArg    = "(101, "++ QArg ++")",
@@ -498,6 +511,17 @@ get_store(#{ running := Contract, store := Store }) ->
 
 set_store(Data, State = #{ running := Contract, store := Store }) ->
     State#{ store => Store#{ Contract => Data } }.
+
+get_contract_fun_types(<<Contract:256>>,_VMVersion, TypeHash, S) ->
+    case maps:get(Contract, S, undefine) of
+        undefined ->
+            io:format("   oops, no such contract!\n"),
+            {error, {no_such_contract, Contract}};
+        SerializedCode ->
+            #{type_info := TypeInfo} = aeso_compiler:deserialize(SerializedCode),
+            aeso_abi:typereps_from_type_hash(TypeHash, TypeInfo)
+    end.
+
 
 call_contract(<<Contract:256>>, _Gas, Value, CallData, _, S = #{running := Caller}) ->
     case maps:is_key(Contract, S) of

--- a/test/sophia_bytecode_aevm_SUITE.erl
+++ b/test/sophia_bytecode_aevm_SUITE.erl
@@ -9,8 +9,7 @@
 %% test case exports
 -export(
    [
-     execute_identity_fun_from_bytecode/1
-   , execute_identity_fun_from_sophia_file/1
+    execute_identity_fun_from_sophia_file/1
    ]).
 
 -include("apps/aecontract/src/aecontract.hrl").
@@ -19,7 +18,6 @@
 
 all() ->
     [
-      execute_identity_fun_from_bytecode,
       execute_identity_fun_from_sophia_file ].
 
 execute_identity_fun_from_sophia_file(_Cfg) ->
@@ -28,10 +26,14 @@ execute_identity_fun_from_sophia_file(_Cfg) ->
     {ok, ContractBin} = file:read_file(FileName),
     Contract = binary_to_list(ContractBin),
     SerializedCode = aeso_compiler:from_string(Contract, [pp_icode, pp_assembler]),
-    #{ byte_code := Code} = aeso_compiler:deserialize(SerializedCode),
+    #{ byte_code := Code,
+       type_info := TypeInfo} = aeso_compiler:deserialize(SerializedCode),
+    {ok, ArgType} = aeso_abi:arg_typerep_from_function(<<"main">>, TypeInfo),
+    CallDataType = {tuple, [word, ArgType]},
+    OutType = word,
 
     %% Create the call data
-    CallData = aeso_abi:create_calldata(Code, "main", "(42)"),
+    {ok, CallData} = aect_sophia:encode_call_data(SerializedCode, <<"main">>, <<"(42)">>),
     {ok, Res} =
         aevm_eeevm:eval(
           aevm_eeevm_state:init(
@@ -40,6 +42,8 @@ execute_identity_fun_from_sophia_file(_Cfg) ->
                           address => 91210,
                           caller => 0,
                           data => CallData,
+                          call_data_type => CallDataType,
+                          out_type => OutType,
                           gas => 1000000,
                           gasPrice => 1,
                           origin => 0,
@@ -57,49 +61,4 @@ execute_identity_fun_from_sophia_file(_Cfg) ->
          ),
     #{ out := RetVal } = Res,
     <<42:256>> = RetVal,
-    ok.
-
-execute_identity_fun_from_bytecode(_Cfg) ->
-    Code =
-        %% We enter the VM with the calldata on the stack and stored after the
-        %% statedata in memory if required. The calldata is a pair of the type
-        %% (word) and the value (42).
-        %% We should return with a typerep and return value on the stack and 0
-        %% written to the state pointer at address 0, to indicate that we
-        %% didn't update the state. We haven't initialized any state in this
-        %% test though, so the state pointer is already 0.
-                        %% Stack    Mem             Comment
-                        %% P        .. P:Q P+32:N Q:0
-        <<?DUP1,        %% P P
-          ?PUSH1, 32,   %% 32 P P
-          ?ADD,         %% P+32 P
-          ?MLOAD,       %% N
-          ?SWAP1,       %% P N
-          ?MLOAD,       %% Q N
-          ?RETURN>>,
-    {ok, Res} =
-        aevm_eeevm:eval(
-          aevm_eeevm_state:init(
-            #{ exec => #{ code => Code,
-                          store => #{},
-                          address => 91210,
-                          caller => 0,
-                          data => <<32:256, 96:256, 42:256, 0:256>>,
-                          gas => 1000000,
-                          gasPrice => 1,
-                          origin => 0,
-                      value => 0 },
-               env => #{currentCoinbase => 0,
-                        currentDifficulty => 0,
-                        currentGasLimit => 10000,
-                        currentNumber => 0,
-                        currentTimestamp => 0,
-                        chainState => aevm_dummy_chain:new_state(),
-                        chainAPI => aevm_dummy_chain,
-                        vm_version => ?AEVM_01_Sophia_01},
-               pre => #{}},
-            #{trace => true})
-         ),
-    #{ out := << RetVal:256 >> } = Res,
-    42 = RetVal,
     ok.


### PR DESCRIPTION
* Type representions are no longer in call data
* Function names are no longer in call data
* The function signature (argtypes and outtype) is stored in meta data
* Calls are done based on a function hash that includes the type signature
* Call data needs the byte code to be encoded
* Primop types are fetched from the chain when needed (e.g., for oracles)

This makes:
- the byte code smaller
- the memory usage smaller
- the contract calls more type safe
- the chain primops more type safe

TODO:
- Check the type signatures on oracle primops so that the compiled
  code is expecting the correct query/response types.
- Check the types on name resolution. I'm not entirely sure it is safe.

TODO (for this PR):

- [x] Bump protocol version and db dir
- [x] Add release notes
- [x] Consider removing explicit typereps for the `RETURN` op, and use type info instead.
- [x] Merge the new way of constructing call data.
