### PR TITLE
allow signing microblocks with mining auto_start false

### DIFF
--- a/apps/aecore/src/aec_conductor.erl
+++ b/apps/aecore/src/aec_conductor.erl
@@ -732,8 +732,6 @@ bump_nonce(C = #candidate{ nonce = N }) ->
 start_micro_signing(#state{keys_ready = false} = State) ->
     %% We need to get the keys first
     wait_for_keys(State);
-start_micro_signing(#state{mining_state = 'stopped'} = State) ->
-    State;
 start_micro_signing(#state{consensus = #consensus{leader = true}, micro_block_candidate = undefined} = State) ->
     %% We have to wait for a new block candidate first.
     State;


### PR DESCRIPTION
This will let pools' edge nodes act as leaders and sign microblocks after they receive solution from worker nodes.