### PR TITLE
Disable Sophia code execution in code/call API

### DIFF
--- a/apps/aecontract/src/aect_dispatch.erl
+++ b/apps/aecontract/src/aect_dispatch.erl
@@ -32,8 +32,6 @@
 %% -- Running contract code off chain ---------------------------------------
 
 %% TODO: replace language string with vm_version number.
-call(<<"sophia">>, Code, Function, Argument) ->
-    aect_sophia:simple_call(Code, Function, Argument);
 call(<<"sophia-address">>, ContractKey, Function, Argument) ->
     aect_sophia:on_chain_call(ContractKey, Function, Argument);
 call(<<"evm">>, Code, _, CallData) ->

--- a/apps/aehttp/src/aehttp_logic.erl
+++ b/apps/aehttp/src/aehttp_logic.erl
@@ -187,11 +187,6 @@ contract_call(ABI, EncodedCode, Function, Argument) ->
                 _ ->
                     {error, <<"Invalid hash for contract address">>}
             end;
-        <<"sophia">> ->
-            case aehttp_api_encoder:safe_decode(contract_bytearray, EncodedCode) of
-                {ok, Code} -> Call(Code, Argument);
-                {error, _} -> {error, <<"Illegal code">>}
-            end;
         <<"evm">> ->
             case aehttp_api_encoder:safe_decode(contract_bytearray, EncodedCode) of
                 {ok, Code} ->
@@ -203,7 +198,7 @@ contract_call(ABI, EncodedCode, Function, Argument) ->
                     {error, <<"Illegal code">>}
             end;
         _Other ->
-            {error, "Unknown ABI"}
+            {error, "Unknown/Unsupported ABI"}
     end.
 
 contract_decode_data(Type, Data) ->

--- a/docs/release-notes/next/PT-161980624-offchain_contract_call.md
+++ b/docs/release-notes/next/PT-161980624-offchain_contract_call.md
@@ -1,1 +1,2 @@
-* Introduces a dry-run API where a list of SpendTx, ContractCreateTx and ContractCallTx can be sent for off-chain evaluation.
+* Introduces a dry-run API where a list of SpendTx, ContractCreateTx and ContractCallTx can be sent for off-chain evaluation. At
+  the same time disable the broken off-chain (<<"sophia">> ABI) call through `debug/contracts/code/call`.


### PR DESCRIPTION
It is broken at the moment so no point in exposing it. The new dry-run
API is superior.