### PR TITLE
PT-161440511 mempool nonce check

### DIFF
--- a/apps/aechannel/test/aesc_fsm_SUITE.erl
+++ b/apps/aechannel/test/aesc_fsm_SUITE.erl
@@ -148,6 +148,10 @@ init_per_testcase(leave_reestablish, Config) ->
 init_per_testcase(_, Config) ->
     Config.
 
+end_per_testcase(multiple_channels, _Config) ->
+    Node = aecore_suite_utils:node_name(dev1),
+    aecore_suite_utils:unmock_mempool_nonce_offset(Node),
+    ok;
 end_per_testcase(_Case, _Config) ->
     ok.
 
@@ -711,6 +715,8 @@ multiple_channels(Cfg) ->
     ct:log("Initiator: ~p", [Initiator]),
     Me = self(),
     NumCs = 10,
+    Node = aecore_suite_utils:node_name(dev1),
+    aecore_suite_utils:mock_mempool_nonce_offset(Node, NumCs),
     {ok, Nonce} = rpc(dev1, aec_next_nonce, pick_for_account, [Initiator]),
     Cs = [create_multi_channel([{port, 9360 + N},
                                 {ack_to, Me},

--- a/apps/aecore/src/aec_tx_pool.erl
+++ b/apps/aecore/src/aec_tx_pool.erl
@@ -38,7 +38,6 @@
         , peek/2
         , push/1
         , push/2
-        , push_sync/1
         , size/0
         , top_change/3
         , dbs/0
@@ -101,9 +100,6 @@
 
 -type event() :: tx_created | tx_received.
 
--type push_cfg() :: list(push_cfg_option()).
--type push_cfg_option() :: no_nonce_check.
-
 -ifndef(TEST).
 -define(DEFAULT_TX_TTL, 256).
 -define(DEFAULT_INVALID_TX_TTL, 5).
@@ -134,11 +130,6 @@ stop() ->
 push(Tx) ->
     push(Tx, tx_created).
 
--spec push_sync(aetx_sign:signed_tx()) -> ok | {error, atom()}.
-push_sync(Tx) ->
-    Cfg = [ no_nonce_check ],
-    push_(Tx, safe_tx_hash(Tx), tx_created, Cfg).
-
 -spec push(aetx_sign:signed_tx(), event()) -> ok | {error, atom()}.
 push(Tx, Event = tx_received) ->
     TxHash = safe_tx_hash(Tx),
@@ -158,10 +149,7 @@ safe_tx_hash(Tx) ->
     end.
 
 push_(Tx, TxHash, Event) ->
-    push_(Tx, TxHash, Event, []).
-
-push_(Tx, TxHash, Event, Cfg) ->
-    case check_pool_db_put(Tx, TxHash, Cfg) of
+    case check_pool_db_put(Tx, TxHash, Event) of
         ignore ->
             incr([push, ignore]),
             ok;
@@ -420,7 +408,7 @@ check_candidate(Db, #dbs{gc_db = GCDb} = Dbs,
     Tx1 = aetx_sign:tx(Tx),
     TxTTL = aetx:ttl(Tx1),
     TxGas = aetx:gas(Tx1, Height),
-    case Height < TxTTL andalso TxGas > 0 andalso ok =:= int_check_nonce(Tx, AccountsTree, [no_nonce_check]) of
+    case Height < TxTTL andalso TxGas > 0 andalso ok =:= int_check_nonce(Tx, AccountsTree, check_candidate) of
         true ->
             case Gas - TxGas of
                 RemGas when RemGas >= 0 ->
@@ -631,11 +619,11 @@ update_pool_on_tx_hash(TxHash, {#dbs{gc_db = GCDb} = Dbs, GCHeight}, Handled) ->
             end
     end.
 
--spec check_pool_db_put(aetx_sign:signed_tx(), tx_hash(), push_cfg()) ->
+-spec check_pool_db_put(aetx_sign:signed_tx(), tx_hash(), event()) ->
                                ignore
                              | {'ok', tx_hash()}
                              | {'error', atom()}.
-check_pool_db_put(Tx, TxHash, Cfg) ->
+check_pool_db_put(Tx, TxHash, Event) ->
     case aec_chain:find_tx_location(TxHash) of
         BlockHash when is_binary(BlockHash) ->
             lager:debug("Already have tx: ~p in ~p", [TxHash, BlockHash]),
@@ -653,7 +641,7 @@ check_pool_db_put(Tx, TxHash, Cfg) ->
                      , fun check_minimum_gas_price/3
                      , fun check_tx_ttl/3
                      ],
-            case aeu_validation:run(Checks, [Tx, TxHash, Cfg]) of
+            case aeu_validation:run(Checks, [Tx, TxHash, Event]) of
                 {error, _} = E ->
                     lager:debug("Validation error for tx ~p: ~p", [TxHash, E]),
                     E;
@@ -695,14 +683,14 @@ insert_nonce(NDb, ?KEY(_, _, Account, Nonce, TxHash)) ->
 delete_nonce(NDb, ?KEY(_, _, Account, Nonce, TxHash)) ->
     ets:delete(NDb, {Account, Nonce, TxHash}).
 
-check_tx_ttl(STx, _Hash, _Cfg) ->
+check_tx_ttl(STx, _Hash, _Event) ->
     Tx = aetx_sign:tx(STx),
     case top_height() > aetx:ttl(Tx) of
         true  -> {error, ttl_expired};
         false -> ok
     end.
 
-check_signature(Tx, Hash, _Cfg) ->
+check_signature(Tx, Hash, _Event) ->
     {ok, Trees} = aec_chain:get_top_state(),
     case aetx_sign:verify(Tx, Trees) of
         {error, _} = E ->
@@ -712,12 +700,12 @@ check_signature(Tx, Hash, _Cfg) ->
             ok
     end.
 
-check_nonce(Tx,_Hash, Cfg) ->
-  int_check_nonce(Tx, {block_hash, aec_chain:top_block_hash()}, Cfg).
+check_nonce(Tx, _Hash, Event) ->
+  int_check_nonce(Tx, {block_hash, aec_chain:top_block_hash()}, Event).
 
 
-int_check_nonce(Tx, Source, Cfg) ->
-    DontCheck = lists:member(no_nonce_check, Cfg),
+int_check_nonce(Tx, Source, Event) ->
+    CheckNonce = nonce_check_by_event(Event),
 
     %% Check is conservative and only rejects certain cases
     Unsigned = aetx_sign:tx(Tx),
@@ -730,22 +718,27 @@ int_check_nonce(Tx, Source, Cfg) ->
                     {error, illegal_nonce};
                 true ->
                     case get_account(Pubkey, Source) of
-                        {error, no_state_trees} -> nonce_baseline_check(TxNonce, DontCheck);
-                        none -> nonce_baseline_check(TxNonce, DontCheck);
+                        {error, no_state_trees} -> nonce_baseline_check(TxNonce, CheckNonce);
+                        none -> nonce_baseline_check(TxNonce, CheckNonce);
                         {value, Account} ->
                             Offset =  nonce_offset(),
                             AccountNonce = aec_accounts:nonce(Account),
                             if
                                 TxNonce =< AccountNonce -> {error, nonce_too_low};
                                 TxNonce =< (AccountNonce + Offset) -> ok;
-                                TxNonce >  (AccountNonce + Offset) andalso DontCheck -> ok;
+                                TxNonce >  (AccountNonce + Offset) andalso not CheckNonce -> ok;
                                 TxNonce >  (AccountNonce + Offset) -> {error, nonce_too_high}
                             end
                     end
             end
     end.
 
-nonce_baseline_check(_, true) -> ok;
+nonce_check_by_event(tx_created) -> true;
+nonce_check_by_event(tx_received) -> false;
+nonce_check_by_event(check_candidate) ->
+    false.
+
+nonce_baseline_check(_, false) -> ok;
 nonce_baseline_check(TxNonce, _) ->
     case TxNonce =< nonce_baseline() of
         true -> ok;
@@ -757,7 +750,7 @@ get_account(AccountKey, {account_trees, AccountsTrees}) ->
 get_account(AccountKey, {block_hash, BlockHash}) ->
     aec_chain:get_account_at_hash(AccountKey, BlockHash).
 
-check_minimum_fee(Tx0, _Hash, _Cfg) ->
+check_minimum_fee(Tx0, _Hash, _Event) ->
     Tx = aetx_sign:tx(Tx0),
     Height = top_height(),
     case aetx:fee(Tx) >= aetx:min_fee(Tx, Height) of
@@ -765,7 +758,7 @@ check_minimum_fee(Tx0, _Hash, _Cfg) ->
         false -> {error, too_low_fee}
     end.
 
-check_minimum_gas_price(Tx, _Hash, _Cfg) ->
+check_minimum_gas_price(Tx, _Hash, _Event) ->
     case aetx:gas_price(aetx_sign:tx(Tx)) of
         undefined ->
             ok;

--- a/apps/aecore/src/aec_tx_pool.erl
+++ b/apps/aecore/src/aec_tx_pool.erl
@@ -108,6 +108,8 @@
 -define(DEFAULT_INVALID_TX_TTL, 2).
 -endif.
 
+-define(DEFAULT_NONCE_OFFSET_NO_ACCOUNT, 1).
+
 %%%===================================================================
 %%% API
 %%%===================================================================
@@ -715,10 +717,8 @@ int_check_nonce(Tx, Source) ->
                     {error, illegal_nonce};
                 true ->
                     case get_account(Pubkey, Source) of
-                        {error, no_state_trees} ->
-                            ok;
-                        none ->
-                            ok;
+                        {error, no_state_trees} -> no_account_nonce_check(TxNonce);
+                        none -> no_account_nonce_check(TxNonce);
                         {value, Account} ->
                             case aetx_utils:check_nonce(Account, TxNonce) of
                                 ok -> ok;
@@ -730,6 +730,12 @@ int_check_nonce(Tx, Source) ->
                             end
                     end
             end
+    end.
+
+no_account_nonce_check(TxNonce) ->
+    case TxNonce =< nonce_offset_no_account() of
+        true -> ok;
+        false -> {error, nonce_too_high}
     end.
 
 get_account(AccountKey, {account_trees, AccountsTrees}) ->
@@ -772,3 +778,7 @@ tx_ttl() ->
 invalid_tx_ttl() ->
     aeu_env:user_config_or_env([<<"mempool">>, <<"invalid_tx_ttl">>],
                                aecore, mempool_invalid_tx_ttl, ?DEFAULT_INVALID_TX_TTL).
+
+nonce_offset_no_account() ->
+    aeu_env:user_config_or_env([<<"mempool">>, <<"nonce_offset_no_account">>],
+                               aecore, mempool_nonce_offset_no_account, ?DEFAULT_NONCE_OFFSET_NO_ACCOUNT).

--- a/apps/aecore/src/aec_tx_pool.erl
+++ b/apps/aecore/src/aec_tx_pool.erl
@@ -108,8 +108,8 @@
 -define(DEFAULT_INVALID_TX_TTL, 2).
 -endif.
 
+-define(DEFAULT_NONCE_BASELINE, 1).
 -define(DEFAULT_NONCE_OFFSET, 5).
--define(DEFAULT_NONCE_OFFSET_NO_ACCOUNT, 1).
 
 %%%===================================================================
 %%% API
@@ -718,8 +718,8 @@ int_check_nonce(Tx, Source) ->
                     {error, illegal_nonce};
                 true ->
                     case get_account(Pubkey, Source) of
-                        {error, no_state_trees} -> no_account_nonce_check(TxNonce);
-                        none -> no_account_nonce_check(TxNonce);
+                        {error, no_state_trees} -> nonce_baseline_check(TxNonce);
+                        none -> nonce_baseline_check(TxNonce);
                         {value, Account} ->
                             Offset =  nonce_offset(),
                             AccountNonce = aec_accounts:nonce(Account),
@@ -732,8 +732,8 @@ int_check_nonce(Tx, Source) ->
             end
     end.
 
-no_account_nonce_check(TxNonce) ->
-    case TxNonce =< nonce_offset_no_account() of
+nonce_baseline_check(TxNonce) ->
+    case TxNonce =< nonce_baseline() of
         true -> ok;
         false -> {error, nonce_too_high}
     end.
@@ -779,10 +779,10 @@ invalid_tx_ttl() ->
     aeu_env:user_config_or_env([<<"mempool">>, <<"invalid_tx_ttl">>],
                                aecore, mempool_invalid_tx_ttl, ?DEFAULT_INVALID_TX_TTL).
 
+nonce_baseline() ->
+    aeu_env:user_config_or_env([<<"mempool">>, <<"nonce_baseline">>],
+                               aecore, mempool_nonce_baseline, ?DEFAULT_NONCE_BASELINE).
+
 nonce_offset() ->
     aeu_env:user_config_or_env([<<"mempool">>, <<"nonce_offset">>],
                                aecore, mempool_nonce_offset, ?DEFAULT_NONCE_OFFSET).
-
-nonce_offset_no_account() ->
-    aeu_env:user_config_or_env([<<"mempool">>, <<"nonce_offset_no_account">>],
-                               aecore, mempool_nonce_offset_no_account, ?DEFAULT_NONCE_OFFSET_NO_ACCOUNT).

--- a/apps/aecore/test/aec_tx_pool_tests.erl
+++ b/apps/aecore/test/aec_tx_pool_tests.erl
@@ -35,7 +35,7 @@ tx_pool_test_() ->
      end,
      fun(TmpKeysDir) ->
              ok = application:unset_env(aecore, mempool_nonce_offset),
-             ok = application:unset_env(aecore, mempool_nonce_offset_no_account),
+             ok = application:unset_env(aecore, mempool_nonce_baseline),
              ok = application:unset_env(aecore, beneficiary),
              ok = aec_test_utils:aec_keys_cleanup(TmpKeysDir),
              ok = application:stop(gproc),
@@ -142,7 +142,7 @@ tx_pool_test_() ->
        {timeout, 10, fun() ->
                MaxNonce = 400,
                %% setup nonce offset for pubkey without account present
-               ok = application:set_env(aecore, mempool_nonce_offset_no_account, MaxNonce),
+               ok = application:set_env(aecore, mempool_nonce_baseline, MaxNonce),
 
                %% No txs to serve to peers.
                ?assertEqual({ok, []}, aec_tx_pool:peek(1)),

--- a/apps/aecore/test/aecore_pof_SUITE.erl
+++ b/apps/aecore/test/aecore_pof_SUITE.erl
@@ -83,6 +83,9 @@ siblings_on_key_block(Config) ->
     aecore_suite_utils:connect(N1),
     aecore_suite_utils:connect(N2),
 
+    aecore_suite_utils:mock_mempool_nonce_offset(N1, 100),
+    aecore_suite_utils:mock_mempool_nonce_offset(N2, 100),
+
     {ok, _} = aecore_suite_utils:mine_key_blocks(N1, 1),
 
     Account1 = #{ pubkey := PK1 } = new_keypair(),
@@ -110,6 +113,9 @@ siblings_on_micro_block(Config) ->
 
     aecore_suite_utils:connect(N1),
     aecore_suite_utils:connect(N2),
+
+    aecore_suite_utils:mock_mempool_nonce_offset(N1, 100),
+    aecore_suite_utils:mock_mempool_nonce_offset(N2, 100),
 
     {ok, _} = aecore_suite_utils:mine_key_blocks(N1, 1),
 

--- a/apps/aecore/test/aecore_suite_utils.erl
+++ b/apps/aecore/test/aecore_suite_utils.erl
@@ -12,7 +12,9 @@
          shortcut_dir/1]).
 
 -export([cmd/1,
-         cmd_res/1]).
+         cmd_res/1,
+         set_env/4,
+         unset_env/3]).
 
 -export([start_node/2,
          stop_node/2,
@@ -29,6 +31,9 @@
          sign_on_node/2,
          forks/0,
          latest_fork_height/0]).
+
+-export([mock_mempool_nonce_offset/2,
+         unmock_mempool_nonce_offset/1]).
 
 -export([node_tuple/1,
          node_name/1,
@@ -369,6 +374,13 @@ forks() ->
 latest_fork_height() ->
     lists:max(maps:values(forks())).
 
+mock_mempool_nonce_offset(Node, Offset) ->
+    ok = aecore_suite_utils:set_env(Node, aecore, mempool_nonce_offset, Offset).
+
+unmock_mempool_nonce_offset(Node) ->
+    ok = aecore_suite_utils:unset_env(Node, aecore, mempool_nonce_offset).
+
+
 top_dir(DataDir) ->
     %% Split the DataDir path at "_build"
     [Top, _] = re:split(DataDir, "_build", [{return, list}]),
@@ -635,6 +647,11 @@ take(K, L, Def) ->
             {V, Rest}
     end.
 
+set_env(Node, App, Key, Value) ->
+    ok = rpc:call(Node, application, set_env, [App, Key, Value], 5000).
+
+unset_env(Node, App, Key) ->
+    ok = rpc:call(Node, application, unset_env, [App, Key], 5000).
 
 config_apply_options(_Node, Cfg, []) ->
     Cfg;

--- a/apps/aecore/test/aecore_txs_SUITE.erl
+++ b/apps/aecore/test/aecore_txs_SUITE.erl
@@ -79,6 +79,7 @@ txs_gc(Config) ->
     aecore_suite_utils:start_node(dev1, Config),
     N1 = aecore_suite_utils:node_name(dev1),
     aecore_suite_utils:connect(N1),
+    ok = aecore_suite_utils:set_env(N1, aecore, mempool_nonce_offset, 100),
 
     Height0 = 0,
 

--- a/apps/aehttp/test/aehttp_contracts_SUITE.erl
+++ b/apps/aehttp/test/aehttp_contracts_SUITE.erl
@@ -138,9 +138,13 @@ end_per_group(_Group, Config) ->
     ok.
 
 init_per_testcase(_Case, Config) ->
+    [{_, Node} | _] = ?config(nodes, Config),
+    aecore_suite_utils:mock_mempool_nonce_offset(Node, 100),
     [{tc_start, os:timestamp()}|Config].
 
 end_per_testcase(_Case, Config) ->
+    [{_, Node} | _] = ?config(nodes, Config),
+    aecore_suite_utils:unmock_mempool_nonce_offset(Node),
     Ts0 = ?config(tc_start, Config),
     ct:log("Events during TC: ~p", [[{N, aecore_suite_utils:all_events_since(N, Ts0)}
                                      || {_,N} <- ?config(nodes, Config)]]),

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -59,7 +59,8 @@
     get_transaction_by_hash/1,
     get_transaction_info_by_hash/1,
     post_spend_tx/1,
-    post_contract_and_call_tx/1
+    post_contract_and_call_tx/1,
+    nonce_limit/1
    ]).
 
 -export(
@@ -354,7 +355,8 @@ groups() ->
       ]},
      {post_tx_to_mempool, [],
       [
-       post_spend_tx
+       post_spend_tx,
+       nonce_limit
       ]},
      {tx_info, [sequence],
       [
@@ -845,12 +847,16 @@ init_per_testcase(_Case, Config) ->
     init_per_testcase_all(Config).
 
 init_per_testcase_all(Config) ->
+    [{_, Node} | _] = ?config(nodes, Config),
+    aecore_suite_utils:mock_mempool_nonce_offset(Node, 100),
     [{tc_start, os:timestamp()} | Config].
 
 end_per_testcase(_Case, Config) ->
     end_per_testcase_all(Config).
 
 end_per_testcase_all(Config) ->
+    [{_, Node} | _] = ?config(nodes, Config),
+    aecore_suite_utils:unmock_mempool_nonce_offset(Node),
     Ts0 = ?config(tc_start, Config),
     ct:log("Events during TC: ~p",
            [[{N, aecore_suite_utils:all_events_since(N, Ts0)}
@@ -1478,6 +1484,27 @@ post_spend_tx(Config) ->
           payload      => ?config(payload, Config)},
     {TxHash, Tx} = prepare_tx(spend_tx, TxArgs),
     ok = post_tx(TxHash, Tx),
+    ok.
+
+nonce_limit(Config) ->
+    [{_, Node} | _] = ?config(nodes, Config),
+    aecore_suite_utils:mock_mempool_nonce_offset(Node, 5),
+
+    aecore_suite_utils:mine_blocks(Node, 3),
+    {ok, []} = rpc(aec_tx_pool, peek, [infinity]),
+
+    Txs = lists:map(
+            fun(_N) ->
+                    {ok, 200, #{<<"tx">> := SpendTx}} =
+                    post_spend_tx(aehttp_api_encoder:encode(account_pubkey, random_hash()),
+                                  ?config(amount, Config),
+                                  ?config(fee, Config)),
+                    {_, Code, _} = sign_and_post_tx_(SpendTx),
+                    Code
+            end,
+            lists:seq(1, 6)),
+
+    ?assertEqual([200, 200, 200, 200, 200, 400], Txs),
     ok.
 
 post_contract_and_call_tx(_Config) ->
@@ -5534,11 +5561,23 @@ remove_leading_all(L      ) -> L.
 intersperse([H|T], Delim) ->
     lists:flatten([H | [[Delim, E] || E <- T]]).
 
-
 sign_and_post_tx(EncodedUnsignedTx) ->
     sign_and_post_tx(EncodedUnsignedTx, on_node).
 
 sign_and_post_tx(EncodedUnsignedTx, PrivKey) ->
+    %% Check that we get the correct hash
+    {ok, 200, #{<<"tx_hash">> := TxHash}} = sign_and_post_tx_(EncodedUnsignedTx, PrivKey),
+    %% Check tx is in mempool.
+    Fun = fun() ->
+                  tx_in_mempool(TxHash)
+          end,
+    {ok, true} = aec_test_utils:wait_for_it_or_timeout(Fun, true, 5000),
+    TxHash.
+
+sign_and_post_tx_(EncodedUnsignedTx) ->
+    sign_and_post_tx_(EncodedUnsignedTx, on_node).
+
+sign_and_post_tx_(EncodedUnsignedTx, PrivKey) ->
     {ok, SerializedUnsignedTx} = aehttp_api_encoder:safe_decode(transaction, EncodedUnsignedTx),
     UnsignedTx = aetx:deserialize_from_binary(SerializedUnsignedTx),
     {ok, SignedTx} =
@@ -5547,15 +5586,7 @@ sign_and_post_tx(EncodedUnsignedTx, PrivKey) ->
             false -> {ok, aec_test_utils:sign_tx(UnsignedTx, PrivKey)}
         end,
     SerializedTx = aetx_sign:serialize_to_binary(SignedTx),
-    %% Check that we get the correct hash
-    TxHash = aehttp_api_encoder:encode(tx_hash, aetx_sign:hash(SignedTx)),
-    {ok, 200, #{<<"tx_hash">> := TxHash}} = post_transactions_sut(aehttp_api_encoder:encode(transaction, SerializedTx)),
-    %% Check tx is in mempool.
-    Fun = fun() ->
-                  tx_in_mempool(TxHash)
-          end,
-    {ok, true} = aec_test_utils:wait_for_it_or_timeout(Fun, true, 5000),
-    TxHash.
+    post_transactions_sut(aehttp_api_encoder:encode(transaction, SerializedTx)).
 
 tx_in_mempool(TxHash) ->
     case get_transactions_by_hash_sut(TxHash) of

--- a/apps/aetx/src/aetx_utils.erl
+++ b/apps/aetx/src/aetx_utils.erl
@@ -9,7 +9,6 @@
 %% API
 -export([check_account/3,
          check_account/4,
-         check_nonce/2,
          check_ttl/2]).
 
 %%%===================================================================

--- a/apps/aeutils/priv/epoch_config_schema.json
+++ b/apps/aeutils/priv/epoch_config_schema.json
@@ -45,7 +45,7 @@
                     "description" : "Maximum nonce offset accepted",
                     "type" : "integer"
                 },
-                "nonce_offset_no_account" : {
+                "nonce_baseline" : {
                     "description" : "Maximum nonce accepted when pubkey is not present in state",
                     "type" : "integer"
                 }

--- a/apps/aeutils/priv/epoch_config_schema.json
+++ b/apps/aeutils/priv/epoch_config_schema.json
@@ -40,6 +40,10 @@
                 "sync_interval" : {
                     "description" : "Interval between mempool (re-)synchronization (in ms)",
                     "type" : "integer"
+                },
+                "nonce_offset_no_account" : {
+                    "description" : "Maximum nonce accepted when pubkey is not present in state",
+                    "type" : "integer"
                 }
             }
         },

--- a/apps/aeutils/priv/epoch_config_schema.json
+++ b/apps/aeutils/priv/epoch_config_schema.json
@@ -41,6 +41,10 @@
                     "description" : "Interval between mempool (re-)synchronization (in ms)",
                     "type" : "integer"
                 },
+                "nonce_offset" : {
+                    "description" : "Maximum nonce offset accepted",
+                    "type" : "integer"
+                },
                 "nonce_offset_no_account" : {
                     "description" : "Maximum nonce accepted when pubkey is not present in state",
                     "type" : "integer"

--- a/apps/aeutils/test/data/epoch_full.yaml
+++ b/apps/aeutils/test/data/epoch_full.yaml
@@ -54,6 +54,8 @@ mempool:
     invalid_tx_ttl: 5
     # Mempool (re-)synchronization interval (in ms)
     sync_interval: 1800000
+    # Maximum nonce offset accepted
+    nonce_offset: 1
     # Maximum nonce accepted when pubkey is not present in state
     nonce_offset_no_account: 1
 

--- a/apps/aeutils/test/data/epoch_full.yaml
+++ b/apps/aeutils/test/data/epoch_full.yaml
@@ -54,6 +54,8 @@ mempool:
     invalid_tx_ttl: 5
     # Mempool (re-)synchronization interval (in ms)
     sync_interval: 1800000
+    # Maximum nonce accepted when pubkey is not present in state
+    nonce_offset_no_account: 1
 
 http:
     cors:

--- a/apps/aeutils/test/data/epoch_full.yaml
+++ b/apps/aeutils/test/data/epoch_full.yaml
@@ -55,9 +55,9 @@ mempool:
     # Mempool (re-)synchronization interval (in ms)
     sync_interval: 1800000
     # Maximum nonce offset accepted
-    nonce_offset: 1
+    nonce_offset: 5
     # Maximum nonce accepted when pubkey is not present in state
-    nonce_offset_no_account: 1
+    nonce_baseline: 1
 
 http:
     cors:

--- a/system_test/aest_sync_SUITE_data/epoch.yaml.mustache
+++ b/system_test/aest_sync_SUITE_data/epoch.yaml.mustache
@@ -25,6 +25,9 @@ keys:
 chain:
     persist: true
 
+mempool:
+    nonce_offset: 1000
+
 mining:
     beneficiary: "ak_2VoAhMd7tVJrDYM5vPJwFRjueZyirDJumVJNeBWL9j1eNTHsRx"
     autostart: true


### PR DESCRIPTION
[PT-161440511](https://www.pivotaltracker.com/story/show/161440511)

Two configuration options are present: 
`mempool.nonce_offset (default 5)` - when account is present mempool accepts on chain nonce + nonce_offset
`mempool.nonce_baseline (defualt 1)` - value is used when account is not present 

~~Sync uses `aec_tx_pool:push_sync/1` where upper limit is not defined by offset~~