### PR TITLE
PT-161093573 Add ttl state gas to oracle txs

### DIFF
--- a/apps/aecontract/test/aecontract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_SUITE.erl
@@ -2327,7 +2327,7 @@ sophia_oracles_gas_ttl__measure_gas_used(Sc, Height, Gas) ->
 %% Test that gas charged by oracle primop depends on TTL of state object.
 %% Test approach: run primop with low and high TTLs, then compare consumed gas. This proves that TTL-related gas computation kicks in without relying on absolute minimum value of gas used.
 sophia_oracles_gas_ttl__oracle_registration(_Cfg) ->
-    {Part, Whole} = aec_governance:state_gas_per_block(oracle_registration),
+    {Part, Whole} = aec_governance:state_gas_per_block(oracle_register_tx),
     ?assertMatch(X when X > 0, Whole), %% Hardcoded expectation on governance - for test readability.
     ?assertMatch(X when X > 0, Part), %% Hardcoded expectation on governance - for test readability.
     MM = fun(H, Ttl, Gas) ->
@@ -2369,7 +2369,7 @@ sophia_oracles_gas_ttl__oracle_registration(_Cfg) ->
     ok.
 
 sophia_oracles_gas_ttl__oracle_extension(_Cfg) ->
-    {Part, Whole} = aec_governance:state_gas_per_block(oracle_extension),
+    {Part, Whole} = aec_governance:state_gas_per_block(oracle_extend_tx),
     ?assertMatch(X when X > 0, Whole), %% Hardcoded expectation on governance - for test readability.
     ?assertMatch(X when X > 0, Part), %% Hardcoded expectation on governance - for test readability.
     MM = fun(H, Ttl, Gas) ->
@@ -2401,7 +2401,7 @@ sophia_oracles_gas_ttl__oracle_extension(_Cfg) ->
     ok.
 
 sophia_oracles_gas_ttl__query(_Cfg) ->
-    {Part, Whole} = aec_governance:state_gas_per_block(oracle_query),
+    {Part, Whole} = aec_governance:state_gas_per_block(oracle_query_tx),
     ?assertMatch(X when X > 0, Whole), %% Hardcoded expectation on governance - for test readability.
     ?assertMatch(X when X > 0, Part), %% Hardcoded expectation on governance - for test readability.
     MM = fun(H, Ttl, Gas) ->
@@ -2439,7 +2439,7 @@ sophia_oracles_gas_ttl__query(_Cfg) ->
     ok.
 
 sophia_oracles_gas_ttl__response(_Cfg) ->
-    {Part, Whole} = aec_governance:state_gas_per_block(oracle_response),
+    {Part, Whole} = aec_governance:state_gas_per_block(oracle_response_tx),
     ?assertMatch(X when X > 0, Whole), %% Hardcoded expectation on governance - for test readability.
     ?assertMatch(X when X > 0, Part), %% Hardcoded expectation on governance - for test readability.
     MM = fun(H, Ttl, Gas) ->

--- a/apps/aecore/src/aec_block_micro_candidate.erl
+++ b/apps/aecore/src/aec_block_micro_candidate.erl
@@ -210,7 +210,7 @@ add_txs_to_trees(MaxGas, Trees, Txs, Env) ->
 add_txs_to_trees(_MaxGas, Trees, [], Acc,_Env) ->
     {lists:reverse(Acc), Trees};
 add_txs_to_trees(MaxGas, Trees, [Tx | Txs], Acc, Env) ->
-    TxGas = aetx:gas(aetx_sign:tx(Tx)),
+    TxGas = aetx:gas(aetx_sign:tx(Tx), aetx_env:height(Env)),
     case TxGas =< MaxGas of
         true ->
             case aec_trees:apply_txs_on_state_trees([Tx], Trees, Env) of

--- a/apps/aecore/src/aec_blocks.erl
+++ b/apps/aecore/src/aec_blocks.erl
@@ -236,8 +236,9 @@ difficulty(Block) ->
     aec_pow:target_to_difficulty(target(Block)).
 
 -spec gas(micro_block()) -> non_neg_integer().
