### PR TITLE
Make db_backend configurable (via schema) based on platform.

### DIFF
--- a/apps/aecore/src/aec_db.erl
+++ b/apps/aecore/src/aec_db.erl
@@ -151,6 +151,7 @@ tab_vsn(_) -> 1.
 tab_type(_) -> set.
 
 tab_copies(disc) -> {rocksdb_copies, [node()]};
+tab_copies(disc_legacy) -> {disc_copies, [node()]};
 tab_copies(ram ) -> {ram_copies , [node()]}.
 
 clear_db() ->
@@ -612,6 +613,7 @@ wait_for_tables(Tabs, Sofar, _, _) ->
 check_db() ->
     try
         Mode = case application:get_env(aecore, persist, false) of
+                   legacy -> disc_legacy;
                    true  -> disc;
                    false -> ram
                end,
@@ -696,6 +698,14 @@ ensure_schema_storage_mode(ram) ->
         {true, Dir} ->
             lager:warning("Will not use existing Mnesia db (~s)", [Dir]),
             set_dummy_mnesia_dir(Dir);
+        false ->
+            ok
+    end;
+ensure_schema_storage_mode(disc_legacy) ->
+    case disc_db_exists() of
+        {true, Dir} ->
+            lager:warning("Will use existing Mnesia db (~s)", [Dir]),
+            existing_schema;
         false ->
             ok
     end;

--- a/apps/aeutils/priv/epoch_config_schema.json
+++ b/apps/aeutils/priv/epoch_config_schema.json
@@ -330,6 +330,13 @@
                     "description" :
                     "If true, all changes to the chain are written to disk.",
                     "type" : "boolean" },
+                "db_backend" : {
+                    "description" : "Choice of database backend.",
+                    "type" : "string",
+                    "pattern" : "^([a-z]+|([a-z0-9\\*]+:[a-z]+)|([a-z0-9\\*]+:[a-z]+(\\h*\\|\\h*[a-z0-9\\*]+:[a-z]+))+)$",
+                    "example" : "'rocksdb' OR 'unix:rocksdb' OR 'unix:rocksdb|*:mnesia",
+                    "default" : "unix:rocksdb|*:mnesia"
+                },
                 "db_path"   : {
                     "description" :
                     "The directory where the chain is persisted to disk.",


### PR DESCRIPTION
    Make db_backend configurable (via schema) based on platform.

[ based on PR #1837 ]
    
    The item "chain:db_backend" in the schema supports either a simple
    backend name, or a pattern "<platform>:<backend>", or a series of
    such patterns, where <platform> may be "*" (wild-card). This allows
    for different platforms to use different db backends by default,
    and also simplifies testing of new backends.
    Supported backends are "rocksdb" and "mnesia", where the mnesia
    backend uses `disc_copies` if persistent==true.
