### PR TITLE
Add cuckoo section to example epoch configuration file to use lean30 …

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -39,7 +39,7 @@ mining:
         miner:
             executable: lean29-generic
             extra_args: ""
-            node_bits: 30
+            edge_bits: 29
 
 ```
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -37,7 +37,7 @@ mining:
     beneficiary: "encoded_beneficiary_pubkey_to_be_replaced"
     cuckoo:
         miner:
-            executable: lean30
+            executable: lean29-generic
             extra_args: ""
             node_bits: 30
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -43,7 +43,7 @@ mining:
 
 ```
 
-Note that if want to use the default miner, remove the `mining.cuckoo` section and increase the docker container memory at least 4GB. 
+Note that if you want to use the default miner, remove the `mining.cuckoo` section and increase the docker container memory at least 4GB. 
 
 #### Generating beneficiary account for the first time
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -35,7 +35,15 @@ chain:
 mining:
     autostart: true
     beneficiary: "encoded_beneficiary_pubkey_to_be_replaced"
+    cuckoo:
+        miner:
+            executable: lean30
+            extra_args: ""
+            node_bits: 30
+
 ```
+
+Note that if want to use the default miner, remove the `mining.cuckoo` section and increase the docker container memory at least 4GB. 
 
 #### Generating beneficiary account for the first time
 


### PR DESCRIPTION
…to make it work with default docker container memory limit of 2GB. Also added a note to increase the memory limit to 4GB if one wants to use the default miner.