### PR TITLE
Pt 162089378 cleanup compiler errors

### DIFF
--- a/apps/aehttp/test/aehttp_contracts_SUITE.erl
+++ b/apps/aehttp/test/aehttp_contracts_SUITE.erl
@@ -24,6 +24,7 @@
 %% external endpoints
 -export([
          abort_test_contract/1,
+         compiler_error_contract/1,
          counter_contract/1,
          dutch_auction_contract/1,
          environment_contract/1,
@@ -36,7 +37,6 @@
          simple_storage_contract/1,
          spend_test_contract/1,
          stack_contract/1,
-         type_error_contract/1,
          null/1
         ]).
 
@@ -65,7 +65,7 @@ groups() ->
        dutch_auction_contract,
        fundme_contract,
        erc20_token_contract,
-       type_error_contract,
+       compiler_error_contract,
        null                                     %This allows to end with ,
       ]}
     ].
@@ -1050,18 +1050,37 @@ erc20_token_contract(Config) ->
 
     ok.
 
-type_error_contract(_Cfg) ->
-    {ok, 403, #{<<"reason">> := Error}} =
+%% compiler_error_contract(Config)
+%%  Check HTTP output from compiler errors.
+
+compiler_error_contract(_Config) ->
+    %% Test syntax error.
+    {ok,403,#{<<"reason">> := SyntaxError}} =
+        get_contract_bytecode(<<"contract Fail = function fail(x : string) == x + 1">>),
+    <<"** Parse errors\n\n",_/binary>> = SyntaxError,
+
+    %% Test type error.
+    {ok,403,#{<<"reason">> := TypeError}} =
         get_contract_bytecode(<<"contract Fail = function fail(x : string) = x + 1">>),
-    Error =
-        <<"** Type errors\n\n"
-          "Cannot unify string\n"
-          "         and int\n"
-          "when checking the application at line 1, column 47 of\n"
-          "  (+) : (int, int) => int\n"
-          "to arguments\n"
-          "  x : string\n"
-          "  1 : int\n">>,
+    TypeError = <<"** Type errors\n\n"
+                  "Cannot unify string\n"
+                  "         and int\n"
+                  "when checking the application at line 1, column 47 of\n"
+                  "  (+) : (int, int) => int\n"
+                  "to arguments\n"
+                  "  x : string\n"
+                  "  1 : int\n">>,
+
+    %% Test code gen error.
+    {ok,403,#{<<"reason">> := GenError}} =
+        get_contract_bytecode(<<"contract Fail =\n  function fail(x : address) = Chain.balance">>),
+    <<"** Code errors\n\n",_/binary>> = GenError,
+
+    %% This generates a function_clause error.
+    {ok,403,#{<<"reason">> := DeclError}} =
+        get_contract_bytecode(<<"contract Fail =\n  type sune\n  function fail(x : address) = Chain.balance">>),
+    <<"Error: function_clause",_/binary>> = DeclError,
+
     ok.
 
 %% Data structure functions.

--- a/apps/aesophia/src/aeso_ast_infer_types.erl
+++ b/apps/aesophia/src/aeso_ast_infer_types.erl
@@ -60,7 +60,7 @@
 -type field_info() :: #field_info{}.
 
 -define(PRINT_TYPES(Fmt, Args),
-	when_option(pp_types, fun () -> io:format(Fmt, Args) end)).
+        when_option(pp_types, fun () -> io:format(Fmt, Args) end)).
 
 %% Environment containing language primitives
 -spec global_env() -> [{string(), aeso_syntax:type()}].
@@ -352,8 +352,8 @@ infer_letrec(Env, {letrec, Attrs, Defs}) ->
             Expect = typesig_to_fun_t(TypeSig),
             unify(Got, Expect, {check_typesig, Name, Got, Expect}),
             solve_field_constraints(),
-	    ?PRINT_TYPES("Checked ~s : ~s\n",
-			 [Name, pp(dereference_deep(Got))]),
+            ?PRINT_TYPES("Checked ~s : ~s\n",
+                         [Name, pp(dereference_deep(Got))]),
             Res
           end || LF <- Defs ],
     destroy_and_report_unsolved_constraints(),
@@ -1316,10 +1316,11 @@ create_type_errors() ->
 
 destroy_and_report_type_errors() ->
     Errors   = ets_tab2list(type_errors),
+    %% io:format("Type errors now: ~p\n", [Errors]),
     PPErrors = [ pp_error(Err) || Err <- Errors ],
     ets_delete(type_errors),
-    [ error({type_errors, [lists:flatten(Err) || Err <- PPErrors]})
-      || Errors /= [] ].
+    Errors /= [] andalso
+        error({type_errors, [lists:flatten(Err) || Err <- PPErrors]}).
 
 pp_error({cannot_unify, A, B, When}) ->
     io_lib:format("Cannot unify ~s\n"

--- a/apps/aesophia/src/aeso_compiler.erl
+++ b/apps/aesophia/src/aeso_compiler.erl
@@ -244,17 +244,17 @@ parse_string(Text) ->
     case aeso_parser:string(Text) of
         %% Yay, it worked!
         {ok, Contract} -> Contract;
+        %% Scan errors.
+        {error, {Pos, scan_error}} ->
+            parse_error(Pos, "scan error");
+        {error, {Pos, scan_error_no_state}} ->
+            parse_error(Pos, "scan error");
         %% Parse errors.
         {error, {Pos, parse_error, Error}} ->
             parse_error(Pos, Error);
         {error, {Pos, ambiguous_parse, As}} ->
             ErrorString = io_lib:format("Ambiguous ~p", [As]),
-            parse_error(Pos, ErrorString);
-        %% Scan errors.
-        {error, {scan_error, Pos, Line}} ->
-            parse_error({Line,Pos}, "scan error");
-        {error, {scan_error_no_state, Pos, Line}} ->
-            parse_error({Line,Pos}, "scan error")
+            parse_error(Pos, ErrorString)
     end.
 
 parse_error({Line,Pos}, ErrorString) ->

--- a/apps/aesophia/src/aeso_compiler.erl
+++ b/apps/aesophia/src/aeso_compiler.erl
@@ -240,13 +240,26 @@ pp(Code, Options, Option, PPFun) ->
 %% TODO: Tempoary parser hook below...
 
 parse_string(Text) ->
+    %% Try and return something sensible here!
     case aeso_parser:string(Text) of
+        %% Yay, it worked!
         {ok, Contract} -> Contract;
-        Err = {error, {_Line, aeso_scan,_Reason}} ->
-            error(Err);
-        Err = {error, {_Line, aeso_parser,_Reason}} ->
-            error(Err)
+        %% Parse errors.
+        {error, {Pos, parse_error, Error}} ->
+            parse_error(Pos, Error);
+        {error, {Pos, ambiguous_parse, As}} ->
+            ErrorString = io_lib:format("Ambiguous ~p", [As]),
+            parse_error(Pos, ErrorString);
+        %% Scan errors.
+        {error, {scan_error, Pos, Line}} ->
+            parse_error({Line,Pos}, "scan error");
+        {error, {scan_error_no_state, Pos, Line}} ->
+            parse_error({Line,Pos}, "scan error")
     end.
+
+parse_error({Line,Pos}, ErrorString) ->
+    Error = io_lib:format("line ~p, column ~p: ~s", [Line,Pos,ErrorString]),
+    error({parse_errors,[Error]}).
 
 read_contract(Name) ->
     {ok, Bin} = file:read_file(filename:join(contract_path(), lists:concat([Name, ".aes"]))),

--- a/apps/aesophia/src/aeso_parser.erl
+++ b/apps/aesophia/src/aeso_parser.erl
@@ -13,7 +13,9 @@
                     {ok, aeso_syntax:ast()}
                         | {error, {aeso_parse_lib:pos(),
                                    atom(),
-                                   term()}}.
+                                   term()}}
+                        | {error, {aeso_parse_lib:pos(),
+                                   atom()}}.
 string(String) ->
   parse_and_scan(file(), String).
 

--- a/apps/aesophia/src/aeso_scan_lib.erl
+++ b/apps/aesophia/src/aeso_scan_lib.erl
@@ -112,7 +112,7 @@ string(Lexer, Stack, String, Pos) ->
     string(Lexer, Stack, Lines, Pos, []).
 
 string(_Lexers, [], [Line | _Rest], Pos, _Acc) ->
-    {error, {scan_error_no_state, Pos, Line}};
+    {error, {{Line,Pos}, scan_error_no_state}};
 string(_Lexers, _Stack, [], _Pos, Acc) ->
     {ok, lists:reverse(Acc)};
 string(Lexers, [State | Stack], [Line | Lines], Pos, Acc) ->
@@ -130,7 +130,7 @@ string(Lexers, [State | Stack], [Line | Lines], Pos, Acc) ->
                      end,
             string(Lexers, Stack1, [Line1 | Lines], Pos1, Acc1);
         end_of_file -> string(Lexers, [State | Stack], Lines, next_pos("\n", Pos), Acc);
-        error       -> {error, {scan_error, Pos, Line}}
+        error       -> {error, {{Line,Pos}, scan_error}}
     end.
 
 %% -- Internal functions -----------------------------------------------------


### PR DESCRIPTION
The compiler returns errors in many different ways, and this is first step to clean it up. It is now easier to which errors are those generated by the compiler and which are generated by bugs. The compiler generates 3 types of errors `parse_errors`, `type_errors` and `core_errors` coming from different phases. We now generate better text as well. It is backwards compatible in the HTTP interface through the `aect_sophia:compile` generating better text.

This is just a first stage but more cleanup would entail making some decisions about how would we like it to work which should be discussed after the release.

This fixes [PT-162089378](https://www.pivotaltracker.com/story/show/162089378).
