### PR TITLE
Fix minimal tx fee validation

### DIFF
--- a/apps/aechannel/test/aesc_test_utils.erl
+++ b/apps/aechannel/test/aesc_test_utils.erl
@@ -208,7 +208,7 @@ create_tx_default_spec(InitiatorPubKey, State) ->
       channel_reserve    => 20,
       lock_period        => 100,
       ttl                => 0,
-      fee                => 3,
+      fee                => 50000,
       nonce              => try next_nonce(InitiatorPubKey, State) catch _:_ -> 0 end}.
 
 %%%===================================================================
@@ -229,7 +229,7 @@ close_mutual_tx_spec(ChannelId, Spec0, State) ->
 close_mutual_tx_default_spec(Initiator, State) ->
     #{initiator_amount_final => 10,
       responder_amount_final => 10,
-      fee                    => 3,
+      fee                    => 50000,
       nonce                  => try next_nonce(Initiator, State) catch _:_ -> 0 end}.
 
 %%%===================================================================
@@ -250,7 +250,7 @@ close_solo_tx_spec(ChannelPubKey, FromPubKey, Payload, PoI, Spec0, State) ->
       nonce       => maps:get(nonce, Spec)}.
 
 close_solo_tx_default_spec(FromPubKey, State) ->
-    #{fee         => 3,
+    #{fee         => 50000,
       nonce       => try next_nonce(FromPubKey, State) catch _:_ -> 0 end}.
 
 %%%===================================================================
@@ -273,7 +273,7 @@ deposit_tx_spec(ChannelId, FromPubKey, Spec0, State) ->
 
 deposit_tx_default_spec(FromPubKey, State) ->
     #{amount      => 10,
-      fee         => 3,
+      fee         => 50000,
       state_hash  => ?BOGUS_STATE_HASH,
       round       => 42,
       nonce       => try next_nonce(FromPubKey, State) catch _:_ -> 0 end}.
@@ -298,7 +298,7 @@ withdraw_tx_spec(ChannelId, ToPubKey, Spec0, State) ->
 
 withdraw_tx_spec(ToPubKey, State) ->
     #{amount      => 10,
-      fee         => 3,
+      fee         => 50000,
       state_hash  => ?BOGUS_STATE_HASH,
       round       => 42,
       nonce       => try next_nonce(ToPubKey, State) catch _:_ -> 0 end}.
@@ -321,7 +321,7 @@ slash_tx_spec(ChannelId, FromPubKey, Payload, PoI, Spec0, State) ->
       nonce       => maps:get(nonce, Spec)}.
 
 slash_tx_default_spec(FromPubKey, State) ->
-    #{fee         => 3,
+    #{fee         => 50000,
       nonce       => try next_nonce(FromPubKey, State) catch _:_ -> 0 end}.
 
 %%%===================================================================
@@ -344,7 +344,7 @@ settle_tx_spec(ChannelId, FromPubKey, Spec0, State) ->
 settle_tx_default_spec(FromPubKey, State) ->
     #{initiator_amount => 10,
       responder_amount => 10,
-      fee              => 3,
+      fee              => 50000,
       nonce            => try next_nonce(FromPubKey, State) catch _:_ -> 0 end}.
 
 %%%===================================================================
@@ -364,7 +364,7 @@ snapshot_solo_tx_spec(ChannelPubKey, FromPubKey, Payload, Spec0, State) ->
 snapshot_solo_tx_default_spec(FromPubKey, State) ->
     #{initiator_amount => 10,
       responder_amount => 10,
-      fee              => 3,
+      fee              => 50000,
       nonce            => try next_nonce(FromPubKey, State) catch _:_ -> 0 end}.
 
 state_tx(ChannelPubKey, Initiator, Responder, Spec0) ->
@@ -441,6 +441,6 @@ force_progress_tx_spec(ChannelId, FromPubKey, Payload, Update, StateHash,
           ttl             => maps:get(ttl, Spec, 0)}.
 
 force_progress_default_spec(FromPubKey, State) ->
-    #{fee              => 3,
+    #{fee              => 50000,
       nonce            => try next_nonce(FromPubKey, State) catch _:_ -> 0 end}.
 

