### PR TITLE
Pt 162011421 more time for db insertion

### DIFF
--- a/apps/aecore/src/aec_conductor.erl
+++ b/apps/aecore/src/aec_conductor.erl
@@ -133,7 +133,7 @@ is_leader() ->
 post_block(Block) ->
     case aec_validation:validate_block(Block) of
         ok ->
-            gen_server:call(?SERVER, {post_block, Block});
+            gen_server:call(?SERVER, {post_block, Block}, 30000);
         {error, {header, Reason}} ->
             epoch_mining:info("Header failed validation: ~p", [Reason]),
             {error, Reason};
@@ -151,7 +151,7 @@ add_synced_generation_batched(#{} = Generation, AddKeyBlock) when is_boolean(Add
     Generation1 = Generation#{add_keyblock => AddKeyBlock},
     case aec_validation:validate_block(Generation1) of
         ok ->
-            gen_server:call(?SERVER, {add_synced_generation, Generation1});
+            gen_server:call(?SERVER, {add_synced_generation, Generation1}, 30000);
         {error, {header, Reason}} ->
             epoch_mining:info("Header failed validation: ~p", [Reason]),
             {error, Reason};

--- a/config/vm.args
+++ b/config/vm.args
@@ -10,4 +10,4 @@
 # useful to increase parallelism of queries to rocksdb
 #
 # See also https://gitlab.com/barrel-db/barrel/blob/cf81d1c031e0bc746fe64cb7c8882e91bd2970c0/config/vm.args#L20
-+SDio 10
++SDio 64


### PR DESCRIPTION
We may wait a bit longer for the database if we have a large micro-block.

Timing out on this insertion after 5 seconds has shown to be risky. Increase timer to 30 seconds.