### PR TITLE
PT-161918976 Add minimal tx fee check to micro block validation

### DIFF
--- a/apps/aecore/src/aec_blocks.erl
+++ b/apps/aecore/src/aec_blocks.erl
@@ -421,6 +421,7 @@ validate_key_block(#key_block{} = Block) ->
 validate_micro_block(#mic_block{} = Block) ->
     Validators = [fun validate_txs_hash/1,
                   fun validate_gas_limit/1,
+                  fun validate_txs_fee/1,
                   fun validate_pof/1
                  ],
     case aec_headers:validate_micro_block_header(to_micro_header(Block)) of
@@ -448,6 +449,17 @@ validate_gas_limit(#mic_block{} = Block) ->
     case gas(Block) =< aec_governance:block_gas_limit() of
         true  -> ok;
         false -> {error, gas_limit_exceeded}
+    end.
+
+-spec validate_txs_fee(block()) -> ok | {error, invalid_minimal_tx_fee}.
+validate_txs_fee(#mic_block{header = Header, txs = STxs}) ->
+    Height = aec_headers:height(Header),
+    case lists:all(fun(STx) ->
+                           Tx = aetx_sign:tx(STx),
+                           aetx:fee(Tx) >= aetx:min_fee(Tx, Height)
+                   end, STxs) of
+        true -> ok;
+        false -> {error, invalid_minimal_tx_fee}
     end.
 
 validate_pof(#mic_block{pof = no_fraud}) -> ok;


### PR DESCRIPTION
To be reviewed after mainnet launch.

[PT-161918976](https://www.pivotaltracker.com/n/projects/2124891/stories/161918976)

This change adds minimal tx fee check to the caller of
`aec_conductor:add_synced_block/1` and `aec_conductor:post_block/1` which
may offload the conductor process. The check is also performed before a micro
block is added to the database by conductor (but now it's less likely there
would be any errors).