### PR TITLE
PT-161750304 upstream sync cuckoo

### DIFF
--- a/apps/aecore/src/aec_pow_cuckoo.erl
+++ b/apps/aecore/src/aec_pow_cuckoo.erl
@@ -178,7 +178,7 @@ generate_int(Header, Target) ->
 
 generate_int(Header, Target, MinerBin, MinerExtraArgs) ->
     BinDir = aecuckoo:bin_dir(),
-    Cmd = lists:concat([ld_lib_env(), " ",  "./", MinerBin,
+    Cmd = lists:concat(["./", MinerBin,
                         " -h ", Header, " ", MinerExtraArgs]),
     ?info("Executing cmd: ~p", [Cmd]),
     Old = process_flag(trap_exit, true),
@@ -355,19 +355,6 @@ pack_header_and_nonce(Hash, Nonce) when byte_size(Hash) == 32 ->
     %% we need only return the two base64 encoded strings concatenated.
     %% 44 + 12 = 56 bytes
     HashStr ++ NonceStr.
-
-%%------------------------------------------------------------------------------
-%% @doc
-%%   Prefix setting load path to command so that blake2b.so is found in priv/lib
-%% @end
-%%------------------------------------------------------------------------------
--spec ld_lib_env() -> string().
-ld_lib_env() ->
-    LdPathVar = case os:type() of
-                 {unix, darwin} -> "DYLD_LIBRARY_PATH";
-                 {unix, _}      -> "LD_LIBRARY_PATH"
-                end,
-    "env " ++ LdPathVar ++ "=../lib:$" ++ LdPathVar.
 
 %%------------------------------------------------------------------------------
 %% @doc

--- a/apps/aecore/test/aec_pow_cuckoo_tests.erl
+++ b/apps/aecore/test/aec_pow_cuckoo_tests.erl
@@ -89,7 +89,7 @@ pow_test_() ->
        end},
       {"Attempt to verify nonce that is too big shall fail gracefully",
        fun() ->
-               % this is a premined working solution for size 28 
+               % this is a premined working solution for size 27
                Hash = <<83,237,15,231,60,2,35,26,173,64,55,84,59,100,88,146,91,
                         124,171,211,193,86,167,83,17,153,168,99,84,72,33,186>>,
                Pow = [2253069,4506519,4850569,8551070,9391218,15176443,22052028,
@@ -148,7 +148,7 @@ kill_ospid_miner_test_() ->
             timer:sleep(1000),                       %% give it some time to kill the miner OS pid
             ?assertEqual([], exec:which_children()), %% at least erlexec believes it died
 
-            Res = os:cmd("ps | grep mean30s-generic | grep -v grep"),
+            Res = os:cmd("ps | grep mean29-generic | grep -v grep"),
             ?assertMatch([], Res)
         end}
      ]

--- a/apps/aecore/test/aec_test_utils.erl
+++ b/apps/aecore/test/aec_test_utils.erl
@@ -98,10 +98,10 @@ unmock_time() ->
     meck:unload(aeu_time).
 
 mock_fast_cuckoo_pow() ->
-    mock_fast_cuckoo_pow({"mean16s-generic", "-t 5", 16, false}).
+    mock_fast_cuckoo_pow({"mean15-generic", "-t 5", 15, false}).
 
 mock_fast_and_deterministic_cuckoo_pow() ->
-    mock_fast_cuckoo_pow({"mean16s-generic", "", 16, false}).
+    mock_fast_cuckoo_pow({"mean15-generic", "", 15, false}).
 
 mock_fast_cuckoo_pow({_MinerBin, _MinerExtraArgs, _NodeBits, _EncodedHeader} = Cfg) ->
     meck:expect(aeu_env, get_env, 3,

--- a/apps/aecuckoo/Makefile
+++ b/apps/aecuckoo/Makefile
@@ -1,101 +1,92 @@
 EXECUTABLES = \
-	priv/bin/mean30s-generic \
-	priv/bin/mean28s-generic \
-	priv/bin/mean16s-generic \
-	priv/bin/mean30s-avx2 \
-	priv/bin/mean28s-avx2 \
-	priv/bin/mean16s-avx2 \
-	priv/bin/lean30 \
-	priv/bin/lean28 \
-	priv/bin/lean16 \
-	priv/bin/verify30 \
-	priv/bin/verify28 \
-	priv/bin/verify16
+	mean29-generic \
+	mean15-generic \
+	mean29-sse2 \
+	mean29-avx2 \
+	lean29 \
+	lean15
+PRIVEXECS = $(addprefix $(PRIV)/, $(EXECUTABLES))
 
-LIBBLAKE = priv/lib/libblake2b.so
+PRIV=priv/bin
+CUCKOO=c_src/src/cuckoo
 
-SRC_EXECUTABLES = $(patsubst %,c_src/src/%,$(foreach ex,$(patsubst priv/bin/%,%,$(EXECUTABLES)),$(SRC_EXECUTABLE_NOTDIR_$(ex))))
+HDRS=$(CUCKOO)/cuckoo.h $(CUCKOO)/../crypto/siphash.h
 
-# Distinguish by self-explanatory name the mean miner binaries
-# requiring AVX2 instructions.
-SRC_EXECUTABLE_NOTDIR_mean30s-generic = mean30sx1
-SRC_EXECUTABLE_NOTDIR_mean28s-generic = mean28sx1
-SRC_EXECUTABLE_NOTDIR_mean16s-generic = mean16sx1
-SRC_EXECUTABLE_NOTDIR_mean30s-avx2    = mean30sx8
-SRC_EXECUTABLE_NOTDIR_mean28s-avx2    = mean28sx8
-SRC_EXECUTABLE_NOTDIR_mean16s-avx2    = mean16sx8
-SRC_EXECUTABLE_NOTDIR_lean30          = lean30
-SRC_EXECUTABLE_NOTDIR_lean28          = lean28
-SRC_EXECUTABLE_NOTDIR_lean16          = lean16
-SRC_EXECUTABLE_NOTDIR_verify30        = verify30
-SRC_EXECUTABLE_NOTDIR_verify28        = verify28
-SRC_EXECUTABLE_NOTDIR_verify16        = verify16
+# Flags from upstream makefile
+OPT ?= -O3
 
-SRC_LIBBLAKE = $(patsubst priv/lib/%,c_src/src/%,$(LIBBLAKE))
+GPP_ARCH_FLAGS ?= -m64 -x c++ -march=native
 
-SRC_ARCH_FLAGS = -m64
+# -Wno-deprecated-declarations shuts up Apple OSX clang
+FLAGS ?= -Wall -Wno-format -Wno-deprecated-declarations -D_POSIX_C_SOURCE=200112L $(OPT) -DPREFETCH -I. $(CPPFLAGS) -pthread
+GPP ?= g++ $(GPP_ARCH_FLAGS) -std=c++11 $(FLAGS)
+BLAKE_2B_SRC ?= ../crypto/blake2b-ref.c
+
+# end Flags from upstream
 
 REPO = https://github.com/aeternity/cuckoo.git
-COMMIT = 042735e184ff85f1a53ffe2197ced8efccf37df6
+COMMIT = 51351332d23a11bc30e2457bd98f1c2ba358eb1e
+#COMMIT = 4e1e308fa597645ae086d714ee1f66b9a7b08e6a
 
 .PHONY: all
-all: $(LIBBLAKE) $(EXECUTABLES)
+all: $(EXECUTABLES)
 	@: # Silence the `Nothing to be done for 'all'.` message when running `make all`.
 
 .PHONY: clean
 clean:
-	rm -f $(SRC_EXECUTABLES) $(EXECUTABLES) $(SRC_LIBBLAKE) $(LIBBLAKE)
+	(cd $(PRIV); rm -f $(EXECUTABLES))
+	(cd $(CUCKOO); rm -f $(EXECUTABLES))
 
 .PHONY: distclean
 distclean:
 	rm -rf c_src priv
 
-# Use `.LOW_RESOLUTION_TIME` for preventing unnecessary target
-# recomputation caused by inability of `cp -p `to set high resolution
-# timestamp on certain filesystems.
-.LOW_RESOLUTION_TIME: $(LIBBLAKE)
-$(LIBBLAKE): $(SRC_LIBBLAKE) | priv/lib
-	cp -p $< $@
+.SECONDEXPANSION:
+.PHONY: $(EXECUTABLES)
+$(EXECUTABLES): | c_src/.git $(PRIV)
+$(EXECUTABLES): git-version $(CUCKOO)/$$@ $(PRIV)/$$@
 
-priv/lib priv/bin:
+# So we need check out the right commit or cleanup if
+# pointing to the wrong/old/dirty thing.
+.PHONY: git-version
+git-version:
+ifneq ($(strip $(shell cd c_src; git rev-parse HEAD)),$(COMMIT))
+	(cd c_src; git fetch; git checkout --force $(COMMIT))
+else
+ifneq ($(strip $(shell cd c_src; git diff-index $(COMMIT) | wc -l)),0)
+	(cd c_src; git fetch; git checkout --force $(COMMIT))
+endif
+endif
+
+# One rule to copy them all
+$(PRIVEXECS): $(CUCKOO)/$$(@F)
+	cp $(CUCKOO)/$(@F) $(PRIV)
+
+# The args vary slightly so spell out the compilation rules
+$(CUCKOO)/lean15: $(HDRS) $(CUCKOO)/lean.hpp $(CUCKOO)/lean.cpp
+	(cd $(CUCKOO); $(GPP) -o $(@F) -DATOMIC -DEDGEBITS=15 lean.cpp $(BLAKE_2B_SRC))
+
+$(CUCKOO)/lean29: $(HDRS) $(CUCKOO)/lean.hpp $(CUCKOO)/lean.cpp
+	(cd $(CUCKOO); $(GPP) -o $(@F) -DATOMIC -DEDGEBITS=29 lean.cpp $(BLAKE_2B_SRC))
+
+$(CUCKOO)/mean15-generic: $(HDRS) $(CUCKOO)/lean.hpp $(CUCKOO)/lean.cpp
+	(cd $(CUCKOO); $(GPP) -o $(@F) -DSAVEEDGES -DXBITS=0 -DNSIPHASH=1 -DEDGEBITS=15 mean.cpp $(BLAKE_2B_SRC))
+
+$(CUCKOO)/mean29-generic: $(HDRS) $(CUCKOO)/mean.hpp $(CUCKOO)/mean.cpp
+	(cd $(CUCKOO); $(GPP) -o $(@F) -DSAVEEDGES -DNSIPHASH=1 -DEDGEBITS=29 mean.cpp $(BLAKE_2B_SRC))
+
+$(CUCKOO)/mean29-sse2: $(HDRS) $(CUCKOO)/mean.hpp $(CUCKOO)/mean.cpp
+	(cd $(CUCKOO); $(GPP) -o $(@F) -DSAVEEDGES -mno-avx2 -DNSIPHASH=4 -DEDGEBITS=29 mean.cpp $(BLAKE_2B_SRC))
+
+$(CUCKOO)/mean29-avx2: $(HDRS) $(CUCKOO)/mean.hpp $(CUCKOO)/mean.cpp
+	(cd $(CUCKOO); $(GPP) -o $(@F) -DSAVEEDGES -mavx2 -DNSIPHASH=8 -DEDGEBITS=29 mean.cpp $(BLAKE_2B_SRC))
+
+# Create the private dir
+$(PRIV):
 	mkdir -p $@
-
-# Do not silence the recursive make call, in order to show compiler
-# flags used.
-$(SRC_LIBBLAKE): | c_src/.git
-	( cd $(@D) && \
-		$(MAKE) $(@F) \
-			GCC_ARCH_FLAGS=$(SRC_ARCH_FLAGS) \
-			GPP_ARCH_FLAGS=$(SRC_ARCH_FLAGS); )
-
-# Do not silence the recursive make call, in order to show compiler
-# flags used.
-$(SRC_EXECUTABLES): c_src/src/%: | c_src/.git
-	( cd $(@D) && \
-		$(MAKE) libblake2b.so $* \
-			GCC_ARCH_FLAGS=$(SRC_ARCH_FLAGS) \
-			GPP_ARCH_FLAGS=$(SRC_ARCH_FLAGS); )
 
 # Clone without checking out, so that recipe interrupted after clone
 # does not leave working directory distinct from the expected commit.
 c_src/.git:
 	git clone -n $(REPO) $(@D)
-	( cd $(@D) && git checkout $(COMMIT); )
 
-.SECONDEXPANSION:
-# For each target defined after the special target `.SECONDEXPANSION`,
-# expand all the prerequisites a second time.
-
-# Use `.LOW_RESOLUTION_TIME` for preventing unnecessary target
-# recomputation caused by inability of `cp -p `to set high resolution
-# timestamp on certain filesystems.
-.LOW_RESOLUTION_TIME: $(EXECUTABLES)
-# Rely on secondary expansion to expand the prerequisite a second
-# time, in order to determine the name of the source executable from
-# the (stem of the) pattern.  E.g. target `priv/bin/mean30s-generic`
-# has stem `mean30s-generic` and prerequisite
-# `c_src/src/$(SRC_EXECUTABLE_NOTDIR_mean30s-generic)` (because `$` is
-# escaped as `$$`) that, during secondary expansion, becomes
-# `c_src/src/mean30sx1`.
-$(EXECUTABLES): priv/bin/%: c_src/src/$$(SRC_EXECUTABLE_NOTDIR_%) | priv/bin
-	cp -p $< $@

--- a/apps/aecuckoo/Makefile
+++ b/apps/aecuckoo/Makefile
@@ -85,10 +85,10 @@ $(CUCKOO)/mean29-avx2: $(HDRS) $(CUCKOO)/mean.hpp $(CUCKOO)/mean.cpp
 	(cd $(CUCKOO); $(GPP) -o $(@F) -DSAVEEDGES -mavx2 -DNSIPHASH=8 -DEDGEBITS=29 mean.cpp $(BLAKE_2B_SRC))
 
 $(CUCKOO)/lcuda29:	$(CUCKOO)/../crypto/siphash.cuh $(CUCKOO)/lean.cu
-	(cd $(CUCKOO); nvcc -o $@ -DEDGEBITS=29 -arch sm_35 lean.cu $(BLAKE_2B_SRC))
+	(cd $(CUCKOO); nvcc -o $(@F) -DEDGEBITS=29 -arch sm_35 lean.cu $(BLAKE_2B_SRC))
 
 $(CUCKOO)/cuda29:		$(CUCKOO)/../crypto/siphash.cuh $(CUCKOO)/mean.cu
-	(cd $(CUCKOO); nvcc -o $@ -DEDGEBITS=29 -arch sm_35 mean.cu $(BLAKE_2B_SRC))
+	(cd $(CUCKOO); nvcc -o $(@F) -DEDGEBITS=29 -arch sm_35 mean.cu $(BLAKE_2B_SRC))
 
 # Create the private dir
 $(PRIV):

--- a/apps/aecuckoo/Makefile
+++ b/apps/aecuckoo/Makefile
@@ -1,21 +1,22 @@
 EXECUTABLES = \
 	mean29-generic \
-	mean15-generic \
-	mean29-sse2 \
 	mean29-avx2 \
-	lean29 \
-	lean15
+	lean29-generic \
+	lean29-avx2 \
+	mean15-generic \
+	lean15-generic
+
 PRIVEXECS = $(addprefix $(PRIV)/, $(EXECUTABLES))
 
-PRIV=priv/bin
-CUCKOO=c_src/src/cuckoo
+PRIV = priv/bin
+CUCKOO = c_src/src/cuckoo
 
 HDRS=$(CUCKOO)/cuckoo.h $(CUCKOO)/../crypto/siphash.h
 
 # Flags from upstream makefile
 OPT ?= -O3
 
-GPP_ARCH_FLAGS ?= -m64 -x c++ -march=native
+GPP_ARCH_FLAGS ?= -m64 -x c++
 
 # -Wno-deprecated-declarations shuts up Apple OSX clang
 FLAGS ?= -Wall -Wno-format -Wno-deprecated-declarations -D_POSIX_C_SOURCE=200112L $(OPT) -DPREFETCH -I. $(CPPFLAGS) -pthread
@@ -26,7 +27,6 @@ BLAKE_2B_SRC ?= ../crypto/blake2b-ref.c
 
 REPO = https://github.com/aeternity/cuckoo.git
 COMMIT = 51351332d23a11bc30e2457bd98f1c2ba358eb1e
-#COMMIT = 4e1e308fa597645ae086d714ee1f66b9a7b08e6a
 
 .PHONY: all
 all: $(EXECUTABLES)
@@ -34,12 +34,15 @@ all: $(EXECUTABLES)
 
 .PHONY: clean
 clean:
-	(cd $(PRIV); rm -f $(EXECUTABLES))
-	(cd $(CUCKOO); rm -f $(EXECUTABLES))
+	@if [ -d $(PRIV) ]; then (cd $(PRIV); rm -f $(EXECUTABLES)); fi
+	@if [ -d $(CUCKOO) ]; then (cd $(CUCKOO); rm -f $(EXECUTABLES)); fi
 
 .PHONY: distclean
 distclean:
 	rm -rf c_src priv
+
+# We want rules also for cuda29/lcuda29
+EXECUTABLES += lcuda29 cuda29
 
 .SECONDEXPANSION:
 .PHONY: $(EXECUTABLES)
@@ -50,10 +53,10 @@ $(EXECUTABLES): git-version $(CUCKOO)/$$@ $(PRIV)/$$@
 # pointing to the wrong/old/dirty thing.
 .PHONY: git-version
 git-version:
-ifneq ($(strip $(shell cd c_src; git rev-parse HEAD)),$(COMMIT))
+ifneq ($(strip $(shell if [ -d c_src ]; then (cd c_src; git rev-parse HEAD); fi)),$(COMMIT))
 	(cd c_src; git fetch; git checkout --force $(COMMIT))
 else
-ifneq ($(strip $(shell cd c_src; git diff-index $(COMMIT) | wc -l)),0)
+ifneq ($(strip $(shell cd c_src && git diff-index $(COMMIT) | wc -l)),0)
 	(cd c_src; git fetch; git checkout --force $(COMMIT))
 endif
 endif
@@ -63,23 +66,29 @@ $(PRIVEXECS): $(CUCKOO)/$$(@F)
 	cp $(CUCKOO)/$(@F) $(PRIV)
 
 # The args vary slightly so spell out the compilation rules
-$(CUCKOO)/lean15: $(HDRS) $(CUCKOO)/lean.hpp $(CUCKOO)/lean.cpp
+$(CUCKOO)/lean15-generic: $(HDRS) $(CUCKOO)/lean.hpp $(CUCKOO)/lean.cpp
 	(cd $(CUCKOO); $(GPP) -o $(@F) -DATOMIC -DEDGEBITS=15 lean.cpp $(BLAKE_2B_SRC))
 
-$(CUCKOO)/lean29: $(HDRS) $(CUCKOO)/lean.hpp $(CUCKOO)/lean.cpp
+$(CUCKOO)/lean29-generic: $(HDRS) $(CUCKOO)/lean.hpp $(CUCKOO)/lean.cpp
 	(cd $(CUCKOO); $(GPP) -o $(@F) -DATOMIC -DEDGEBITS=29 lean.cpp $(BLAKE_2B_SRC))
 
-$(CUCKOO)/mean15-generic: $(HDRS) $(CUCKOO)/lean.hpp $(CUCKOO)/lean.cpp
+$(CUCKOO)/lean29-avx2: $(HDRS) $(CUCKOO)/lean.hpp $(CUCKOO)/lean.cpp
+	(cd $(CUCKOO); $(GPP) -o $(@F) -DATOMIC -mavx2 -DNSIPHASH=8 -DEDGEBITS=29 lean.cpp $(BLAKE_2B_SRC))
+
+$(CUCKOO)/mean15-generic: $(HDRS) $(CUCKOO)/mean.hpp $(CUCKOO)/mean.cpp
 	(cd $(CUCKOO); $(GPP) -o $(@F) -DSAVEEDGES -DXBITS=0 -DNSIPHASH=1 -DEDGEBITS=15 mean.cpp $(BLAKE_2B_SRC))
 
 $(CUCKOO)/mean29-generic: $(HDRS) $(CUCKOO)/mean.hpp $(CUCKOO)/mean.cpp
 	(cd $(CUCKOO); $(GPP) -o $(@F) -DSAVEEDGES -DNSIPHASH=1 -DEDGEBITS=29 mean.cpp $(BLAKE_2B_SRC))
 
-$(CUCKOO)/mean29-sse2: $(HDRS) $(CUCKOO)/mean.hpp $(CUCKOO)/mean.cpp
-	(cd $(CUCKOO); $(GPP) -o $(@F) -DSAVEEDGES -mno-avx2 -DNSIPHASH=4 -DEDGEBITS=29 mean.cpp $(BLAKE_2B_SRC))
-
 $(CUCKOO)/mean29-avx2: $(HDRS) $(CUCKOO)/mean.hpp $(CUCKOO)/mean.cpp
 	(cd $(CUCKOO); $(GPP) -o $(@F) -DSAVEEDGES -mavx2 -DNSIPHASH=8 -DEDGEBITS=29 mean.cpp $(BLAKE_2B_SRC))
+
+$(CUCKOO)/lcuda29:	$(CUCKOO)/../crypto/siphash.cuh $(CUCKOO)/lean.cu
+	(cd $(CUCKOO); nvcc -o $@ -DEDGEBITS=29 -arch sm_35 lean.cu $(BLAKE_2B_SRC))
+
+$(CUCKOO)/cuda29:		$(CUCKOO)/../crypto/siphash.cuh $(CUCKOO)/mean.cu
+	(cd $(CUCKOO); nvcc -o $@ -DEDGEBITS=29 -arch sm_35 mean.cu $(BLAKE_2B_SRC))
 
 # Create the private dir
 $(PRIV):

--- a/apps/aecuckoo/test/aecuckoo_SUITE.erl
+++ b/apps/aecuckoo/test/aecuckoo_SUITE.erl
@@ -33,13 +33,11 @@ groups() ->
     ].
 
 init_per_group(smoke_tests_15, Config) ->
-    [{nonce, 86},
-     {cyclehash, "c6bf28762af60c78600203ea018de966ebee3f37d84ea21f07b114553fe1692f"}
-     | Config];
+    [{nonce, 86} | Config];
 init_per_group(mean15, Config) ->
     [{miner, 'mean15-generic'} | Config];
 init_per_group(lean15, Config) ->
-    [{miner, 'lean15'} | Config].
+    [{miner, 'lean15-generic'} | Config].
 
 end_per_group(_Group, _Config) ->
     ok.

--- a/apps/aeutils/priv/epoch_config_schema.json
+++ b/apps/aeutils/priv/epoch_config_schema.json
@@ -391,21 +391,21 @@
                             "required" : [
                                 "executable",
                                 "extra_args",
-                                "node_bits"
+                                "edge_bits"
                             ],
                             "properties" : {
                                 "executable" : {
-                                    "description" : "Executable binary of the miner. Options are: \"mean30s-generic\" (memory-intensive), \"mean30s-avx2\" (memory-intensive, benefits from faster CPU supporting AVX2 instructions), \"lean30\" (CPU-intensive, useful if memory-constrained).",
+                                    "description" : "Executable binary of the miner. Options are: \"mean29-generic\" (memory-intensive), \"mean29-sse2\" (memory-intensive, benefits from faster CPU supporting SSE2 instructions), \"mean29-avx2\" (memory-intensive, benefits from faster CPU supporting AVX2 instructions), \"lean29\" (CPU-intensive, useful if memory-constrained).",
                                     "type" : "string",
-                                    "default": "mean30s-generic"
+                                    "default": "mean29-generic"
                                 },
                                 "extra_args" : {
                                     "description" : "Extra arguments to pass to the miner executable binary. The safest choice is specifying no arguments i.e. empty string.",
                                     "type" : "string",
                                     "default": "-t 5"
                                 },
-                                "node_bits" : {
-                                    "description" : "Number of bits used for representing a node in the Cuckoo Cycle problem. It affects both PoW generation (mining) and verification. WARNING: Changing this makes the node incompatible with the chain of other nodes in the network, do not change from the default unless you know what you are doing.",
+                                "edge_bits" : {
+                                    "description" : "Number of bits used for representing an edge in the Cuckoo Cycle problem. It affects both PoW generation (mining) and verification. WARNING: Changing this makes the node incompatible with the chain of other nodes in the network, do not change from the default unless you know what you are doing.",
                                     "type": "integer",
                                     "default": 30
                                 },

--- a/apps/aeutils/priv/epoch_config_schema.json
+++ b/apps/aeutils/priv/epoch_config_schema.json
@@ -395,7 +395,7 @@
                             ],
                             "properties" : {
                                 "executable" : {
-                                    "description" : "Executable binary of the miner. Options are: \"mean29-generic\" (memory-intensive), \"mean29-sse2\" (memory-intensive, benefits from faster CPU supporting SSE2 instructions), \"mean29-avx2\" (memory-intensive, benefits from faster CPU supporting AVX2 instructions), \"lean29\" (CPU-intensive, useful if memory-constrained).",
+                                    "description" : "Executable binary of the miner. Options are: \"mean29-generic\" (memory-intensive), \"mean29-avx2\" (memory-intensive, benefits from faster CPU supporting AVX2 instructions), \"lean29-generic\" (CPU-intensive, useful if memory-constrained), \"lean29-avx2\" (CPU-intensive, useful if memory-constrained, benefits from faster CPU supporting AVX2 instructions).",
                                     "type" : "string",
                                     "default": "mean29-generic"
                                 },

--- a/apps/aeutils/test/data/epoch_full.yaml
+++ b/apps/aeutils/test/data/epoch_full.yaml
@@ -116,11 +116,11 @@ mining:
     cuckoo:
         miner:
             # Executable binary of the miner.
-            executable: mean30
+            executable: mean29-generic
             # Extra arguments to pass to the miner executable binary.
             extra_args: "-t 5"
-            # Number of bits used for representing a node in the Cuckoo Cycle problem.
-            node_bits: 30
+            # Number of bits used for representing an edge in the Cuckoo Cycle problem.
+            edge_bits: 29
             # Hexadecimal encode the header argument that is send to the miner executable. CUDA executables expect hex encoded header.
             hex_encoded_header: false
             # Miner process priority (niceness) in a UNIX fashion. Higher `nice` means lower priority. Keep it unset to inherit parent process priority.

--- a/apps/aeutils/test/data/epoch_no_newline.yaml
+++ b/apps/aeutils/test/data/epoch_no_newline.yaml
@@ -64,11 +64,11 @@ mining:
     cuckoo:
         miner:
             # Executable binary of the miner.
-            executable: mean30
+            executable: mean29-generic
             # Extra arguments to pass to the miner executable binary.
             extra_args: "-t 5"
-            # Number of bits used for representing a node in the Cuckoo Cycle problem.
-            node_bits: 30
+            # Number of bits used for representing an edge in the Cuckoo Cycle problem.
+            edge_bits: 29
 
 logging:
     # Controls the overload protection in the logs.

--- a/config/dev.config
+++ b/config/dev.config
@@ -25,7 +25,7 @@
       {peer_password, <<"secret">>},
       {db_path, "."},
       {persist, false},
-      {aec_pow_cuckoo, {"mean30s-generic", "-t 5", 30, false}}
+      {aec_pow_cuckoo, {"mean29-generic", "-t 5", 29, false}}
     ]
   },
 

--- a/config/dev1/sys.config
+++ b/config/dev1/sys.config
@@ -37,7 +37,7 @@
       {db_path, "."},
       {persist, false},
       {autostart, false},
-      {aec_pow_cuckoo, {"mean16s-generic", "-t 5", 16, false}}
+      {aec_pow_cuckoo, {"mean15-generic", "-t 5", 15, false}}
     ]
   },
 

