### PR TITLE
PT-161476994 more efficient gossip

### DIFF
--- a/apps/aecore/src/aec_connection_sup.erl
+++ b/apps/aecore/src/aec_connection_sup.erl
@@ -43,6 +43,7 @@ init([]) ->
                 , period => 10},
     ChildSpecs = [ aec_peer_connection_sup_spec() % outgoing connections
                  , worker(aec_tx_pool_sync)
+                 , worker(aec_tx_gossip_cache)
                  , worker(aec_peers)
                  , worker(aec_sync)
                  , peer_listener_spec()           % incoming connections

--- a/apps/aecore/src/aec_peer_connection.erl
+++ b/apps/aecore/src/aec_peer_connection.erl
@@ -38,6 +38,10 @@
         , tx_pool_sync_unfold/2
         ]).
 
+%% API for gossip serialization
+-export([gossip_serialize_block/1,
+         gossip_serialize_tx/1]).
+
 -include("aec_peer_messages.hrl").
 
 -behaviour(gen_server).
@@ -106,11 +110,11 @@ tx_pool_sync_get(PeerId, TxHashes) ->
 tx_pool_sync_finish(PeerId, Done) ->
     call(PeerId, {tx_pool, [sync_finish, Done]}).
 
-send_tx(PeerId, Tx) ->
-    cast(PeerId, {send_tx, Tx}).
+send_tx(PeerId, SerTx) ->
+    cast(PeerId, {send_tx, SerTx}).
 
-send_block(PeerId, Tx) ->
-    cast(PeerId, {send_block, Tx}).
+send_block(PeerId, SerBlock) ->
+    cast(PeerId, {send_block, SerBlock}).
 
 stop(PeerCon) ->
     gen_server:cast(PeerCon, stop).
@@ -220,11 +224,11 @@ init([Opts]) ->
 handle_call(Request, From, State) ->
     handle_request(State, Request, From).
 
-handle_cast({send_tx, Hash}, State) ->
-    send_send_tx(State, Hash),
+handle_cast({send_tx, SerTx}, State) ->
+    send_send_tx(State, SerTx),
     {noreply, State};
-handle_cast({send_block, Hash}, State) ->
-    send_send_block(State, Hash),
+handle_cast({send_block, SerBlock}, State) ->
+    send_send_block(State, SerBlock),
     {noreply, State};
 handle_cast({expand_micro_block, MicroBlockFragment}, State) ->
     {noreply, expand_micro_block(State, MicroBlockFragment)};
@@ -921,16 +925,15 @@ handle_tx_pool_sync_rsp(S, Action, {tx_pool, From, _TRef}, MsgObj) ->
 
 %% -- Send Block --------------------------------------------------------------
 