-gas(#mic_block{txs = Txs}) ->
-    lists:foldl(fun(Tx, Acc) -> aetx:gas(aetx_sign:tx(Tx)) + Acc end, 0, Txs).
+gas(#mic_block{txs = Txs} = Block) ->
+    Height = aec_headers:height(to_header(Block)),
+    lists:foldl(fun(Tx, Acc) -> aetx:gas(aetx_sign:tx(Tx), Height) + Acc end, 0, Txs).
 
 -spec time_in_msecs(block()) -> non_neg_integer().
 time_in_msecs(Block) ->

--- a/apps/aecore/src/aec_governance.erl
+++ b/apps/aecore/src/aec_governance.erl
@@ -153,10 +153,10 @@ accepted_future_block_time_shift() ->
 %% Expressed as a fraction because otherwise it would become too large
 %% when multiplied by the number of key blocks.
 -spec state_gas_per_block(atom()) -> {Part::pos_integer(), Whole::pos_integer()}.
-state_gas_per_block(oracle_registration) -> {?ORACLE_STATE_GAS_PER_YEAR, ?EXPECTED_BLOCKS_IN_A_YEAR_FLOOR};
-state_gas_per_block(oracle_extension)    -> state_gas_per_block(oracle_registration);
-state_gas_per_block(oracle_query)        -> state_gas_per_block(oracle_registration);
-state_gas_per_block(oracle_response)     -> state_gas_per_block(oracle_registration).
+state_gas_per_block(oracle_register_tx) -> {?ORACLE_STATE_GAS_PER_YEAR, ?EXPECTED_BLOCKS_IN_A_YEAR_FLOOR};
+state_gas_per_block(oracle_extend_tx)   -> state_gas_per_block(oracle_register_tx);
+state_gas_per_block(oracle_query_tx)    -> state_gas_per_block(oracle_register_tx);
+state_gas_per_block(oracle_response_tx) -> state_gas_per_block(oracle_register_tx).
 
 %% As primops are not meant to be called from contract call
 %% transactions, calling a primop costs (apart from the fees for the

--- a/apps/aecore/src/aec_tx_pool.erl
+++ b/apps/aecore/src/aec_tx_pool.erl
@@ -408,7 +408,7 @@ check_candidate(Db, #dbs{gc_db = GCDb} = Dbs,
     Tx1 = aetx_sign:tx(Tx),
     TxTTL = aetx:ttl(Tx1),
     TxGas = aetx:gas(Tx1, Height),
-    case Height < TxTTL andalso ok =:= int_check_nonce(Tx, AccountsTree) of
+    case Height < TxTTL andalso TxGas > 0 andalso ok =:= int_check_nonce(Tx, AccountsTree) of
         true ->
             case Gas - TxGas of
                 RemGas when RemGas >= 0 ->

--- a/apps/aecore/src/aec_tx_pool.erl
+++ b/apps/aecore/src/aec_tx_pool.erl
@@ -407,7 +407,7 @@ check_candidate(Db, #dbs{gc_db = GCDb} = Dbs,
                 AccountsTree, Height, Gas, Acc) ->
     Tx1 = aetx_sign:tx(Tx),
     TxTTL = aetx:ttl(Tx1),
-    TxGas = aetx:gas(Tx1),
+    TxGas = aetx:gas(Tx1, Height),
     case Height < TxTTL andalso ok =:= int_check_nonce(Tx, AccountsTree) of
         true ->
             case Gas - TxGas of
@@ -739,7 +739,8 @@ get_account(AccountKey, {block_hash, BlockHash}) ->
 
 check_minimum_fee(Tx0, _Hash) ->
     Tx = aetx_sign:tx(Tx0),
-    case aetx:fee(Tx) >= aetx:min_fee(Tx) of
+    Height = top_height(),
+    case aetx:fee(Tx) >= aetx:min_fee(Tx, Height) of
         true  -> ok;
         false -> {error, too_low_fee}
     end.

--- a/apps/aecore/test/aec_spend_tx_tests.erl
+++ b/apps/aecore/test/aec_spend_tx_tests.erl
@@ -148,7 +148,7 @@ process_test_() ->
                                                   nonce => 11,
                                                   payload => <<"foo bar">>}),
 
-              ?assert(aetx:gas(SpendTx1) < aetx:gas(SpendTx2))
+              ?assert(aetx:gas(SpendTx1, 1) < aetx:gas(SpendTx2, 1))
        end}].
 
 spend_tx(Data) ->

--- a/apps/aecore/test/aec_tx_pool_tests.erl
+++ b/apps/aecore/test/aec_tx_pool_tests.erl
@@ -88,10 +88,11 @@ tx_pool_test_() ->
                STxs = [ a_signed_tx(PubKey, me, Nonce, 20000, 10) || Nonce <- lists:seq(1,400) ],
                [ aec_tx_pool:push(STx, tx_created) || STx <- STxs ],
 