--- a/apps/aecontract/test/aect_test_utils.erl
+++ b/apps/aecontract/test/aect_test_utils.erl
@@ -114,7 +114,7 @@ create_tx(PubKey, Spec0, State) ->
     Tx.
 
 create_tx_default_spec(PubKey, State) ->
-    #{ fee        => 5
+    #{ fee        => 1000000
      , owner_id   => aec_id:create(account, PubKey)
      , nonce      => try next_nonce(PubKey, State) catch _:_ -> 0 end
      , code       => dummy_bytecode()
@@ -145,7 +145,7 @@ call_tx(PubKey, ContractKey, Spec0, State) ->
     Tx.
 
 call_tx_default_spec(PubKey, ContractKey, State) ->
-    #{ fee         => 5
+    #{ fee         => 600000
      , contract_id => aec_id:create(contract, ContractKey)
      , caller_id   => aec_id:create(account, PubKey)
      , nonce       => try next_nonce(PubKey, State) catch _:_ -> 0 end
@@ -162,7 +162,7 @@ call_tx_default_spec(PubKey, ContractKey, State) ->
 %%%===================================================================
 
 setup_new_account(State) ->
-    setup_new_account(1000000, State).
+    setup_new_account(10000000, State).
 
 setup_new_account(Balance, State) ->
     {PubKey, PrivKey} = new_key_pair(),

--- a/apps/aecore/src/aec_blocks.erl
+++ b/apps/aecore/src/aec_blocks.erl
@@ -420,7 +420,6 @@ validate_key_block(#key_block{} = Block) ->
 validate_micro_block(#mic_block{} = Block) ->
     Validators = [fun validate_txs_hash/1,
                   fun validate_gas_limit/1,
-                  fun validate_txs_fee/1,
                   fun validate_pof/1
                  ],
     case aec_headers:validate_micro_block_header(to_micro_header(Block)) of
@@ -448,16 +447,6 @@ validate_gas_limit(#mic_block{} = Block) ->
     case gas(Block) =< aec_governance:block_gas_limit() of
         true  -> ok;
         false -> {error, gas_limit_exceeded}
-    end.
-
--spec validate_txs_fee(block()) -> ok | {error, invalid_minimal_tx_fee}.
-validate_txs_fee(#mic_block{txs = STxs}) ->
-    case lists:all(fun(STx) ->
-                           Tx = aetx_sign:tx(STx),
-                           aetx:fee(Tx) >= (aetx:min_gas(Tx) * aec_governance:minimum_gas_price())
-                   end, STxs) of
-        true -> ok;
-        false -> {error, invalid_minimal_tx_fee}
     end.
 
 validate_pof(#mic_block{pof = no_fraud}) -> ok;

--- a/apps/aecore/src/aec_governance.erl
+++ b/apps/aecore/src/aec_governance.erl
@@ -11,7 +11,6 @@
          tx_base_gas/1,
          byte_gas/0,
          beneficiary_reward_delay/0,
-         minimum_tx_fee/0,
          minimum_gas_price/0,
          name_preclaim_expiration/0,
          name_claim_burned_fee/0,
@@ -126,9 +125,6 @@ tx_base_gas(_) ->
 
 byte_gas() ->
     ?BYTE_GAS.
-
-minimum_tx_fee() ->
-    1.
 
 minimum_gas_price() ->
     1.

--- a/apps/aecore/test/aec_block_micro_candidate_tests.erl
+++ b/apps/aecore/test/aec_block_micro_candidate_tests.erl
@@ -40,10 +40,10 @@ block_extension_test_() ->
       [{"Generate a block in one step, compared with two steps, with a spend tx",
         fun() ->
           {ok, Tx} = aec_spend_tx:new(#{ sender_id => ?TEST_ID, recipient_id => ?TEST_ID
-                                       , amount => 10, fee => 1, ttl => 100, nonce => 1, payload => <<>> }),
+                                       , amount => 10, fee => 20000, ttl => 100, nonce => 1, payload => <<>> }),
           STx = aec_test_utils:sign_tx(Tx, ?TEST_PRIV),
 
-          AccMap = #{ preset_accounts => [{?TEST_PUB, 1000}] },
+          AccMap = #{ preset_accounts => [{?TEST_PUB, 100000}] },
           {Block0, Trees0} = aec_block_genesis:genesis_block_with_state(AccMap),
 
           meck:expect(aeu_time, now_in_msecs, 0, 1234567890),
@@ -75,10 +75,10 @@ block_extension_test_() ->
                      GasPrice)),
 
           {ok, Tx} = aec_spend_tx:new(#{ sender_id => ?TEST_ID, recipient_id => ?TEST_ID
-                                       , amount => 10, fee => 1, ttl => 100, nonce => 1, payload => <<>> }),
+                                       , amount => 10, fee => 20000, ttl => 100, nonce => 1, payload => <<>> }),
           STx = aec_test_utils:sign_tx(Tx, ?TEST_PRIV),
 
