### PR TITLE
PT-162396161 Disable mining autostart and do not require beneficiary …

### DIFF
--- a/apps/aecore/src/aec_conductor.hrl
+++ b/apps/aecore/src/aec_conductor.hrl
@@ -30,12 +30,12 @@
                 micro_block_candidate                     :: #candidate{} | 'undefined',
                 blocked_tags            = []              :: ordsets:ordset(atom()),
                 keys_ready              = false           :: boolean(),
-                mining_state            = running         :: mining_state(),
+                mining_state            = stopped         :: mining_state(),
                 top_block_hash                            :: binary() | 'undefined',
                 top_key_block_hash                        :: binary() | 'undefined',
                 workers                 = []              :: workers(),
                 consensus                                 :: #consensus{},
-                beneficiary                               :: <<_:(32*8)>>,  % Maybe move beneficiary out of conductor's state
+                beneficiary                               :: <<_:(32*8)>> | 'undefined',
                 fraud_list              = []              :: list({binary(), aec_pof:pof()}),
                 pending_key_block                         :: aec_blocks:block() | 'undefined'
                }).

--- a/apps/aehttp/priv/swagger.json
+++ b/apps/aehttp/priv/swagger.json
@@ -155,6 +155,12 @@
               "$ref" : "#/definitions/KeyBlock"
             }
           },
+          "400" : {
+            "description" : "Beneficiary not configured",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
           "404" : {
             "description" : "Block not found",
             "schema" : {
@@ -1859,6 +1865,12 @@
             "description" : "Successful operation",
             "schema" : {
               "$ref" : "#/definitions/PubKey"
+            }
+          },
+          "404" : {
+            "description" : "Beneficiary error",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
             }
           }
         }

