### PR TITLE
PT-161714006 Add syntax for map lookup/update with default value

### DIFF
--- a/apps/aecontract/test/aecontract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_SUITE.erl
@@ -2550,6 +2550,12 @@ sophia_maps(_Cfg) ->
          || {Fn, FnS, Map, Err} <- [{get_i, get_state_i, MapI, 4},
                                     {get_s, get_state_s, MapS, <<"four">>}],
             K <- maps:keys(Map) ++ [Err] ] ++
+        %% get_def
+        [ [{Fn,  Pt, {K, Def, Map}, maps:get(K, Map, Def)},
+           {FnS, Pt, {K, Def},      maps:get(K, Map, Def)}]
+         || {Fn, FnS, Map, Err, Def} <- [{get_def_i, get_def_state_i, MapI, 4, {88, 99}},
+                                         {get_def_s, get_def_state_s, MapS, <<"four">>, {88, 99}}],
+            K <- maps:keys(Map) ++ [Err] ] ++
         %% lookup
         [ [{Fn,  {option, Pt}, {K, Map}, MkOption(maps:get(K, Map, undefined))},
            {FnS, {option, Pt}, K,        MkOption(maps:get(K, Map, undefined))}]
@@ -2581,6 +2587,11 @@ sophia_maps(_Cfg) ->
         [ [{Fn, Type, {K, V, Map}, case Map of #{K := {X, Y}} -> Map#{K => {X + V, Y}}; _ -> OogErr end}]
          || {Fn, Type, Map, New, V} <- [{addx_i, IntMap, MapI, 4, 7},
                                         {addx_s, StrMap, MapS, <<"four">>, 7}],
+            K <- maps:keys(Map) ++ [New] ] ++
+        %% addx_def
+        [ [{Fn, Type, {K, Def, V, Map}, begin {X, Y} = maps:get(K, Map, Def), Map#{K => {X + V, Y}} end}]
+         || {Fn, Type, Map, New, V, Def} <- [{addx_def_i, IntMap, MapI, 4, 7, {100, 100}},
+                                             {addx_def_s, StrMap, MapS, <<"four">>, 7, {100, 100}}],
             K <- maps:keys(Map) ++ [New] ] ++
         %% delete (not delete_state)
         [ [{Fn, Type, {K, Map}, maps:remove(K, Map)}]

--- a/apps/aesophia/src/aeso_pretty.erl
+++ b/apps/aesophia/src/aeso_pretty.erl
@@ -289,7 +289,7 @@ expr_p(P, {proj, _, E, X}) ->
 expr_p(P, {map_get, _, E, Key}) ->
     paren(P > 900, beside([expr_p(900, E), list([expr(Key)])]));
 expr_p(P, {map_get, Ann, E, Key, Val}) ->
-    paren(P > 900, beside([expr_p(900, E), list([expr({'=', Ann, Key, Val})])]));
+    paren(P > 900, beside([expr_p(900, E), list([expr(equals(Ann, Key, Val))])]));
 expr_p(P, {typed, _, E, T}) ->
     paren(P > 0, typed(expr(E), T));
 expr_p(P, {assign, _, LV, E}) ->
@@ -297,8 +297,6 @@ expr_p(P, {assign, _, LV, E}) ->
 %% -- Operators
 expr_p(_, {app, _, {'..', _}, [A, B]}) ->
     list([infix(0, '..', A, B)]);
-expr_p(P, {'=', _, K, V}) ->  %% map defaults
-    infix(P, '=', K, V);
 expr_p(P, E = {app, _, F = {Op, _}, Args}) when is_atom(Op) ->
     case {aeso_syntax:get_ann(format, E), Args} of
         {infix, [A, B]} -> infix(P, Op, A, B);
@@ -375,6 +373,9 @@ un_prec('-')    -> {650, 650};
 un_prec('!')    -> {800, 800};
 un_prec('bnot') -> {800, 800}.
 
+equals(Ann, A, B) ->
+    {app, [{format, infix} | Ann], {'=', Ann}, [A, B]}.
+
 -spec infix(integer(), aeso_syntax:bin_op(), aeso_syntax:expr(), aeso_syntax:expr()) -> doc().
 infix(P, Op, A, B) ->
     {Top, L, R} = bin_prec(Op),
@@ -403,7 +404,7 @@ lvalue([E | Es]) ->
 
 elim({proj, _, X})         -> name(X);
 elim({map_get, Ann, K})    -> expr_p(0, {list, Ann, [K]});
-elim({map_get, Ann, K, V}) -> expr_p(0, {list, Ann, [{'=', Ann, K, V}]}).
+elim({map_get, Ann, K, V}) -> expr_p(0, {list, Ann, [equals(Ann, K, V)]}).
 
 elim1(Proj={proj, _, _})      -> beside(text("."), elim(Proj));
 elim1(Get={map_get, _, _})    -> elim(Get);

--- a/apps/aesophia/src/aeso_pretty.erl
+++ b/apps/aesophia/src/aeso_pretty.erl
@@ -288,6 +288,8 @@ expr_p(P, {proj, _, E, X}) ->
     paren(P > 900, beside([expr_p(900, E), text("."), name(X)]));
 expr_p(P, {map_get, _, E, Key}) ->
     paren(P > 900, beside([expr_p(900, E), list([expr(Key)])]));
+expr_p(P, {map_get, Ann, E, Key, Val}) ->
+    paren(P > 900, beside([expr_p(900, E), list([expr({'=', Ann, Key, Val})])]));
 expr_p(P, {typed, _, E, T}) ->
     paren(P > 0, typed(expr(E), T));
 expr_p(P, {assign, _, LV, E}) ->
@@ -295,6 +297,8 @@ expr_p(P, {assign, _, LV, E}) ->
 %% -- Operators
 expr_p(_, {app, _, {'..', _}, [A, B]}) ->
     list([infix(0, '..', A, B)]);
+expr_p(P, {'=', _, K, V}) ->  %% map defaults
+    infix(P, '=', K, V);
 expr_p(P, E = {app, _, F = {Op, _}, Args}) when is_atom(Op) ->
     case {aeso_syntax:get_ann(format, E), Args} of
         {infix, [A, B]} -> infix(P, Op, A, B);
@@ -344,6 +348,7 @@ stmt_p({else, Else}) ->
 
 -spec bin_prec(aeso_syntax:bin_op()) -> {integer(), integer(), integer()}.
 bin_prec('..')   -> {  0,   0,   0};  %% Always printed inside '[ ]'
+bin_prec('=')    -> {  0,   0,   0};  %% Always printed inside '[ ]'
 bin_prec('||')   -> {200, 300, 200};
 bin_prec('&&')   -> {300, 400, 300};
 bin_prec('<')    -> {400, 500, 500};
@@ -396,11 +401,13 @@ field({field_upd, _, LV, Fun}) ->
 lvalue([E | Es]) ->
     beside([elim(E) | lists:map(fun elim1/1, Es)]).
 
-elim({proj, _, X})      -> name(X);
-elim({map_get, Ann, K}) -> expr_p(0, {list, Ann, [K]}).
+elim({proj, _, X})         -> name(X);
+elim({map_get, Ann, K})    -> expr_p(0, {list, Ann, [K]});
+elim({map_get, Ann, K, V}) -> expr_p(0, {list, Ann, [{'=', Ann, K, V}]}).
 
-elim1(Proj={proj, _, _})   -> beside(text("."), elim(Proj));
-elim1(Get={map_get, _, _}) -> elim(Get).
+elim1(Proj={proj, _, _})      -> beside(text("."), elim(Proj));
+elim1(Get={map_get, _, _})    -> elim(Get);
+elim1(Get={map_get, _, _, _}) -> elim(Get).
 
 alt({'case', _, Pat, Body}) ->
     block_expr(0, hsep(expr_p(500, Pat), text("=>")), Body).

--- a/apps/aesophia/src/aeso_syntax.erl
+++ b/apps/aesophia/src/aeso_syntax.erl
@@ -94,6 +94,7 @@
      | {map, ann(), expr(), [field(expr())]}    %% map update
      | {map, ann(), [{expr(), expr()}]}
      | {map_get, ann(), expr(), expr()}
+     | {map_get, ann(), expr(), expr(), expr()}
      | {block, ann(), [stmt()]}
      | {op(), ann()}
      | id() | qid() | con() | qcon()
@@ -117,7 +118,8 @@
 -type lvalue() :: nonempty_list(elim()).
 
 -type elim() :: {proj, ann(), id()}
-              | {map_get, ann(), expr()}.
+              | {map_get, ann(), expr()}
+              | {map_get, ann(), expr(), expr()}.
 
 -type pat() :: {app, ann(), con() | op(), [pat()]}
              | {tuple, ann(), [pat()]}

--- a/apps/aesophia/src/aeso_syntax_utils.erl
+++ b/apps/aesophia/src/aeso_syntax_utils.erl
@@ -51,6 +51,7 @@ used_ids({record, _, E, Fs}) -> used_ids([E, Fs]);
 used_ids({map, _, E, Fs})    -> used_ids([E, Fs]);
 used_ids({map, _, KVs})      -> used_ids([ [K, V] || {K, V} <- KVs ]);
 used_ids({map_get, _, M, K}) -> used_ids([M, K]);
+used_ids({map_get, _, M, K, V}) -> used_ids([M, K, V]);
 used_ids({block, _, Ss})     -> used_ids_s(Ss);
 used_ids({Op, _}) when is_atom(Op) -> none();
 used_ids({id, _, X})   -> [X];

--- a/apps/aesophia/test/contracts/maps.aes
+++ b/apps/aesophia/test/contracts/maps.aes
@@ -26,6 +26,12 @@ contract Maps =
   function get_state_i(k) = get_i(k, state.map_i)
   function get_state_s(k) = get_s(k, state.map_s)
 
+  // m[k = v]
+  function get_def_i(k, v, m : map(int,    pt)) = m[k = v]
+  function get_def_s(k, v, m : map(string, pt)) = m[k = v]
+  function get_def_state_i(k, v) = get_def_i(k, v, state.map_i)
+  function get_def_state_s(k, v) = get_def_s(k, v, state.map_s)
+
   // m{[k] = v}
   function set_i(k, p, m : map(int,    pt)) = m{ [k] = p }
   function set_s(k, p, m : map(string, pt)) = m{ [k] = p }
@@ -43,6 +49,10 @@ contract Maps =
   function addx_s(k, d, m : map(string, pt)) = m{ [k].x @ x = x + d }
   function addx_state_i(k, d) = put(state{ map_i[k].x @ x = x + d })
   function addx_state_s(k, d) = put(state{ map_s[k].x @ x = x + d })
+
+  // m{[k = def] @ x = v }
+  function addx_def_i(k, v, d, m : map(int,    pt)) = m{ [k = v].x @ x = x + d }
+  function addx_def_s(k, v, d, m : map(string, pt)) = m{ [k = v].x @ x = x + d }
 
   // Map.member
   function member_i(k, m : map(int,    pt)) = Map.member(k, m)

--- a/docs/release-notes/next/map-default-syntax.md
+++ b/docs/release-notes/next/map-default-syntax.md
@@ -1,0 +1,2 @@
+* Adds Sophia syntax for map lookup and update with default values.
+


### PR DESCRIPTION
- `m[k = v]` is equivalent to `Map.lookup_default(k, m, v)`
- `m{ [k = v] @ x = f(x) }` is equivalent to `m{ [k] = f(m[k = v]) }`

Protocol PR: https://github.com/aeternity/protocol/pull/260
Pivotal: https://www.pivotaltracker.com/story/show/161714006