### PR TITLE
Set CI in next branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,8 @@ references:
           && cd libsodium-src \
           && ./configure && make -j$(nproc) && sudo make install && sudo ldconfig
 
+  next_branch: &next_branch minerva
+
   rebar_cache_key: &rebar_cache_key rebar-cache-{{ checksum "rebar.lock" }}-{{ checksum "rebar.config" }}
   restore_rebar_cache: &restore_rebar_cache
     restore_cache:
@@ -167,6 +169,7 @@ references:
       name: Send failure notification
       environment:
         NOTIFY_BRANCH: master
+        NOTIFY_BRANCH_2: *next_branch
         HOOK_TEMPLATE: |
           {
             "text": "CircleCI job **%s** failed on branch **%s** by @%s",
@@ -180,7 +183,7 @@ references:
           }
       command: |
         if [ -n "$CIRCLE_BRANCH" ]; then
-          if [ "$CIRCLE_BRANCH" = "${NOTIFY_BRANCH:?}" ]; then
+          if [ "$CIRCLE_BRANCH" = "${NOTIFY_BRANCH:?}" -o "$CIRCLE_BRANCH" = "${NOTIFY_BRANCH_2:?}" ]; then
             HOOK_DATA=$(printf "$HOOK_TEMPLATE" "${CIRCLE_JOB:?}" "${CIRCLE_BRANCH:?}" "${CIRCLE_USERNAME:-unknown}" "${CIRCLE_BUILD_URL:?}")
             curl -X POST -H 'Content-Type: application/json' ${ROCKET_HOOK_URL:?} --data "${HOOK_DATA:?}"
           fi
@@ -192,6 +195,7 @@ references:
       name: Send failure notification on system test
       environment:
         NOTIFY_BRANCH: master
+        NOTIFY_BRANCH_2: *next_branch
         HOOK_TEMPLATE: |
           {
             "text": "CircleCI job **%s** failed on branch **%s** by @%s",
@@ -205,7 +209,7 @@ references:
           }
       command: |
         if [ -n "$CIRCLE_BRANCH" ]; then
-          if [ "$CIRCLE_BRANCH" = "${NOTIFY_BRANCH:?}" ]; then
+          if [ "$CIRCLE_BRANCH" = "${NOTIFY_BRANCH:?}" -o "$CIRCLE_BRANCH" = "${NOTIFY_BRANCH_2:?}" ]; then
             HOOK_DATA=$(printf "$HOOK_TEMPLATE" "${CIRCLE_JOB:?}" "${CIRCLE_BRANCH:?}" "${CIRCLE_USERNAME:-unknown}" "${CIRCLE_BUILD_URL:?}")
             curl -X POST -H 'Content-Type: application/json' ${ROCKET_HOOK_URL_SYSTEM_TEST:?} --data "${HOOK_DATA:?}"
           fi
@@ -664,6 +668,7 @@ workflows:
                 - env/dev2
                 - system-tests
                 - master
+                - *next_branch
 
       - deploy_api_docs:
           requires:
@@ -776,6 +781,7 @@ workflows:
             branches:
               ignore:
                 - system-tests
+                - *next_branch
             tags:
               only: /^v.*$/
 
@@ -784,6 +790,7 @@ workflows:
             branches:
               only:
                 - master
+                - *next_branch
             tags:
               only: /^v.*$/
 
@@ -812,6 +819,7 @@ workflows:
             branches:
               only:
                 - master
+                - *next_branch
 
       - deploy_dev1:
           requires:
@@ -946,5 +954,17 @@ workflows:
             branches:
               only:
                 - master
+    jobs:
+      - docker_system_tests
+
+  system_tests_next:
+    triggers:
+      - schedule:
+          # run Mon, Wed, Fri at 1am UTC
+          cron: "0 1 * * 1,3,5"
+          filters:
+            branches:
+              only:
+                - *next_branch
     jobs:
       - docker_system_tests


### PR DESCRIPTION
Delivers https://www.pivotaltracker.com/story/show/162452107

Depends on #1899 

Features on branch `minerva`:
* Push Docker image [`:minerva`](https://hub.docker.com/r/aeternity/epoch/tags/)
* Run system tests a few times a week
* Check that OSX package can be built - on each commit

This also enables failure notifications for the next branch. These failure notifications work:
* No notifications sent on success. [Sample CI workflow](https://circleci.com/workflow-run/adfd2156-0216-4b45-9631-76cfd6b02352) (check notification channels).
* Notifications sent on failure. [Sample CI workflow](https://circleci.com/workflow-run/0b10c5af-4ab6-4bf1-95a1-65318a0a8fd8) (check notification channels).

The `*next_branch` YAML syntax works e.g. see that job `docker_test_push_branch` was queued in [this CI workflow](https://circleci.com/workflow-run/f41f7390-57a2-4cee-9774-54288e395bde) that had `next_branch: &next_branch PT-162452107-ci-next`.

TODO:
* [x] Rebase on master once #1899 is merged (removing commits "Check that successful job does not notify" and "Check that failed job notifies")
* [x] Fine-tune next branch name (in one place i.e. `next_branch`)
* [x] Edit PR amending base branch to the correct "next" one
* [ ] ~Squash&merge~