--- a/config/dev2/sys.config
+++ b/config/dev2/sys.config
@@ -37,7 +37,7 @@
       {db_path, "."},
       {persist, false},
       {autostart, false},
-      {aec_pow_cuckoo, {"mean16s-generic", "-t 5", 16, false}},
+      {aec_pow_cuckoo, {"mean15-generic", "-t 5", 15, false}},
       {ping_interval, 500}
     ]
   },

--- a/config/dev3/sys.config
+++ b/config/dev3/sys.config
@@ -37,7 +37,7 @@
       {db_path, "."},
       {persist, false},
       {autostart, false},
-      {aec_pow_cuckoo, {"mean16s-generic", "-t 5", 16, false}}
+      {aec_pow_cuckoo, {"mean15-generic", "-t 5", 15, false}}
     ]
   },
 

--- a/config/sys.config
+++ b/config/sys.config
@@ -38,7 +38,7 @@
       {peer_password, <<"secret">>},
       {db_path, "."},
       {persist, false},
-      {aec_pow_cuckoo, {"mean30s-generic", "-t 5", 30, false}}
+      {aec_pow_cuckoo, {"mean29-generic", "-t 5", 29, false}}
     ]
   },
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-# Small local network of three nodes using the fastest mean16
+# Small local network of three nodes using the fastest mean15
 version: '3'
 services:
   node1:
