### PR TITLE
Support multiple simultaneous Sophia compilation runs

### DIFF
--- a/apps/aesophia/src/aeso_ast_infer_types.erl
+++ b/apps/aesophia/src/aeso_ast_infer_types.erl
@@ -59,6 +59,9 @@
 
 -type field_info() :: #field_info{}.
 
+-define(PRINT_TYPES(Fmt, Args),
+	when_option(pp_types, fun () -> io:format(Fmt, Args) end)).
+
 %% Environment containing language primitives
 -spec global_env() -> [{string(), aeso_syntax:type()}].
 global_env() ->
@@ -173,7 +176,7 @@ infer(Contracts, Options) ->
                     [Alias("oracle", 2), Alias("oracle_query", 2)]
             end,
         create_options(Options),
-        ets_new(type_vars, [set, named_table, public]),
+        ets_new(type_vars, [set]),
         infer1(TypeEnv, Contracts)
     after
         clean_up_ets()
@@ -349,10 +352,8 @@ infer_letrec(Env, {letrec, Attrs, Defs}) ->
             Expect = typesig_to_fun_t(TypeSig),
             unify(Got, Expect, {check_typesig, Name, Got, Expect}),
             solve_field_constraints(),
-            PP = fun () -> io:format("Checked ~s : ~s\n",
-                                     [Name, pp(dereference_deep(Got))])
-                 end,
-            when_option(pp_types, PP),
+	    ?PRINT_TYPES("Checked ~s : ~s\n",
+			 [Name, pp(dereference_deep(Got))]),
             Res
           end || LF <- Defs ],
     destroy_and_report_unsolved_constraints(),
@@ -373,8 +374,7 @@ infer_letfun(Env, {letfun, Attrib, {id, NameAttrib, Name}, Args, What, Body}) ->
      {letfun, Attrib, {id, NameAttrib, Name}, NewArgs, ResultType, NewBody}}.
 
 print_typesig({Name, TypeSig}) ->
-    PP = fun () -> io:format("Inferred ~s : ~s\n", [Name, pp(TypeSig)]) end,
-    when_option(pp_types, PP).
+    ?PRINT_TYPES("Inferred ~s : ~s\n", [Name, pp(TypeSig)]).
 
 arg_type({id, Attrs, "_"}) ->
     fresh_uvar(Attrs);
@@ -737,7 +737,7 @@ ets_tab2list(Name) ->
 %% Options
 
 create_options(Options) ->
-    ets_new(options, [public, named_table, set]),
+    ets_new(options, [set]),
     Tup = fun(Opt) when is_atom(Opt) -> {Opt, true};
              (Opt) when is_tuple(Opt) -> Opt end,
     ets_insert(options, lists:map(Tup, Options)).
@@ -755,9 +755,9 @@ when_option(Opt, Do) ->
 
 create_type_defs(Defs) ->
     %% A map from type names to definitions
-    ets_new(type_defs, [public, named_table, set]),
+    ets_new(type_defs, [set]),
     %% A relation from field names to types
-    ets_new(record_fields, [public, named_table, bag]),
+    ets_new(record_fields, [bag]),
     [ case Def of
         {type_def, _Attrs, Id, Args, Typedef} ->
             insert_typedef(Id, Args, Typedef);
@@ -854,7 +854,7 @@ destroy_and_report_unsolved_constraints() ->
 %% -- Named argument constraints --
 
 create_named_argument_constraints() ->
-    ets_new(named_argument_constraints, [public, named_table, bag]).
+    ets_new(named_argument_constraints, [bag]).
 
 destroy_named_argument_constraints() ->
     ets_delete(named_argument_constraints).
@@ -901,7 +901,7 @@ destroy_and_report_unsolved_named_argument_constraints() ->
 
 create_field_constraints() ->
     %% A relation from uvars to constraints
-    ets_new(field_constraints, [public, named_table, bag]).
+    ets_new(field_constraints, [bag]).
 
 destroy_field_constraints() ->
     ets_delete(field_constraints).
@@ -1249,7 +1249,7 @@ fresh_uvar(Attrs) ->
     {uvar, Attrs, make_ref()}.
 
 create_freshen_tvars() ->
-    ets_new(freshen_tvars, [set, public, named_table]).
+    ets_new(freshen_tvars, [set]).
 
 destroy_freshen_tvars() ->
     ets_delete(freshen_tvars).
@@ -1312,12 +1312,11 @@ type_error(Err) ->
     ets_insert(type_errors, Err).
 
 create_type_errors() ->
-    ets_new(type_errors, [bag, named_table, public]).
+    ets_new(type_errors, [bag]).
 
 destroy_and_report_type_errors() ->
     Errors   = ets_tab2list(type_errors),
     PPErrors = [ pp_error(Err) || Err <- Errors ],
-    [ io:format("~s", [Err]) || Err <- PPErrors ],
     ets_delete(type_errors),
     [ error({type_errors, [lists:flatten(Err) || Err <- PPErrors]})
       || Errors /= [] ].

--- a/apps/aesophia/src/aeso_compiler.erl
+++ b/apps/aesophia/src/aeso_compiler.erl
@@ -63,7 +63,8 @@ from_string(ContractString, Options) ->
     Ast = parse(ContractString, Options),
     ok = pp_sophia_code(Ast, Options),
     ok = pp_ast(Ast, Options),
-    TypedAst = aeso_ast_infer_types:infer(Ast),
+    TypedAst = aeso_ast_infer_types:infer(Ast, Options),
+    %% pp_types is handled inside aeso_ast_infer_types.
     ok = pp_typed_ast(TypedAst, Options),
     ICode = to_icode(TypedAst, Options),
     TypeInfo = extract_type_info(ICode),
@@ -221,7 +222,7 @@ pp_sophia_code(C, Opts)->  pp(C, Opts, pp_sophia_code, fun(Code) ->
                                 io:format("~s\n", [prettypr:format(aeso_pretty:decls(Code))])
                             end).
 pp_ast(C, Opts)      ->  pp(C, Opts, pp_ast, fun aeso_ast:pp/1).
-pp_typed_ast(C, Opts)->  pp(C, Opts, pp_typed, fun aeso_ast:pp_typed/1).
+pp_typed_ast(C, Opts)->  pp(C, Opts, pp_typed_ast, fun aeso_ast:pp_typed/1).
 pp_icode(C, Opts)    ->  pp(C, Opts, pp_icode, fun aeso_icode:pp/1).
 pp_assembler(C, Opts)->  pp(C, Opts, pp_assembler, fun aeb_asm:pp/1).
 pp_bytecode(C, Opts) ->  pp(C, Opts, pp_bytecode, fun aeb_disassemble:pp/1).

--- a/apps/aesophia/test/aeso_test_utils.erl
+++ b/apps/aesophia/test/aeso_test_utils.erl
@@ -70,7 +70,8 @@ dummy_state(Code, Data) ->
      }, #{ trace => true }).
 
 compile(Name) ->
-  aeso_compiler:from_string(read_contract(Name), [pp_sophia_code, pp_typed, pp_icode]).
+  aeso_compiler:from_string(read_contract(Name),
+                            [pp_sophia_code, pp_typed_ast, pp_icode]).
 
 run_contract(Name, Fun, Args, Type) ->
   Code = compile(Name),


### PR DESCRIPTION
Fix the compiler so the state is not kept in named ETS tables. An added feature is that printing types is now no longer the default but controlled by an option `pp_types`.

This refers to [PT-161958728](https://www.pivotaltracker.com/story/show/161958728).
