### PR TITLE
Improve contract execution performance

### DIFF
--- a/apps/aecontract/src/aect_call_tx.erl
+++ b/apps/aecontract/src/aect_call_tx.erl
@@ -390,7 +390,7 @@ check_call(#contract_call_tx{ vm_version = VmVersion,
     %% check and this is the least convoluted way of writing it that Dialyzer's
     %% static analysis cannot see through.
     NegativeAmount = -Value > 0,
-    case aect_state_tree:lookup_contract(ContractPubKey, ContractsTree) of
+    case aect_state_tree:lookup_contract(ContractPubKey, ContractsTree, [no_store]) of
         _ when NegativeAmount -> {error, negative_amount};
         {value, C} ->
             case aect_contracts:vm_version(C) == VmVersion of

--- a/apps/aecore/src/aec_vm_chain.erl
+++ b/apps/aecore/src/aec_vm_chain.erl
@@ -618,7 +618,7 @@ aens_revoke_(Tx, Signature, #state{ account = ContractKey } = State) ->
 get_contract_fun_types(Target, VMVersion, TypeHash, State) ->
     Trees = get_top_trees(State),
     CT = aec_trees:contracts(Trees),
-    case aect_state_tree:lookup_contract(Target, CT) of
+    case aect_state_tree:lookup_contract(Target, CT, [no_store]) of  %% no store
         {value, Contract} ->
             case aect_contracts:vm_version(Contract) of
                 VMVersion ->
@@ -641,7 +641,7 @@ call_contract(Target, Gas, Value, CallData, CallStack,
               State = #state{account = ContractKey}) ->
     Trees = get_top_trees(State),
     CT = aec_trees:contracts(Trees),
-    case aect_state_tree:lookup_contract(Target, CT) of
+    case aect_state_tree:lookup_contract(Target, CT, [no_store]) of  %% skip store, we look it up later
         {value, Contract} ->
             AT = aec_trees:accounts(Trees),
             {value, ContractAccount} = aec_accounts_trees:lookup(ContractKey, AT),
@@ -702,7 +702,7 @@ do_get_store(PubKey, Trees) ->
 do_set_store(Store, PubKey, Trees) ->
     ContractsTree = aec_trees:contracts(Trees),
     NewContract =
-        case aect_state_tree:lookup_contract(PubKey, ContractsTree) of
+        case aect_state_tree:lookup_contract(PubKey, ContractsTree, [no_store]) of
             {value, Contract} -> aect_contracts:set_state(Store, Contract)
         end,
     aect_state_tree:enter_contract(NewContract, ContractsTree).

--- a/apps/aevm/src/aevm_eeevm_state.erl
+++ b/apps/aevm/src/aevm_eeevm_state.erl
@@ -195,10 +195,10 @@ is_reentrant_call(State) ->
 
 %% TODO: Currently the Store is saved both in the chain state and the VM state.
 %%       Refactor?
-get_store(#{chain_api := ChainAPI, chain_state := ChainState}) ->
-    ChainAPI:get_store(ChainState).
+get_store(#{storage := Store}) -> Store.
 
-import_state_from_store(Store, State) ->
+import_state_from_store(Store, State0) ->
+    State = State0#{ storage := Store },
     case aevm_eeevm_store:get_sophia_state_type(Store) of
         false ->
             %% No state yet (init function). Write 0 to the state pointer.


### PR DESCRIPTION
Improve contract execution performance by not looking up the store all the time

Getting the store from the state trees is expensive, so we shouldn't do it more than we have to. Two fixes:
- Save the store in the VM state during contract execution
- Add a version of looking up a contract in the state trees that does not return the store
  and use this when appropriate