@@ -11,7 +11,7 @@ services:
       -aecore expected_mine_rate ${EPOCH_MINE_RATE:-15000}
       -aehttp enable_debug_endpoints true
     volumes:
-      - ${PWD}/docker/epoch_node1_mean16.yaml:/home/epoch/epoch.yaml
+      - ${PWD}/docker/epoch_node1_mean15.yaml:/home/epoch/epoch.yaml
       - ${PWD}/docker/keys/node1:/home/epoch/node/keys
       - node1_db:/home/epoch/node/data/mnesia
 
@@ -24,7 +24,7 @@ services:
       -aecore expected_mine_rate ${EPOCH_MINE_RATE:-15000}
       -aehttp enable_debug_endpoints true
     volumes:
-      - ${PWD}/docker/epoch_node2_mean16.yaml:/home/epoch/epoch.yaml
+      - ${PWD}/docker/epoch_node2_mean15.yaml:/home/epoch/epoch.yaml
       - ${PWD}/docker/keys/node2:/home/epoch/node/keys
       - node2_db:/home/epoch/node/data/mnesia
 
@@ -37,7 +37,7 @@ services:
       -aecore expected_mine_rate ${EPOCH_MINE_RATE:-15000}
       -aehttp enable_debug_endpoints true
     volumes:
