### PR TITLE
PT-161915745 fix serialize exploits

### DIFF
--- a/apps/aesophia/src/aeso_data.erl
+++ b/apps/aesophia/src/aeso_data.erl
@@ -7,6 +7,7 @@
         , binary_to_heap/4
         , heap_to_heap/3
         , heap_to_binary/3
+        , heap_to_binary/4
         , binary_to_binary/2
         , heap_value/3
         , heap_value/4
@@ -116,7 +117,7 @@ heap_value_heap({_, Heap}) -> Heap#heap.heap.
 %% Takes a binary encoded with to_binary/1 and returns a heap fragment starting at Offs.
 binary_to_heap(Type, <<Ptr:32/unit:8, Heap/binary>>, NextId, Offs) ->
     try
-        {Addr, {Maps, _, Mem}} = convert(binary, heap, no_store(), #{}, Type, Ptr,
+        {Addr, {Maps, _, Mem}} = convert(binary, heap, infinity, no_store(), #{}, Type, Ptr,
                                          heap_fragment(no_maps(NextId), 32, Heap), Offs),
         {ok, heap_value(Maps, Addr, list_to_binary(Mem), Offs)}
     catch _:Err ->
@@ -130,13 +131,21 @@ binary_to_heap(_Type, <<>>, _NextId, _Offs) ->
 
 -spec heap_to_binary(Type :: ?Type(), Store :: store(), Heap :: heap_value()) ->
         {ok, binary_value()} | {error, term()}.
-heap_to_binary(Type, Store, {Ptr, Heap}) ->
+heap_to_binary(Type, Store, HeapVal) ->
+    heap_to_binary(Type, Store, HeapVal, infinity).
+
+-spec heap_to_binary(Type :: ?Type(), Store :: store(), Heap :: heap_value(), infinity | non_neg_integer()) ->
+        {ok, binary_value()} | {error, term()}.
+heap_to_binary(Type, Store, {Ptr, Heap}, MaxSize) ->
     try
-        {Addr, {_, _, Memory}} = convert(heap, binary, Store, #{}, Type, Ptr, Heap, 32),
+        {Addr, {_, _, Memory}} = convert(heap, binary, MaxSize, Store, #{}, Type, Ptr, Heap, 32),
         {ok, <<Addr:256, (list_to_binary(Memory))/binary>>}
-    catch _:Err ->
-        io:format("** Error: heap_to_binary failed with ~p\n  ~p\n", [Err, erlang:get_stacktrace()]),
-        {error, Err}
+    catch
+        throw:max_size_exceeded ->
+            {error, out_of_gas};
+        _:Err ->
+            io:format("** Error: heap_to_binary failed with ~p\n  ~p\n", [Err, erlang:get_stacktrace()]),
+            {error, Err}
     end.
 
 %% -- Binary to binary -------------------------------------------------------
@@ -145,7 +154,7 @@ heap_to_binary(Type, Store, {Ptr, Heap}) ->
         {ok, binary_value()} | {error, term()}.
 binary_to_binary(Type, <<Ptr:32/unit:8, Heap/binary>>) ->
     try
-        {Addr, {_, _, Memory}} = convert(binary, binary, no_store(), #{}, Type, Ptr,
+        {Addr, {_, _, Memory}} = convert(binary, binary, infinity, no_store(), #{}, Type, Ptr,
                                          heap_fragment(no_maps(0), 32, Heap), 32),
         {ok, <<Addr:256, (list_to_binary(Memory))/binary>>}
     catch _:Err ->
@@ -160,7 +169,7 @@ binary_to_binary(Type, <<Ptr:32/unit:8, Heap/binary>>) ->
         {ok, heap_value()} | {error, term()}.
 heap_to_heap(Type, {Ptr, Heap}, Offs) ->
     try
-        {Addr, {Maps, _, Mem}} = convert(heap, heap, no_store(), #{}, Type, Ptr, Heap, Offs),
+        {Addr, {Maps, _, Mem}} = convert(heap, heap, infinity, no_store(), #{}, Type, Ptr, Heap, Offs),
         {ok, heap_value(Maps, Addr, list_to_binary(Mem), Offs)}
     catch _:Err ->
         io:format("** Error: heap_to_heap failed with ~p\n  ~p\n", [Err, erlang:get_stacktrace()]),
@@ -172,23 +181,24 @@ heap_to_heap(Type, {Ptr, Heap}, Offs) ->
 -type visited() :: #{pointer() => true}.
 -type format() :: heap | binary.
 
--spec convert(Input :: format(), Output :: format(),
+-spec convert(Input :: format(), Output :: format(), MaxSize :: non_neg_integer(),
               Store :: store(), visited(), ?Type(), pointer(),
               heap_fragment(), offset()) -> {pointer(), {#maps{}, offset(), [iodata()]}}.
-convert(_, _, _, _, word, Val, Heap, _) ->
+convert(_, _, _, _, _, word, Val, Heap, _) ->
     {Val, {no_maps(Heap), 0, []}};
-convert(_, _, _, _Visited, string, Val, Heap, BaseAddr) ->
+convert(_, _, MaxSize, _, _Visited, string, Val, Heap, BaseAddr) ->
     Size  = get_word(Heap, Val),
     Words = 1 + (Size + 31) div 32, %% 1 + ceil(Size / 32)
     Bytes = Words * 32,
+    check_size(MaxSize, Bytes),
     {BaseAddr, {no_maps(Heap), Bytes, [get_chunk(Heap, Val, Bytes)]}};
-convert(Input, Output, Store, Visited, {list, T}, Val, Heap, BaseAddr) ->
+convert(Input, Output, MaxSize, Store, Visited, {list, T}, Val, Heap, BaseAddr) ->
     <<Nil:256>> = <<(-1):256>>,   %% empty list is -1
     case Val of
         Nil -> {Nil, {no_maps(Heap), 0, []}};
-        _   -> convert(Input, Output, Store, Visited, {tuple, [T, {list, T}]}, Val, Heap, BaseAddr)
+        _   -> convert(Input, Output, MaxSize, Store, Visited, {tuple, [T, {list, T}]}, Val, Heap, BaseAddr)
     end;
-convert(Input, binary, Store, _Visited, {map, KeyT, ValT}, MapId, Heap, BaseAddr) ->
+convert(Input, binary, MaxSize, Store, _Visited, {map, KeyT, ValT}, MapId, Heap, BaseAddr) ->
     {_NoMaps, Map0} = convert_map(Input, binary, Store, KeyT, ValT, MapId, Heap),
     %% Will be a no-op if Input == binary
     Map  = aevm_eeevm_maps:flatten_map(Store, MapId, Map0),
@@ -202,10 +212,13 @@ convert(Input, binary, Store, _Visited, {map, KeyT, ValT}, MapId, Heap, BaseAddr
                         {[[<<KeySize:256>>, Key, <<ValSize:256>>, Val] | Mem],
                          Base1}
                     end, {[], BaseAddr + 32}, KVs),
+    %% Checking after the fact, but the resulting binary is made up of binaries
+    %% already existing in the state so it can't be arbitrarily big.
+    check_size(MaxSize, FinalBase - BaseAddr),
     Mem  = lists:reverse(RMem),
     %% Target is binary so no maps required
     {BaseAddr, {no_maps(Heap), FinalBase - BaseAddr, [<<Size:256>>, Mem]}};
-convert(Input, heap, Store, _Visited, {map, KeyT, ValT}, Ptr, Heap, _BaseAddr) ->
+convert(Input, heap, _MaxSize, Store, _Visited, {map, KeyT, ValT}, Ptr, Heap, _BaseAddr) ->
     {InnerMaps, PMap} = convert_map(Input, heap, Store, KeyT, ValT, Ptr, Heap),
     case PMap#pmap.data of
         stored -> %% Keep the id of stored maps (only possible if Input == heap)
@@ -221,19 +234,21 @@ convert(Input, heap, Store, _Visited, {map, KeyT, ValT}, Ptr, Heap, _BaseAddr) -
                     {Id, {Maps, 0, []}}
             end
     end;
-convert(_, _, _, _, {tuple, []}, _Ptr, Heap, _BaseAddr) ->
+convert(_, _, _, _, _, {tuple, []}, _Ptr, Heap, _BaseAddr) ->
     {0, {no_maps(Heap), 0, []}}; %% Use 0 for the empty tuple (need a unique value).
-convert(Input, Output, Store, Visited, {tuple, Ts}, Ptr, Heap, BaseAddr) ->
+convert(Input, Output, MaxSize, Store, Visited, {tuple, Ts}, Ptr, Heap, BaseAddr) ->
     Visited1  = visit(Visited, Ptr),
-    BaseAddr1 = BaseAddr + 32 * length(Ts),  %% store component data after the tuple cell
+    TupleCellSize = 32 * length(Ts),
+    BaseAddr1 = BaseAddr + TupleCellSize,  %% store component data after the tuple cell
     Ptrs      = [ P || <<P:256>> <= get_chunk(Heap, Ptr, 32 * length(Ts)) ],
-    {BaseAddr2, Maps, NewPtrs, Memory} = convert_components(Input, Output, Store, Visited1, Ts, Ptrs, Heap, BaseAddr1),
+    {BaseAddr2, Maps, NewPtrs, Memory} = convert_components(Input, Output, subtract_size(MaxSize, TupleCellSize), Store, Visited1, Ts, Ptrs, Heap, BaseAddr1),
+    check_size(MaxSize, BaseAddr2 - BaseAddr),
     {BaseAddr, {Maps, BaseAddr2 - BaseAddr, [NewPtrs, Memory]}};
-convert(Input, Output, Store, Visited, {variant, Cs}, Ptr, Heap, BaseAddr) ->
+convert(Input, Output, MaxSize, Store, Visited, {variant, Cs}, Ptr, Heap, BaseAddr) ->
     Tag = get_word(Heap, Ptr),
     Ts  = lists:nth(Tag + 1, Cs),
-    convert(Input, Output, Store, Visited, {tuple, [word | Ts]}, Ptr, Heap, BaseAddr);
-convert(Input, Output, Store, Visited, typerep, Ptr, Heap, BaseAddr) ->
+    convert(Input, Output, MaxSize, Store, Visited, {tuple, [word | Ts]}, Ptr, Heap, BaseAddr);
+convert(Input, Output, MaxSize, Store, Visited, typerep, Ptr, Heap, BaseAddr) ->
     Typerep = {variant, [[],                         %% word
                          [],                         %% string
                          [typerep],                  %% list
@@ -242,19 +257,27 @@ convert(Input, Output, Store, Visited, typerep, Ptr, Heap, BaseAddr) ->
                          [],                         %% typerep
                          [typerep, typerep]          %% map
                         ]},
-    convert(Input, Output, Store, Visited, Typerep, Ptr, Heap, BaseAddr).
+    convert(Input, Output, MaxSize, Store, Visited, Typerep, Ptr, Heap, BaseAddr).
 
-convert_components(Input, Output, Store, Visited, Ts, Ps, Heap, BaseAddr) ->
-    convert_components(Input, Output, Store, Visited, Ts, Ps, Heap, BaseAddr, [], [], no_maps(Heap)).
+convert_components(Input, Output, MaxSize, Store, Visited, Ts, Ps, Heap, BaseAddr) ->
+    convert_components(Input, Output, MaxSize, Store, Visited, Ts, Ps, Heap, BaseAddr, [], [], no_maps(Heap)).
 
-convert_components(_, _, _, _Visited, [], [], _Heap, BaseAddr, PtrAcc, MemAcc, Maps) ->
+convert_components(_, _, _, _, _Visited, [], [], _Heap, BaseAddr, PtrAcc, MemAcc, Maps) ->
     {BaseAddr, Maps, lists:reverse(PtrAcc), lists:reverse(MemAcc)};
-convert_components(Input, Output, Store, Visited, [T | Ts], [Ptr | Ptrs], Heap, BaseAddr, PtrAcc, MemAcc, Maps) ->
+convert_components(Input, Output, MaxSize, Store, Visited, [T | Ts], [Ptr | Ptrs], Heap, BaseAddr, PtrAcc, MemAcc, Maps) ->
     %% (Ab)use the next_id field in the input heap for suitable next_id of the output heap.
     Heap1 = set_next_id(Heap, Maps#maps.next_id),
-    {NewPtr, {Maps1, Size, Mem}} = convert(Input, Output, Store, Visited, T, Ptr, Heap1, BaseAddr),
-    convert_components(Input, Output, Store, Visited, Ts, Ptrs, Heap, BaseAddr + Size,
+    {NewPtr, {Maps1, Size, Mem}} = convert(Input, Output, MaxSize, Store, Visited, T, Ptr, Heap1, BaseAddr),
+    convert_components(Input, Output, subtract_size(MaxSize, Size), Store, Visited, Ts, Ptrs, Heap, BaseAddr + Size,
                          [<<NewPtr:256>> | PtrAcc], [Mem | MemAcc], merge_maps(Maps, Maps1)).
+
+subtract_size(infinity, _)   -> infinity;
+subtract_size(MaxSize, Size) ->
+    check_size(MaxSize, Size),
+    MaxSize - Size.
+
+check_size(MaxSize, Size) when Size > MaxSize -> throw(max_size_exceeded);
+check_size(_, _) -> ok.
 
 get_map(heap, _KeyT, _ValT, MapId, Heap) ->
     #{ MapId := Map } = Heap#heap.maps#maps.maps,
@@ -287,7 +310,7 @@ convert_map_value(_Input, _Output, _Store, _ValT, tombstone, Heap) ->
 convert_map_value(Input, Output, Store, ValT, <<ValPtr:256, ValBin/binary>>, Heap) ->
     ValHeap = heap_fragment(Heap#heap.maps, 32, ValBin),
     Visited = #{},  %% Map values are self contained so start with fresh circularity check
-    {ValPtr1, {Maps, _Size, ValBin1}} = convert(Input, Output, Store, Visited, ValT, ValPtr, ValHeap, 32),
+    {ValPtr1, {Maps, _Size, ValBin1}} = convert(Input, Output, infinity, Store, Visited, ValT, ValPtr, ValHeap, 32),
     {Maps, <<ValPtr1:256, (list_to_binary(ValBin1))/binary>>}.
 
 %% -- Compute used map ids ---------------------------------------------------

--- a/apps/aesophia/test/contracts/exploits.aes
+++ b/apps/aesophia/test/contracts/exploits.aes
@@ -1,0 +1,6 @@
+
+contract Exploits =
+
+  // We'll hack the bytecode of this changing the return type to string.
+  function pair(n : int) = (n, 0)
+

--- a/apps/aevm/src/aevm_ae_primops.erl
+++ b/apps/aevm/src/aevm_ae_primops.erl
@@ -536,32 +536,44 @@ map_call_get(Data, State) ->
     [MapId]   = get_args([word], Data),
     {KeyType, _ValType} = aevm_eeevm_maps:map_type(MapId, State),
     [_, KeyPtr]  = get_args([word, word], Data),
-    {ok, KeyBin} = aevm_eeevm_state:heap_to_binary(KeyType, KeyPtr, State),
-    Res = case aevm_eeevm_maps:get(MapId, KeyBin, State) of
-            false -> aeso_data:to_binary(none);
-            <<ValPtr:256, ValBin/binary>> ->
-                %% Some hacky juggling to build an option value.
-                NewPtr = 32 + byte_size(ValBin),
-                <<NewPtr:256, ValBin/binary, 1:256, ValPtr:256>>
-          end,
-    {ok, {ok, Res}, 0, State}.
+    case aevm_eeevm_state:heap_to_binary(KeyType, KeyPtr, State) of
+        {ok, KeyBin, GasUsed} ->
+            Res = case aevm_eeevm_maps:get(MapId, KeyBin, State) of
+                    false -> aeso_data:to_binary(none);
+                    <<ValPtr:256, ValBin/binary>> ->
+                        %% Some hacky juggling to build an option value.
+                        NewPtr = 32 + byte_size(ValBin),
+                        <<NewPtr:256, ValBin/binary, 1:256, ValPtr:256>>
+                  end,
+            {ok, {ok, Res}, GasUsed, State};
+        {error, _} = Err ->
+            {ok, Err, aevm_eeevm_state:gas(State), State}
+    end.
 
 map_call_put(Data, State) ->
     [MapId]             = get_args([word], Data),
     {KeyType, ValType}  = aevm_eeevm_maps:map_type(MapId, State),
     [_, KeyPtr, ValPtr] = get_args([word, word, word], Data),
-    {ok, KeyBin}        = aevm_eeevm_state:heap_to_binary(KeyType, KeyPtr, State),
-    {ok, ValBin}        = aevm_eeevm_state:heap_to_heap(ValType, ValPtr, State),
-    {NewMapId, State1}  = aevm_eeevm_maps:put(MapId, KeyBin, ValBin, State),
-    {ok, {ok, <<NewMapId:256>>}, 0, State1}.
+    case aevm_eeevm_state:heap_to_binary(KeyType, KeyPtr, State) of
+        {ok, KeyBin, GasUsed} ->
+            {ok, ValBin}        = aevm_eeevm_state:heap_to_heap(ValType, ValPtr, State),
+            {NewMapId, State1}  = aevm_eeevm_maps:put(MapId, KeyBin, ValBin, State),
+            {ok, {ok, <<NewMapId:256>>}, GasUsed, State1};
+        {error, _} = Err ->
+            {ok, Err, aevm_eeevm_state:gas(State), State}
+    end.
 
 map_call_delete(Data, State) ->
     [MapId]      = get_args([word], Data),
     {KeyType, _} = aevm_eeevm_maps:map_type(MapId, State),
     [_, KeyPtr]  = get_args([word, word], Data),
-    {ok, KeyBin} = aevm_eeevm_state:heap_to_binary(KeyType, KeyPtr, State),
-    {NewMapId, State1} = aevm_eeevm_maps:delete(MapId, KeyBin, State),
-    {ok, {ok, <<NewMapId:256>>}, 0, State1}.
+    case aevm_eeevm_state:heap_to_binary(KeyType, KeyPtr, State) of
+        {ok, KeyBin, GasUsed} ->
+            {NewMapId, State1} = aevm_eeevm_maps:delete(MapId, KeyBin, State),
+            {ok, {ok, <<NewMapId:256>>}, GasUsed, State1};
+        {error, _} = Err ->
+            {ok, Err, aevm_eeevm_state:gas(State), State}
+    end.
 
 map_call_tolist(Data, State) ->
     [MapId] = get_args([word], Data),

--- a/apps/aevm/src/aevm_eeevm.erl
+++ b/apps/aevm/src/aevm_eeevm.erl
@@ -50,9 +50,14 @@
 %%
 eval(State) ->
     case eval_code(State) of
-        {Res, State1} ->
+        {ok, State1} ->
             %% Turn storage map into binary and save in state tree.
-            {Res, aevm_eeevm_state:save_store(State1)};
+            case aevm_eeevm_state:save_store(State1) of
+                {ok, State2}  -> {ok, State2};
+                {error, What} -> {error, What, State1}
+            end;
+        {revert, State1} ->
+            {revert, State1};
         {error, What, State1} ->
             %% Don't save state on error.
             {error, What, State1}

--- a/apps/aevm/src/aevm_eeevm.erl
+++ b/apps/aevm/src/aevm_eeevm.erl
@@ -1111,8 +1111,7 @@ loop(CP, StateIn) ->
                     %% µ'i ≡ M(µi, µs[0], µs[1]) TODO: This
                     {Us0, State1} = pop(State0),
                     {Us1, State2} = pop(State1),
-                    {State3, MapsMemCost} = aevm_eeevm_state:do_return(Us0, Us1, State2),
-                    spend_gas_common({mem}, MapsMemCost, spend_mem_gas(State, State3));
+                    aevm_eeevm_state:do_return(Us0, Us1, State2);
                 ?DELEGATECALL ->
                     %% 0xf4 DELEGATECALL  δ=6 α=1
                     %% Message-call into this account with an

--- a/apps/aevm/src/aevm_eeevm.erl
+++ b/apps/aevm/src/aevm_eeevm.erl
@@ -1111,7 +1111,8 @@ loop(CP, StateIn) ->
                     %% µ'i ≡ M(µi, µs[0], µs[1]) TODO: This
                     {Us0, State1} = pop(State0),
                     {Us1, State2} = pop(State1),
-                    aevm_eeevm_state:do_return(Us0, Us1, State2);
+                    {State3, GasUsed} = aevm_eeevm_state:do_return(Us0, Us1, State2),
+                    spend_gas_common({mem}, GasUsed, State3);
                 ?DELEGATECALL ->
                     %% 0xf4 DELEGATECALL  δ=6 α=1
                     %% Message-call into this account with an

--- a/docs/release-notes/next/PT-161915745-serialize-exploits.md
+++ b/docs/release-notes/next/PT-161915745-serialize-exploits.md
@@ -1,0 +1,1 @@
+* Charges gas for serialization of Sophia values in the VM. This affects consensus.

--- a/py/tests/integration/setup.yaml
+++ b/py/tests/integration/setup.yaml
@@ -115,7 +115,7 @@ tests: # test specific settings
         deposit: 2
         amount: 1
         gas: 75000
-        gas_used: 178
+        gas_used: 193
         gas_price: 1
         fee: 200000
         function: "init"

--- a/py/tests/integration/test_contracts.py
+++ b/py/tests/integration/test_contracts.py
@@ -31,15 +31,18 @@ def read_id_contract(api):
 def test_compile_and_call_id():
     # Alice should be able to compile a sophia contract with an identity
     # function into bytecode and call it.
+
     test_settings = settings["test_compile_and_call_id"]
     (root_dir, node, external_api, internal_api) = setup_node(test_settings, "alice")
 
-    bytecode = read_id_contract(internal_api)
+    # NOTE: This doesn't work, since the contract state is not available!
 
-    # Call contract bytecode
-    call_input = ContractCallInput("sophia", bytecode, "main", "42")
-    call_result = internal_api.call_contract(call_input)
-    assert_regexp_matches(call_result.out, 'cb_.*')
+    # bytecode = read_id_contract(internal_api)
+
+    # # Call contract bytecode
+    # call_input = ContractCallInput("sophia", bytecode, "main", "42")
+    # call_result = internal_api.call_contract(call_input)
+    # assert_regexp_matches(call_result.out, 'cb_.*')
 
     # stop node
     common.stop_node(node)
@@ -70,14 +73,16 @@ def test_id_call():
     test_settings = settings["test_id_call"]
     (root_dir, node, external_api, internal_api) = setup_node(test_settings, "alice")
 
-    bytecode = read_id_contract(internal_api)
+    # NOTE: This doesn't work, since the contract state is not available!
 
-    call_input = ContractCallInput("sophia", bytecode, "main", "42")
-    result = internal_api.call_contract(call_input)
-    print(result)
+    # bytecode = read_id_contract(internal_api)
 
-    retval = common.hexstring_to_contract_bytearray('0x000000000000000000000000000000000000000000000000000000000000002a')
-    assert_equals(result.out, retval)
+    # call_input = ContractCallInput("sophia", bytecode, "main", "42")
+    # result = internal_api.call_contract(call_input)
+    # print(result)
+
+    # retval = common.hexstring_to_contract_bytearray('0x000000000000000000000000000000000000000000000000000000000000002a')
+    # assert_equals(result.out, retval)
     # stop node
     common.stop_node(node)
     shutil.rmtree(root_dir)

--- a/py/tests/integration/test_unsigned_tx.py
+++ b/py/tests/integration/test_unsigned_tx.py
@@ -117,7 +117,7 @@ def test_contract_call():
                   + create_settings["create_contract"]["amount"])
 
     bytecode = read_id_contract(internal_api)
-    call_input = ContractCallInput("sophia", bytecode,
+    call_input = ContractCallInput("sophia-address", encoded_contract_id,
                                              call_contract["data"]["function"],
                                              call_contract["data"]["argument"])
     result = internal_api.call_contract(call_input)

--- a/test/sophia_bytecode_aevm_SUITE.erl
+++ b/test/sophia_bytecode_aevm_SUITE.erl
@@ -38,7 +38,7 @@ execute_identity_fun_from_sophia_file(_Cfg) ->
         aevm_eeevm:eval(
           aevm_eeevm_state:init(
             #{ exec => #{ code => Code,
-                          store => #{},
+                          store => aevm_eeevm_store:from_sophia_state(aeso_data:to_binary({{tuple, []}, {}})),
                           address => 91210,
                           caller => 0,
                           data => CallData,


### PR DESCRIPTION
In the process of fixing this I also fixed a serious problem where errors saving the store were silently ignored. Now the contract call fails if the store can't be saved. As a consequence the `/debug/contracts/code/call` endpoint no longer works with the `sophia` abi (where you submit the bytecode of the contract to call). The reason is that the contract state isn't available: it's not supplied by the user and you're not calling a contract on the chain. This previously worked (purely accidentally) on functions that didn't look at the state, since the crash trying to write the bogus state was ignored.

Properly fixing this endpoint is out of scope of this ticket, but it's something I expect the apps guys might want to have. Some design work is needed to figure out how to handle state for this though.