### PR TITLE
ensure updated GCHeight before pool put

### DIFF
--- a/apps/aecore/src/aec_tx_pool.erl
+++ b/apps/aecore/src/aec_tx_pool.erl
@@ -540,13 +540,14 @@ sel_return(L) when is_list(L) -> L;
 sel_return('$end_of_table' ) -> [];
 sel_return({Matches, _Cont}) -> Matches.
 
-do_top_change(Type, OldHash, NewHash, State) ->
+do_top_change(Type, OldHash, NewHash, State0) ->
     %% Add back transactions to the pool from discarded part of the chain
     %% Mind that we don't need to add those which are incoming in the fork
 
     %% NG: does this work for common ancestor for micro blocks?
     {ok, Ancestor} = aec_chain:find_common_ancestor(OldHash, NewHash),
-    Info = {State#state.dbs, State#state.gc_height},
+    {GCHeight, State} = get_gc_height(State0),
+    Info = {State#state.dbs, GCHeight},
 
     Handled = ets:new(foo, [private, set]),
     update_pool_from_blocks(Ancestor, OldHash, Info, Handled),


### PR DESCRIPTION
See [PT #161594482](https://www.pivotaltracker.com/n/projects/2124891/stories/161594482)

From a chat discussion:
> the background is that `new_sync_top` causes a background job to be spawned that updates `gc_height`, among other things. `gc_height` is then set to `undefined` in the meantime, and if you need the new `gc_height` value before it's ready, you need to wait for it.