-      - ${PWD}/docker/epoch_node3_mean16.yaml:/home/epoch/epoch.yaml
+      - ${PWD}/docker/epoch_node3_mean15.yaml:/home/epoch/epoch.yaml
       - ${PWD}/docker/keys/node3:/home/epoch/node/keys
       - node3_db:/home/epoch/node/data/mnesia
 

--- a/docker/epoch_node1_mean15.yaml
+++ b/docker/epoch_node1_mean15.yaml
@@ -1,6 +1,6 @@
 ---
 peers:
-    - aenode://pp_HdcpgTX2C1aZ5sjGGysFEuup67K9XiFsWqSPJs4RahEcSyF7X@node1:3015
+    - aenode://pp_28uQUgsPcsy7TQwnRxhF8GMKU4ykFLKsgf4TwDwPMNaSCXwWV8@node2:3015
     - aenode://pp_Dxq41rJN33j26MLqryvh7AnhuZywefWKEPBiiYu2Da2vDWLBq@node3:3015
 
 http:
@@ -22,6 +22,6 @@ mining:
     autostart: true
     cuckoo:
         miner:
-            executable: mean16s-generic
+            executable: mean15-generic
             extra_args: ""
-            node_bits: 16
+            edge_bits: 15

--- a/docker/epoch_node2_mean15.yaml
+++ b/docker/epoch_node2_mean15.yaml
@@ -1,6 +1,6 @@
 ---
 peers:
