### PR TITLE
PT-160256544 calldata creation part

### DIFF
--- a/apps/aehttp/priv/swagger.json
+++ b/apps/aehttp/priv/swagger.json
@@ -3847,7 +3847,7 @@
     },
     "ContractCallInput" : {
       "type" : "object",
-      "required" : [ "abi", "arg", "code", "function" ],
+      "required" : [ "abi", "code" ],
       "properties" : {
         "abi" : {
           "type" : "string"
@@ -3860,9 +3860,14 @@
         },
         "arg" : {
           "type" : "string"
+        },
+        "call" : {
+          "type" : "string",
+          "description" : "Source code for a contract with a function __call() = f(args), if calling a function f"
         }
       },
       "example" : {
+        "call" : "call",
         "code" : "code",
         "function" : "function",
         "arg" : "arg",
@@ -4026,7 +4031,7 @@
     },
     "ContractCreateCompute" : {
       "type" : "object",
-      "required" : [ "amount", "arguments", "code", "deposit", "fee", "gas", "gas_price", "owner_id", "vm_version" ],
+      "required" : [ "amount", "code", "deposit", "fee", "gas", "gas_price", "owner_id", "vm_version" ],
       "properties" : {
         "owner_id" : {
           "type" : "string",
@@ -4078,11 +4083,16 @@
         },
         "arguments" : {
           "type" : "string",
-          "description" : "Contract call data init function arguments"
+          "description" : "Contract call data init function arguments (deprecated, use call)"
+        },
+        "call" : {
+          "type" : "string",
+          "description" : "Source code for a contract with a function __call() = init(args)"
         }
       },
       "example" : {
         "gas_price" : 0,
+        "call" : "call",
         "vm_version" : 153,
         "amount" : 0,
         "code" : "code",
@@ -4162,7 +4172,7 @@
     },
     "ContractCallCompute" : {
       "type" : "object",
-      "required" : [ "amount", "arguments", "caller_id", "contract_id", "fee", "function", "gas", "gas_price", "vm_version" ],
+      "required" : [ "amount", "caller_id", "contract_id", "fee", "gas", "gas_price", "vm_version" ],
       "properties" : {
         "caller_id" : {
           "description" : "Contract caller pub_key",
@@ -4209,15 +4219,20 @@
         },
         "function" : {
           "type" : "string",
-          "description" : "Contract call data function"
+          "description" : "Contract call data function (deprecated, use call)"
         },
         "arguments" : {
           "type" : "string",
-          "description" : "Contract call data function arguments"
+          "description" : "Contract call data function arguments (deprecated, use call)"
+        },
+        "call" : {
+          "type" : "string",
+          "description" : "Source code for a contract with a function __call() = f(args), if calling a function f"
         }
       },
       "example" : {
         "gas_price" : 0,
+        "call" : "call",
         "vm_version" : 153,
         "amount" : 0,
         "caller_id" : { },

--- a/apps/aesophia/src/aeso_abi.erl
+++ b/apps/aesophia/src/aeso_abi.erl
@@ -257,6 +257,8 @@ old_encode_call(ContractCode, Function, ArgumentAst) ->
     end.
 
 old_ast_to_erlang({int, _, N}) -> N;
+old_ast_to_erlang({hash, _, <<N:256>>}) -> N;
+old_ast_to_erlang({hash, _, <<Hi:256, Lo:256>>}) -> {Hi, Lo};    %% signature
 old_ast_to_erlang({bool, _, true}) -> 1;
 old_ast_to_erlang({bool, _, false}) -> 0;
 old_ast_to_erlang({string, _, Bin}) -> Bin;

--- a/apps/aesophia/src/aeso_ast_infer_types.erl
+++ b/apps/aesophia/src/aeso_ast_infer_types.erl
@@ -190,7 +190,7 @@ infer_contract(Env, Defs) ->
     check_reserved_entrypoints(FunMap),
     DepGraph  = maps:map(fun(_, Def) -> aeso_syntax_utils:used_ids(Def) end, FunMap),
     SCCs      = aeso_utils:scc(DepGraph),
-    io:format("Dependency sorted functions:\n  ~p\n", [SCCs]),
+    %% io:format("Dependency sorted functions:\n  ~p\n", [SCCs]),
     TypeDefs ++ check_sccs(Env2, FunMap, SCCs, []).
 
 check_typedefs(Env, Defs) ->
@@ -199,7 +199,7 @@ check_typedefs(Env, Defs) ->
     TypeMap  = maps:from_list([ {GetName(Def), Def} || Def <- Defs ]),
     DepGraph = maps:map(fun(_, Def) -> aeso_syntax_utils:used_types(Def) end, TypeMap),
     SCCs     = aeso_utils:scc(DepGraph),
-    io:format("Dependency sorted types:\n  ~p\n", [SCCs]),
+    %% io:format("Dependency sorted types:\n  ~p\n", [SCCs]),
     Env1     = check_typedef_sccs(Env, TypeMap, SCCs),
     destroy_and_report_type_errors(),
     SCCNames = fun({cyclic, Xs}) -> Xs; ({acyclic, X}) -> [X] end,

--- a/apps/aesophia/src/aeso_ast_infer_types.erl
+++ b/apps/aesophia/src/aeso_ast_infer_types.erl
@@ -371,8 +371,11 @@ infer_expr(_Env, Body={int, As, _}) ->
     {typed, As, Body, {id, As, "int"}};
 infer_expr(_Env, Body={string, As, _}) ->
     {typed, As, Body, {id, As, "string"}};
-infer_expr(_Env, Body={hash, As, _}) ->
-    {typed, As, Body, {id, As, "address"}};
+infer_expr(_Env, Body={hash, As, Hash}) ->
+    case byte_size(Hash) of
+        32 -> {typed, As, Body, {id, As, "address"}};
+        64 -> {typed, As, Body, {id, As, "signature"}}
+    end;
 infer_expr(_Env, Body={id, As, "_"}) ->
     {typed, As, Body, fresh_uvar(As)};
 infer_expr(Env, Body={id, As, Name}) ->

--- a/apps/aesophia/src/aeso_ast_to_icode.erl
+++ b/apps/aesophia/src/aeso_ast_to_icode.erl
@@ -9,7 +9,7 @@
 %%%-------------------------------------------------------------------
 -module(aeso_ast_to_icode).
 
--export([ast_typerep/1, type_value/1,
+-export([ast_typerep/1, ast_typerep/2, type_value/1,
          convert_typed/2]).
 
 -include_lib("aebytecode/include/aeb_opcodes.hrl").

--- a/apps/aesophia/src/aeso_ast_to_icode.erl
+++ b/apps/aesophia/src/aeso_ast_to_icode.erl
@@ -319,8 +319,13 @@ ast_body({bool, _, Bool}, _Icode) ->        %BOOL as ints
 ast_body({int, _, Value}, _Icode) ->
     #integer{value = Value};
 ast_body({hash, _, Hash}, _Icode) ->
-    <<Value:32/unit:8>> = Hash,
-    #integer{value = Value};
+    case Hash of
+        <<Value:32/unit:8>> ->              %% address
+            #integer{value = Value};
+        <<Hi:32/unit:8, Lo:32/unit:8>> ->   %% signature
+            #tuple{cpts = [#integer{value = Hi},
+                           #integer{value = Lo}]}
+    end;
 ast_body({string,_,Bin}, _Icode) ->
     Cpts = [size(Bin)|aeso_data:binary_to_words(Bin)],
     #tuple{cpts = [#integer{value=X} || X <- Cpts]};

--- a/apps/aesophia/src/aeso_compiler.erl
+++ b/apps/aesophia/src/aeso_compiler.erl
@@ -81,7 +81,7 @@ from_string(ContractString, Options) ->
 %% function (foo, say) and a function __call() = foo(args) calling this
 %% function. Returns the name of the called functions, typereps and Erlang
 %% terms for the arguments.
--spec check_call(string(), options()) -> {ok, string(), {[Type], Type}, [term()]} | {error, term()}
+-spec check_call(string(), options()) -> {ok, string(), {[Type], Type | any}, [term()]} | {error, term()}
     when Type :: term().
 check_call(ContractString, Options) ->
     io:format("Contract call code:\n~s\n", [ContractString]),
@@ -93,7 +93,10 @@ check_call(ContractString, Options) ->
     ok = pp_typed_ast(TypedAst, Options),
     Icode = to_icode(TypedAst, Options),
     ArgVMTypes = [ aeso_ast_to_icode:ast_typerep(T, Icode) || T <- ArgTypes ],
-    RetVMType  = aeso_ast_to_icode:ast_typerep(RetType, Icode),
+    RetVMType  = case RetType of
+                    {id, _, "_"} -> any;
+                    _            -> aeso_ast_to_icode:ast_typerep(RetType, Icode)
+                end,
     ok = pp_icode(Icode, Options),
     #{ functions := Funs } = Icode,
     ArgIcode = get_arg_icode(Funs),

--- a/apps/aesophia/src/aeso_compiler.erl
+++ b/apps/aesophia/src/aeso_compiler.erl
@@ -88,7 +88,7 @@ check_call(ContractString, Options) ->
     Ast = parse(ContractString, Options),
     ok = pp_sophia_code(Ast, Options),
     ok = pp_ast(Ast, Options),
-    TypedAst = aeso_ast_infer_types:infer(Ast),
+    TypedAst = aeso_ast_infer_types:infer(Ast, [permissive_address_literals]),
     {ok, {FunName, {fun_t, _, _, ArgTypes, RetType}}} = get_call_type(TypedAst),
     ok = pp_typed_ast(TypedAst, Options),
     Icode = to_icode(TypedAst, Options),

--- a/apps/aesophia/src/aeso_compiler.erl
+++ b/apps/aesophia/src/aeso_compiler.erl
@@ -14,6 +14,7 @@
         , file/1
         , file/2
         , from_string/2
+        , check_call/2
         , version/0
         ]).
 
@@ -23,6 +24,9 @@
         ]).
 
 -endif.
+
+-include_lib("aebytecode/include/aeb_opcodes.hrl").
+-include("aeso_icode.hrl").
 
 
 -type option() :: pp_sophia_code | pp_ast | pp_icode | pp_assembler |
@@ -70,6 +74,86 @@ from_string(ContractString, Options) ->
     ByteCode = << << B:8 >> || B <- ByteCodeList >>,
     ok = pp_bytecode(ByteCode, Options),
     serialize(ByteCode, TypeInfo, ContractString).
+
+-define(CALL_NAME, "__call").
+
+%% Takes a string containing a contract with a declaration/prototype of a
+%% function (foo, say) and a function __call() = foo(args) calling this
+%% function. Returns the name of the called functions, typereps and Erlang
+%% terms for the arguments.
+-spec check_call(string(), options()) -> {ok, string(), {[Type], Type}, [term()]} | {error, term()}
+    when Type :: term().
+check_call(ContractString, Options) ->
+    io:format("Contract call code:\n~s\n", [ContractString]),
+    Ast = parse(ContractString, Options),
+    ok = pp_sophia_code(Ast, Options),
+    ok = pp_ast(Ast, Options),
+    TypedAst = aeso_ast_infer_types:infer(Ast),
+    {ok, {FunName, {fun_t, _, _, ArgTypes, RetType}}} = get_call_type(TypedAst),
+    ok = pp_typed_ast(TypedAst, Options),
+    Icode = to_icode(TypedAst, Options),
+    ArgVMTypes = [ aeso_ast_to_icode:ast_typerep(T, Icode) || T <- ArgTypes ],
+    RetVMType  = aeso_ast_to_icode:ast_typerep(RetType, Icode),
+    ok = pp_icode(Icode, Options),
+    #{ functions := Funs } = Icode,
+    ArgIcode = get_arg_icode(Funs),
+    try [ icode_to_term(T, Arg) || {T, Arg} <- lists:zip(ArgVMTypes, ArgIcode) ] of
+        ArgTerms ->
+            {ok, FunName, {ArgVMTypes, RetVMType}, ArgTerms}
+    catch throw:Err ->
+        {error, Err}
+    end.
+
+get_arg_icode(Funs) ->
+    [Args] = [ Args || {?CALL_NAME, _, _, {funcall, _, Args}, _} <- Funs ],
+    Args.
+
+get_call_type([{contract, _, _, Defs}]) ->
+    case [ {FunName, FunType}
+          || {letfun, _, {id, _, ?CALL_NAME}, [], _Ret,
+                {typed, _,
+                    {app, _,
+                        {typed, _, {id, _, FunName}, FunType}, _}, _}} <- Defs ] of
+        [Call] -> {ok, Call};
+        []     -> {error, missing_call_function}
+    end;
+get_call_type([_ | Contracts]) ->
+    %% The __call should be in the final contract
+    get_call_type(Contracts).
+
+%% Translate an icode value (error if not value) to an Erlang term that can be
+%% consumed by aeso_data:to_binary().
+icode_to_term(word, {integer, N}) -> N;
+icode_to_term(string, {tuple, [{integer, Len} | Words]}) ->
+    <<Str:Len/binary, _/binary>> = << <<W:256>> || {integer, W} <- Words >>,
+    Str;
+icode_to_term({list, T}, {list, Vs}) ->
+    [ icode_to_term(T, V) || V <- Vs ];
+icode_to_term({tuple, Ts}, {tuple, Vs}) ->
+    list_to_tuple(icodes_to_terms(Ts, Vs));
+icode_to_term({variant, Cs}, {tuple, [{integer, Tag} | Args]}) ->
+    Ts = lists:nth(Tag + 1, Cs),
+    {variant, Tag, icodes_to_terms(Ts, Args)};
+icode_to_term(T = {map, KT, VT}, M) ->
+    %% Maps are compiled to builtin and primop calls, so this gets a little hairy
+    case M of
+        {funcall, {var_ref, {builtin, map_put}}, [M1, K, V]} ->
+            Map = icode_to_term(T, M1),
+            Key = icode_to_term(KT, K),
+            Val = icode_to_term(VT, V),
+            Map#{ Key => Val };
+        #prim_call_contract{ address = {integer, 0},
+                             arg = {tuple, [{integer, ?PRIM_CALL_MAP_EMPTY}, _, _]} } ->
+            #{};
+        _ -> throw({todo, M})
+    end;
+icode_to_term(typerep, _) ->
+    throw({todo, typerep});
+icode_to_term(T, V) ->
+    throw({not_a_value, T, V}).
+
+icodes_to_terms(Ts, Vs) ->
+    [ icode_to_term(T, V) || {T, V} <- lists:zip(Ts, Vs) ].
 
 parse(C,_Options) ->
     parse_string(C).

--- a/apps/aesophia/src/aeso_scan.erl
+++ b/apps/aesophia/src/aeso_scan.erl
@@ -120,5 +120,8 @@ parse_hex("0x" ++ Chars) -> list_to_integer(Chars, 16).
 
 parse_hash("#" ++ Chars) ->
     N = list_to_integer(Chars, 16),
-    <<N:256>>.
+    case length(Chars) > 64 of  %% 64 hex digits = 32 bytes
+        true  -> <<N:64/unit:8>>;   %% signature
+        false -> <<N:32/unit:8>>    %% address
+    end.
 

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -2933,11 +2933,12 @@ definitions:
         type: string
       arg:
        type: string
+      call:
+       type: string
+       description: Source code for a contract with a function __call() = f(args), if calling a function f
     required:
       - abi
       - code
-      - function
-      - arg
   CallResult:
     type: object
     properties:
@@ -3086,7 +3087,10 @@ definitions:
         type: integer
         minimum: 0
       arguments:
-        description: Contract call data init function arguments
+        description: Contract call data init function arguments (deprecated, use call)
+        type: string
+      call:
+        description: Source code for a contract with a function __call() = init(args)
         type: string
     required:
       - owner_id
@@ -3097,7 +3101,6 @@ definitions:
       - gas
       - gas_price
       - fee
-      - arguments
   ContractCallTx:
     type: object
     properties:
@@ -3185,11 +3188,14 @@ definitions:
         type: integer
         minimum: 0
       function:
-        description: Contract call data function
+        description: Contract call data function (deprecated, use call)
         type: string
       arguments:
-        description: Contract call data function arguments
+        description: Contract call data function arguments (deprecated, use call)
         type: string
+      call:
+        type: string
+        description: Source code for a contract with a function __call() = f(args), if calling a function f
     required:
       - caller_id
       - contract_id
@@ -3198,8 +3204,6 @@ definitions:
       - amount
       - gas
       - gas_price
-      - function
-      - arguments
   UnsignedTx:
     type: object
     properties:

--- a/docs/release-notes/next/PT-160256544-create-calldata
+++ b/docs/release-notes/next/PT-160256544-create-calldata
@@ -1,0 +1,1 @@
+* Changes the API for constructing contract create and call transactions, allowing calls with user-defined types.

--- a/test/aevm_chain_SUITE.erl
+++ b/test/aevm_chain_SUITE.erl
@@ -67,7 +67,7 @@ setup_chain() ->
 create_contract(Owner, S) ->
     OwnerPrivKey = aect_test_utils:priv_key(Owner, S),
     IdContract   = aect_test_utils:compile_contract("contracts/identity.aes"),
-    {ok, CallData} = aect_sophia:encode_call_data(IdContract, <<"init">>, <<"()">>),
+    {ok, CallData} = aect_sophia:encode_call_data(IdContract, <<"init : () => _">>, <<>>),
 
     Overrides    = #{ code => IdContract
                     , call_data => CallData
@@ -90,7 +90,7 @@ sign_and_apply_transaction(Tx, PrivKey, S1) ->
 
 call_data(Arg) ->
     Code = aect_test_utils:compile_contract("contracts/identity.aes"),
-    {ok, CallData} = aect_sophia:encode_call_data(Code, <<"main">>, Arg),
+    {ok, CallData} = aect_sophia:encode_call_data(Code, <<"main : int => _">>, Arg),
     CallData.
 
 %%%===================================================================

--- a/test/sophia_bytecode_aevm_SUITE.erl
+++ b/test/sophia_bytecode_aevm_SUITE.erl
@@ -33,7 +33,7 @@ execute_identity_fun_from_sophia_file(_Cfg) ->
     OutType = word,
 
     %% Create the call data
-    {ok, CallData} = aect_sophia:encode_call_data(SerializedCode, <<"main">>, <<"(42)">>),
+    {ok, CallData} = aect_sophia:encode_call_data(SerializedCode, <<"main : int => _">>, <<"42">>),
     {ok, Res} =
         aevm_eeevm:eval(
           aevm_eeevm_state:init(


### PR DESCRIPTION
See https://github.com/aeternity/epoch/pull/1702 for the other part of the ticket.

Previously you created calldata by giving a function name and a Sophia constant for the arguments. The new way to create calldata for a call to `foo` is to give a complete contract of the form
```
contract SomeName =
  // here can be type defs
  function foo : (t1, t2, t3) => ret_t  // ret_t can be _ in which case it's not checked 
  function __call() = foo(arg1, arg2, arg3)
```
This contract is run through the type checker and can include type definitions necessary for the type of `foo`. To make updating the tests not take weeks I kept the interface of passing a function string and an argument string. For the example above you set the function to `""` and pass the contract code in the argument. There's also a shorthand which made updating tests less of a nightmare: setting the function to `"foo : (t1, t2, t3) => ret_t"` and the arguments to `"arg1, arg2, arg3"` will build the contract code above. This isn't super nice but meant I only had to add a type signature to update most of the tests.

I'm not sure what's the best way to handle the `CreateCompute` and `CallCompute` entrypoints though. At the moment `CreateCompute` only takes `argument` and not a function name (since it's always `init`), so you can't use the shorthand with that. `CallCompute` maps directly to `create_calldata` so admits the shorthand. In the long term I think we'd like to change the arguments to these entrypoints to something nicer, but that would mean a lot of time spent on updating tests.

TODO
  - [x] Release notes
  - [x] Update EncodeCallData entrypoint
  - [x] Document entrypoint changes: https://github.com/aeternity/protocol/pull/257
  - [x] Tests for new entrypoints