### PR TITLE
Fixes #161719589 - prep_stop block generator workers

### DIFF
--- a/apps/aecore/src/aec_block_generator.erl
+++ b/apps/aecore/src/aec_block_generator.erl
@@ -13,6 +13,8 @@
 
 -export([start_generation/0, stop_generation/0]).
 
+-export([prep_stop/0]).
+
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
          terminate/2, code_change/3]).
@@ -47,6 +49,9 @@ start_generation() ->
 stop_generation() ->
     gen_server:cast(?MODULE, stop_generation).
 
+prep_stop() ->
+    gen_server:call(?MODULE, prep_stop).
+
 %% -- gen_server callbacks ---------------------------------------------------
 
 init([]) ->
@@ -59,6 +64,8 @@ handle_call(get_candidate, _From, State = #state{ candidate = undefined }) ->
     {reply, {error, no_candidate}, State};
 handle_call(get_candidate, _From, State = #state{ candidate = Candidate }) ->
     {reply, {ok, Candidate}, State};
+handle_call(prep_stop, _From, State) ->
+    {reply, ok, do_stop_generation(State)};
 handle_call(Req, _From, State) ->
     lager:info("Unexpected call: ~p", [Req]),
     {reply, ok, State}.

--- a/apps/aecore/src/aecore_app.erl
+++ b/apps/aecore/src/aecore_app.erl
@@ -36,6 +36,7 @@ start_phase(start_reporters, _StartType, _PhaseArgs) ->
     aec_metrics:start_reporters().
 
 prep_stop(State) ->
+    aec_block_generator:prep_stop(),
     aec_metrics:prep_stop(State).
 
 stop(_State) ->


### PR DESCRIPTION
This is to avoid spurious crashes during shutdown

See [PT #161719589](https://www.pivotaltracker.com/story/show/161719589)