+               GenesisHeight = aec_block_genesis:height(),
                {ok, Hash} = aec_headers:hash_header(aec_block_genesis:genesis_header()),
                {ok, STxs2} = aec_tx_pool:get_candidate(aec_governance:block_gas_limit(), Hash),
-               TotalGas = lists:sum([ aetx:gas(aetx_sign:tx(T)) || T <- STxs2 ]),
-               MinGas = aetx:gas(aetx_sign:tx(hd(STxs))),
+               TotalGas = lists:sum([ aetx:gas(aetx_sign:tx(T), GenesisHeight) || T <- STxs2 ]),
+               MinGas = aetx:gas(aetx_sign:tx(hd(STxs)), GenesisHeight),
 
                %% No single tx would have fitted on top of this
                ?assert(MinGas > aec_governance:block_gas_limit() - TotalGas)
@@ -310,9 +311,9 @@ tx_pool_test_() ->
                STx2 = signed_ct_create_tx(PK2,    1, 800000,  1000),
                STx3 = signed_ct_call_tx(  PK3,    1, 800000,  1000),
 
-               GasTx1 = aetx:gas(aetx_sign:tx(STx1)),
-               GasTx2 = aetx:gas(aetx_sign:tx(STx2)),
-               GasTx3 = aetx:gas(aetx_sign:tx(STx3)),
+               GasTx1 = aetx:gas(aetx_sign:tx(STx1), 0),
+               GasTx2 = aetx:gas(aetx_sign:tx(STx2), 0),
+               GasTx3 = aetx:gas(aetx_sign:tx(STx3), 0),
 
                ?assert(GasTx2 > GasTx1),
                ?assert(GasTx3 > GasTx1),

--- a/apps/aeoracle/src/aeo_extend_tx.erl
+++ b/apps/aeoracle/src/aeo_extend_tx.erl
@@ -107,13 +107,7 @@ check(#oracle_extend_tx{nonce = Nonce, oracle_ttl = OTTL, fee = Fee} = Tx,
     Checks =
         [fun() -> check_oracle_extension_ttl(OTTL) end,
          fun() -> aetx_utils:check_account(OraclePK, Trees, Nonce, Fee) end,
-         fun() -> ensure_oracle(OraclePK, Trees) end
-         | case aetx_env:context(Env) of
-               %% Contract is paying tx fee as gas.
-               aetx_contract -> [];
-               aetx_transaction ->
-                   [fun() -> aeo_utils:check_ttl_fee(Height, OTTL, Fee) end] %% TODO Deduct portion of fee already accounted for by `aetx:check` before checking state TTL portion of fee.
-           end],
+         fun() -> ensure_oracle(OraclePK, Trees) end],
 
     case aeu_validation:run(Checks) of
         ok              -> {ok, Trees};

--- a/apps/aeoracle/src/aeo_query_tx.erl
+++ b/apps/aeoracle/src/aeo_query_tx.erl
@@ -154,14 +154,7 @@ check(#oracle_query_tx{nonce = Nonce, query_fee = QFee, query_ttl = QTTL,
     Checks =
         [fun() -> aetx_utils:check_account(SenderPubKey, Trees, Nonce, Fee + QFee) end,
          fun() -> check_oracle(OraclePubKey, Trees, Height, QTx) end,
-         fun() -> check_query_not_present(QTx, Trees, Height) end
-         | case aetx_env:context(Env) of
-               %% Contract is paying tx fee as gas.
-               aetx_contract -> [];
-               aetx_transaction ->
-                   [fun() -> aeo_utils:check_ttl_fee(Height, QTTL, Fee) end] %% TODO Deduct portion of fee already accounted for by `aetx:check` before checking state TTL portion of fee.
-           end
-        ],
+         fun() -> check_query_not_present(QTx, Trees, Height) end],
 
     case aeu_validation:run(Checks) of
         ok              -> {ok, Trees};

