### PR TITLE
Fix misleading expected mine interval in example yamls

### DIFF
--- a/apps/aeutils/test/data/epoch_full.yaml
+++ b/apps/aeutils/test/data/epoch_full.yaml
@@ -113,7 +113,7 @@ mining:
     # Maximum time (milliseconds) for each attempt to mine a block with a specific nonce.
     attempt_timeout: 3600000
     # Expected mine rate (milliseconds) between blocks. Used in governance.
-    expected_mine_rate: 300000
+    expected_mine_rate: 180000
     micro_block_cycle: 3000
     # Public key of beneficiary account that will receive fees from mining on a node.
     beneficiary: "ak_DummyPubKeyDoNotEverUse999999999999999999999999999"

--- a/apps/aeutils/test/data/epoch_no_newline.yaml
+++ b/apps/aeutils/test/data/epoch_no_newline.yaml
@@ -58,7 +58,7 @@ mining:
     # Maximum time (milliseconds) for each attempt to mine a block with a specific nonce.
     attempt_timeout: 3600000
     # Expected mine rate (milliseconds) between blocks. Used in governance.
-    expected_mine_rate: 300000
+    expected_mine_rate: 180000
     # Public key of beneficiary account that will receive fees from mining on a node.
     beneficiary: "ak_DummyPubKeyDoNotEverUse999999999999999999999999999"
     cuckoo:


### PR DESCRIPTION
The expected mining time is 3 minutes.