### PR TITLE
Polymorphic abort

### DIFF
--- a/apps/aesophia/src/aeso_ast_infer_types.erl
+++ b/apps/aesophia/src/aeso_ast_infer_types.erl
@@ -108,7 +108,7 @@ global_env() ->
      {"state", State},
      {"put",   Fun1(State, Unit)},
      %% Abort
-     {"abort", Fun1(String, Unit)},
+     {"abort", Fun1(String, A)},
      %% Oracles
      {["Oracle", "register"],     SignFun([Address, Fee, TTL], Oracle(Q, R))},
      {["Oracle", "query_fee"],    Fun([Oracle(Q, R)], Fee)},

--- a/apps/aesophia/test/contracts/abort_test.aes
+++ b/apps/aesophia/test/contracts/abort_test.aes
@@ -8,7 +8,7 @@ contract AbortTest =
     { value = v }
 
   // Aborting
-  public function do_abort(v : int, s : string) =
+  public function do_abort(v : int, s : string) : () =
     put_value(v)
     revert_abort(s)
 


### PR DESCRIPTION
Abort never returns, so can be used at any type.

Protocol: https://github.com/aeternity/protocol/pull/266