### PR TITLE
introduced network ids to docker

### DIFF
--- a/docker/epoch_node1_mean15.yaml
+++ b/docker/epoch_node1_mean15.yaml
@@ -25,3 +25,6 @@ mining:
             executable: mean15-generic
             extra_args: ""
             edge_bits: 15
+
+fork_management:
+    network_id: ae_docker

--- a/docker/epoch_node2_mean15.yaml
+++ b/docker/epoch_node2_mean15.yaml
@@ -25,3 +25,6 @@ mining:
             executable: mean15-generic
             extra_args: ""
             edge_bits: 15
+
+fork_management:
+    network_id: ae_docker

--- a/docker/epoch_node3_mean15.yaml
+++ b/docker/epoch_node3_mean15.yaml
@@ -25,3 +25,6 @@ mining:
             executable: mean15-generic
             extra_args: ""
             edge_bits: 15
+
+fork_management:
+    network_id: ae_docker


### PR DESCRIPTION
 ae_mainnet default chooses slower initial target