--- a/apps/aehttp/src/aehttp_dispatch_ext.erl
+++ b/apps/aehttp/src/aehttp_dispatch_ext.erl
@@ -166,6 +166,8 @@ handle_request_('GetPendingKeyBlock', _Req, _Context) ->
                 error ->
                     {404, [], #{reason => <<"Block not found">>}}
             end;
+        {error, beneficiary_not_configured} ->
+            {400, [], #{reason => <<"Beneficiary not configured">>}};
         {error, _} ->
             {404, [], #{reason => <<"Block not found">>}}
     end;

--- a/apps/aehttp/src/aehttp_dispatch_int.erl
+++ b/apps/aehttp/src/aehttp_dispatch_int.erl
@@ -444,8 +444,12 @@ handle_request_('PostOracleRespond', #{'OracleRespondTx' := Req}, _Context) ->
     process_request(ParseFuns, Req);
 
 handle_request_('GetNodeBeneficiary', _, _Context) ->
-    {ok, Pubkey} = aec_conductor:get_beneficiary(),
-    {200, [], #{pub_key => aehttp_api_encoder:encode(account_pubkey, Pubkey)}};
+    case aec_conductor:get_beneficiary() of
+        {ok, PubKey} ->
+            {200, [], #{pub_key => aehttp_api_encoder:encode(account_pubkey, PubKey)}};
+        {error, Reason} ->
+            {404, [], #{reason =>  atom_to_binary(Reason, utf8)}}
+    end;
 
 handle_request_('GetNodePubkey', _, _Context) ->
     case aec_keys:pubkey() of

--- a/apps/aeutils/priv/epoch_config_schema.json
+++ b/apps/aeutils/priv/epoch_config_schema.json
@@ -365,7 +365,6 @@
         "mining" : {
             "type" : "object",
             "additionalProperties" : false,
-            "required" : ["beneficiary"],
             "properties" : {
                 "autostart" : {
                     "description" :
@@ -379,7 +378,7 @@
                 },
                 "beneficiary" : {
                     "description" :
-                    "Public key of beneficiary account that will receive fees from mining on a node.",
+                    "Public key of beneficiary account that will receive fees from mining on a node. Required when 'mining.autostart' is set to 'true'.",
                     "type" : "string",
                     "example" : "ak_DummyPubKeyDoNotEverUse999999999999999999999999999",
                     "pattern": "^ak_[1-9A-HJ-NP-Za-km-z]*$"

--- a/config/dev.config
+++ b/config/dev.config
@@ -26,7 +26,7 @@
       {enable_debug_endpoints, true} %% CAUTION: Debug endpoints may be inefficient
   ]},
 
-  {aecore, [{beneficiary, <<"ak_tjnw1KcmnwfqXvhtGa9GRjanbHM3t6PmEWEWtNMM3ouvNKRu5">>},
+  {aecore, [
       {peers, []},
       {peer_password, <<"secret">>},
       {db_path, "."},

--- a/config/dev1/sys.config
+++ b/config/dev1/sys.config
@@ -43,7 +43,6 @@
       {peer_password, <<"secret">>},
       {db_path, "."},
       {persist, false},
-      {autostart, false},
       {aec_pow_cuckoo, {"mean15-generic", "-t 5", 15, false}}
     ]
   },

--- a/config/dev2/sys.config
+++ b/config/dev2/sys.config
@@ -43,7 +43,6 @@
       {peer_password, <<"secret">>},
       {db_path, "."},
       {persist, false},
-      {autostart, false},
       {aec_pow_cuckoo, {"mean15-generic", "-t 5", 15, false}},
       {ping_interval, 500}
     ]

--- a/config/dev3/sys.config
+++ b/config/dev3/sys.config
@@ -43,7 +43,6 @@
       {peer_password, <<"secret">>},
       {db_path, "."},
       {persist, false},
-      {autostart, false},
       {aec_pow_cuckoo, {"mean15-generic", "-t 5", 15, false}}
     ]
   },

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -144,6 +144,10 @@ paths:
           description: 'Successful operation'
           schema:
             $ref: '#/definitions/KeyBlock'
+        '400':
+          description: 'Beneficiary not configured'
+          schema:
+            $ref: '#/definitions/Error'
         '404':
           description: 'Block not found'
           schema:
@@ -1581,6 +1585,10 @@ paths:
           description: 'Successful operation'
           schema:
             $ref: '#/definitions/PubKey'
+        '404':
+          description: 'Beneficiary error'
+          schema:
+            $ref: '#/definitions/Error'
       security:
   /debug/accounts/node:
     get:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -69,7 +69,108 @@ listening can be set using the `websocket` > `channel` > `listen_address`
 parameter. Note that this address has a default value of `127.0.0.1` and thus
 the WebSocket endpoint is not exposed.
 
-### Beneficiary account
+## Network ID
+
+The release package is preconfigured with Roma network_id. Please change the configuration to interact with testnet.
+The testnet (internally called UAT) has the network ID `ae_uat` - this is set in the configuration:
+
+```yaml
+fork_management:
+    network_id: ae_uat
+```
+
+For Roma network the network ID defaults to `ae_mainnet`.
+
+## Instructions
+
+The instructions below assume that:
+* The node is deployed in directory `/tmp/node`;
+* No custom peers are specified under the `peers` key in the config. If the `peers` key is undefined, the *Roma network* seed peers (built-in in the package source) are used.
+
+If any of the assumptions does not hold, you need to amend the instructions accordingly.
+
+Create the file `/tmp/node/epoch.yaml` with the below content.
+Make sure you amend the `sync` > `port` parameter with your actual value.
+
+```yaml
+---
+sync:
+    port: 3015
+
+keys:
+    dir: keys
+    peer_password: "secret"
+
+http:
+    external:
+        port: 3013
+    internal:
+        port: 3113
+
+websocket:
+    channel:
+        port: 3014
+
+mining:
+    autostart: false
+
+chain:
+    persist: true
+    db_path: ./my_db
+
+fork_management:
+    network_id: ae_mainnet
+
+```
+
+The node automatically creates the directory `db_path`, for storing the blockchain, if not present.
+
+The above sample config has `mining` > `autostart` set to `false`, so mining will not start automatically.
+To configure your node to mine, go to the [Miner configuration section](#miner-configuration).
+
+Note that YAML files have significant whitespace so make sure that you indent the file correctly and that the file ends with a newline.
+
+You can validate the configuration file before starting the node:
+```bash
+cd /tmp/node
+bin/epoch check_config epoch.yaml
+```
+You shall read output like the following:
+```
+OK
+```
+If the file is valid YAML but does not contain a valid configuration, it prints a helpful output.
+
+## Miner configuration
+
+The instructions below assume that you already know your `beneficiary` account public key (if you don't, see [Beneficiary account section](#beneficiary-account)).
+
+If you want to use your node to mine, you can use the default mining by setting
+```yaml
+mining:
+    beneficiary: "beneficiary_pubkey_to_be_replaced"
+    autostart: true
+```
+in the epoch.yaml configuration file.
+
+Make sure you replace `mining` > `beneficiary` parameter with your public key!
+
+Note that in order to improve sync performance, before configuring your miner, you should start a node with `autostart: false`.
+Change this value to `autostart: true` when you are in sync, then restart the node.
+
+Your mining setup needs to meet your hardware capacity. Therefore, you need to make a choice in how you want to configure your miner. You can read the documentation on setting up CUDA mining, or you can use all but one of the cores on your computer to mine (keep one core available for transaction gossiping, synchronising, etc).
+If you have 16 cores, you could (loosely spoken) assign 14 of them to mining using the following configuration:
+```yaml
+mining:
+    beneficiary: "beneficiary_pubkey_to_be_replaced"
+    cuckoo:
+        miner:
+            edge_bits: 29
+            executable: mean29-avx2
+            extra_args: -t 14
+```
+
+## Beneficiary account
 
 In order to configure who receives fees from mining on a node, you must configure a beneficiary public key.
 
@@ -98,100 +199,3 @@ Generated keypair with encoded pubkey: ak_2D9REvQsrAgnJgmdwPq585D8YksJC8PSAA8Msc
 
 In the example the generated public key is `ak_2D9REvQsrAgnJgmdwPq585D8YksJC8PSAA8MscQdxinbkFC7rq`, but **do not use it in your config**!
 This is just an **example** value to show what public key format you should expect after running `bin/epoch keys_gen` command.
-
-## Network ID
-
-The release package is preconfigured with Roma network_id. Please change the configuration to interact with testnet.
-The testnet (internally called UAT) has the network ID `ae_uat` - this is set in the configuration:
-
-```yaml
-fork_management:
-    network_id: ae_uat
-```
-
-For Roma network the network ID defaults to `ae_mainnet`.
-
-## Instructions
-
-The instructions below assume that:
-* The node is deployed in directory `/tmp/node`;
-* You already know your `beneficiary` account public key (if you don't, see [Beneficiary account section](#beneficiary-account));
-* No custom peers are specified under the `peers:` key in the config. If the `peers:` key is undefined, the *Roma network* seed peers (built-in in the package source) are used.
-
-If any of the assumptions does not hold, you need to amend the instructions accordingly.
-
-Create the file `/tmp/node/epoch.yaml` with the below content.
-Make sure you amend:
-* the `mining` > `beneficiary` parameter, i.e. replace `encoded_beneficiary_pubkey_to_be_replaced` with your public key;
-* the `sync` > `port` parameter with your actual value if you need to change it
-* set `autostart: false` if you have not yet synced with the blockchain to improve sync performance. Change this value to `autostart: true` and [configure your miner](#Miner-Configuration) when you are in sync, then restart the node.
-
-```yaml
----
-sync:
-    port: 3015
-
-keys:
-    dir: keys
-    peer_password: "secret"
-
-http:
-    external:
-        port: 3013
-    internal:
-        port: 3113
-
-websocket:
-    channel:
-        port: 3014
-
-mining:
-    beneficiary: "beneficiary_pubkey_to_be_replaced"
-    autostart: true
-
-chain:
-    persist: true
-    db_path: ./my_db
-
-fork_management:
-    network_id: ae_mainnet
-
-```
-
-The node automatically creates the directory `db_path`, for storing the blockchain, if not present.
-
-Note that YAML files have significant whitespace so make sure that you indent the file correctly and that the file ends with a newline.
-
-You can validate the configuration file before starting the node:
-```bash
-cd /tmp/node
-bin/epoch check_config epoch.yaml
-```
-You shall read output like the following:
-```
-OK
-```
-If the file is valid YAML but does not contain a valid configuration, it prints a helpful output.
-
-## Miner Configuration
-
-If you want to use your node to mine, you can use the default mining by setting
-```yaml
-mining:
-    beneficiary: "beneficiary_pubkey_to_be_replaced"
-    autostart: true
-```
-in the epoch.yaml configuration file.
-
-Your mining setup needs to meet your hardware capacity. Therefore, you need to make a choice in how you want to configure your miner. You can read the documentation on setting up CUDA mining, or you can use all but one of the cores on your computer to mine (keep one core available for transaction gossiping, synchronising, etc).
-If you have 16 cores, you could (loosely spoken) assign 14 of them to mining using the following configuration:
-```yaml
-mining:
-    beneficiary: "beneficiary_pubkey_to_be_replaced"
-    cuckoo:
-        miner:
-            edge_bits: 29
-            executable: mean29-avx2
-            extra_args: -t 14
-```
-Read the [beneficiary account section](#beneficiary-account) on how to put your key in this file.

--- a/docs/release-notes/next/PT-162396161.md
+++ b/docs/release-notes/next/PT-162396161.md
@@ -1,0 +1,1 @@
+* Disables mining autostart by default, and makes beneficiary optional when mining is not enabled.


### PR DESCRIPTION
…when mining is turned off.

System tests result:
```
%%% aest_channels_SUITE ==> test_simple_same_node_channel: OK
%%% aest_channels_SUITE ==> test_simple_different_nodes_channel: OK
%%% aest_channels_SUITE ==> on_chain_channel: OK
%%% aest_commands_SUITE ==> epoch_commands: OK
%%% aest_compatibility_SUITE ==> test_mining_algorithms_compatibility: OK
%%% aest_genesis_SUITE ==> test_node_starts_with_30k_accounts: OK
%%% aest_mempool_SUITE ==> test_mempool_ttl_cleanup: OK
%%% aest_mempool_SUITE ==> test_mempool_bad_nonce_cleanup: OK
%%% aest_names_SUITE ==> test_name_registration: OK
%%% aest_names_SUITE ==> test_name_transfer: OK
%%% aest_oracles_SUITE ==> test_simple_same_node_query: OK
%%% aest_oracles_SUITE ==> test_simple_two_nodes_query: OK
%%% aest_oracles_SUITE ==> test_oracle_ttl_extension: OK
%%% aest_oracles_SUITE ==> test_pipelined_same_node_query: OK
%%% aest_oracles_SUITE ==> test_pipelined_two_nodes_query: OK
%%% aest_peers_SUITE ==> test_peer_discovery: OK
%%% aest_peers_SUITE ==> test_inbound_limitation: OK
%%% aest_perf_SUITE ==> long_chain.long_chain_mine_and_export: OK
%%% aest_perf_SUITE ==> long_chain.long_chain_tests.mining_governed_rate: OK
%%% aest_perf_SUITE ==> long_chain.long_chain_tests.startup_speed: OK
%%% aest_perf_SUITE ==> long_chain.long_chain_tests.startup_speed_mining: OK
%%% aest_perf_SUITE ==> long_chain.long_chain_tests.sync_speed: OK
%%% aest_perf_SUITE ==> long_chain.long_chain_tests.stay_in_sync: OK
%%% aest_sync_SUITE ==> new_node_joins_network: OK
%%% aest_sync_SUITE ==> docker_keeps_data: OK
%%% aest_sync_SUITE ==> stop_and_continue_sync: OK
%%% aest_sync_SUITE ==> tx_pool_sync: OK
%%% aest_sync_SUITE ==> net_split_recovery: OK
%%% aest_sync_SUITE ==> net_split_mining_power: OK
%%% aest_sync_SUITE ==> abrupt_stop_new_node: SKIPPED
%%% aest_sync_SUITE ==> {tc_user_skip,database_restart_needs_fix}
%%% aest_sync_SUITE ==> abrupt_stop_mining_node: SKIPPED
%%% aest_sync_SUITE ==> {tc_user_skip,database_restart_needs_fix}
EXPERIMENTAL: Writing retry specification at /Users/zbigniewpekala/src/aeternity/epoch/system_test/logs/retry.spec
              call rebar3 ct with '--retry' to re-run failing cases.
Skipped 2 (2, 0) tests. Passed 29 tests.
```