### PR TITLE
PT-161811195 Allow additional params in content-type header (e.g. cha…

### DIFF
--- a/apps/aehttp/src/aehttp_api_handler.erl
+++ b/apps/aehttp/src/aehttp_api_handler.erl
@@ -34,7 +34,7 @@ allowed_methods(Req, State = #state{ allowed_method = Method }) ->
     {[Method], Req, State}.
 
 content_types_accepted(Req, State) ->
-    {[{<<"application/json">>, handle_request_json}], Req, State}.
+    {[{{<<"application">>, <<"json">>, '*'}, handle_request_json}], Req, State}.
 
 content_types_provided(Req, State) ->
     {[{<<"application/json">>, handle_request_json}], Req, State}.

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -165,6 +165,11 @@
     cors_returned_on_preflight_request/1,
     cors_returned_on_get_request/1]).
 
+%% test case exports
+%% for Cowboy handler tests
+-export([
+    charset_param_in_content_type/1]).
+
 %%
 %% test case exports
 %% wrong http method for all endpoints
@@ -466,6 +471,10 @@ groups() ->
       [cors_not_returned_when_origin_not_sent,
        cors_returned_on_preflight_request,
        cors_returned_on_get_request]},
+
+     {cowboy_handler, [],
+      [charset_param_in_content_type]},
+
      {wrong_http_method_endpoints, [], [
         wrong_http_method_top,
         wrong_http_method_contract_create,
@@ -5209,6 +5218,20 @@ cors_returned_on_get_request(_Config) ->
         httpc_request(get, {Host ++ "/v2/blocks/top", [{"origin", "example.com"}]}, [], []),
 
     "example.com" = proplists:get_value("access-control-allow-origin", Headers),
+    ok.
+
+%% ============================================================
+%% Test Cowboy API handler
+%% ============================================================
+
+charset_param_in_content_type(_Config) ->
+    Host = external_address(),
+    BorkedPayload = <<"anything">>,
+
+    {ok, {{_, 400, "Bad Request"}, _, _}} =
+        httpc_request(post, {Host ++ "/v2/transactions", [], "application/json", BorkedPayload}, [], []),
+    {ok, {{_, 400, "Bad Request"}, _, _}} =
+        httpc_request(post, {Host ++ "/v2/transactions", [], "application/json;charset=UTF-8", BorkedPayload}, [], []),
     ok.
 
 %% ============================================================


### PR DESCRIPTION
…rset)

Before the fix:
```
%%% aehttp_integration_SUITE ==> cowboy_handler.content_type_charset_param_allowed: FAILED
%%% aehttp_integration_SUITE ==> {{badmatch,{ok,{{"HTTP/1.1",415,"Unsupported Media Type"},
                [{"date","Thu, 08 Nov 2018 13:45:12 GMT"},
                 {"server","Cowboy"},
                 {"content-length","0"},
                 {"content-type","application/json"}],
                []}}},
 [{aehttp_integration_SUITE,content_type_charset_param_allowed,1,
                            [{file,"/Users/zp/src/aeternity/epoch/_build/test/lib/aehttp/test/aehttp_integration_SUITE.erl"},
                             {line,5232}]},
  {test_server,ts_tc,3,[{file,"test_server.erl"},{line,1539}]},
  {test_server,run_test_case_eval1,6,[{file,"test_server.erl"},{line,1055}]},
  {test_server,run_test_case_eval,9,[{file,"test_server.erl"},{line,987}]}]}
```

(note `Content-Type: application/json;charset=UTF-8`)
```
curl -vvv -H "Content-Type: application/json;charset=UTF-8" http://localhost:3113/v2/debug/names/preclaim -d '{"commitment_id":"cm_2ijL6NFZ11RsBVWwFB69oZYp6gFV9JSB71xccbnqrPisEiMrji", "account_id": "ak_tjnw1KcmnwfqXvhtGa9GRjanbHM3t6PmEWEWtNMM3ouvNKRu5", "fee": 1, "ttl":1234}'
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 3113 (#0)
> POST /v2/debug/names/preclaim HTTP/1.1
> Host: localhost:3113
> User-Agent: curl/7.54.0
> Accept: */*
> Content-Type: application/json
> Content-Length: 165
>
* upload completely sent off: 165 out of 165 bytes
< HTTP/1.1 415 Unsupported Media Type
< content-length: 0
< content-type: application/json
< date: Thu, 08 Nov 2018 13:14:53 GMT
< server: Cowboy
<
* Connection #0 to host localhost left intact
```

After the fix:
```
curl -vvv -H "Content-Type: application/json;charset=UTF-8" http://localhost:3113/v2/debug/names/preclaim -d '{"commitment_id":"cm_2ijL6NFZ11RsBVWwFB69oZYp6gFV9JSB71xccbnqrPisEiMrji", "account_id": "ak_tjnw1KcmnwfqXvhtGa9GRjanbHM3t6PmEWEWtNMM3ouvNKRu5", "fee": 1, "ttl":1234}'
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 3113 (#0)
> POST /v2/debug/names/preclaim HTTP/1.1
> Host: localhost:3113
> User-Agent: curl/7.54.0
> Accept: */*
> Content-Type: application/json;charset=UTF-8
> Content-Length: 165
>
* upload completely sent off: 165 out of 165 bytes
< HTTP/1.1 404 Not Found
< content-length: 44
< content-type: application/json
< date: Thu, 08 Nov 2018 13:16:30 GMT
< server: Cowboy
<
* Connection #0 to host localhost left intact
{"reason":"Account of account_id not found"}
```

Reference: https://github.com/ninenines/cowboy/issues/431#issuecomment-13601531