### PR TITLE
handshake failed, if fork_management not set

### DIFF
--- a/apps/aeutils/priv/epoch_config_schema.json
+++ b/apps/aeutils/priv/epoch_config_schema.json
@@ -742,8 +742,9 @@
             "properties" : {
                 "network_id" : {
                     "description" :
-                    "Identification of the network in case of hard forks.",
-                    "type" : "string"}
+                    "Identification of the network in case of hard forks.Use 'ae_uat' for testnet and 'ae_mainnet' ",
+                    "type" : "string",
+                    "default" : "ae_uat"}
             }
         }
     },


### PR DESCRIPTION
tested twice, if I did not set:
fork_management:
    network_id: ae_uat

or
fork_management:
    network_id: ae_mainnet

I get these errors:
23:35:21.873 [info] Connection handshake failed - timeout was from <<"52.10.46.160">>
23:35:23.296 [info] Connection handshake failed - timeout was from <<"18.195.109.60">>
23:35:25.545 [info] Connection handshake failed - timeout was from <<"13.250.162.250">>