### PR TITLE
Fix inaccurate config schema description

### DIFF
--- a/apps/aeutils/priv/epoch_config_schema.json
+++ b/apps/aeutils/priv/epoch_config_schema.json
@@ -309,7 +309,7 @@
                 },
                 "peer_password" : {
                     "description" :
-                    "Password used to encrypt the peer key-pair files - if left blank `password` will be used",
+                    "Password used to encrypt the peer key-pair files",
                     "type" : "string"
                 }
             }


### PR DESCRIPTION
`password` cannot be used as default as this key no longer exists in the schema