### PR TITLE
Enable running system tests pushing to branch `system-tests`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -648,6 +648,7 @@ workflows:
               ignore:
                 - env/dev1
                 - env/dev2
+                - system-tests
             tags:
               only: /^v.*$/
 
@@ -657,6 +658,7 @@ workflows:
               ignore:
                 - env/dev1
                 - env/dev2
+                - system-tests
                 - master
 
       - deploy_api_docs:
@@ -678,6 +680,7 @@ workflows:
               ignore:
                 - env/dev1
                 - env/dev2
+                - system-tests
 
       - test:
           requires:
@@ -687,6 +690,7 @@ workflows:
               ignore:
                 - env/dev1
                 - env/dev2
+                - system-tests
 
       - eunit:
           requires:
@@ -696,6 +700,7 @@ workflows:
               ignore:
                 - env/dev1
                 - env/dev2
+                - system-tests
             tags:
               only: /^v.*$/
 
@@ -707,6 +712,7 @@ workflows:
               ignore:
                 - env/dev1
                 - env/dev2
+                - system-tests
             tags:
               only: /^v.*$/
 
@@ -718,8 +724,14 @@ workflows:
               ignore:
                 - env/dev1
                 - env/dev2
+                - system-tests
             tags:
               only: /^v.*$/
+
+      - docker_system_tests:
+          filters:
+            branches:
+              only: system-tests
 
       - static_analysis:
           requires:
@@ -729,6 +741,7 @@ workflows:
               ignore:
                 - env/dev1
                 - env/dev2
+                - system-tests
             tags:
               only: /^v.*$/
 
@@ -740,11 +753,15 @@ workflows:
               ignore:
                 - env/dev1
                 - env/dev2
+                - system-tests
             tags:
               only: /^v.*$/
 
       - linux_package:
           filters:
+            branches:
+              ignore:
+                - system-tests
             tags:
               only: /^v.*$/
 
@@ -752,6 +769,9 @@ workflows:
           requires:
             - linux_package
           filters:
+            branches:
+              ignore:
+                - system-tests
             tags:
               only: /^v.*$/
 


### PR DESCRIPTION
Delivers https://www.pivotaltracker.com/story/show/162379209

* How does CI behave on branch distinct from `system-tests`? CI job `docker_system_tests` does not run. Proof: see CI workflow on this branch.
* How does CI behave on branch `system-tests`? CI job `docker_system_tests` runs. Proof: see [this](https://circleci.com/workflow-run/8d54562f-67b7-4da3-a3c8-a69278dcec4f) CI workflow.

TODO:
* [x] Update wiki.
  * [Preparatory changes](https://github.com/aeternity/epoch/wiki/System-Testing/_compare/db88b8e750faafb625ef24939eaf5e7779a110b3...49d7a371fa177d5d4afbbdcf3fb33eeaabf525b1).
  * [Changes re `system-tests` special branch](https://github.com/aeternity/epoch/wiki/System-Testing/_compare/49d7a371fa177d5d4afbbdcf3fb33eeaabf525b1...d388bb127cb47d5529c4e5e810d3a1fcabfa5c27).