### PR TITLE
PT-161722828 Add network_id to /status endpoint

### DIFF
--- a/apps/aehttp/priv/swagger.json
+++ b/apps/aehttp/priv/swagger.json
@@ -3483,7 +3483,7 @@
     },
     "Status" : {
       "type" : "object",
-      "required" : [ "difficulty", "genesis_key_block_hash", "listening", "node_revision", "node_version", "peer_count", "pending_transactions_count", "protocols", "solutions", "syncing" ],
+      "required" : [ "difficulty", "genesis_key_block_hash", "listening", "network_id", "node_revision", "node_version", "peer_count", "pending_transactions_count", "protocols", "solutions", "syncing" ],
       "properties" : {
         "genesis_key_block_hash" : {
           "$ref" : "#/definitions/EncodedHash"
@@ -3524,6 +3524,9 @@
           "type" : "integer",
           "format" : "int64",
           "minimum" : 0
+        },
+        "network_id" : {
+          "type" : "string"
         }
       },
       "example" : {
@@ -3532,6 +3535,7 @@
         "peer_count" : 0,
         "pending_transactions_count" : 0,
         "genesis_key_block_hash" : { },
+        "network_id" : "network_id",
         "syncing" : true,
         "node_revision" : "node_revision",
         "solutions" : 0,

--- a/apps/aehttp/src/aehttp_dispatch_ext.erl
+++ b/apps/aehttp/src/aehttp_dispatch_ext.erl
@@ -561,7 +561,8 @@ handle_request_('GetStatus', _Params, _Context) ->
        <<"node_version">>               => NodeVersion,
        <<"node_revision">>              => NodeRevision,
        <<"peer_count">>                 => PeerCount,
-       <<"pending_transactions_count">> => PendingTxsCount}};
+       <<"pending_transactions_count">> => PendingTxsCount,
+       <<"network_id">>                 => aec_governance:get_network_id()}};
 
 handle_request_('GetContractCallFromTx', Req, _Context) ->
     ParseFuns = [read_required_params([tx_hash]),

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -1842,7 +1842,8 @@ get_status(_Config) ->
        <<"node_version">>               := _NodeVersion,
        <<"node_revision">>              := _NodeRevision,
        <<"peer_count">>                 := PeerCount,
-       <<"pending_transactions_count">> := PendingTxCount
+       <<"pending_transactions_count">> := PendingTxCount,
+       <<"network_id">>                 := NetworkId
       }} = get_status_sut(),
     ?assertMatch({ok, _}, aehttp_api_encoder:safe_decode(key_block_hash, GenesisKeyBlocHash)),
     ?assertMatch(X when is_integer(X) andalso X >= 0, Solutions),
@@ -1856,6 +1857,7 @@ get_status(_Config) ->
                   end, Protocols),
     ?assertMatch(X when is_integer(X) andalso X >= 0, PeerCount),
     ?assertMatch(X when is_integer(X) andalso X >= 0, PendingTxCount),
+    ?assertEqual(NetworkId, aec_governance:get_network_id()),
     ok.
 
 get_status_sut() ->

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -2734,6 +2734,8 @@ definitions:
         type: integer
         format: int64
         minimum: 0
+      network_id:
+        type: string
     required:
       - genesis_key_block_hash
       - solutions
@@ -2745,6 +2747,7 @@ definitions:
       - node_revision
       - peer_count
       - pending_transactions_count
+      - network_id
   Protocol:
     type: object
     properties:

--- a/docs/release-notes/next/PT-161722828.md
+++ b/docs/release-notes/next/PT-161722828.md
@@ -1,0 +1,1 @@
+* Adds `network_id` to `/status` endpoint. This is a backward compatible enhancement of the user HTTP API.


### PR DESCRIPTION
Apparently branches with `/` don't work with `docker_smoke_tests` target (which is needed for `docker_system_smoke_tests`)...

So this supersedes https://github.com/aeternity/epoch/pull/1883.

@gorillainduction @velzevur @fabiankrol Could you approve this one?...