### PR TITLE
Pt 161915896 dont use all gas on recursive call

### DIFF
--- a/apps/aecontract/src/aect_dispatch.erl
+++ b/apps/aecontract/src/aect_dispatch.erl
@@ -171,6 +171,7 @@ create_call(GasUsed, Type, Log, Call) ->
     Call1 = aect_call:set_log(Log, Call),
     aect_call:set_gas_used(GasUsed, aect_call:set_return_type(Type, Call1)).
 
+%% c.f. aec_vm_chain:binary_to_error/1
 error_to_binary(out_of_gas) -> <<"out_of_gas">>;
 error_to_binary(out_of_stack) -> <<"out_of_stack">>;
 error_to_binary(not_allowed_off_chain) -> <<"not_allowed_off_chain">>;

--- a/apps/aecontract/test/aecontract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_SUITE.erl
@@ -700,13 +700,13 @@ call_contract_error_value(_Cfg) ->
     ?assertEqual(Bal(IdC, S1) + 10, Bal(IdC, S2)),
     %% Check no transfer of value in calls that err.
     {{{error, <<"out_of_gas">>}, GasUsed3}, S3} = call_contract(Acc1, IdC, err, word, {}, DefaultOpts#{amount := 5, return_gas_used => true}, S2),
-    ?assertEqual(G, GasUsed3),
-    ?assertEqual(Bal(Acc1, S2) - (F + G), Bal(Acc1, S3)),
+    ?assertEqual(112, GasUsed3),
+    ?assertEqual(Bal(Acc1, S2) - (F + 112), Bal(Acc1, S3)),
     ?assertEqual(Bal(RemC, S2), Bal(RemC, S3)),
     ?assertEqual(Bal(IdC, S2), Bal(IdC, S3)),
     {{{error, <<"out_of_gas">>}, GasUsed4}, S4} = call_contract(Acc1, RemC, callErr, word, {IdC, 7}, DefaultOpts#{amount := 13, return_gas_used => true}, S3),
-    ?assertEqual(G, GasUsed4),
-    ?assertEqual(Bal(Acc1, S3) - (F + G), Bal(Acc1, S4)),
+    ?assertEqual(59330, GasUsed4),
+    ?assertEqual(Bal(Acc1, S3) - (F + 59330), Bal(Acc1, S4)),
     ?assertEqual(Bal(RemC, S3), Bal(RemC, S4)),
     ?assertEqual(Bal(IdC, S3), Bal(IdC, S4)),
     ok.

--- a/apps/aecontract/test/aecontract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_SUITE.erl
@@ -700,15 +700,24 @@ call_contract_error_value(_Cfg) ->
     ?assertEqual(Bal(IdC, S1) + 10, Bal(IdC, S2)),
     %% Check no transfer of value in calls that err.
     {{{error, <<"out_of_gas">>}, GasUsed3}, S3} = call_contract(Acc1, IdC, err, word, {}, DefaultOpts#{amount := 5, return_gas_used => true}, S2),
-    ?assertEqual(112, GasUsed3),
-    ?assertEqual(Bal(Acc1, S2) - (F + 112), Bal(Acc1, S3)),
+    ?assertEqual(G, GasUsed3),
+    ?assertEqual(Bal(Acc1, S2) - (F + GasUsed3), Bal(Acc1, S3)),
     ?assertEqual(Bal(RemC, S2), Bal(RemC, S3)),
     ?assertEqual(Bal(IdC, S2), Bal(IdC, S3)),
     {{{error, <<"out_of_gas">>}, GasUsed4}, S4} = call_contract(Acc1, RemC, callErr, word, {IdC, 7}, DefaultOpts#{amount := 13, return_gas_used => true}, S3),
-    ?assertEqual(59330, GasUsed4),
-    ?assertEqual(Bal(Acc1, S3) - (F + 59330), Bal(Acc1, S4)),
+    ?assertEqual(G, GasUsed4),
+    ?assertEqual(Bal(Acc1, S3) - (F + GasUsed4), Bal(Acc1, S4)),
     ?assertEqual(Bal(RemC, S3), Bal(RemC, S4)),
     ?assertEqual(Bal(IdC, S3), Bal(IdC, S4)),
+    %% Check that you can limit the amount of gas in an error call
+    LimitedGas = 1234,
+    {{{error, <<"out_of_gas">>}, GasUsed5}, S5} = call_contract(Acc1, RemC, callErrLimitGas, word, {IdC, 7, LimitedGas}, DefaultOpts#{amount := 13, return_gas_used => true}, S4),
+    ?assert(GasUsed5 < G),
+    ct:pal("Bal(Acc1, S4): ~p", [Bal(Acc1, S4)]),
+    ct:pal("GasUsed: ~p", [GasUsed5]),
+    ?assertEqual(Bal(Acc1, S4) - (F + GasUsed5), Bal(Acc1, S5)),
+    ?assertEqual(Bal(RemC, S4), Bal(RemC, S5)),
+    ?assertEqual(Bal(IdC, S4), Bal(IdC, S5)),
     ok.
 
 %%%===================================================================
@@ -975,7 +984,7 @@ sophia_no_reentrant(_Cfg) ->
     Acc   = ?call(new_account, 10000000),
     IdC   = ?call(create_contract, Acc, identity, {}),
     RemC  = ?call(create_contract, Acc, remote_call, {}, #{amount => 100}),
-    Err   = {error, <<"out_of_gas">>},
+    Err   = {error, <<"reentrant_call">>},
             %% Should fail due to reentrancy
     Err   = ?call(call_contract, Acc, RemC, staged_call, word, {IdC, RemC, 77}),
     ok.

--- a/apps/aecore/src/aec_vm_chain.erl
+++ b/apps/aecore/src/aec_vm_chain.erl
@@ -709,7 +709,7 @@ apply_call_transaction(Tx, Gas, #state{tx_env = Env} = State) ->
                     {aevm_chain_api:call_result(Bin, GasUsed), State1}
             end;
         {error, Atom} when is_atom(Atom) ->
-            ReturnAtom = binary_to_error(atom_to_binary(Atom, latin1)),
+            ReturnAtom = binary_to_error(atom_to_binary(Atom, utf8)),
             {aevm_chain_api:call_exception(ReturnAtom, Gas), State}
     end.
 

--- a/apps/aehttp/test/aehttp_contracts_SUITE.erl
+++ b/apps/aehttp/test/aehttp_contracts_SUITE.erl
@@ -69,10 +69,6 @@ groups() ->
        type_error_contract,
        remote_gas_test_contract,
        null                                     %This allows to end with ,
-      ]},
-     {remote, [],
-      [
-       remote_gas_test_contract
       ]}
     ].
 

--- a/apps/aehttp/test/aehttp_contracts_SUITE.erl
+++ b/apps/aehttp/test/aehttp_contracts_SUITE.erl
@@ -1124,7 +1124,7 @@ remote_gas_test_contract(Config) ->
                    args_to_binary([DecC2Pub, 2, 3]), error),
     force_fun_calls(Node),
     Balance3 = get_balance(APub),
-    809936 = Balance2 - Balance3,
+    809933 = Balance2 - Balance3,
 
     %% Check that store/state not changed (we tried to write 2).
     call_get(APub, APriv, EncC2Pub,  1),

--- a/apps/aesophia/test/contracts/remote_gas_test.aes
+++ b/apps/aesophia/test/contracts/remote_gas_test.aes
@@ -1,0 +1,20 @@
+contract Remote1 =
+  function set : (int) => int
+
+contract RemoteCall =
+    record state = { i : int }
+
+    function init(x) = { i = x }
+
+    function set( x : int) : int =
+        let old = state.i
+        put(state{ i = x })
+        old
+
+    function call(r : Remote1, x : int, g : int) : int =
+        r.set(gas = g, value = 10, x)
+
+    function get() = state.i
+
+
+

--- a/apps/aesophia/test/contracts/remote_value_on_err.aes
+++ b/apps/aesophia/test/contracts/remote_value_on_err.aes
@@ -9,6 +9,12 @@ contract RemoteValueOnErr =
     value : int) : int =
     r.err(value = value)
 
+  public function callErrLimitGas(
+    r : ValueOnErr,
+    value : int,
+    gas : int) : int =
+    r.err(value = value, gas = gas)
+
   public function callOk(
     r : ValueOnErr,
     value : int) : int =

--- a/apps/aevm/src/aevm_eeevm.erl
+++ b/apps/aevm/src/aevm_eeevm.erl
@@ -19,6 +19,9 @@
 -module(aevm_eeevm).
 -export([eval/1]).
 
+%% TODO: This should move
+-export([eval_error/1]).
+
 %% Exports for tracing. TODO: move to aevm_eeevm_code
 -export([code_get_op/2]).
 
@@ -57,8 +60,8 @@ eval(State) ->
                 {ok, State2}  -> {ok, State2};
                 {error, What} -> {error, What, State1}
             end;
-        {revert, State1} ->
-            {revert, State1};
+        {revert, Msg, GasLeft} ->
+            {revert, Msg, GasLeft};
         {error, What, State1} ->
             %% Don't save state on error.
             {error, What, State1}
@@ -74,23 +77,16 @@ eval_code(State = #{ address := 0 }) ->
 eval_code(State) ->
     try {ok, loop(aevm_eeevm_state:cp(State), valid_jumpdests(State))}
     catch
-        throw:?aevm_eval_error(What, StateOut) ->
-            ?TEST_LOG("Code evaluation error at ~s",
-                      [aeb_disassemble:format_address(aevm_eeevm_state:cp(StateOut))]),
-	    %% Throw away new storage on error.
-            {error, What, old_store(State, StateOut)};
+        throw:?aevm_eval_error(What, GasLeft) ->
+            {error, What, GasLeft};
         throw:?AEVM_SIGNAL(Signal, StateOut) ->
-            handle_signal(Signal, State, StateOut)
+            handle_signal(Signal, StateOut)
     end.
 
-old_store(StateIn, StateOut) ->
-    aevm_eeevm_state:set_storage(
-      aevm_eeevm_state:storage(StateIn), StateOut).
-
-handle_signal(revert, StateIn, StateOut) ->
-    {revert, old_store(StateIn, StateOut)}.
-
-
+handle_signal(revert, StateOut) ->
+    GasOut = aevm_eeevm_state:gas(StateOut),
+    Msg    = aevm_eeevm_state:out(StateOut),
+    {revert, Msg, GasOut}.
 
 valid_jumpdests(State) ->
     Code = aevm_eeevm_state:code(State),
@@ -134,7 +130,7 @@ loop(CP, StateIn) ->
             State  = trace(CP, StateIn),
             case is_valid_instruction(OP, aevm_eeevm_state:vm_version(State)) of
                 true -> ok;
-                false -> eval_error({illegal_instruction, OP}, State)
+                false -> eval_error({illegal_instruction, OP})
             end,
             State0 = spend_op_gas(OP, State),
             case OP of
@@ -685,7 +681,7 @@ loop(CP, StateIn) ->
                     JumpDests =  aevm_eeevm_state:jumpdests(State1),
                     case maps:get(Us0, JumpDests, false) of
                     true  -> next_instruction(Us0-1, State, State1);
-                    false -> eval_error({{invalid_jumpdest, Us0}}, State1)
+                    false -> eval_error({{invalid_jumpdest, Us0}})
                     end;
                 ?JUMPI ->
                     %% 0x57 JUMPI δ=2 α=0
@@ -701,7 +697,7 @@ loop(CP, StateIn) ->
                                 true ->
                                     next_instruction(Us0-1, State, State2);
                                 false ->
-                                    eval_error({{invalid_jumpdest, Us0}}, State1)
+                                    eval_error({{invalid_jumpdest, Us0}})
                             end;
                        true -> next_instruction(CP, State, State2)
                     end;
@@ -1428,7 +1424,7 @@ data_get_bytes(Address, Size, State) ->
     Data = aevm_eeevm_state:data(State),
     try aevm_eeevm_utils:bin_copy(Address, Size, Data)
     catch error:system_limit ->
-        eval_error(out_of_memory, State)
+        eval_error(out_of_memory)
     end.
 
 %% Get a binary of size Size bytes from return data.
@@ -1490,7 +1486,7 @@ spend_gas_common(_Resource, Gas, State) ->
         true ->  aevm_eeevm_state:set_gas(GasLimit - Gas, State);
         false ->
             ?TEST_LOG("Out of gas spending ~p gas for ~p", [Gas, _Resource]),
-            eval_error(out_of_gas, State)
+            eval_error(out_of_gas)
     end.
 
 %% ------------------------------------------------------------------------
@@ -1559,7 +1555,8 @@ recursive_call1(StateIn, Op) ->
     State1            = spend_call_gas(State0, Op),
     Gascap            = aevm_gas:call_cap(Op, State0),
 
-    {_Gas, State2}    = pop(State1), %% Peeked elsewhere.
+    {Gas, State2}     = pop(State1), %% Peeked elsewhere.
+    GasIsLimited      = Gas =/= aevm_eeevm_state:gas(StateIn),
     {To, State3}      = pop(State2),
     {Value, State4}   = case Op of
                             ?CALL         -> pop(State3);
@@ -1576,19 +1573,19 @@ recursive_call1(StateIn, Op) ->
         true  -> ok;
         false ->
             ?TEST_LOG("Out of gas before call", []),
-            eval_error(out_of_gas, State8)
+            eval_error(out_of_gas)
     end,
     Address = aevm_eeevm_state:address(State8),
     AddressBalance = aevm_eeevm_state:accountbalance(Address, State8),
     case Value =< AddressBalance of
-        true  -> recursive_call2(Op, Gascap, To, Value, OSize, OOffset, I, State8, GasAfterSpend, OutT);
+        true  -> recursive_call2(Op, Gascap, To, Value, OSize, OOffset, I, State8, GasAfterSpend, OutT, GasIsLimited);
         false ->
             ?TEST_LOG("Excessive value operand ~p for address ~p, that has balance ~p", [Value, Address, AddressBalance]),
-            {0, aevm_eeevm_state:set_gas(0, State8)}
             %% Consume all gas on failed contract call.
+            eval_error(out_of_gas)
     end.
 
-recursive_call2(Op, Gascap, To, Value, OSize, OOffset, I, State8, GasAfterSpend, OutType) ->
+recursive_call2(Op, Gascap, To, Value, OSize, OOffset, I, State8, GasAfterSpend, OutType, GasIsLimited) ->
     Dest = case Op of
                ?CALL -> To;
                ?CALLCODE -> aevm_eeevm_state:address(State8);
@@ -1626,47 +1623,42 @@ recursive_call2(Op, Gascap, To, Value, OSize, OOffset, I, State8, GasAfterSpend,
                                                         }, State9),
             {1, State10};
         false ->
-             %% State9 =
-             %%     aevm_eeevm_state:add_callcreates(#{ data => I
-             %%                                       , destination => Dest
-             %%                                       , gasLimit => CallGas
-             %%                                       , value => Value
-             %%                                       }, State8),
-            {OutGas, ReturnState, R} =
-                case aevm_eeevm_state:call_contract(Caller, Dest, CallGas, Value, I, State8) of
-                    {ok, {error, out_of_gas}, GasSpent,_OutState1} ->
-                        GasAfterFailedCall = case VmVersion of
-                                                 ?AEVM_01_Solidity_01 -> 0;
-                                                 _ -> max(0, GasAfterSpend - GasSpent)
-                                             end,
-                        FailState = aevm_eeevm_state:set_gas(GasAfterFailedCall, State8),
-                        eval_error(out_of_gas, FailState);
-                    {ok, Res, GasSpent, OutState1} when 0 =< GasSpent, GasSpent =< CallGas ->
-                        {CallGas - GasSpent, OutState1, Res};
-                    {error, ?AEVM_PRIMOP_ERR_REASON_OOG(_OogResource, _OogGas, State9)} ->
-                        ?TEST_LOG("Out of gas spending ~p gas for ~p", [_OogGas, _OogResource]),
-                        eval_error(out_of_gas, State9);
-                    {error, not_allowed_off_chain} ->
-                        ?TEST_LOG("Not allowed calling this contract off-chain", []),
-                        eval_error(not_allowed_off_chain, State8);
-                    {error, _Err} ->
-                        ?TEST_LOG("Invalid call error ~p", [_Err]),
-                        {0, State8, {error, invalid_call}}
-                end,
-            %% TODO: how to handle trace of call?
-            %% CallTrace = aevm_eeevm_state:trace(OutState),
-            %% ReturnState1 = aevm_eeevm_state:add_trace(CallTrace, State9),
-            GasAfterCall = GasAfterSpend  + max(0, OutGas - Stipend),
-            ReturnState2 = aevm_eeevm_state:set_gas(GasAfterCall, ReturnState),
-            case R of
-                {ok, Message} ->
-                    aevm_eeevm_state:return_contract_call_result(Dest, I, OOffset, OSize, Message, OutType, ReturnState2);
-                {error, {revert, RevertMsg}} ->
-                    ReturnState3 = aevm_eeevm_state:set_out(RevertMsg, ReturnState2),
-                    throw(?REVERT_SIGNAL(ReturnState3));
-                {error, _} ->
-                    {0, aevm_eeevm_state:set_gas(0, ReturnState2)}
-                    %% Consume all gas on failed contract call.
+            case aevm_eeevm_state:call_contract(Caller, Dest, CallGas, Value, I, State8) of
+                {ok, Return, GasSpent, OutState} when 0 =< GasSpent, GasSpent =< CallGas ->
+                    GasAfterCall = GasAfterSpend  + max(0, CallGas - GasSpent - Stipend),
+                    ReturnState = aevm_eeevm_state:set_gas(GasAfterCall, OutState),
+                    aevm_eeevm_state:return_contract_call_result(
+                      Dest, I, OOffset, OSize, Return, OutType, ReturnState);
+                {exception, What, GasSpent,_OutState1} ->
+                    ?TEST_LOG("Contract call exception ~p (~p spent)", [What, GasSpent]),
+                    case VmVersion of
+                        ?AEVM_01_Solidity_01 ->
+                            eval_error(What);
+                        ?AEVM_01_Sophia_01 when CallGas =:= GasSpent, not GasIsLimited ->
+                            %% When the gas IS NOT explicitly limited,
+                            %% and all gas was consumed in the call,
+                            %% all gas in the current execution is consumed.
+                            eval_error(What);
+                        ?AEVM_01_Sophia_01 when GasIsLimited ->
+                            %% When the gas IS explicitly limited, or
+                            %% there was an exception below in the call stack
+                            %% in a call that WAS explicitly limited,
+                            %% we only consume the gas of the exception.
+                            GasAfterFailedCall = GasAfterSpend  + max(0, CallGas - GasSpent - Stipend),
+                            eval_call_error(What, GasAfterFailedCall)
+                    end;
+                {revert, RevertMsg, GasSpent, OutState} ->
+                    ?TEST_LOG("Contract call revert ~p (~p spent)", [RevertMsg, GasSpent]),
+                    GasAfterCall = GasAfterSpend  + max(0, CallGas - GasSpent - Stipend),
+                    ReturnState1 = aevm_eeevm_state:set_gas(GasAfterCall, OutState),
+                    ReturnState2 = aevm_eeevm_state:set_out(RevertMsg, ReturnState1),
+                    throw(?REVERT_SIGNAL(ReturnState2));
+                {primop_error, Reason} when Reason =:= not_allowed_off_chain ->
+                    ?TEST_LOG("Primop error ~p", [Reason]),
+                    eval_error(Reason);
+                {primop_error,_What} ->
+                    ?TEST_LOG("Primop error ~p", [_What]),
+                    eval_error(out_of_gas)
             end
     end.
 
@@ -1674,6 +1666,10 @@ recursive_call2(Op, Gascap, To, Value, OSize, OOffset, I, State8, GasAfterSpend,
 %% Error handling
 %% ------------------------------------------------------------------------
 
--spec eval_error(_, _) -> no_return().
-eval_error(What, State) ->
-    throw(?aevm_eval_error(What, State)).
+-spec eval_error(_) -> no_return().
+eval_error(What) ->
+    throw(?aevm_eval_error(What, 0)).
+
+-spec eval_call_error(ErrorReason :: any(), GasLeft :: non_neg_integer()) -> no_return().
+eval_call_error(What, GasLeft) ->
+    throw(?aevm_eval_error(What, GasLeft)).

--- a/apps/aevm/src/aevm_eeevm_state.erl
+++ b/apps/aevm/src/aevm_eeevm_state.erl
@@ -81,6 +81,19 @@
 
 -export_type([state/0]).
 
+-ifdef(COMMON_TEST).
+-define(TEST_LOG(Format, Data),
+        try ct:log(Format, Data)
+        catch
+            %% Enable setting up node with "test" rebar profile.
+            error:undef -> ok
+        end).
+-define(DEBUG_LOG(Format, Data), begin lager:debug(Format, Data), ?TEST_LOG(Format, Data) end).
+-else.
+-define(TEST_LOG(Format, Data), ok).
+-define(DEBUG_LOG(Format, Data), lager:debug(Format, Data)).
+-endif.
+
 -spec init(map(), map()) -> state().
 init(#{ env  := Env
       , exec := Exec

--- a/apps/aevm/src/aevm_eeevm_state.erl
+++ b/apps/aevm/src/aevm_eeevm_state.erl
@@ -277,8 +277,8 @@ heap_to_binary(Type, Ptr, State) ->
 spend_gas(Gas, State) ->
     TotalGas = gas(State),
     case TotalGas - Gas of
-        GasLeft when GasLeft >  0 -> set_gas(GasLeft, State);
-        GasLeft when GasLeft =< 0 -> aevm_eeevm:eval_error(out_of_gas)
+        GasLeft when GasLeft >=  0 -> set_gas(GasLeft, State);
+        GasLeft when GasLeft < 0 -> aevm_eeevm:eval_error(out_of_gas)
     end.
 
 heap_to_heap(Type, Ptr, State) ->

--- a/apps/aevm/src/aevm_gas.erl
+++ b/apps/aevm/src/aevm_gas.erl
@@ -120,15 +120,15 @@ call_dynamic_gas(State) ->
 
 call_dynamic_gas_components(State) ->
     Gas = aevm_eeevm_state:gas(State),
-    Us0 = peek(0, State),
-    %%Us1 = peek(1, State), %% TODO: Needed for CNEW.
-    Us2 = peek(2, State),
-    CNew = 0, %% TODO: Is this a new account?
+    Us0 = peek(0, State), %% Gas
+    Us2 = peek(2, State), %% Value
     CXfer = case Us2 =:= 0 of
                 true  -> 0;
                 false -> maps:get('GCALLVALUE', gastable(State))
             end,
-    CExtra = CNew + CXfer + maps:get('GCALL', gastable(State)),
+    %% AEVM does not allow calls to nonexisting addresses
+    %% so no CNew component.
+    CExtra = CXfer + maps:get('GCALL', gastable(State)),
     CGascap = case Gas >= CExtra of
                   true  -> min(all_but_one_64th(Gas - CExtra), Us0);
                   false -> Us0 %% TODO Can this case ever happen without causing out-of-gas when subtracting CExtra?

--- a/apps/aevm/test/aevm_dummy_chain.erl
+++ b/apps/aevm/test/aevm_dummy_chain.erl
@@ -25,5 +25,6 @@ get_balance(_, _S)              -> 0.
 get_store(_)                    -> #{}.
 set_store(_,S)                  -> S.
 spend(_Recipient, _Amount, _S)  -> {error, cant_spend_with_dummy_chain}.
-call_contract(_, _, _, _, _, _) -> {error, cant_call_contracts_with_dummy_chain}.
+call_contract(_, Gas, _, _, _, State) ->
+    {aevm_chain_api:call_exception(cant_call_contracts_with_dummy_chain, Gas), State}.
 

--- a/apps/aevm/test/aevm_ethereum_test_chain.erl
+++ b/apps/aevm/test/aevm_ethereum_test_chain.erl
@@ -52,5 +52,6 @@ spend(_Recipient, _Amount, _S)  -> {error, cant_spend_with_dummy_chain}.
 -spec call_contract(aec_keys:pubkey(), non_neg_integer(), non_neg_integer(), binary(),
                     [non_neg_integer()], chain_state()) ->
         {ok, aevm_chain_api:call_result(), chain_state()} | {error, term()}.
-call_contract(_, _, _, _, _, _) -> {error, cant_call_contracts_with_dummy_chain}.
+call_contract(_, Gas, _, _, _, State) ->
+    {aevm_chain_api:call_exception(cant_call_contracts_with_dummy_chain, Gas), State}.
 


### PR DESCRIPTION
This PR makes sure not all gas is used when calling a recursive function with limited gas. It also keeps the return value of an error from recursive calls.

There are still some things to do:
- [x] Add test of calling a contract with limited gas 
- [x] Test different top level return values.
- [ ] Document gas usage on failure in Protocol