### PR TITLE
PT-162340809 Fix HTTP request validation result

### DIFF
--- a/apps/aehttp/src/aehttp_api_handler.erl
+++ b/apps/aehttp/src/aehttp_api_handler.erl
@@ -63,8 +63,8 @@ handle_request_json(Req0, State = #state{
             Req = cowboy_req:reply(400, #{}, Body, Req1),
             {stop, Req, State}
     catch error:Error ->
-            lager:error("Unexpected validate result: ~p / ~p",
-                        [Error, erlang:get_stacktrace()]),
+            lager:warning("Unexpected validate result: ~p / ~p",
+                          [Error, erlang:get_stacktrace()]),
             Body = jsx:encode(to_error({validation_error, <<>>, <<>>})),
             {stop, cowboy_req:reply(400, #{}, Body, Req0), State}
     end.

--- a/docs/release-notes/next/PT-162340809-unexpected-user-api-validation-result.md
+++ b/docs/release-notes/next/PT-162340809-unexpected-user-api-validation-result.md
@@ -1,0 +1,2 @@
+* Fine tunes the validation of user API requests. The request body must be smaller than approx. 5 MB (was 8 MB) and must be received within 10 s (was 15 s).
+* Fine tunes the severity of the log message in case of unexpected validation result of user HTTP API request - from error to warning.


### PR DESCRIPTION
[PT-162340809](https://www.pivotaltracker.com/n/projects/2124891/stories/162340809)

The current default config of lager:
```
(epoch@localhost)8> lager:status().
Lager status:
File log/epoch_metrics.log (epoch_metrics_lager_event) at level info
File log/epoch_mining.log (epoch_mining_lager_event) at level info
File log/epoch_pow_cuckoo.log (epoch_pow_cuckoo_lager_event) at level debug
Console (epoch_sync_lager_event) at level info
File log/epoch_sync.log (epoch_sync_lager_event) at level debug
Console (lager_event) at level info
File log/epoch.log (lager_event) at level debug
```
It'd be good to set different log levels for the production system so debug, info and notice(?) messages are not logged by default.
