### PR TITLE
Add dry-run HTTP API

### DIFF
--- a/apps/aecore/src/aec_dry_run.erl
+++ b/apps/aecore/src/aec_dry_run.erl
@@ -1,0 +1,59 @@
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2018, Aeternity Anstalt
+%%%-------------------------------------------------------------------
+
+-module(aec_dry_run).
+
+-export([dry_run/2]).
+
+-include("blocks.hrl").
+
+dry_run(TopHash, Txs) ->
+    try
+        {Env, Trees} = aetx_env:tx_env_and_trees_from_hash('aetx_transaction', TopHash),
+        dry_run(Txs, Trees, Env)
+    catch _E:_R ->
+        {error, <<"Failed to get block state and environment">>}
+    end.
+
+dry_run(Txs, Trees, Env) ->
+    STxs = dummy_sign_txs(Txs),
+    {ok, dry_run(STxs, Trees, Env, [])}.
+
+dry_run([], _Trees, _Env, Acc) ->
+    lists:reverse(Acc);
+dry_run([Tx | Txs], Trees, Env, Acc) ->
+    case aec_trees:apply_txs_on_state_trees([Tx], Trees, Env,
+                                            [strict, dont_verify_signature]) of
+        {ok, [Tx], [], Trees1} ->
+            dry_run(Txs, Trees1, Env, [dry_run_res(Tx, Trees1, ok) | Acc]);
+        Err = {error, _Reason} ->
+            dry_run(Txs, Trees, Env, [dry_run_res(Tx, Trees, Err) | Acc])
+    end.
+
+dry_run_res(STx, Trees, ok) ->
+    Tx = aetx_sign:tx(STx),
+    {Type, _} = aetx:specialize_type(Tx),
+    case Type of
+        contract_call_tx ->
+            {CB, CTx} = aetx:specialize_callback(Tx),
+            Contract  = CB:contract_pubkey(CTx),
+            CallId    = CB:call_id(CTx),
+            CallTree = aec_trees:calls(Trees),
+            {value, CallObj} = aect_call_state_tree:lookup_call(Contract, CallId, CallTree),
+            {Type, {ok, CallObj}};
+        contract_create_tx ->
+            %% TODO: Maybe return the state?
+            {Type, ok};
+        spend_tx ->
+            {Type, ok}
+    end;
+dry_run_res(STx, _Trees, Err) ->
+    {Type, _} = aetx:specialize_type(aetx_sign:tx(STx)),
+    {Type, Err}.
+
+dummy_sign_txs(Txs) ->
+    [ aetx_sign:new(Tx, [dummy_sign()]) || Tx <- Txs ].
+
+dummy_sign() ->
+    <<0:(?BLOCK_SIGNATURE_BYTES*8)>>.

--- a/apps/aehttp/priv/swagger.json
+++ b/apps/aehttp/priv/swagger.json
@@ -3954,6 +3954,13 @@
         "top" : {
           "type" : "string"
         },
+        "accounts" : {
+          "type" : "array",
+          "description" : "Accounts",
+          "items" : {
+            "$ref" : "#/definitions/DryRunAccount"
+          }
+        },
         "txs" : {
           "type" : "array",
           "description" : "Txs",
@@ -3964,7 +3971,30 @@
       },
       "example" : {
         "top" : "top",
-        "txs" : [ { }, { } ]
+        "accounts" : [ {
+          "amount" : 0,
+          "pub_key" : { }
+        }, {
+          "amount" : 0,
+          "pub_key" : { }
+        } ],
+        "txs" : [ null, null ]
+      }
+    },
+    "DryRunAccount" : {
+      "type" : "object",
+      "required" : [ "amount", "pub_key" ],
+      "properties" : {
+        "pub_key" : {
+          "$ref" : "#/definitions/EncodedHash"
+        },
+        "amount" : {
+          "type" : "integer"
+        }
+      },
+      "example" : {
+        "amount" : 0,
+        "pub_key" : { }
       }
     },
     "DryRunResults" : {

--- a/apps/aehttp/priv/swagger.json
+++ b/apps/aehttp/priv/swagger.json
@@ -1974,6 +1974,38 @@
         }
       }
     },
