### PR TITLE
Fix CI tag version regex matching

### DIFF
--- a/.circleci/set_package_path.sh
+++ b/.circleci/set_package_path.sh
@@ -9,7 +9,7 @@ elif [ "$(uname -s)" == "Linux" ]; then
 fi
 
 VERSION=${CIRCLE_SHA1:-unknown}
-if [[ -n $CIRCLE_TAG && $CIRCLE_TAG =~ ^v([0-9]+\.[0-9]+\.[0-9]+)(-[a-z0-9]+)*$ ]]; then
+if [[ -n $CIRCLE_TAG && $CIRCLE_TAG =~ ^v([0-9]+\.[0-9]+\.[0-9]+(-[a-z0-9]+)*)$ ]]; then
     VERSION=${BASH_REMATCH[1]}
 fi
 


### PR DESCRIPTION
Using subgroup instead of additional group