-send_send_block(#{ status := error }, _Block) ->
+send_send_block(#{ status := error }, _SerBlock) ->
     ok;
-send_send_block(#{ status := {disconnecting, _ESock} }, _Block) ->
+send_send_block(#{ status := {disconnecting, _ESock} }, _SerBlock) ->
     ok;
-send_send_block(S = #{ status := {connected, _ESock} }, Block) ->
+send_send_block(S = #{ status := {connected, _ESock} }, {Type, SerBlock}) ->
     {MsgType, Msg} =
-        case aec_blocks:type(Block) of
-            key   -> {key_block, #{ key_block => serialize_key_block(Block) }};
-            micro -> {micro_block, #{ micro_block => serialize_light_micro_block(Block),
-                                      light => true }}
+        case Type of
+            key_block         -> {key_block, #{ key_block => SerBlock }};
+            light_micro_block -> {micro_block, #{ micro_block => SerBlock, light => true }}
         end,
     send_msg(S, MsgType, aec_peer_messages:serialize(MsgType, Msg)).
 
@@ -1076,13 +1079,12 @@ fill_txs([_TH | _TATHs], [], _Acc) ->
 
 %% -- Send TX --------------------------------------------------------------
 
-send_send_tx(#{ status := error }, _Tx) ->
+send_send_tx(#{ status := error }, _SerTx) ->
     ok;
-send_send_tx(#{ status := {disconnecting, _ESock} }, _Tx) ->
+send_send_tx(#{ status := {disconnecting, _ESock} }, _SerTx) ->
     ok;
-send_send_tx(S = #{ status := {connected, _ESock} }, Tx) ->
-    TxSerialized = aetx_sign:serialize_to_binary(Tx),
-    Msg = aec_peer_messages:serialize(txs, #{ txs => [TxSerialized] }),
+send_send_tx(S = #{ status := {connected, _ESock} }, SerTx) ->
+    Msg = aec_peer_messages:serialize(txs, #{ txs => [SerTx] }),
     send_msg(S, txs, Msg).
 
 handle_new_txs(S, Msg) ->
@@ -1172,6 +1174,15 @@ close_timeout() ->
                                aecore, sync_close_timeout,
                                ?DEFAULT_CLOSE_TIMEOUT).
 %% -- Helper functions -------------------------------------------------------
+
+gossip_serialize_block(Block) ->
+    case aec_blocks:type(Block) of
+        key   -> {key_block, serialize_key_block(Block)};
+        micro -> {light_micro_block, serialize_light_micro_block(Block)}
+    end.
+
+gossip_serialize_tx(Tx) ->
+    aetx_sign:serialize_to_binary(Tx).
 
 serialize_key_block(KeyBlock) ->
     key = aec_blocks:type(KeyBlock),

--- a/apps/aecore/src/aec_sync.erl
+++ b/apps/aecore/src/aec_sync.erl
@@ -514,13 +514,12 @@ enqueue(Kind, Data, PeerIds) ->
     spawn(fun() ->
     case Kind of
         block ->
+            %% Getting blocks to spread is a priority, bypass the gossip queue
             SerBlock = aec_peer_connection:gossip_serialize_block(Data),
-            [ aec_jobs_queues:run(sync_gossip, fun() -> do_forward_block(SerBlock, PId) end)
-              || PId <- PeerIds ];
+            [ do_forward_block(SerBlock, PId) || PId <- PeerIds ];
         tx ->
             SerTx = aec_peer_connection:gossip_serialize_tx(Data),
-            [ aec_jobs_queues:run(sync_gossip, fun() -> do_forward_tx(SerTx, PId) end)
-              || PId <- PeerIds ]
+            aec_jobs_queues:run(sync_gossip, fun() -> [ do_forward_tx(SerTx, PId) || PId <- PeerIds ] end)
     end end).
 
 ping_peer(PeerId) ->

--- a/apps/aecore/src/aec_tx_gossip_cache.erl
+++ b/apps/aecore/src/aec_tx_gossip_cache.erl
@@ -1,0 +1,110 @@
+%%%=============================================================================
+%%% @copyright 2018, Aeternity Anstalt
+%%% @doc
+%%%    Module holding a short lived cache for gossiped TXs - the rationale
+%%%    being that most TXs arrives close in time and thus the mempool/DB
+%%%    can be offloaded by a first level filter.
+%%% @end
+%%%=============================================================================
+-module(aec_tx_gossip_cache).
+
+-behaviour(gen_server).
+
+%% API for supervisor
+-export([ start_link/0
+        , stop/0
+        ]).
+
+%% Cache API
+-export([ in_cache/1
+        , reset/0
+        , stats/0
+        ]).
+
+
+%% gen_server callbacks
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3]).
+
+-define(SERVER, ?MODULE).
+-define(CACHE_TIMEOUT, 3000).
+-define(CACHE_SIZE, 200).
+
+-type tx_hash() :: binary().
+
+-record(state, { size    = 0           :: non_neg_integer()
+               , evict_q = queue:new() :: queue:queue(tx_hash())
+               , cache   = #{}         :: #{ tx_hash() := term() }
+               , hit     = 0           :: non_neg_integer()
+               , miss    = 0           :: non_neg_integer() }).
+%% -- API --------------------------------------------------------------------
+start_link() ->
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+
+stop() ->
+    gen_server:stop(?SERVER).
+
+in_cache(TxHash) ->
+    call({in_cache, TxHash}, false).
+
+reset() ->
+    gen_server:cast(?SERVER, reset).
+
+stats() ->
+    call(stats, timeout).
+
+call(Msg, TimeoutResult) ->
+    try
+        gen_server:call(?SERVER, Msg, ?CACHE_TIMEOUT)
+    catch _:_ ->
+        lager:debug("TX gossip cache timeout"),
+        TimeoutResult
+    end.
+
+%% -- gen_server callbacks ---------------------------------------------------
+
+init([]) ->
+    {ok, #state{}}.
+
+handle_call({in_cache, TxHash}, _From, State) ->
+    {Res, NewState} = in_cache(TxHash, State),
+    {reply, Res, NewState};
+handle_call(stats, _From, State) ->
+    {reply, #{ hit => State#state.hit, miss => State#state.miss }, State};
+handle_call(Request, From, State) ->
+    lager:warning("Ignoring unknown call request from ~p: ~p", [From, Request]),
+    {noreply, State}.
+
+handle_cast(reset, _State) ->
+    NewState = init_state(),
+    {noreply, NewState};
+handle_cast(Msg, State) ->
+    lager:warning("Ignoring unknown cast message: ~p", [Msg]),
+    {noreply, State}.
+
+handle_info(Msg, State) ->
+    lager:warning("Ignoring unknown info message: ~p", [Msg]),
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%% -- local functions --------------------------------------------------------
+init_state() ->
+    #state{}.
+
+in_cache(TxHash, State = #state{ size = S, evict_q = Q, cache = C, hit = H, miss = M }) ->
+    case maps:is_key(TxHash, C) of
+        true ->
+            {true, State#state{ hit = H + 1 }};
+        false when S == ?CACHE_SIZE ->
+            {{value, Evicted}, Q1} = queue:out(Q),
+            C1 = maps:put(TxHash, x, maps:remove(Evicted, C)),
+            {false, State#state{ evict_q = queue:in(TxHash, Q1), cache = C1, miss = M + 1 }};
+        false ->
+            {false, State#state{ size = S + 1, evict_q = queue:in(TxHash, Q),
+                                 cache = maps:put(TxHash, x, C), miss = M + 1 }}
+    end.

--- a/apps/aecore/src/aec_tx_pool.erl
+++ b/apps/aecore/src/aec_tx_pool.erl
@@ -129,27 +129,36 @@ push(Tx) ->
 
 -spec push(aetx_sign:signed_tx(), event()) -> ok | {error, atom()}.
 push(Tx, Event = tx_received) ->
-    %% Verify that this is a signed transaction.
-    aec_jobs_queues:run(tx_pool_push, fun() -> push_(Tx, Event) end);
+    TxHash = safe_tx_hash(Tx),
+    case aec_tx_gossip_cache:in_cache(TxHash) of
+        true -> ok;
+        false ->
+            aec_jobs_queues:run(tx_pool_push, fun() -> push_(Tx, TxHash, Event) end)
+    end;
 push(Tx, Event = tx_created) ->
     push_(Tx, Event).
 
-push_(Tx, Event) ->
-    try aetx_sign:tx(Tx)
+safe_tx_hash(Tx) ->
+    try aetx_sign:hash(Tx)
     catch _:_ ->
             incr([push, illegal]),
             error({illegal_transaction, Tx})
-    end,
-    case check_pool_db_put(Tx) of
+    end.
+
+push_(Tx, Event) ->
+    push_(Tx, safe_tx_hash(Tx), Event).
+
+push_(Tx, TxHash, Event) ->
+    case check_pool_db_put(Tx, TxHash) of
         ignore ->
             incr([push, ignore]),
             ok;
         {error,_} = E ->
             incr([push, error]),
             E;
-        {ok, Hash} ->
+        ok ->
             incr([push]),
-            gen_server:call(?SERVER, {push, Tx, Hash, Event})
+            gen_server:call(?SERVER, {push, Tx, TxHash, Event})
     end.
 
 incr(Metric) ->
@@ -592,21 +601,20 @@ update_pool_on_tx_hash(TxHash, {#dbs{gc_db = GCDb} = Dbs, GCHeight}, Handled) ->
             end
     end.
 
--spec check_pool_db_put(aetx_sign:signed_tx()) ->
+-spec check_pool_db_put(aetx_sign:signed_tx(), tx_hash()) ->
                                ignore
                              | {'ok', tx_hash()}
                              | {'error', atom()}.
-check_pool_db_put(Tx) ->
-    Hash = aetx_sign:hash(Tx),
-    case aec_chain:find_tx_location(Hash) of
+check_pool_db_put(Tx, TxHash) ->
+    case aec_chain:find_tx_location(TxHash) of
         BlockHash when is_binary(BlockHash) ->
-            lager:debug("Already have tx: ~p in ~p", [Hash, BlockHash]),
+            lager:debug("Already have tx: ~p in ~p", [TxHash, BlockHash]),
             {error, already_accepted};
         mempool ->
-            %% lager:debug("Already have tx: ~p in ~p", [Hash, mempool]),
+            %% lager:debug("Already have tx: ~p in ~p", [TxHash, mempool]),
             ignore;
         none ->
-            lager:debug("Already have GC:ed tx: ~p", [Hash]),
+            lager:debug("Already have GC:ed tx: ~p", [TxHash]),
             ignore;
         not_found ->
             Checks = [ fun check_signature/2
@@ -615,12 +623,12 @@ check_pool_db_put(Tx) ->
                      , fun check_minimum_gas_price/2
                      , fun check_tx_ttl/2
                      ],
-            case aeu_validation:run(Checks, [Tx, Hash]) of
+            case aeu_validation:run(Checks, [Tx, TxHash]) of
                 {error, _} = E ->
-                    lager:debug("Validation error for tx ~p: ~p", [Hash, E]),
+                    lager:debug("Validation error for tx ~p: ~p", [TxHash, E]),
                     E;
                 ok ->
-                    {ok, Hash}
+                    ok
             end
     end.
 

--- a/apps/aecore/src/aec_tx_pool.erl
+++ b/apps/aecore/src/aec_tx_pool.erl
@@ -647,7 +647,7 @@ pool_db_raw_put(#dbs{db = Db, nonce_db = NDb, gc_db = GCDb},
                 GCHeight, Key, Tx, TxHash) ->
     ets:insert(Db, {Key, Tx}),
     insert_nonce(NDb, Key),
-    enter_tx_gc(GCDb, TxHash, Key, GCHeight + tx_ttl()).
+    enter_tx_gc(GCDb, TxHash, Key, min(GCHeight + tx_ttl(), aetx:ttl(aetx_sign:tx(Tx)))).
 
 insert_nonce(NDb, ?KEY(_, _, Account, Nonce, TxHash)) ->
     ets:insert(NDb, {{Account, Nonce, TxHash}}).

--- a/apps/aecore/src/aec_tx_pool.erl
+++ b/apps/aecore/src/aec_tx_pool.erl
@@ -128,9 +128,11 @@ push(Tx) ->
     push(Tx, tx_created).
 
 -spec push(aetx_sign:signed_tx(), event()) -> ok | {error, atom()}.
-push(Tx, Event) when ?PUSH_EVENT(Event) ->
+push(Tx, Event = tx_received) ->
     %% Verify that this is a signed transaction.
-    aec_jobs_queues:run(tx_pool_push, fun() -> push_(Tx, Event) end).
+    aec_jobs_queues:run(tx_pool_push, fun() -> push_(Tx, Event) end);
+push(Tx, Event = tx_created) ->
+    push_(Tx, Event).
 
 push_(Tx, Event) ->
     try aetx_sign:tx(Tx)

--- a/apps/aecore/test/aecore_txs_SUITE.erl
+++ b/apps/aecore/test/aecore_txs_SUITE.erl
@@ -93,7 +93,7 @@ txs_gc(Config) ->
 
     {ok, TxH5} = add_spend_tx(N1, 1000, 1,  5,  10), %% Non consecutive nonce
     {ok, _}    = add_spend_tx(N1, 1000, 1,  7,  10), %% Non consecutive nonce
-    {ok, _}    = add_spend_tx(N1, 1000, 1,  8,  5),  %% Short TTL - expires at 5 + 2 = 7
+    {ok, _}    = add_spend_tx(N1, 1000, 1,  8,  7),  %% Short TTL - expires at 7
 
     %% Now there should be 7 transactions in mempool
     {ok, Txs1} = pool_peek(N1),

--- a/apps/aeutils/priv/epoch_config_schema.json
+++ b/apps/aeutils/priv/epoch_config_schema.json
@@ -579,7 +579,7 @@
                     "properties" : {
                         "counter" : {
                             "type" : "integer",
-                            "default" : 10
+                            "default" : 5
                         },
                         "rate" : {
                             "type" : "integer",
@@ -602,11 +602,11 @@
                     "properties" : {
                         "counter" : {
                             "type" : "integer",
-                            "default" : 0
+                            "default" : 5
                         },
                         "rate" : {
                             "type" : "integer",
-                            "default" : 100
+                            "default" : 0
                         },
                         "max_size" : {
                             "type" : "integer",
@@ -685,11 +685,11 @@
                         },
                         "rate" : {
                             "type" : "integer",
-                            "default" : 150
+                            "default" : 0
                         },
                         "max_size" : {
                             "type" : "integer",
-                            "default" : 100
+                            "default" : 50
                         },
                         "max_time" : {
                             "type" : "integer",
@@ -704,11 +704,11 @@
                     "properties" : {
                         "counter" : {
                             "type" : "integer",
-                            "default" : 10
+                            "default" : 5
                         },
                         "rate" : {
                             "type" : "integer",
-                            "default" : 200
+                            "default" : 0
                         },
                         "max_size" : {
                             "type" : "integer",

--- a/apps/aeutils/priv/epoch_config_schema.json
+++ b/apps/aeutils/priv/epoch_config_schema.json
@@ -610,7 +610,7 @@
                         },
                         "max_size" : {
                             "type" : "integer",
-                            "default" : 0
+                            "default" : 5000
                         },
                         "max_time" : {
                             "type" : "integer",


### PR DESCRIPTION
This PR includes a number of "obvious" improvements. The results from load test improve a lot. However, I still think there should be a gossiped TX-cache to further offload the mempool/DB and there is also aspects of the results I still don't fully understand.

- Offload gossiped TX handling to a worker process
- Change queue parameters and prioritize blocks in gossip
- Look at TTL when schedule TX GC
- Make created tx:s bypass the mempool push queue
- Only serialize once for gossip