-    - aenode://pp_28uQUgsPcsy7TQwnRxhF8GMKU4ykFLKsgf4TwDwPMNaSCXwWV8@node2:3015
+    - aenode://pp_HdcpgTX2C1aZ5sjGGysFEuup67K9XiFsWqSPJs4RahEcSyF7X@node1:3015
     - aenode://pp_Dxq41rJN33j26MLqryvh7AnhuZywefWKEPBiiYu2Da2vDWLBq@node3:3015
 
 http:
@@ -22,6 +22,6 @@ mining:
     autostart: true
     cuckoo:
         miner:
-            executable: mean16s-generic
+            executable: mean15-generic
             extra_args: ""
-            node_bits: 16
+            edge_bits: 15

--- a/docker/epoch_node3_mean15.yaml
+++ b/docker/epoch_node3_mean15.yaml
@@ -22,6 +22,6 @@ mining:
     autostart: true
     cuckoo:
         miner:
-            executable: mean16s-generic
+            executable: mean15-generic
             extra_args: ""
-            node_bits: 16
+            edge_bits: 15

--- a/docs/cuda-miner.md
+++ b/docs/cuda-miner.md
@@ -56,13 +56,13 @@ Compilation of CUDA miner is done by invoking:
 
 ```bash
 cd apps/aecuckoo && make c_src/.git
-cd c_src/src && make libblake2b.so cuda30
+cd c_src/src && make cuda29
 ```
 
 Finally the actual installation of the miner binary is copying it to the node corresponding path, the documentation assumes the `epoch` node is installed in `~/node` directory.
 
 ```bash
-cp cuda30 ~/node/lib/aecuckoo-0.1.0/priv/bin
+cp cuda29 ~/node/lib/aecuckoo-0.1.0/priv/bin
 ```
 
 ## Configuration