-          AccMap = #{ preset_accounts => [{?TEST_PUB, 1000}] },
+          AccMap = #{ preset_accounts => [{?TEST_PUB, 100000}] },
           {Block0, Trees0} = aec_block_genesis:genesis_block_with_state(AccMap),
 
           meck:expect(aeu_time, now_in_msecs, 0, 1234567890),

--- a/apps/aecore/test/aec_pof_tests.erl
+++ b/apps/aecore/test/aec_pof_tests.erl
@@ -66,12 +66,12 @@ validation_fail_siblings() ->
 
 make_fraud_headers() ->
     #{ public := PubKey, secret := PrivKey } = enacl:sign_keypair(),
-    PresetAccounts = [{PubKey, 1000}],
+    PresetAccounts = [{PubKey, 1000000}],
     meck:expect(aec_genesis_block_settings, preset_accounts, 0, PresetAccounts),
 
     %% Create main chain
     TxsFun = fun(1) ->
-                     Tx1 = aec_test_utils:sign_tx(make_spend_tx(PubKey, 1, PubKey, 1, 2), PrivKey),
+                     Tx1 = aec_test_utils:sign_tx(make_spend_tx(PubKey, 1, PubKey, 20000, 2), PrivKey),
                      [Tx1];
                 (_) ->
                      []
@@ -81,7 +81,7 @@ make_fraud_headers() ->
     [_KB0,_KB1, MB] = blocks_only_chain(Chain0),
 
     CommonChain = [B0, B1],
-    Txs = [aec_test_utils:sign_tx(make_spend_tx(PubKey, 1, PubKey, 1, 3), PrivKey)],
+    Txs = [aec_test_utils:sign_tx(make_spend_tx(PubKey, 1, PubKey, 20000, 3), PrivKey)],
     Fork = aec_test_utils:extend_block_chain_with_micro_blocks(CommonChain, Txs),
     [_, _, MBF] = blocks_only_chain(Fork),
 

--- a/apps/aecore/test/aec_trees_tests.erl
+++ b/apps/aecore/test/aec_trees_tests.erl
@@ -52,12 +52,12 @@ signatures_check_test_() ->
                     aec_test_utils:signed_spend_tx(
                       #{recipient_id => aec_id:create(account, <<1:32/unit:8>>),
                         amount => 1,
-                        fee => 1,
+                        fee => 20000,
                         nonce => 1,
                         payload => <<>>}),
             SignedTxs = [SignedSpend],
             {ok, SenderPubkey, _} = aec_test_utils:wait_for_pubkey(),
-            Account = aec_accounts:new(SenderPubkey, 1000),
+            Account = aec_accounts:new(SenderPubkey, 1000000),
             TreesIn = aec_test_utils:create_state_tree_with_account(Account),
             Env = aetx_env:tx_env(1),
             {ok, ValidTxs, _InvalidTxs, _Trees} =
@@ -81,7 +81,7 @@ make_spend_tx(Sender, Recipient) ->
     {ok, SpendTx} = aec_spend_tx:new(#{sender_id => aec_id:create(account, Sender),
                                        recipient_id => aec_id:create(account, Recipient),
                                        amount => 1,
-                                       fee => 1,
+                                       fee => 20000,
                                        nonce => 1,
                                        payload => <<>>}),
     SpendTx.
@@ -659,7 +659,7 @@ make_contract(Owner, VmVersion) ->
 
 ct_create_tx(Sender, VmVersion) ->
     Spec =
-        #{ fee        => 5
+        #{ fee        => 750000
          , owner_id   => aec_id:create(account, Sender)
          , nonce      => 0
          , code       => <<"NOT PROPER BYTE CODE">>