--- a/apps/aeoracle/src/aeo_register_tx.erl
+++ b/apps/aeoracle/src/aeo_register_tx.erl
@@ -140,13 +140,7 @@ check(#oracle_register_tx{nonce = Nonce, oracle_ttl = OTTL, fee = Fee,
     Checks =
         [fun() -> aetx_utils:check_account(AccountPubKey, Trees, Nonce, Fee) end,
          fun() -> ensure_not_oracle(AccountPubKey, Trees) end,
-         fun() -> aeo_utils:check_vm_version(VMVersion) end
-         | case aetx_env:context(Env) of
-               %% Contract is paying tx fee as gas.
-               aetx_contract -> [];
-               aetx_transaction ->
-                   [fun() -> aeo_utils:check_ttl_fee(Height, OTTL, Fee) end] %% TODO Deduct portion of fee already accounted for by `aetx:check` before checking state TTL portion of fee.
-           end],
+         fun() -> aeo_utils:check_vm_version(VMVersion) end],
 
     case aeu_validation:run(Checks) of
         ok              -> {ok, Trees};

--- a/apps/aeoracle/src/aeo_response_tx.erl
+++ b/apps/aeoracle/src/aeo_response_tx.erl
@@ -133,7 +133,7 @@ check(#oracle_response_tx{nonce = Nonce, query_id = QueryId,
                      %% Contract is paying tx fee as gas.
                      aetx_contract -> [];
                      aetx_transaction ->
-                         [fun() -> aetx_utils:check_account(OraclePubKey, Trees, Nonce, Fee) end, %% Sender must be able to pay transaction fee before receiving query fee.
+                         [fun() -> aetx_utils:check_account(OraclePubKey, Trees, Nonce, Fee) end] %% Sender must be able to pay transaction fee before receiving query fee.
                  end],
 
             case aeu_validation:run(Checks) of
@@ -160,7 +160,7 @@ process(#oracle_response_tx{nonce = Nonce, query_id = QueryId,
     Query1 = aeo_query:add_response(Height, Response, Query0),
     OraclesTree1 = aeo_state_tree:enter_query(Query1, OraclesTree0),
 
-    OracleAccountd = aec_accounts_trees:get(OraclePubKey, AccountsTree0),
+    OracleAccount0 = aec_accounts_trees:get(OraclePubKey, AccountsTree0),
     {ok, OracleAccount1} = aec_accounts:spend(OracleAccount0, Fee, Nonce),
     QueryFee = aeo_query:fee(Query0),
     {ok, OracleAccount2} = aec_accounts:earn(OracleAccount1, QueryFee),

--- a/apps/aeoracle/src/aeo_response_tx.erl
+++ b/apps/aeoracle/src/aeo_response_tx.erl
@@ -134,8 +134,8 @@ check(#oracle_response_tx{nonce = Nonce, query_id = QueryId,
                      aetx_contract -> [];
                      aetx_transaction ->
                          [fun() -> aetx_utils:check_account(OraclePubKey, Trees, Nonce, Fee) end, %% Sender must be able to pay transaction fee before receiving query fee.
-                          fun() -> aeo_utils:check_ttl_fee(Height, ResponseTTL, Fee) end] %% TODO Deduct portion of fee already accounted for by `aetx:check` before checking state TTL portion of fee.
                  end],
+
             case aeu_validation:run(Checks) of
                 ok              -> {ok, Trees};
                 {error, Reason} -> {error, Reason}
@@ -160,7 +160,7 @@ process(#oracle_response_tx{nonce = Nonce, query_id = QueryId,
     Query1 = aeo_query:add_response(Height, Response, Query0),
     OraclesTree1 = aeo_state_tree:enter_query(Query1, OraclesTree0),
 
-    OracleAccount0 = aec_accounts_trees:get(OraclePubKey, AccountsTree0),
+    OracleAccountd = aec_accounts_trees:get(OraclePubKey, AccountsTree0),
     {ok, OracleAccount1} = aec_accounts:spend(OracleAccount0, Fee, Nonce),
     QueryFee = aeo_query:fee(Query0),
     {ok, OracleAccount2} = aec_accounts:earn(OracleAccount1, QueryFee),

--- a/apps/aeoracle/src/aeo_utils.erl
+++ b/apps/aeoracle/src/aeo_utils.erl
@@ -8,50 +8,28 @@
 -module(aeo_utils).
 
 -export([check_format/3,
-         check_ttl_fee/3,
          check_vm_version/1,
          ttl_delta/2,
-         ttl_expiry/2,
-         ttl_fee/2]).
+         ttl_expiry/2
+        ]).
 
 -include_lib("apps/aecontract/src/aecontract.hrl").
 
--define(ORACLE_TTL_FEE, {1, 1000}). %% One part over a thousand.
+-spec ttl_delta(aec_blocks:height(), aeo_oracles:ttl()) ->
+    non_neg_integer() | {error, too_low_height}.
+ttl_delta(_CurrHeight, {delta, D}) -> D;
+ttl_delta(CurrHeight, {block, H}) when H > CurrHeight -> H - CurrHeight;
+ttl_delta(_CurrHeight, {block, _H}) -> {error, too_low_height}.
 
-%% TODO: This should also include size of the thing that has a TTL
--spec check_ttl_fee(aec_blocks:height(), aeo_oracles:ttl(), non_neg_integer()) ->
-                        ok | {error, too_low_fee} | {error, too_low_height}.
-check_ttl_fee(Height, TTL, Fee) ->
-    try
-        NBlocks = ttl_delta(Height, TTL),
-        case ttl_fee(0, NBlocks) =< Fee of
-            true  -> ok;
-            false -> {error, too_low_fee}
-        end
-    catch error:{too_low_height, _, _} ->
-        {error, too_low_height}
-    end.
-
--spec ttl_delta(aec_blocks:height(), aeo_oracles:ttl()) -> non_neg_integer().
-ttl_delta(CurrHeight, TTL) ->
-    case TTL of
-        {delta, D} -> D;
-        {block, H} when H > CurrHeight -> H - CurrHeight;
-        {block, H} -> error({too_low_height, H, CurrHeight})
-    end.
-
--spec ttl_expiry(aec_blocks:height(), aeo_oracles:ttl()) -> aec_blocks:height().
+-spec ttl_expiry(aec_blocks:height(), aeo_oracles:ttl()) ->
+    aec_blocks:height() | {error, too_low_height}.
 ttl_expiry(CurrentHeight, TTL) ->
-    CurrentHeight + ttl_delta(CurrentHeight, TTL).
-
--spec ttl_fee(non_neg_integer(), non_neg_integer()) -> non_neg_integer().
-ttl_fee(_Size, NBlocks) when is_integer(NBlocks), NBlocks >= 0 ->
-    {Part, Whole} = ?ORACLE_TTL_FEE,
-    TmpNBlocks = Part * NBlocks,
-    (TmpNBlocks div Whole) + (case (TmpNBlocks rem Whole) of
-                                  0                           -> 0;
-                                  X when is_integer(X), X > 0 -> 1
-                              end).
+    case ttl_delta(CurrentHeight, TTL) of
+        TTLDelta when is_integer(TTLDelta) ->
+            CurrentHeight + TTLDelta;
+        {error, _Rsn} = Err ->
+            Err
+    end.
 
 check_vm_version(?AEVM_NO_VM) -> ok;
 check_vm_version(?AEVM_01_Sophia_01) -> ok;

--- a/apps/aeoracle/test/aeoracle_SUITE.erl
+++ b/apps/aeoracle/test/aeoracle_SUITE.erl
@@ -498,7 +498,7 @@ query_response_fee_depends_on_response_size(Cfg) ->
 
     %% Deduce minimal fee for response tx with SmallResponse
     RTx0        = aeo_test_utils:response_tx(OracleKey, ID, SmallResponse, #{}, S1),
-    MinimalFee  = aetx:min_fee(RTx0),
+    MinimalFee  = aetx:min_fee(RTx0, ?ORACLE_RSP_HEIGHT),
 
     %% Test oracle response tx with SmallResponse is accepted with MinimalFee
     RTx1        = aeo_test_utils:response_tx(OracleKey, ID, SmallResponse, #{fee => MinimalFee}, S1),
@@ -507,13 +507,13 @@ query_response_fee_depends_on_response_size(Cfg) ->
 
     %% Test oracle response tx with BiggerResponse is not accepted with MinimalFee
     RTx2        = aeo_test_utils:response_tx(OracleKey, ID, BiggerResponse, #{fee => MinimalFee}, S1),
-    MinimalFee2 = aetx:min_fee(RTx2),
+    MinimalFee2 = aetx:min_fee(RTx2, ?ORACLE_RSP_HEIGHT),
     true        = MinimalFee2 > MinimalFee1,
     {error, too_low_fee} = aetx:check(RTx2, Trees, Env),
 
     %% Test oracle response tx with BiggerResponse is accepted with MinimalFee2
     RTx3        = aeo_test_utils:response_tx(OracleKey, ID, BiggerResponse, #{fee => MinimalFee2}, S1),
-    MinimalFee3 = aetx:min_fee(RTx3),
+    MinimalFee3 = aetx:min_fee(RTx3, ?ORACLE_RSP_HEIGHT),
     MinimalFee3 = MinimalFee2,
     {ok, Trees} = aetx:check(RTx3, Trees, Env),
     ok.

--- a/apps/aeoracle/test/aeoracle_SUITE.erl
+++ b/apps/aeoracle/test/aeoracle_SUITE.erl
@@ -133,15 +133,17 @@ register_oracle_negative_dynamic_fee(_Cfg) ->
 
     %% Test minimum fee for increasing TTL.
     ?assertEqual({error, too_low_fee}, F(#{oracle_ttl => {delta, 0}, fee => 0})),
-    ?assertMatch({ok, _}             , F(#{oracle_ttl => {delta, 0}, fee => 20000})),
+    ?assertMatch({ok, _}             , F(#{oracle_ttl => {delta, 0}, fee => 17000})),
     ?assertEqual({error, too_low_fee}, F(#{oracle_ttl => {delta, 1}, fee => 1})),
-    ?assertMatch({ok, _}             , F(#{oracle_ttl => {delta, 1}, fee => 20000})),
-    ?assertMatch({ok, _}             , F(#{oracle_ttl => {delta, 999}, fee => 20000})),
-    ?assertMatch({ok, _}             , F(#{oracle_ttl => {delta, 1000}, fee => 20000})),
-    ?assertEqual({error, too_low_fee}, F(#{oracle_ttl => {delta, 1001}, fee => 1})),
-    ?assertMatch({ok, _}             , F(#{oracle_ttl => {delta, 1001}, fee => 40000})),
+    ?assertMatch({ok, _}             , F(#{oracle_ttl => {delta, 1}, fee => 17000})),
+    ?assertMatch({error, too_low_fee}, F(#{oracle_ttl => {delta, 1000}, fee => 16500})),
+    ?assertMatch({ok, _}             , F(#{oracle_ttl => {delta, 1000}, fee => 17000})),
+    ?assertMatch({error, too_low_fee}, F(#{oracle_ttl => {delta, 4000}, fee => 17000})),
+    ?assertMatch({ok, _}             , F(#{oracle_ttl => {delta, 4000}, fee => 17500})),
+    ?assertEqual({error, too_low_fee}, F(#{oracle_ttl => {delta, 9000}, fee => 17500})),
+    ?assertMatch({ok, _}             , F(#{oracle_ttl => {delta, 9000}, fee => 19000})),
     %% Test more than minimum fee considering TTL.
-    ?assertMatch({ok, _}             , F(#{oracle_ttl => {delta, 1001}, fee => 45000})),
+    ?assertMatch({ok, _}             , F(#{oracle_ttl => {delta, 9000}, fee => 40000})),
     ok.
 
 register_oracle(Cfg) ->
@@ -218,15 +220,17 @@ extend_oracle_negative_dynamic_fee(Cfg) ->
         end,
     %% Test minimum fee for increasing TTL.
     ?assertEqual({error, too_low_fee}, F(#{oracle_ttl => {delta, 0}, fee => 0})),
-    ?assertEqual({error, zero_relative_oracle_extension_ttl}, F(#{oracle_ttl => {delta, 0}, fee => 20000})),
+    ?assertEqual({error, zero_relative_oracle_extension_ttl}, F(#{oracle_ttl => {delta, 0}, fee => 16000})),
     ?assertEqual({error, too_low_fee}, F(#{oracle_ttl => {delta, 1}, fee => 1})),
-    ?assertMatch({ok, _}             , F(#{oracle_ttl => {delta, 1}, fee => 20000})),
-    ?assertMatch({ok, _}             , F(#{oracle_ttl => {delta, 999}, fee => 20000})),
-    ?assertMatch({ok, _}             , F(#{oracle_ttl => {delta, 1000}, fee => 20000})),
-    ?assertEqual({error, too_low_fee}, F(#{oracle_ttl => {delta, 1001}, fee => 1})),
-    ?assertMatch({ok, _}             , F(#{oracle_ttl => {delta, 1001}, fee => 20000})),
+    ?assertMatch({ok, _}             , F(#{oracle_ttl => {delta, 1}, fee => 16000})),
+    ?assertMatch({error, too_low_fee}, F(#{oracle_ttl => {delta, 1000}, fee => 16000})),
+    ?assertMatch({ok, _}             , F(#{oracle_ttl => {delta, 1000}, fee => 16500})),
+    ?assertMatch({error, too_low_fee}, F(#{oracle_ttl => {delta, 4000}, fee => 16500})),
+    ?assertMatch({ok, _}             , F(#{oracle_ttl => {delta, 4000}, fee => 17000})),
+    ?assertEqual({error, too_low_fee}, F(#{oracle_ttl => {delta, 9000}, fee => 17000})),
+    ?assertMatch({ok, _}             , F(#{oracle_ttl => {delta, 9000}, fee => 20000})),
     %% Test more than minimum fee considering TTL.
-    ?assertMatch({ok, _}             , F(#{oracle_ttl => {delta, 1001}, fee => 20000})),
+    ?assertMatch({ok, _}             , F(#{oracle_ttl => {delta, 9000}, fee => 40000})),
     ok.
 
 extend_oracle(Cfg) ->
@@ -323,15 +327,15 @@ query_oracle_negative_dynamic_fee(Cfg) ->
 
     %% Test minimum fee for increasing TTL.
     ?assertEqual({error, too_low_fee}, F(#{query_ttl => {delta, 0}, fee => 0})),
-    ?assertMatch({ok, _}             , F(#{query_ttl => {delta, 0}, fee => 20000})),
+    ?assertMatch({ok, _}             , F(#{query_ttl => {delta, 0}, fee => 17000})),
     ?assertEqual({error, too_low_fee}, F(#{query_ttl => {delta, 1}, fee => 1})),
-    ?assertMatch({ok, _}             , F(#{query_ttl => {delta, 1}, fee => 20000})),
-    ?assertMatch({ok, _}             , F(#{query_ttl => {delta, 999}, fee => 20000})),
-    ?assertMatch({ok, _}             , F(#{query_ttl => {delta, 1000}, fee => 20000})),
-    ?assertEqual({error, too_low_fee}, F(#{query_ttl => {delta, 1001}, fee => 1})),
-    ?assertMatch({ok, _}             , F(#{query_ttl => {delta, 1001}, fee => 20000})),
+    ?assertMatch({ok, _}             , F(#{query_ttl => {delta, 1}, fee => 17000})),
+    ?assertMatch({error, too_low_fee}, F(#{query_ttl => {delta, 1000}, fee => 17000})),
+    ?assertMatch({ok, _}             , F(#{query_ttl => {delta, 1000}, fee => 17150})),
+    ?assertEqual({error, too_low_fee}, F(#{query_ttl => {delta, 1500}, fee => 17150})),
+    ?assertMatch({ok, _}             , F(#{query_ttl => {delta, 1500}, fee => 17200})),
     %% Test more than minimum fee considering TTL.
-    ?assertMatch({ok, _}             , F(#{query_ttl => {delta, 1001}, fee => 20000})),
+    ?assertMatch({ok, _}             , F(#{query_ttl => {delta, 1500}, fee => 40000})),
     ok.
 
 query_oracle_type_check(_Cfg) ->
@@ -444,15 +448,14 @@ query_response_negative_dynamic_fee(Cfg) ->
 
     %% Test minimum fee for increasing TTL.
     ?assertException(error, {illegal,response_ttl,{delta,0}}, F({delta, 0}, 0)),
-    ?assertException(error, {illegal,response_ttl,{delta,0}}, F({delta, 0}, 20000)),
+    ?assertException(error, {illegal,response_ttl,{delta,0}}, F({delta, 0}, 16850)),
     ?assertEqual({error, too_low_fee}, F({delta, 1},    1)),
-    ?assertMatch({ok, _}             , F({delta, 1},    20000)),
-    ?assertMatch({ok, _}             , F({delta, 999},  20000)),
-    ?assertMatch({ok, _}             , F({delta, 1000}, 20000)),
-    ?assertEqual({error, too_low_fee}, F({delta, 1001}, 1)),
-    ?assertMatch({ok, _}             , F({delta, 1001}, 20000)),
+    ?assertMatch({ok, _}             , F({delta, 1},    16850)),
+    ?assertMatch({ok, _}             , F({delta, 1000}, 16850)),
+    ?assertEqual({error, too_low_fee}, F({delta, 1500}, 16850)),
+    ?assertMatch({ok, _}             , F({delta, 1500}, 17000)),
     %% Test more than minimum fee considering TTL.
-    ?assertMatch({ok, _}             , F({delta, 1001}, 20000)),
+    ?assertMatch({ok, _}             , F({delta, 1500}, 40000)),
     ok.
 
 query_response(Cfg) ->

--- a/apps/aevm/src/aevm_ae_primops.erl
+++ b/apps/aevm/src/aevm_ae_primops.erl
@@ -334,7 +334,7 @@ oracle_call_register(_Value, Data, #chain{api = API, state = State} = Chain) ->
                             end
                         end,
                     SizeGas = size_gas(Tx),
-                    StateGas = state_gas(oracle_registration, DeltaTTL),
+                    StateGas = state_gas(oracle_register_tx, DeltaTTL),
                     DynGas = SizeGas + StateGas,
                     ?TEST_LOG("~s computed gas ~p - size gas: ~p, state gas: ~p (relative TTL: ~p)",
                                 [?FUNCTION_NAME, DynGas, SizeGas, StateGas, DeltaTTL]),
@@ -362,7 +362,7 @@ oracle_call_query(Value, Data, #chain{api = API, state = State} = Chain) ->
                                     end
                                 end,
                             SizeGas = size_gas(Tx),
-                            StateGas = state_gas(oracle_query, DeltaQTTL),
+                            StateGas = state_gas(oracle_query_tx, DeltaQTTL),
                             DynGas = SizeGas + StateGas,
                             ?TEST_LOG("~s computed gas ~p - size gas: ~p, state gas: ~p (relative TTL: ~p)",
                                         [?FUNCTION_NAME, DynGas, SizeGas, StateGas, DeltaQTTL]),
@@ -391,7 +391,7 @@ oracle_call_respond(_Value, Data, #chain{api = API, state = State} = Chain) ->
                                 {error, _} = Err -> Err;
                                 {ok, Tx} ->
                                     SizeGas = size_gas(Tx),
-                                    StateGas = state_gas(oracle_response, DeltaRTTL),
+                                    StateGas = state_gas(oracle_response_tx, DeltaRTTL),
                                     DynGas = SizeGas + StateGas,
                                     ?TEST_LOG("~s computed gas ~p - size gas: ~p, state gas: ~p (relative TTL: ~p)",
                                             [?FUNCTION_NAME, DynGas, SizeGas, StateGas, DeltaRTTL]),
@@ -415,7 +415,7 @@ oracle_call_extend(_Value, Data, #chain{api = API, state = State} = Chain) ->
                     Callback = fun(ChainAPI, ChainState) ->
                                     ChainAPI:oracle_extend(Tx, to_sign(Sign0), ChainState)
                             end,
-                    StateGas = state_gas(oracle_extension, DeltaTTL),
+                    StateGas = state_gas(oracle_extend_tx, DeltaTTL),
                     ?TEST_LOG("~s computed gas ~p - state gas: ~p (relative TTL: ~p)",
                                 [?FUNCTION_NAME, StateGas, StateGas, DeltaTTL]),
                     {ok, StateGas, fun() -> cast_chain(Callback, Chain) end}

--- a/docs/release-notes/next/PT-161093573-ttl-state-gas-oracle-txs.md
+++ b/docs/release-notes/next/PT-161093573-ttl-state-gas-oracle-txs.md
@@ -1,0 +1,1 @@
+* Increases the gas of oracle transactions by adding a TTL state gas. Therefore, the fees for oracle transactions are higher. This affects consensus.

--- a/system_test/only_local/aest_heavy_sync_SUITE.erl
+++ b/system_test/only_local/aest_heavy_sync_SUITE.erl
@@ -114,7 +114,7 @@ many_spend_txs(Cfg) ->
                                      , ttl => 10000000
                                      , nonce => 1000
                                      , payload => <<"node3">>}),
-    Gas = aetx:gas(FakeTx),
+    Gas = aetx:gas(FakeTx, 0),
 
     TxsPerMB = aec_governance:block_gas_limit() div Gas,
     ct:log("We can put approx ~p Txs in a micro block (gas per spend ~p, ~p)\n", [TxsPerMB, Gas, FakeTx]),


### PR DESCRIPTION
[PT-161093573](https://www.pivotaltracker.com/n/projects/2124891/stories/161093573)

Oracle primops had TTL state gas, but it was missing in oracle transactions. This PR fixes it.