### PR TITLE
Upgrade to new base58 dep to fix decoding of binaries with only zeros

### DIFF
--- a/apps/aehttp/test/aehttp_api_encoder_tests.erl
+++ b/apps/aehttp/test/aehttp_api_encoder_tests.erl
@@ -112,5 +112,27 @@ encode_decode_test_() ->
               end,
               ?TYPES)
       end
-     }
+     },
+     {"Encode/decode binary with only zeros",
+      fun() ->
+          Bins = [<<0:Size/unit:8>> || Size <- lists:seq(1,64)],
+          lists:foreach(
+            fun(Bin) ->
+                lists:foreach(
+                  fun({Type, S}) ->
+                      case S =:= byte_size(Bin) orelse S =:= not_applicable of
+                        true ->
+                          Encoded = ?TEST_MODULE:encode(Type, Bin),
+                          {ok, Decoded} = ?TEST_MODULE:safe_decode(Type, Encoded),
+                          ?assertEqual(Decoded, Bin);
+                        false ->
+                          ok
+                      end,
+                      Encoded1 = base58:binary_to_base58(Bin),
+                      Decoded1 = base58:base58_to_binary(Encoded1),
+                      ?assertEqual(Bin, Decoded1)
+                  end, ?TYPES)
+            end,
+            Bins)
+      end}
      ].

--- a/rebar.config
+++ b/rebar.config
@@ -37,7 +37,7 @@
         {exometer_core, {git, "https://github.com/Feuerlabs/exometer_core.git", {ref, "f088de5"}}},
         {poolboy, "1.5.1"},
         {yamerl, "0.7.0"},
-        {base58, {git, "https://github.com/aeternity/erl-base58.git", {ref,"7ea179a"}}},
+        {base58, {git, "https://github.com/aeternity/erl-base58.git", {ref,"60a3356"}}},
         {eper, ".*", {git, "git://github.com/aeternity/eper.git", {ref, "03d4be3"}}},
         {erlexec, ".*", {git, "https://github.com/saleyn/erlexec.git", {ref, "97a5188"}}},
         {sha3, {git, "https://github.com/szktty/erlang-sha3", {ref, "dbdfd12"}}},

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,7 +1,7 @@
 {"1.1.0",
 [{<<"base58">>,
   {git,"https://github.com/aeternity/erl-base58.git",
-       {ref,"7ea179ada7933a555c84f2ec007a92b80b654564"}},
+       {ref,"60a335668a60328a29f9731b67c4a0e9e3d50ab6"}},
   0},
  {<<"bear">>,
   {git,"git://github.com/boundary/bear.git",


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/162121241

Corresponding PR in erl-base58: https://github.com/aeternity/erl-base58/pull/3