@@ -73,9 +73,9 @@ Once the CUDA miner is in place, one should change the node configuration to sta
 mining:
     cuckoo:
         miner:
-            executable: cuda30
+            executable: cuda29
             extra_args: ""
-            node_bits: 30
+            edge_bits: 29
             hex_encoded_header: true
 ```
 
@@ -93,9 +93,9 @@ The address of a GPU device used by the miner can be set with `-d` argument, for
 mining:
     cuckoo:
         miner:
-            executable: cuda30
+            executable: cuda29
             extra_args: "-d 0"
-            node_bits: 30
+            edge_bits: 29
             hex_encoded_header: true
 ```
 

--- a/docs/cuda-miner.md
+++ b/docs/cuda-miner.md
@@ -61,7 +61,7 @@ cd apps/aecuckoo && make cuda29
 Finally the actual installation of the miner binary is copying it to the node corresponding path, the documentation assumes the `epoch` node is installed in `~/node` directory.
 
 ```bash
-cp cuda29 ~/node/lib/aecuckoo-0.1.0/priv/bin
+cp priv/bin/cuda29 ~/node/lib/aecuckoo-0.1.0/priv/bin
 ```
 
 ## Configuration

--- a/docs/cuda-miner.md
+++ b/docs/cuda-miner.md
@@ -7,7 +7,7 @@ The release packages do not ship with a CUDA miner, but you can build it yoursel
 - Epoch node configuration
 
 The documentation below is tested on:
-- Epoch version 0.19.0
+- Epoch version 1.0.0-rc2
 - CUDA toolkit version 9.2
 - AWS p2.xlarge instance with 16GB EBS
 - Ubuntu 16.04.4
@@ -41,7 +41,7 @@ Epoch source code can be downloaded by cloning the git repository:
 ```bash
 cd ~
 git clone https://github.com/aeternity/epoch.git epoch && cd epoch
-git checkout tags/v0.19.0
+git checkout tags/v1.0.0-rc2
 ```
 
 The documentation below assumes that the `epoch` source code resides in `~/epoch` directory.
@@ -55,8 +55,7 @@ export PATH=/usr/local/cuda-9.2/bin${PATH:+:${PATH}}
 Compilation of CUDA miner is done by invoking:
 
 ```bash
-cd apps/aecuckoo && make c_src/.git
-cd c_src/src && make cuda29
+cd apps/aecuckoo && make cuda29
 ```
 
 Finally the actual installation of the miner binary is copying it to the node corresponding path, the documentation assumes the `epoch` node is installed in `~/node` directory.

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -131,7 +131,7 @@ docker run -d -p 3013:3013 \
 ## Localnet
 
 Small local network (*not* connected to testnet) can be created with `docker-compose`.