--- a/apps/aecore/test/aec_tx_pool_tests.erl
+++ b/apps/aecore/test/aec_tx_pool_tests.erl
@@ -422,8 +422,7 @@ tx_pool_test_() ->
                ?assertEqual(ok, aec_tx_pool:push(STx3)),
 
                %% A transaction with too low fee should be rejected
-               STx4 = a_signed_tx(PubKey1, new_pubkey(), 6,
-                                  aec_governance:minimum_tx_fee() - 1),
+               STx4 = a_signed_tx(PubKey1, new_pubkey(), 6, 0),
                ?assertEqual({error, too_low_fee}, aec_tx_pool:push(STx4)),
 
                %% A transaction with too low gas price should be rejected

--- a/apps/aeoracle/src/aeo_extend_tx.erl
+++ b/apps/aeoracle/src/aeo_extend_tx.erl
@@ -111,7 +111,7 @@ check(#oracle_extend_tx{nonce = Nonce, oracle_ttl = OTTL, fee = Fee} = Tx,
          | case aetx_env:context(Env) of
                aetx_contract -> []; %% TODO Cater for TTL fee from contract.
                aetx_transaction ->
-                   [fun() -> aeo_utils:check_ttl_fee(Height, OTTL, Fee - aec_governance:minimum_tx_fee()) end]
+                   [fun() -> aeo_utils:check_ttl_fee(Height, OTTL, Fee) end]
            end],
 
     case aeu_validation:run(Checks) of

--- a/apps/aeoracle/src/aeo_query_tx.erl
+++ b/apps/aeoracle/src/aeo_query_tx.erl
@@ -158,7 +158,7 @@ check(#oracle_query_tx{nonce = Nonce, query_fee = QFee, query_ttl = QTTL,
          | case aetx_env:context(Env) of
                aetx_contract -> [];
                aetx_transaction ->
-                   [fun() -> aeo_utils:check_ttl_fee(Height, QTTL, Fee - aec_governance:minimum_tx_fee()) end]
+                   [fun() -> aeo_utils:check_ttl_fee(Height, QTTL, Fee) end]
            end
         ],
 

--- a/apps/aeoracle/src/aeo_register_tx.erl
+++ b/apps/aeoracle/src/aeo_register_tx.erl
@@ -145,7 +145,7 @@ check(#oracle_register_tx{nonce = Nonce, oracle_ttl = OTTL, fee = Fee,
                %% Contract is paying tx fee as gas.
                aetx_contract -> [];
                aetx_transaction ->
-                   [fun() -> aeo_utils:check_ttl_fee(Height, OTTL, Fee - aec_governance:minimum_tx_fee()) end
+                   [fun() -> aeo_utils:check_ttl_fee(Height, OTTL, Fee) end
                    ]
            end],
 

--- a/apps/aeoracle/src/aeo_response_tx.erl
+++ b/apps/aeoracle/src/aeo_response_tx.erl
@@ -135,8 +135,7 @@ check(#oracle_response_tx{nonce = Nonce, query_id = QueryId,
                      aetx_transaction ->
                          [fun() -> aetx_utils:check_account(OraclePubKey, Trees,
                                                             Nonce, Fee - QueryFee) end,
-                          fun() -> aeo_utils:check_ttl_fee(Height, ResponseTTL,
-                                                           Fee - aec_governance:minimum_tx_fee()) end]
+                          fun() -> aeo_utils:check_ttl_fee(Height, ResponseTTL, Fee) end]
                  end],
             case aeu_validation:run(Checks) of
                 ok              -> {ok, Trees};

--- a/apps/aeoracle/test/aeoracle_SUITE.erl
+++ b/apps/aeoracle/test/aeoracle_SUITE.erl
@@ -126,19 +126,18 @@ register_oracle_negative_dynamic_fee(_Cfg) ->
             Tx = aeo_test_utils:register_tx(PubKey, RegTxOpts, S1),
             aetx:check(Tx, Trees, Env)
         end,
