### PR TITLE
Misc cleanup while running a local node

### DIFF
--- a/apps/aecore/src/aec_accounts_trees.erl
+++ b/apps/aecore/src/aec_accounts_trees.erl
@@ -79,10 +79,11 @@ lookup(Pubkey, Tree) ->
 enter(Account, Tree) ->
     aeu_mtrees:enter(key(Account), value(Account), Tree).
 
--dialyzer({nowarn_function, delete/2}).
+-ifdef(TEST).
 -spec delete(aec_keys:pubkey(), tree()) -> tree().
 delete(Pubkey, Tree) ->
     aeu_mtrees:delete(Pubkey, Tree).
+-endif.
 
 -spec to_binary_without_backend(tree()) -> binary().
 to_binary_without_backend(Tree) ->

--- a/apps/aecore/src/aec_peers.erl
+++ b/apps/aecore/src/aec_peers.erl
@@ -448,7 +448,7 @@ handle_cast({resolved_hostname, Host, {ok, Addr}}, #state{hostnames = HostMap} =
         {ok, {_, _, PeerMap}} ->
             HostMap2 = maps:remove(Host, HostMap),
             State2 = State#state{ hostnames = HostMap2 },
-            NewState = 
+            NewState =
                 maps:fold(fun
                               (_, {undefined, PeerInfo, IsTrusted}, S) ->
                                   Peer = peer(Addr, PeerInfo, IsTrusted),
@@ -587,8 +587,8 @@ update_ping_metrics(Outcome) ->
 %--- API CALLS HELPER FUNCTIONS ------------------------------------------------
 
 %% Adds or update a peer; called in the caller's process.
-%% We should not block the caller, so we just spawn to make this happen in 
-%% the background. If the process silently fails in the background, we 
+%% We should not block the caller, so we just spawn to make this happen in
+%% the background. If the process silently fails in the background, we
 %% will be able to detect that in the logs since we won't be able to
 %% connect.
 -spec async_add_peer(inet:ip_address() | undefined, peer_info(), boolean()) -> ok.
@@ -601,17 +601,13 @@ async_add_peer(SourceAddr0, #{ host := Host} = PeerInfo, IsTrusted) ->
                      gen_server:cast(?MODULE, {resolve_peer, SourceAddr0,
                                                PeerInfo, IsTrusted});
                  {ok, Addr} when SourceAddr0 == undefined ->
-                     epoch_sync:debug("PEER undefined address ~p ~p -> ~p", [Host, SourceAddr0, Addr]),
                      Peer = peer(Addr, PeerInfo, IsTrusted),
                      gen_server:cast(?MODULE, {add_peer, Addr, Peer});
                  {ok, Addr} when SourceAddr0 =/= undefined ->
-                     %% IP address has changed
-                     [ epoch_sync:debug("New IP address for host ~p ~p -> ~p", [Host, SourceAddr0, Addr]) 
-                       || Addr =/= SourceAddr0 ],
                      Peer = peer(Addr, PeerInfo, IsTrusted),
                      gen_server:cast(?MODULE, {add_peer, SourceAddr0, Peer})
              end
-          end), 
+          end),
     ok.
 
 async_resolve_host(Host) ->

--- a/apps/aecore/src/aec_sync.erl
+++ b/apps/aecore/src/aec_sync.erl
@@ -694,8 +694,8 @@ post_blocks(From, To, [{Height, _Hash, {PeerId, Block}} | Blocks]) ->
 %% blocks we limit the total amount of work the conductor has to perform in
 %% each synchronous call.
 %% Map contains key dir, saying in which direction we sync
-add_generation(#{dir := forward, key_block := KB, micro_blocks := MBs}) ->
-    add_blocks([KB | MBs]);
+add_generation(#{dir := forward, key_block := _KB, micro_blocks := MBs}) ->
+    add_blocks(MBs);
 add_generation(#{dir := backward, key_block := KB, micro_blocks := MBs}) ->
     add_blocks(MBs ++ [KB]).
 

--- a/apps/aecore/src/aec_sync.erl
+++ b/apps/aecore/src/aec_sync.erl
@@ -203,7 +203,7 @@ handle_cast(_, State) ->
 handle_info({gproc_ps_event, Event, #{info := Info}},
             State = #state{ gossip_txs = GossipTxs }) ->
     %% FUTURE: Forward blocks only to outbound connections.
-    %% Take a random subset (possibly empty) of peers that agree with us 
+    %% Take a random subset (possibly empty) of peers that agree with us
     %% on chain height to forward blocks and transactions to.
     PeerIds = [ aec_peers:peer_id(P) || P <- aec_peers:get_random(10) ],
     NonSyncingPeerIds = [ P || P <- PeerIds, not peer_in_sync(State, P) ],
@@ -514,7 +514,7 @@ run_job(Queue, Fun) ->
     proc_lib:spawn(jobs, run, [Queue, Fun]).
 
 %% Gossip Tx or Block - spawn a process and call jobs from there.
-enqueue(Kind, Data, []) ->
+enqueue(_Kind, _Data, []) ->
     ok;
 enqueue(Kind, Data, PeerIds) ->
     spawn(fun() ->

--- a/apps/aecore/src/aec_sync.erl
+++ b/apps/aecore/src/aec_sync.erl
@@ -635,7 +635,7 @@ do_work_on_sync_task(PeerId, Task, LastResult) ->
     case next_work_item(Task, PeerId, LastResult) of
         take_a_break ->
             delayed_run_job(PeerId, Task, sync_tasks,
-                            fun() -> do_work_on_sync_task(PeerId, Task) end, 250);
+                            fun() -> do_work_on_sync_task(PeerId, Task) end, 5000);
         {agree_on_height, Chain} ->
             #{ chain := [#{ hash := TopHash, height := TopHeight } | _] } = Chain,
             LocalHeader = aec_chain:top_header(),

--- a/apps/aecore/test/aec_conductor_tests.erl
+++ b/apps/aecore/test/aec_conductor_tests.erl
@@ -405,9 +405,9 @@ generation_test_() ->
              ok
      end,
      [
-        {"Start signing after mined block", fun test_mined_block_signing/0},
-        {"Start signing after two mined block", fun test_two_mined_block_signing/0},
-        {"Start signing after received block", fun test_received_block_signing/0}
+        {timeout, 10, {"Start signing after mined block", fun test_mined_block_signing/0}},
+        {timeout, 10, {"Start signing after two mined block", fun test_two_mined_block_signing/0}},
+        {timeout, 10, {"Start signing after received block", fun test_received_block_signing/0}}
      ]}.
 
 test_mined_block_signing() ->

--- a/apps/aeoracle/src/aeo_extend_tx.erl
+++ b/apps/aeoracle/src/aeo_extend_tx.erl
@@ -101,8 +101,7 @@ origin(#oracle_extend_tx{} = Tx) ->
 %% Oracle should exist.
 -spec check(tx(), aec_trees:trees(), aetx_env:env()) -> {ok, aec_trees:trees()} | {error, term()}.
 check(#oracle_extend_tx{nonce = Nonce, oracle_ttl = OTTL, fee = Fee} = Tx,
-      Trees, Env) ->
-    Height = aetx_env:height(Env),
+      Trees,_Env) ->
     OraclePK = oracle_pubkey(Tx),
     Checks =
         [fun() -> check_oracle_extension_ttl(OTTL) end,

--- a/apps/aeoracle/src/aeo_query_tx.erl
+++ b/apps/aeoracle/src/aeo_query_tx.erl
@@ -145,8 +145,7 @@ origin(#oracle_query_tx{} = Tx) ->
 %% Oracle should exist, and query_fee should be enough
 %% Fee should cover TTL
 -spec check(tx(), aec_trees:trees(), aetx_env:env()) -> {ok, aec_trees:trees()} | {error, term()}.
-check(#oracle_query_tx{nonce = Nonce, query_fee = QFee, query_ttl = QTTL,
-                       fee = Fee} = QTx,
+check(#oracle_query_tx{nonce = Nonce, query_fee = QFee, fee = Fee} = QTx,
       Trees, Env) ->
     Height       = aetx_env:height(Env),
     SenderPubKey = sender_pubkey(QTx),

--- a/apps/aeoracle/src/aeo_register_tx.erl
+++ b/apps/aeoracle/src/aeo_register_tx.erl
@@ -132,10 +132,8 @@ origin(#oracle_register_tx{} = Tx) ->
 %% Account should exist, and have enough funds for the fee.
 -spec check(tx(), aec_trees:trees(), aetx_env:env()) ->
         {ok, aec_trees:trees()} | {error, term()}.
-check(#oracle_register_tx{nonce = Nonce, oracle_ttl = OTTL, fee = Fee,
-                          vm_version = VMVersion} = Tx,
-      Trees, Env) ->
-    Height = aetx_env:height(Env),
+check(#oracle_register_tx{nonce = Nonce, fee = Fee, vm_version = VMVersion} = Tx,
+      Trees, _Env) ->
     AccountPubKey = account_pubkey(Tx),
     Checks =
         [fun() -> aetx_utils:check_account(AccountPubKey, Trees, Nonce, Fee) end,

--- a/apps/aeoracle/src/aeo_response_tx.erl
+++ b/apps/aeoracle/src/aeo_response_tx.erl
@@ -120,7 +120,6 @@ origin(#oracle_response_tx{} = Tx) ->
         {ok, aec_trees:trees()} | {error, term()}.
 check(#oracle_response_tx{nonce = Nonce, query_id = QueryId,
                           fee = Fee, response_ttl = ResponseTTL} = Tx, Trees, Env) ->
-    Height = aetx_env:height(Env),
     OraclePubKey = oracle_pubkey(Tx),
     case fetch_query(OraclePubKey, QueryId, Trees) of
         {value, I} ->

--- a/apps/aevarna/src/aeva_lint.erl
+++ b/apps/aevarna/src/aeva_lint.erl
@@ -12,12 +12,12 @@
 
 -export([contract/1]).
 
--record(lint, {contract=[],                     %Contract name
-               state=[],                        %State definition.
-               funcs=[],                        %Defined functions
-               errors=[],                       %Error
-               warnings={}                      %Warnings
-              }).
+%% -record(lint, {contract=[],                     %Contract name
+%%                state=[],                        %State definition.
+%%                funcs=[],                        %Defined functions
+%%                errors=[],                       %Error
+%%                warnings={}                      %Warnings
+%%               }).
 
 %% contract(Contract) -> {ok,Warnings} | {error,Errors,Warnings}.
 

--- a/apps/aevm/src/aevm_opcodes.erl
+++ b/apps/aevm/src/aevm_opcodes.erl
@@ -61,8 +61,8 @@ opcode(GasTable, ?CODECOPY)       -> { 3,  0, maps:get('GVERYLOW', GasTable)};
 opcode(GasTable, ?GASPRICE)       -> { 0,  1, maps:get('GBASE', GasTable)};
 opcode(GasTable, ?EXTCODESIZE)    -> { 1,  1, maps:get('GEXTCODESIZE', GasTable)};
 opcode(GasTable, ?EXTCODECOPY)    -> { 4,  0, maps:get('GEXTCODECOPY', GasTable)};
-opcode(GasTable, ?RETURNDATASIZE) -> { 0,  1, 2}; %% TODO
-opcode(GasTable, ?RETURNDATACOPY) -> { 3,  0, 3}; %% TODO
+opcode(_GasTable, ?RETURNDATASIZE) -> { 0,  1, 2}; %% TODO
+opcode(_GasTable, ?RETURNDATACOPY) -> { 3,  0, 3}; %% TODO
 opcode(GasTable, ?BLOCKHASH)      -> { 1,  1, maps:get('GBLOCKHASH', GasTable)};
 opcode(GasTable, ?COINBASE)       -> { 0,  1, maps:get('GBASE', GasTable)};
 opcode(GasTable, ?TIMESTAMP)      -> { 0,  1, maps:get('GBASE', GasTable)};
@@ -74,7 +74,7 @@ opcode(GasTable, ?MLOAD)          -> { 1,  1, maps:get('GVERYLOW', GasTable)};
 opcode(GasTable, ?MSTORE)         -> { 2,  0, maps:get('GVERYLOW', GasTable)};
 opcode(GasTable, ?MSTORE8)        -> { 2,  0, maps:get('GVERYLOW', GasTable)};
 opcode(GasTable, ?SLOAD)          -> { 1,  1, maps:get('GSLOAD', GasTable)};
-opcode(GasTable, ?SSTORE)         -> { 2,  0, 0};
+opcode(_GasTable, ?SSTORE)         -> { 2,  0, 0};
 opcode(GasTable, ?JUMP)           -> { 1,  0, maps:get('GMID', GasTable)};
 opcode(GasTable, ?JUMPI)          -> { 2,  0, maps:get('GHIGH', GasTable)};
 opcode(GasTable, ?PC)             -> { 0,  1, maps:get('GBASE', GasTable)};
@@ -151,10 +151,10 @@ opcode(GasTable, ?LOG2)           -> { 4,  0, maps:get('GLOG', GasTable) + 2*map
 opcode(GasTable, ?LOG3)           -> { 5,  0, maps:get('GLOG', GasTable) + 3*maps:get('GLOGTOPIC', GasTable)};
 opcode(GasTable, ?LOG4)           -> { 6,  0, maps:get('GLOG', GasTable) + 4*maps:get('GLOGTOPIC', GasTable)};
 opcode(GasTable, ?CREATE)         -> { 3,  1, maps:get('GCREATE', GasTable)};
-opcode(GasTable, ?CALL)           -> { 7,  1, 0};
-opcode(GasTable, ?CALLCODE)       -> { 7,  1, 0};
+opcode(_GasTable, ?CALL)           -> { 7,  1, 0};
+opcode(_GasTable, ?CALLCODE)       -> { 7,  1, 0};
 opcode(GasTable, ?RETURN)         -> { 2,  0, maps:get('GZERO', GasTable)};
-opcode(GasTable, ?DELEGATECALL)   -> { 6,  1, 0};
-opcode(GasTable, ?STATICCALL)     -> { 6,  1, 40}; %% TODO
-opcode(GasTable, ?REVERT)         -> { 2,  0, 0};
+opcode(_GasTable, ?DELEGATECALL)   -> { 6,  1, 0};
+opcode(_GasTable, ?STATICCALL)     -> { 6,  1, 40}; %% TODO
+opcode(_GasTable, ?REVERT)         -> { 2,  0, 0};
 opcode(GasTable, ?SUICIDE)        -> { 1,  0, maps:get('GSELFDESTRUCT', GasTable)}. %% TODO


### PR DESCRIPTION
* Compiler warnings
* Don't re-insert key block when adding forward generations (it will fail for the genesis block and generate a warning!)
* Remove excessive (and confusing/incorrect) debug logging in aec_peers
* Don't busy loop sync workers so agressively
* Fix intermittent eunit test failure (running out of time occasionally)
* Fix intermittent test failure (micro-forks left mempool non-empty)