+    "/debug/transactions/dry-run" : {
+      "post" : {
+        "tags" : [ "internal", "debug" ],
+        "description" : "Dry-run transactions on top of a given block. Supports SpendTx, ContractCreateTx and ContractCallTx",
+        "operationId" : "DryRunTxs",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "in" : "body",
+          "name" : "body",
+          "description" : "transactions",
+          "required" : true,
+          "schema" : {
+            "$ref" : "#/definitions/DryRunInput"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Dry-run result",
+            "schema" : {
+              "$ref" : "#/definitions/DryRunResults"
+            }
+          },
+          "403" : {
+            "description" : "Invalid input",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
     "/debug/contracts/code/decode-data" : {
       "post" : {
         "tags" : [ "internal", "contract", "debug" ],
@@ -3913,6 +3945,103 @@
       },
       "example" : {
         "out" : "out"
+      }
+    },
+    "DryRunInput" : {
+      "type" : "object",
+      "required" : [ "txs" ],
+      "properties" : {
+        "top" : {
+          "type" : "string"
+        },
+        "txs" : {
+          "type" : "array",
+          "description" : "Txs",
+          "items" : {
+            "$ref" : "#/definitions/EncodedHash"
+          }
+        }
+      },
+      "example" : {
+        "top" : "top",
+        "txs" : [ { }, { } ]
+      }
+    },
+    "DryRunResults" : {
+      "type" : "object",
+      "required" : [ "results" ],
+      "properties" : {
+        "results" : {
+          "type" : "array",
+          "description" : "results",
+          "items" : {
+            "$ref" : "#/definitions/DryRunResult"
+          }
+        }
+      },
+      "example" : {
+        "results" : [ {
+          "result" : "result",
+          "reason" : "reason",
+          "type" : "type",
+          "call_obj" : {
+            "gas_price" : 1,
+            "return_type" : "return_type",
+            "return_value" : { },
+            "caller_id" : { },
+            "contract_id" : null,
+            "gas_used" : 5,
+            "caller_nonce" : 0,
+            "height" : 6
+          }
+        }, {
+          "result" : "result",
+          "reason" : "reason",
+          "type" : "type",
+          "call_obj" : {
+            "gas_price" : 1,
+            "return_type" : "return_type",
+            "return_value" : { },
+            "caller_id" : { },
+            "contract_id" : null,
+            "gas_used" : 5,
+            "caller_nonce" : 0,
+            "height" : 6
+          }
+        } ]
+      }
+    },
+    "DryRunResult" : {
+      "type" : "object",
+      "required" : [ "result", "type" ],
+      "properties" : {
+        "type" : {
+          "type" : "string"
+        },
+        "result" : {
+          "type" : "string"
+        },
+        "reason" : {
+          "type" : "string"
+        },
+        "call_obj" : {
+          "$ref" : "#/definitions/ContractCallObject"
+        }
+      },
+      "example" : {
+        "result" : "result",
+        "reason" : "reason",
+        "type" : "type",
+        "call_obj" : {
+          "gas_price" : 1,
+          "return_type" : "return_type",
+          "return_value" : { },
+          "caller_id" : { },
+          "contract_id" : null,
+          "gas_used" : 5,
+          "caller_nonce" : 0,
+          "height" : 6
+        }
       }
     },
     "Calldata" : {

--- a/apps/aehttp/src/aehttp_dispatch_int.erl
+++ b/apps/aehttp/src/aehttp_dispatch_int.erl
@@ -24,6 +24,9 @@
                         , unsigned_tx_response/1
                         , ok_response/1
                         , process_request/2
+                        , dry_run_top/1
+                        , dry_run_txs/1
+                        , dry_run_results/1
                         ]).
 
 -spec handle_request(
@@ -173,6 +176,27 @@ handle_request_('CallContract', Req, _Context) ->
                     end;
                 {error, Reason} ->
                     {403, [], #{reason => <<"Bad request: ", Reason/binary>>}}
+            end;
+        _ -> {403, [], #{reason => <<"Bad request">>}}
+    end;
+
+handle_request_('DryRunTxs', Req, _Context) ->
+    case Req of
+        #{'DryRunInput' :=
+            #{ <<"txs">> := Txs0 } = Input} ->
+            case {dry_run_top(Input), dry_run_txs(Txs0)} of
+                {{ok, BlockHash}, {ok, Txs}} ->
+                    case aec_dry_run:dry_run(BlockHash, Txs) of
+                        {ok, Res0} ->
+                            Res = dry_run_results(Res0),
+                            {200, [], #{ results => Res }};
+                        {error, Reason} ->
+                            {403, [], #{ reason => <<"Bad request: ", Reason/binary>>}}
+                    end;
+                {{error, Reason}, _} ->
+                    {403, [], #{ reason => <<"Bad request: ", Reason/binary>>}};
+                {_, {error, Reason}} ->
+                    {403, [], #{ reason => <<"Bad request: ", Reason/binary>>}}
             end;
         _ -> {403, [], #{reason => <<"Bad request">>}}
     end;

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -1680,6 +1680,33 @@ paths:
           description: Invalid contract
           schema:
             $ref: '#/definitions/Error'
+  /debug/transactions/dry-run:
+    post:
+      tags:
+        - internal
+        - debug
+      operationId: 'DryRunTxs'
+      description: 'Dry-run transactions on top of a given block. Supports SpendTx, ContractCreateTx and ContractCallTx'
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: transactions
+          required: true
+          schema:
+            $ref: '#/definitions/DryRunInput'
+      responses:
+        '200':
+          description: Dry-run result
+          schema:
+            $ref: '#/definitions/DryRunResults'
+        '403':
+          description: Invalid input
+          schema:
+            $ref: '#/definitions/Error'
   /debug/contracts/code/decode-data:
     post:
       tags:
@@ -2972,6 +2999,42 @@ definitions:
         type: string
     required:
       - out
+  DryRunInput:
+    type: object
+    properties:
+      top:
+        type: string
+      txs:
+        type: array
+        description: Txs
+        items:
+          $ref: '#/definitions/EncodedHash'
+    required:
+      - txs
+  DryRunResults:
+    type: object
+    properties:
+      results:
+        type: array
+        description: results
+        items:
+          $ref: '#/definitions/DryRunResult'
+    required:
+      - results
+  DryRunResult:
+    type: object
+    properties:
+      type:
+        type: string
+      result:
+        type: string
+      reason:
+        type: string
+      call_obj:
+        $ref: '#/definitions/ContractCallObject'
+    required:
+      - type
+      - result
   Calldata:
     type: object
     properties:

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -3004,6 +3004,11 @@ definitions:
     properties:
       top:
         type: string
+      accounts:
+        type: array
+        description: Accounts
+        items:
+          $ref: '#/definitions/DryRunAccount'
       txs:
         type: array
         description: Txs
@@ -3011,6 +3016,16 @@ definitions:
           $ref: '#/definitions/EncodedHash'
     required:
       - txs
+  DryRunAccount:
+    type: object
+    properties:
+      pub_key:
+        $ref: '#/definitions/EncodedHash'
+      amount:
+        type: integer
+    required:
+      - pub_key
+      - amount
   DryRunResults:
     type: object
     properties:

--- a/docs/release-notes/next/PT-161980624-offchain_contract_call.md
+++ b/docs/release-notes/next/PT-161980624-offchain_contract_call.md
@@ -1,0 +1,1 @@
+* Introduces a dry-run API where a list of SpendTx, ContractCreateTx and ContractCallTx can be sent for off-chain evaluation.


### PR DESCRIPTION
At /debug/transactions/dry-run a list of transactions can be posted to be evaluated off-chain at the
state of a certain block hash. The API supports SpendTx, ContractCreateTx and
ContractCallTx.

https://www.pivotaltracker.com/story/show/161980624