-    1 = MinFee = aec_governance:minimum_tx_fee(),
 
     %% Test minimum fee for increasing TTL.
     ?assertEqual({error, too_low_fee}, F(#{oracle_ttl => {delta, 0}, fee => 0})),
-    ?assertMatch({ok, _}             , F(#{oracle_ttl => {delta, 0}, fee => MinFee})),
-    ?assertEqual({error, too_low_fee}, F(#{oracle_ttl => {delta, 1}, fee => MinFee})),
-    ?assertMatch({ok, _}             , F(#{oracle_ttl => {delta, 1}, fee => 1 + MinFee})),
-    ?assertMatch({ok, _}             , F(#{oracle_ttl => {delta, 999}, fee => 1 + MinFee})),
-    ?assertMatch({ok, _}             , F(#{oracle_ttl => {delta, 1000}, fee => 1 + MinFee})),
-    ?assertEqual({error, too_low_fee}, F(#{oracle_ttl => {delta, 1001}, fee => 1 + MinFee})),
-    ?assertMatch({ok, _}             , F(#{oracle_ttl => {delta, 1001}, fee => 2 + MinFee})),
+    ?assertMatch({ok, _}             , F(#{oracle_ttl => {delta, 0}, fee => 20000})),
+    ?assertEqual({error, too_low_fee}, F(#{oracle_ttl => {delta, 1}, fee => 1})),
+    ?assertMatch({ok, _}             , F(#{oracle_ttl => {delta, 1}, fee => 20000})),
+    ?assertMatch({ok, _}             , F(#{oracle_ttl => {delta, 999}, fee => 20000})),
+    ?assertMatch({ok, _}             , F(#{oracle_ttl => {delta, 1000}, fee => 20000})),
+    ?assertEqual({error, too_low_fee}, F(#{oracle_ttl => {delta, 1001}, fee => 1})),
+    ?assertMatch({ok, _}             , F(#{oracle_ttl => {delta, 1001}, fee => 40000})),
     %% Test more than minimum fee considering TTL.
-    ?assertMatch({ok, _}             , F(#{oracle_ttl => {delta, 1001}, fee => 3 + MinFee})),
+    ?assertMatch({ok, _}             , F(#{oracle_ttl => {delta, 1001}, fee => 45000})),
     ok.
 
 register_oracle(Cfg) ->
@@ -213,19 +212,17 @@ extend_oracle_negative_dynamic_fee(Cfg) ->
             Tx = aeo_test_utils:extend_tx(OracleKey, ExtTxOpts, S2),
             aetx:check(Tx, Trees2, Env)
         end,
-    1 = MinFee = aec_governance:minimum_tx_fee(),
-
     %% Test minimum fee for increasing TTL.
     ?assertEqual({error, too_low_fee}, F(#{oracle_ttl => {delta, 0}, fee => 0})),
-    ?assertEqual({error, zero_relative_oracle_extension_ttl}, F(#{oracle_ttl => {delta, 0}, fee => MinFee})),
-    ?assertEqual({error, too_low_fee}, F(#{oracle_ttl => {delta, 1}, fee => MinFee})),
-    ?assertMatch({ok, _}             , F(#{oracle_ttl => {delta, 1}, fee => 1 + MinFee})),
-    ?assertMatch({ok, _}             , F(#{oracle_ttl => {delta, 999}, fee => 1 + MinFee})),
-    ?assertMatch({ok, _}             , F(#{oracle_ttl => {delta, 1000}, fee => 1 + MinFee})),
-    ?assertEqual({error, too_low_fee}, F(#{oracle_ttl => {delta, 1001}, fee => 1 + MinFee})),
-    ?assertMatch({ok, _}             , F(#{oracle_ttl => {delta, 1001}, fee => 2 + MinFee})),
+    ?assertEqual({error, zero_relative_oracle_extension_ttl}, F(#{oracle_ttl => {delta, 0}, fee => 20000})),
+    ?assertEqual({error, too_low_fee}, F(#{oracle_ttl => {delta, 1}, fee => 1})),
+    ?assertMatch({ok, _}             , F(#{oracle_ttl => {delta, 1}, fee => 20000})),
+    ?assertMatch({ok, _}             , F(#{oracle_ttl => {delta, 999}, fee => 20000})),
+    ?assertMatch({ok, _}             , F(#{oracle_ttl => {delta, 1000}, fee => 20000})),
+    ?assertEqual({error, too_low_fee}, F(#{oracle_ttl => {delta, 1001}, fee => 1})),
+    ?assertMatch({ok, _}             , F(#{oracle_ttl => {delta, 1001}, fee => 20000})),
     %% Test more than minimum fee considering TTL.
-    ?assertMatch({ok, _}             , F(#{oracle_ttl => {delta, 1001}, fee => 3 + MinFee})),
+    ?assertMatch({ok, _}             , F(#{oracle_ttl => {delta, 1001}, fee => 20000})),
     ok.
 
 extend_oracle(Cfg) ->
@@ -303,7 +300,7 @@ query_oracle_negative(Cfg) ->
     ok.
 
 query_oracle_negative_dynamic_fee(Cfg) ->
-    {OracleKey, S}  = register_oracle(Cfg, #{oracle_ttl => {block, 2000 + ?ORACLE_QUERY_HEIGHT}, fee => 25}),
+    {OracleKey, S}  = register_oracle(Cfg, #{oracle_ttl => {block, 2000 + ?ORACLE_QUERY_HEIGHT}, fee => 25000}),
     OracleId        = aec_id:create(oracle, OracleKey),
     {SenderKey, S2} = aeo_test_utils:setup_new_account(S),
     Trees           = aeo_test_utils:trees(S2),
@@ -314,19 +311,18 @@ query_oracle_negative_dynamic_fee(Cfg) ->
             Tx = aeo_test_utils:query_tx(SenderKey, OracleId, QTxOpts, S2),
             aetx:check(Tx, Trees, Env)
         end,
-    1 = MinFee = aec_governance:minimum_tx_fee(),
 
     %% Test minimum fee for increasing TTL.
     ?assertEqual({error, too_low_fee}, F(#{query_ttl => {delta, 0}, fee => 0})),
-    ?assertMatch({ok, _}             , F(#{query_ttl => {delta, 0}, fee => MinFee})),
-    ?assertEqual({error, too_low_fee}, F(#{query_ttl => {delta, 1}, fee => MinFee})),
-    ?assertMatch({ok, _}             , F(#{query_ttl => {delta, 1}, fee => 1 + MinFee})),
-    ?assertMatch({ok, _}             , F(#{query_ttl => {delta, 999}, fee => 1 + MinFee})),
-    ?assertMatch({ok, _}             , F(#{query_ttl => {delta, 1000}, fee => 1 + MinFee})),
-    ?assertEqual({error, too_low_fee}, F(#{query_ttl => {delta, 1001}, fee => 1 + MinFee})),
-    ?assertMatch({ok, _}             , F(#{query_ttl => {delta, 1001}, fee => 2 + MinFee})),
+    ?assertMatch({ok, _}             , F(#{query_ttl => {delta, 0}, fee => 20000})),
+    ?assertEqual({error, too_low_fee}, F(#{query_ttl => {delta, 1}, fee => 1})),
+    ?assertMatch({ok, _}             , F(#{query_ttl => {delta, 1}, fee => 20000})),
+    ?assertMatch({ok, _}             , F(#{query_ttl => {delta, 999}, fee => 20000})),
+    ?assertMatch({ok, _}             , F(#{query_ttl => {delta, 1000}, fee => 20000})),
+    ?assertEqual({error, too_low_fee}, F(#{query_ttl => {delta, 1001}, fee => 1})),
+    ?assertMatch({ok, _}             , F(#{query_ttl => {delta, 1001}, fee => 20000})),
     %% Test more than minimum fee considering TTL.
-    ?assertMatch({ok, _}             , F(#{query_ttl => {delta, 1001}, fee => 3 + MinFee})),
+    ?assertMatch({ok, _}             , F(#{query_ttl => {delta, 1001}, fee => 20000})),
     ok.
 
 query_oracle_type_check(_Cfg) ->
@@ -421,26 +417,25 @@ query_response_negative_dynamic_fee(Cfg) ->
     F = fun(RTTL, Fee) ->
                 QTxSpec = #{ response_ttl => RTTL },
                 RTxSpec = #{ response_ttl => RTTL, fee => Fee },
-                {OracleKey, ID, S1}  = query_oracle(Cfg, #{oracle_ttl => {block, 2000 + ?ORACLE_RSP_HEIGHT}, fee => 25}, QTxSpec),
+                {OracleKey, ID, S1}  = query_oracle(Cfg, #{oracle_ttl => {block, 2000 + ?ORACLE_RSP_HEIGHT}, fee => 25000}, QTxSpec),
                 Trees      = aeo_test_utils:trees(S1),
                 CurrHeight = ?ORACLE_RSP_HEIGHT,
                 Env        = aetx_env:tx_env(CurrHeight),
                 Tx = aeo_test_utils:response_tx(OracleKey, ID, <<"42">>, RTxSpec, S1),
                 aetx:check(Tx, Trees, Env)
         end,
-    1 = MinFee = aec_governance:minimum_tx_fee(),
 
     %% Test minimum fee for increasing TTL.
     ?assertException(error, {illegal,response_ttl,{delta,0}}, F({delta, 0}, 0)),
-    ?assertException(error, {illegal,response_ttl,{delta,0}}, F({delta, 0}, MinFee)),
-    ?assertEqual({error, too_low_fee}, F({delta, 1},    MinFee)),
-    ?assertMatch({ok, _}             , F({delta, 1},    1 + MinFee)),
-    ?assertMatch({ok, _}             , F({delta, 999},  1 + MinFee)),
-    ?assertMatch({ok, _}             , F({delta, 1000}, 1 + MinFee)),
-    ?assertEqual({error, too_low_fee}, F({delta, 1001}, 1 + MinFee)),
-    ?assertMatch({ok, _}             , F({delta, 1001}, 2 + MinFee)),
+    ?assertException(error, {illegal,response_ttl,{delta,0}}, F({delta, 0}, 20000)),
+    ?assertEqual({error, too_low_fee}, F({delta, 1},    1)),
+    ?assertMatch({ok, _}             , F({delta, 1},    20000)),
+    ?assertMatch({ok, _}             , F({delta, 999},  20000)),
+    ?assertMatch({ok, _}             , F({delta, 1000}, 20000)),
+    ?assertEqual({error, too_low_fee}, F({delta, 1001}, 1)),
+    ?assertMatch({ok, _}             , F({delta, 1001}, 20000)),
     %% Test more than minimum fee considering TTL.
-    ?assertMatch({ok, _}             , F({delta, 1001}, 3 + MinFee)),
+    ?assertMatch({ok, _}             , F({delta, 1001}, 20000)),
     ok.
 
 query_response(Cfg) ->

--- a/apps/aetx/src/aetx.erl
+++ b/apps/aetx/src/aetx.erl
@@ -249,7 +249,7 @@ check_tx(#aetx{ cb = CB, tx = Tx } = AeTx, Trees, Env) ->
     end.
 
 check_minimum_fee(AeTx) ->
-    case fee(AeTx) >= aec_governance:minimum_tx_fee() of
+    case fee(AeTx) >= (min_gas(AeTx) * aec_governance:minimum_gas_price()) of
         true  -> ok;
         false -> {error, too_low_fee}
     end.

--- a/apps/aetx/test/aetx_tests.erl
+++ b/apps/aetx/test/aetx_tests.erl
@@ -30,8 +30,8 @@ apply_signed_txs_test_() ->
                {ok, MinerPubkey} = aec_keys:pubkey(),
                {ok, MinerPrivkey} = aec_keys:sign_privkey(),
 
-               MinerAccount = aec_accounts:set_nonce(aec_accounts:new(MinerPubkey, 100), 10),
-               AnotherAccount = aec_accounts:set_nonce(aec_accounts:new(?RECIPIENT_PUBKEY, 80), 12),
+               MinerAccount = aec_accounts:set_nonce(aec_accounts:new(MinerPubkey, 100000), 10),
+               AnotherAccount = aec_accounts:set_nonce(aec_accounts:new(?RECIPIENT_PUBKEY, 80000), 12),
                StateTree0 = aec_test_utils:create_state_tree_with_accounts([MinerAccount, AnotherAccount]),
 
                BlockHeight = 30,
@@ -40,7 +40,7 @@ apply_signed_txs_test_() ->
                                  #{sender_id => aec_id:create(account, MinerPubkey),
                                    recipient_id => aec_id:create(account, ?RECIPIENT_PUBKEY),
                                    amount => 40,
-                                   fee => 9,
+                                   fee => 20000,
                                    ttl => 100,
                                    nonce => 11,
                                    payload => <<"">>}),
@@ -48,7 +48,7 @@ apply_signed_txs_test_() ->
                                        #{sender_id => aec_id:create(account, MinerPubkey),
                                          recipient_id => aec_id:create(account, ?RECIPIENT_PUBKEY),
                                          amount => 30000,
-                                         fee => 10,
+                                         fee => 20000,
                                          ttl => 100,
                                          nonce => 13,
                                          payload => <<"">>}),
@@ -67,7 +67,7 @@ apply_signed_txs_test_() ->
                {value, ResultRecipientAccount} = aec_accounts_trees:lookup(?RECIPIENT_PUBKEY, ResultAccountsTree),
 
                %% Initial balance - spend_tx amount - spend_tx fee
-               ?assertEqual(100 - 40 - 9, aec_accounts:balance(ResultMinerAccount)),
-               ?assertEqual(80 + 40, aec_accounts:balance(ResultRecipientAccount))
+               ?assertEqual(100000 - 40 - 20000, aec_accounts:balance(ResultMinerAccount)),
+               ?assertEqual(80000 + 40, aec_accounts:balance(ResultRecipientAccount))
        end
       }]}.

--- a/test/name_resolution_SUITE.erl
+++ b/test/name_resolution_SUITE.erl
@@ -43,7 +43,7 @@ init_state(N) ->
                              || #{public := Pub, secret := Priv} <- KeysList]),
     Trees0 = aec_trees:new_without_backend(),
     ATrees = lists:foldl(fun(#{public := Pubkey}, AccTrees) ->
-                                 Account = aec_accounts:new(Pubkey, 1000),
+                                 Account = aec_accounts:new(Pubkey, 100000),
                                  aec_accounts_trees:enter(Account, AccTrees)
                          end,
                          aec_trees:accounts(Trees0),
@@ -108,14 +108,14 @@ register_name(Pubkey, Name, S) ->
     CommitmentId = commitment_id(aens_hash:commitment_hash(Ascii, Salt)),
     PreclaimSpec = #{ account_id => account_id(Pubkey)
                     , commitment_id => CommitmentId
-                    , fee  => 1
+                    , fee  => 20000
                     , nonce => 1
                     },
     {ok, Preclaim} = aens_preclaim_tx:new(PreclaimSpec),
     ClaimSpec  = #{ account_id => account_id(Pubkey)
                   , name => Name
                   , name_salt => Salt
-                  , fee  => 1
+                  , fee  => 20000
                   , nonce => 2
                   },
     {ok, Claim} = aens_claim_tx:new(ClaimSpec),
@@ -130,7 +130,7 @@ update_pointers(Tag, ToPubkey, Pubkey, NameID, Nonce, S) ->
                    , name_ttl => 100
                    , pointers => Pointers
                    , client_ttl => 100
-                   , fee => 1
+                   , fee => 20000
                    },
     {ok, Update} = aens_update_tx:new(UpdateSpec),
     apply_txs([Update], S).
@@ -150,7 +150,7 @@ type2id(oracle_pubkey)   -> oracle.
 spend_to_name(_Cfg) ->
     {[Pubkey1, Pubkey2], S1} = init_state(2),
     Amount = 100,
-    Fee    = 1,
+    Fee    = 20000,
     {S2, NameId} = register_name(Pubkey2, S1),
     S3 = update_pointers(account_pubkey, Pubkey2, Pubkey2, NameId, 3, S2),
     {ok, Spend} = aec_spend_tx:new(#{ sender_id    => account_id(Pubkey1)
@@ -186,7 +186,7 @@ transfer_name_to_named_account(_Cfg) ->
                     , nonce   => 3
                     , name_id => NameId2
                     , recipient_id => NameId1
-                    , fee => 5
+                    , fee => 20000
                     },
     {ok, Transfer} = aens_transfer_tx:new(TransferSpec),
     S5 = apply_txs([Transfer], S4),


### PR DESCRIPTION
Related to #1722 and [PT-161183355](https://www.pivotaltracker.com/n/projects/2124891/stories/161183355).

The check of minimal tx fee is moved from `aec_blocks.erl` to `aetx.erl`.