### PR TITLE
Restrict listen address of Distributed Erlang port

### DIFF
--- a/config/dev.config
+++ b/config/dev.config
@@ -1,4 +1,10 @@
 [
+  { kernel,
+    [
+     {inet_dist_use_interface, {127,0,0,1}}
+    ]
+  },
+
   { epoch, [
   ]},
 

--- a/config/dev1/sys.config
+++ b/config/dev1/sys.config
@@ -1,4 +1,10 @@
 [
+  { kernel,
+    [
+     {inet_dist_use_interface, {127,0,0,1}}
+    ]
+  },
+
   { epoch, [
   ]},
 

--- a/config/dev2/sys.config
+++ b/config/dev2/sys.config
@@ -1,4 +1,10 @@
 [
+  { kernel,
+    [
+     {inet_dist_use_interface, {127,0,0,1}}
+    ]
+  },
+
   { epoch, [
   ]},
 

--- a/config/dev3/sys.config
+++ b/config/dev3/sys.config
@@ -1,4 +1,10 @@
 [
+  { kernel,
+    [
+     {inet_dist_use_interface, {127,0,0,1}}
+    ]
+  },
+
   { epoch, [
   ]},
 

--- a/config/sys.config
+++ b/config/sys.config
@@ -1,5 +1,10 @@
 
 [
+  { kernel,
+    [
+     {inet_dist_use_interface, {127,0,0,1}}
+    ]
+  },
 
   { epoch, [
   ]},

--- a/config/test.config
+++ b/config/test.config
@@ -1,4 +1,10 @@
 [
+  { kernel,
+    [
+     {inet_dist_use_interface, {127,0,0,1}}
+    ]
+  },
+
   {setup, [
            {data_dir, "../../rel/epoch/data"}
           ]}

--- a/docs/release-notes/PT-162237191-erl-dist-listen-address.md
+++ b/docs/release-notes/PT-162237191-erl-dist-listen-address.md
@@ -1,0 +1,1 @@
+* Restricts the listen address of the operations TCP port (Distributed Erlang) to localhost (`127.0.0.1`).


### PR DESCRIPTION
Delivers https://www.pivotaltracker.com/story/show/162237191
Supersedes https://github.com/aeternity/epoch/pull/1858

TODO:
* [x] Add release note line.

From https://github.com/aeternity/epoch/pull/1857#discussion_r236732564
> > Alternative:
> > From [OTP 20.1 doc](http://erlang.org/documentation/doc-9.1/lib/kernel-5.4/doc/html/kernel_app.html): `{inet_dist_use_interface, ip_address()}`.
> > Used [here](https://github.com/erlang/otp/blob/OTP-20.1/lib/kernel/src/inet_tcp_dist.erl#L117).
> 
> `net_kernel` checks `proto_dist` init argument and if none it uses `inet_tcp_dist` ([doc](https://github.com/erlang/otp/blob/OTP-20.1/erts/doc/src/erl.xml#L439-L444), [code](https://github.com/erlang/otp/blob/OTP-20.1/lib/kernel/src/net_kernel.erl#L1380-L1384)).
> 
> `net_kernel` listens calling [`inet_tcp_dist:listen(Name)`](https://github.com/erlang/otp/blob/OTP-20.1/lib/kernel/src/net_kernel.erl#L1399-L1400) that calls internal `inet_tcp_dist:do_listen` [with `Driver` `inet_tcp` (hardcoded)](https://github.com/erlang/otp/blob/OTP-20.1/lib/kernel/src/inet_tcp_dist.erl#L71-L75). This, if `application:get_env(kernel, inet_dist_use_interface)` returns `{ok, Ip}`, adds `{ip, Ip}` to options passed to `Driver:listen(First, Options)` i.e. [`gen_tcp:listen/2`](https://github.com/erlang/otp/blob/OTP-20.1/lib/kernel/src/inet_tcp.erl#L140), that in turn [parses option `{ip, _}`](https://github.com/erlang/otp/blob/OTP-20.1/lib/kernel/src/inet.erl#L802).
> 
> So option `inet_dist_use_interface` seems hooked properly.

From https://github.com/aeternity/epoch/pull/1858#discussion_r236755784
> On [f3b537f](https://github.com/aeternity/epoch/commit/f3b537f53d55a21d02b8de37a59e4bb41a5db280) I conducted this test:
> 
> Package built by `make prod-package`, installed&configured&started as per instructions referred to by release notes.
> 
> I checked address-port:
> 
> ```
> epmd -names
> epmd: up and running on port 4369 with data:
> name epoch at port 62480
> ...
> netstat -atn | less
> ...
> tcp4       0      0  127.0.0.1.62480        *.*                    LISTEN
> ```