-It runs three nodes using the `mean16s-generic` miner (fastest generic miner) and a proxy server to allow CORS.
+It runs three nodes using the `mean15-generic` miner (fastest generic miner) and a proxy server to allow CORS.
 
 All local network nodes have `ak_25eTK8PaiLpREqBkP3yDNWJAwXjWSR8tbn3zu8SXaNx824A1AJ` set as node beneficiary (for more details on beneficiary see [configuration documentation](configuration.md#beneficiary-account)).
 Public-private keypair of `ak_25eTK8PaiLpREqBkP3yDNWJAwXjWSR8tbn3zu8SXaNx824A1AJ` beneficiary can be found [here](/docker/keys/beneficiary): as the private key is publicly available, this setup must *not* be connected on the live network.

--- a/docs/release-notes/next/PT-161750304-upstream_sync_cuckoo.md
+++ b/docs/release-notes/next/PT-161750304-upstream_sync_cuckoo.md
@@ -1,0 +1,3 @@
+* Changes naming scheme for miner executables. Used to be `lean/mean/cuda<node-bits>`, this is changed to
+  `lean/mean/cuds<edge-bits>` to align with upstream cuckoo. An upstream sync is also performed. *NOTE:*
+  changes in `epoch.yaml` are necessary (i.e. `lean30 -> lean29`, etc.). Does not affect consensus.

--- a/docs/release-notes/next/PT-161750304-upstream_sync_cuckoo.md
+++ b/docs/release-notes/next/PT-161750304-upstream_sync_cuckoo.md
@@ -1,3 +1,3 @@
 * Changes naming scheme for miner executables. Used to be `lean/mean/cuda<node-bits>`, this is changed to
-  `lean/mean/cuds<edge-bits>` to align with upstream cuckoo. An upstream sync is also performed. *NOTE:*
-  changes in `epoch.yaml` are necessary (i.e. `lean30 -> lean29`, etc.). Does not affect consensus.
+  `lean/mean/cuda<edge-bits>` to align with upstream cuckoo. An upstream sync is also performed. *NOTE:*
+  changes in `epoch.yaml` are necessary (i.e. `mean30-generic -> mean29-generic`, etc.). Does not affect consensus.

--- a/py/tests/integration/common.py
+++ b/py/tests/integration/common.py
@@ -119,9 +119,9 @@ mining:
     beneficiary_reward_delay: 2
     cuckoo:
         miner:
-            executable: mean16s-generic
-            extra_args: "-t 5"
-            node_bits: 16
+            executable: mean15-generic
+            extra_args: ""
+            edge_bits: 15
 """
     return install_user_config(root_dir, file_name, conf)
 
@@ -139,9 +139,9 @@ mining:
     beneficiary_reward_delay: 2
     cuckoo:
         miner:
-            executable: mean16s-generic
-            extra_args: "-t 5"
-            node_bits: 16
+            executable: mean15-generic
+            extra_args: ""
+            edge_bits: 15
 """.format(beneficiary['enc_pubk'])
     return install_user_config(root_dir, file_name, conf)
 

--- a/py/tests/integration/test_use_cases.py
+++ b/py/tests/integration/test_use_cases.py
@@ -81,9 +81,9 @@ mining:
     beneficiary: "ak_2QLChDdERfod9QajLkCTsJnYP3RNqZJmAFWQWQZWr99fSrC55h"
     cuckoo:
         miner:
-            executable: mean16s-generic
-            extra_args: "-t 5"
-            node_bits: 16
+            executable: mean15-generic
+            extra_args: ""
+            edge_bits: 15
 """
     p_conf = """\
 ---
@@ -282,9 +282,9 @@ mining:
     beneficiary: "ak_2QLChDdERfod9QajLkCTsJnYP3RNqZJmAFWQWQZWr99fSrC55h"
     cuckoo:
         miner:
-            executable: mean16s-generic
-            extra_args: "-t 5"
-            node_bits: 16
+            executable: mean15-generic
+            extra_args: ""
+            edge_bits: 15
 """.format(sync_port, key_dir, mining)
     return common.install_user_config(root_dir, file_name, conf)
 
@@ -312,9 +312,9 @@ mining:
     beneficiary: "ak_2QLChDdERfod9QajLkCTsJnYP3RNqZJmAFWQWQZWr99fSrC55h"
     cuckoo:
         miner:
-            executable: mean16s-generic
-            extra_args: "-t 5"
-            node_bits: 16
+            executable: mean15-generic
+            extra_args: ""
+            edge_bits: 15
 """
     return common.install_user_config(root_dir, file_name, conf)
 
@@ -342,9 +342,9 @@ mining:
     beneficiary: "ak_2QLChDdERfod9QajLkCTsJnYP3RNqZJmAFWQWQZWr99fSrC55h"
     cuckoo:
         miner:
-            executable: mean16s-generic
-            extra_args: "-t 5"
-            node_bits: 16
+            executable: mean15-generic
+            extra_args: ""
+            edge_bits: 15
 """
     return common.install_user_config(root_dir, file_name, conf)
 

--- a/py/tests/release.py
+++ b/py/tests/release.py
@@ -53,9 +53,9 @@ mining:
     beneficiary: "ak_RShHyLiaQJF8AZ7Thi4Sgjm6ncHhqguqBBqCzQRG3fyjvKj6V"
     cuckoo:
         miner:
-            executable: mean16s-generic
-            extra_args: "-t 5"
-            node_bits: 16
+            executable: mean15-generic
+            extra_args: ""
+            edge_bits: 15
 
 chain:
     persist: true
@@ -99,9 +99,9 @@ mining:
     beneficiary: "ak_2WPFUrtoxvdpaMySJUfyhGeBg5o725y6wFJTWAdv9YQ7pJMHjT"
     cuckoo:
         miner:
-            executable: mean16s-generic
-            extra_args: "-t 5"
-            node_bits: 16
+            executable: mean15-generic
+            extra_args: ""
+            edge_bits: 15
 
 chain:
     persist: true
@@ -145,9 +145,9 @@ mining:
     beneficiary: "ak_uDBX3LjznjmtoFzVmVWBnAaMXhvsReKYkxMrA1QMSxudhbjuf"
     cuckoo:
         miner:
-            executable: mean16s-generic
-            extra_args: "-t 5"
-            node_bits: 16
+            executable: mean15-generic
+            extra_args: ""
+            edge_bits: 15
 
 chain:
     persist: true

--- a/system_test/aest_channels_SUITE_data/epoch.yaml.mustache
+++ b/system_test/aest_channels_SUITE_data/epoch.yaml.mustache
@@ -39,7 +39,7 @@ mining:
     expected_mine_rate: 1000
     cuckoo:
         miner:
-            executable: mean16s-generic
+            executable: mean15-generic
             extra_args: ""
-            node_bits: 16
+            edge_bits: 15
 {{/epoch_config}}

--- a/system_test/aest_commands_SUITE_data/epoch.yaml.mustache
+++ b/system_test/aest_commands_SUITE_data/epoch.yaml.mustache
@@ -28,7 +28,7 @@ mining:
     autostart: true
     cuckoo:
         miner:
-            executable: mean16s-generic
+            executable: mean15-generic
             extra_args: ""
-            node_bits: 16
+            edge_bits: 15
 {{/epoch_config}}

--- a/system_test/aest_compatibility_SUITE.erl
+++ b/system_test/aest_compatibility_SUITE.erl
@@ -76,7 +76,7 @@ test_mining_algorithms_compatibility(Cfg) ->
 
     %% Setup nodes
     setup([?NODE1], #{ beneficiary => Beneficiary1, algorithm => <<"mean15-generic">> }, Cfg),
-    setup([?NODE2], #{ beneficiary => Beneficiary2, algorithm => <<"lean15">> }, Cfg),
+    setup([?NODE2], #{ beneficiary => Beneficiary2, algorithm => <<"lean15-generic">> }, Cfg),
     start_node(node1, Cfg),
     start_node(node2, Cfg),
     wait_for_startup([node1, node2], 0, Cfg),

--- a/system_test/aest_compatibility_SUITE.erl
+++ b/system_test/aest_compatibility_SUITE.erl
@@ -75,8 +75,8 @@ test_mining_algorithms_compatibility(Cfg) ->
     Beneficiary2 = aehttp_api_encoder:encode(account_pubkey, PubKey2),
 
     %% Setup nodes
-    setup([?NODE1], #{ beneficiary => Beneficiary1, algorithm => <<"mean16s-generic">> }, Cfg),
-    setup([?NODE2], #{ beneficiary => Beneficiary2, algorithm => <<"lean16">> }, Cfg),
+    setup([?NODE1], #{ beneficiary => Beneficiary1, algorithm => <<"mean15-generic">> }, Cfg),
+    setup([?NODE2], #{ beneficiary => Beneficiary2, algorithm => <<"lean15">> }, Cfg),
     start_node(node1, Cfg),
     start_node(node2, Cfg),
     wait_for_startup([node1, node2], 0, Cfg),

--- a/system_test/aest_compatibility_SUITE_data/epoch.yaml.mustache
+++ b/system_test/aest_compatibility_SUITE_data/epoch.yaml.mustache
@@ -31,5 +31,5 @@ mining:
         miner:
             executable: {{config.algorithm}}
             extra_args: ""
-            node_bits: 16
+            edge_bits: 15
 {{/epoch_config}}

--- a/system_test/aest_genesis_SUITE_data/epoch.yaml.mustache
+++ b/system_test/aest_genesis_SUITE_data/epoch.yaml.mustache
@@ -29,7 +29,7 @@ mining:
     expected_mine_rate: 1000
     cuckoo:
         miner:
-            executable: mean16s-generic
+            executable: mean15-generic
             extra_args: ""
-            node_bits: 16
+            edge_bits: 15
 {{/epoch_config}}

--- a/system_test/aest_mempool_SUITE_data/epoch.yaml.mustache
+++ b/system_test/aest_mempool_SUITE_data/epoch.yaml.mustache
@@ -32,7 +32,7 @@ mining:
     expected_mine_rate: 1000
     cuckoo:
         miner:
-            executable: mean16s-generic
+            executable: mean15-generic
             extra_args: ""
-            node_bits: 16
+            edge_bits: 15
 {{/epoch_config}}

--- a/system_test/aest_names_SUITE_data/epoch.yaml.mustache
+++ b/system_test/aest_names_SUITE_data/epoch.yaml.mustache
@@ -28,7 +28,7 @@ mining:
     expected_mine_rate: 1000
     cuckoo:
         miner:
-            executable: mean16s-generic
+            executable: mean15-generic
             extra_args: ""
-            node_bits: 16
+            edge_bits: 15
 {{/epoch_config}}

--- a/system_test/aest_oracles_SUITE_data/epoch.yaml.mustache
+++ b/system_test/aest_oracles_SUITE_data/epoch.yaml.mustache
@@ -34,7 +34,7 @@ mining:
     expected_mine_rate: 1000
     cuckoo:
         miner:
-            executable: mean16s-generic
+            executable: mean15-generic
             extra_args: ""
-            node_bits: 16
+            edge_bits: 15
 {{/epoch_config}}

--- a/system_test/aest_peers_SUITE_data/epoch.yaml.mustache
+++ b/system_test/aest_peers_SUITE_data/epoch.yaml.mustache
@@ -32,7 +32,7 @@ mining:
     micro_block_cycle: 100
     cuckoo:
         miner:
-            executable: mean16s-generic
+            executable: mean15-generic
             extra_args: ""
-            node_bits: 16
+            edge_bits: 15
 {{/epoch_config}}

--- a/system_test/aest_perf_SUITE_data/epoch.yaml.mustache
+++ b/system_test/aest_perf_SUITE_data/epoch.yaml.mustache
@@ -31,7 +31,7 @@ mining:
     expected_mine_rate: 1000
     cuckoo:
         miner:
-            executable: mean16s-generic
+            executable: mean15-generic
             extra_args: ""
-            node_bits: 16
+            edge_bits: 15
 {{/epoch_config}}

--- a/system_test/aest_sync_SUITE_data/epoch.yaml.mustache
+++ b/system_test/aest_sync_SUITE_data/epoch.yaml.mustache
@@ -32,7 +32,7 @@ mining:
     expected_mine_rate: 1000
     cuckoo:
         miner:
-            executable: mean16s-generic
+            executable: mean15-generic
             extra_args: ""
-            node_bits: 16
+            edge_bits: 15
 {{/epoch_config}}

--- a/system_test/helpers/aest_docker.erl
+++ b/system_test/helpers/aest_docker.erl
@@ -202,7 +202,7 @@ setup_node(Spec, BackendState) ->
                       %% This may be improved upon.
                       [#{executable => maps:get(ex, CuckooMiner),
                          extra_args => maps:get(args, CuckooMiner),
-                         node_bits => maps:get(bits, CuckooMiner)
+                         edge_bits => maps:get(bits, CuckooMiner)
                         }]}
         end,
     HardForkVars =

--- a/system_test/only_local/aest_heavy_sync_SUITE_data/epoch.yaml.mustache
+++ b/system_test/only_local/aest_heavy_sync_SUITE_data/epoch.yaml.mustache
@@ -31,7 +31,7 @@ mining:
     autostart: {{mining.autostart}}
     cuckoo:
         miner:
-            executable: mean28s-generic
-            extra_args: ""
-            node_bits: 28
+            executable: mean29-generic
+            extra_args: "-t 5"
+            edge_bits: 29
 {{/epoch_config}}


### PR DESCRIPTION
    Do an upstream sync with tromp/cuckoo.git
    
    Change naming of miners to lean<edge_bits> instead of lean<node_bits>
    to align better with upstream (and cause less confusion).
