### PR TITLE
PT-162445499 improve mining efficiency

### DIFF
--- a/apps/aecore/src/aec_pow.erl
+++ b/apps/aecore/src/aec_pow.erl
@@ -132,7 +132,11 @@ pick_nonce() ->
 
 -spec next_nonce(aec_pow:nonce()) -> aec_pow:nonce().
 next_nonce(N) ->
-    (N + 1) band ?MAX_NONCE.
+    Step = aec_pow_cuckoo:get_miner_repeats(),
+    case N + 2 * Step < ?MAX_NONCE of
+        true  -> N + Step;
+        false -> 0
+    end.
 
 %%------------------------------------------------------------------------------
 %% Test if binary is under the target threshold

--- a/apps/aecore/test/aec_test_utils.erl
+++ b/apps/aecore/test/aec_test_utils.erl
@@ -99,12 +99,12 @@ unmock_time() ->
     meck:unload(aeu_time).
 
 mock_fast_cuckoo_pow() ->
-    mock_fast_cuckoo_pow({"mean15-generic", "-t 5", 15, false}).
+    mock_fast_cuckoo_pow({"mean15-generic", "-t 5", 15, false, 10}).
 
 mock_fast_and_deterministic_cuckoo_pow() ->
-    mock_fast_cuckoo_pow({"mean15-generic", "", 15, false}).
+    mock_fast_cuckoo_pow({"mean15-generic", "", 15, false, 10}).
 
-mock_fast_cuckoo_pow({_MinerBin, _MinerExtraArgs, _NodeBits, _EncodedHeader} = Cfg) ->
+mock_fast_cuckoo_pow({_MinerBin, _MinerExtraArgs, _NodeBits, _EncodedHeader, _Repeats} = Cfg) ->
     meck:expect(aeu_env, get_env, 3,
                 fun
                     (aecore, aec_pow_cuckoo, _) ->

--- a/apps/aecuckoo/Makefile
+++ b/apps/aecuckoo/Makefile
@@ -22,11 +22,12 @@ GPP_ARCH_FLAGS ?= -m64 -x c++
 FLAGS ?= -Wall -Wno-format -Wno-deprecated-declarations -D_POSIX_C_SOURCE=200112L $(OPT) -DPREFETCH -I. $(CPPFLAGS) -pthread
 GPP ?= g++ $(GPP_ARCH_FLAGS) -std=c++11 $(FLAGS)
 BLAKE_2B_SRC ?= ../crypto/blake2b-ref.c
+NVCC ?= nvcc -std=c++11
 
 # end Flags from upstream
 
 REPO = https://github.com/aeternity/cuckoo.git
-COMMIT = a66b88ab8514b7232b1e148a4760f9258d5457f0
+COMMIT = bef99e62e69a0821edc4a8353168a6c306a4acb9
 
 .PHONY: all
 all: $(EXECUTABLES)
@@ -85,10 +86,11 @@ $(CUCKOO)/mean29-avx2: $(HDRS) $(CUCKOO)/mean.hpp $(CUCKOO)/mean.cpp
 	(cd $(CUCKOO); $(GPP) -o $(@F) -DSAVEEDGES -mavx2 -DNSIPHASH=8 -DEDGEBITS=29 mean.cpp $(BLAKE_2B_SRC))
 
 $(CUCKOO)/lcuda29:	$(CUCKOO)/../crypto/siphash.cuh $(CUCKOO)/lean.cu
-	(cd $(CUCKOO); nvcc -o $(@F) -DEDGEBITS=29 -arch sm_35 lean.cu $(BLAKE_2B_SRC))
+	(cd $(CUCKOO); $(NVCC) -o $(@F) -DEDGEBITS=29 -arch sm_35 lean.cu $(BLAKE_2B_SRC))
 
 $(CUCKOO)/cuda29:		$(CUCKOO)/../crypto/siphash.cuh $(CUCKOO)/mean.cu
-	(cd $(CUCKOO); nvcc -o $(@F) -DEDGEBITS=29 -arch sm_35 mean.cu $(BLAKE_2B_SRC))
+	(cd $(CUCKOO); $(NVCC) -o $(@F) -DEDGEBITS=29 -arch sm_35 mean.cu $(BLAKE_2B_SRC))
+
 
 # Create the private dir
 $(PRIV):

--- a/apps/aecuckoo/Makefile
+++ b/apps/aecuckoo/Makefile
@@ -27,7 +27,7 @@ NVCC ?= nvcc -std=c++11
 # end Flags from upstream
 
 REPO = https://github.com/aeternity/cuckoo.git
-COMMIT = 58f2e7770d84397f24cdca095795bd12aa4227a0
+COMMIT = 81435b2cb86a63c5e7ea0251d01d836ec54c4f74
 
 .PHONY: all
 all: $(EXECUTABLES)

--- a/apps/aecuckoo/Makefile
+++ b/apps/aecuckoo/Makefile
@@ -27,7 +27,7 @@ NVCC ?= nvcc -std=c++11
 # end Flags from upstream
 
 REPO = https://github.com/aeternity/cuckoo.git
-COMMIT = bef99e62e69a0821edc4a8353168a6c306a4acb9
+COMMIT = 58f2e7770d84397f24cdca095795bd12aa4227a0
 
 .PHONY: all
 all: $(EXECUTABLES)

--- a/apps/aecuckoo/test/aecuckoo_SUITE.erl
+++ b/apps/aecuckoo/test/aecuckoo_SUITE.erl
@@ -49,7 +49,7 @@ smoke_test(Config) ->
 
     LibDir = ?TEST_MODULE:lib_dir(),
     MinBin = ?TEST_MODULE:bin(atom_to_list(Miner)),
-    Cmd = io_lib:format("'~s' -n ~B | grep '^Solution '", [MinBin, Nonce]),
+    Cmd = io_lib:format("'~s' -n ~B | grep '^Solution'", [MinBin, Nonce]),
     ct:log("Command: ~s~n", [Cmd]),
     CmdRes = lib:nonl(os:cmd(Cmd)),
     ct:log("Command result: ~s~n", [CmdRes]),

--- a/apps/aecuckoo/test/aecuckoo_SUITE.erl
+++ b/apps/aecuckoo/test/aecuckoo_SUITE.erl
@@ -33,7 +33,7 @@ groups() ->
     ].
 
 init_per_group(smoke_tests_15, Config) ->
-    [{nonce, 28} | Config];
+    [{nonce, 91} | Config];
 init_per_group(mean15, Config) ->
     [{miner, 'mean15-generic'} | Config];
 init_per_group(lean15, Config) ->
@@ -55,7 +55,7 @@ smoke_test(Config) ->
     ct:log("Command result: ~s~n", [CmdRes]),
 
     Solution = lists:map(fun(X) -> list_to_integer(X, 16) end, tl(string:tokens(CmdRes, " "))),
-    HeaderEquivalent = <<0:((80-4)*8), Nonce:32/little-unsigned-integer>>,
+    HeaderEquivalent = <<0:(44*8), (base64:encode(<<Nonce:64/little-unsigned-integer>>))/binary, 0:(24*8)>>,
 
     42 = length(Solution),
     true = aec_pow_cuckoo:verify_proof_(HeaderEquivalent, Solution, 15),

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -1174,7 +1174,7 @@ post_key_block(_CurrentBlockType, Config) ->
 
 mine_key_block(HeaderBin, Target, Nonce, Attempts) when Attempts > 0 ->
     case rpc(aec_mining, mine, [HeaderBin, Target, Nonce]) of
-        {ok, {Nonce, _PowEvidence}} = Res ->
+        {ok, {_Nonce, _PowEvidence}} = Res ->
             Res;
         {error, no_solution} ->
             mine_key_block(HeaderBin, Target, aec_pow:next_nonce(Nonce), Attempts - 1)

--- a/apps/aeutils/priv/epoch_config_schema.json
+++ b/apps/aeutils/priv/epoch_config_schema.json
@@ -437,6 +437,11 @@
                                 "nice" : {
                                     "description" : "Miner process priority (niceness) in a UNIX fashion. Higher `nice` means lower priority. Keep it unset to inherit parent process priority.",
                                     "type": "integer"
+                                },
+                                "repeats" : {
+                                    "description" : "Number of tries to do in each miner context - WARNING: it should be set so the miner process runs for 3-5s or else the node risk missing out on new micro blocks.",
+                                    "type": "integer",
+                                    "default": 1
                                 }
                             }
                         }

--- a/apps/aeutils/test/data/epoch_full.yaml
+++ b/apps/aeutils/test/data/epoch_full.yaml
@@ -129,6 +129,8 @@ mining:
             hex_encoded_header: false
             # Miner process priority (niceness) in a UNIX fashion. Higher `nice` means lower priority. Keep it unset to inherit parent process priority.
             nice: 0
+            # Number of tries to do in each miner context - WARNING: it should be set so the miner process runs for 3-5s or else the node risk missing out on new micro blocks.
+            repeats: 1
 
 logging:
     # Controls the overload protection in the logs.

--- a/config/dev.config
+++ b/config/dev.config
@@ -31,7 +31,7 @@
       {peer_password, <<"secret">>},
       {db_path, "."},
       {persist, false},
-      {aec_pow_cuckoo, {"mean29-generic", "-t 1", 29, false}}
+      {aec_pow_cuckoo, {"mean29-generic", "-t 1", 29, false, 1}}
     ]
   },
 

--- a/config/dev1/sys.config
+++ b/config/dev1/sys.config
@@ -43,7 +43,7 @@
       {peer_password, <<"secret">>},
       {db_path, "."},
       {persist, false},
-      {aec_pow_cuckoo, {"mean15-generic", "-t 5", 15, false}}
+      {aec_pow_cuckoo, {"mean15-generic", "-t 5", 15, false, 10}}
     ]
   },
 

--- a/config/dev2/sys.config
+++ b/config/dev2/sys.config
@@ -43,7 +43,7 @@
       {peer_password, <<"secret">>},
       {db_path, "."},
       {persist, false},
-      {aec_pow_cuckoo, {"mean15-generic", "-t 5", 15, false}},
+      {aec_pow_cuckoo, {"mean15-generic", "-t 5", 15, false, 10}},
       {ping_interval, 500}
     ]
   },

--- a/config/dev3/sys.config
+++ b/config/dev3/sys.config
@@ -43,7 +43,7 @@
       {peer_password, <<"secret">>},
       {db_path, "."},
       {persist, false},
-      {aec_pow_cuckoo, {"mean15-generic", "-t 5", 15, false}}
+      {aec_pow_cuckoo, {"mean15-generic", "-t 5", 15, false, 10}}
     ]
   },
 

--- a/config/sys.config
+++ b/config/sys.config
@@ -80,7 +80,7 @@
       {peer_password, <<"secret">>},
       {db_path, "."},
       {persist, false},
-      {aec_pow_cuckoo, {"mean29-generic", "-t 1", 29, false}}
+      {aec_pow_cuckoo, {"mean29-generic", "-t 1", 29, false, 1}}
     ]
   },
 

--- a/docs/cuda-miner.md
+++ b/docs/cuda-miner.md
@@ -84,6 +84,43 @@ After configuration could be started (or restarted if it's already running):
 ~/node/bin/epoch start
 ```
 
+### Mining efficiency
+
+There is quite a bit of overhead starting the GPU miner, thus running single
+mining attempts is not the best option. Therefore there is the configuration
+option `repeats: N` which will make multiple mining attempts (with different
+nonces) in one miner context. However, this option has to be used with CAUTION,
+the total run-time of the miner should preferrably not exceed 5 seconds. The
+reason being that with the short block interval of BitCoin NG micro blocks (3
+seconds) - we risk mining on old blocks otherwise. (And thereby missing out on
+the reward collected from the transaction fees in the micro blocks.)
+
+To fine tune the parameter, you should try running the miner in a shell
+```
+$ time ~/node/lib/aecuckoo-0.1.0/priv/bin/cuda29 -r 5
+...
+real 0m4.634s
+user ...
+sys  ...
+```
+Here it took 4.6s, which is rather close to 5s, so maybe `4` is the best value
+for this node.
+
+Repeats are configured like this:
+```yaml
+mining:
+    cuckoo:
+        miner:
+            executable: cuda29
+            repeats: 4
+            extra_args: ""
+            edge_bits: 29
+            hex_encoded_header: true
+```
+
+**Don't be tempted to use `-r` as `extra_args`** the `epoch` node will **not**
+handle nonces correctly in this case.
+
 ### Multiple GPU devices
 
 The address of a GPU device used by the miner can be set with `-d` argument, for example to set device with address 0:

--- a/docs/release-notes/next/PT-162445499-improve_mining.md
+++ b/docs/release-notes/next/PT-162445499-improve_mining.md
@@ -1,0 +1,2 @@
+* Re-designs how the node interacts with the miner. Passing the nonce as a separate option.
+* Introduces the `repeats` option to mining to allow the miner to make several attempts in one context.

--- a/py/tests/integration/common.py
+++ b/py/tests/integration/common.py
@@ -83,19 +83,21 @@ def setup_node_with_tokens(node, beneficiary, blocks_to_mine):
     ext_api = external_api(node)
     int_api = internal_api(node)
 
+    top0 = ext_api.get_current_key_block()
     bal0 = get_account_balance(ext_api, beneficiary['enc_pubk'])
 
     # populate the chain so node had mined some blocks and has tokens
     # to spend
     wait_until_height(ext_api, blocks_to_mine)
-    top = ext_api.get_current_key_block()
-    assert_equals(top.height >= blocks_to_mine, True)
+    top1 = ext_api.get_current_key_block()
+    assert_equals(top1.height >= blocks_to_mine, True)
     # Now the node has at least blocks_to_mine blocks mined
 
     bal1 = get_account_balance(ext_api, beneficiary['enc_pubk'])
-    assert_equals(bal1 > bal0, True)
+    if top1.height > top0.height:
+        assert_equals(bal1 > bal0, True)
 
-    return (root_dir, ext_api, int_api, top)
+    return (root_dir, ext_api, int_api, top1)
 
 def install_user_config(root_dir, file_name, conf):
     user_config = os.path.join(root_dir, file_name)


### PR DESCRIPTION
This is all about doing more attempts in one CPU/GPU context. There are possibly a few CPUs fast enough to also gain from this. The caveat is to not produce too long running mining processes since it will behave badly from a network perspective and create micro-forks.

The PR does change how we interface the miner, instead of packaging key_header+nonce and send to miner we send only key_header and then pass the nonce as a separate (numeric) parameter. By doing this the miner can use the -r parameter to do multiple attempts in the same context. The PR also changes the parser slightly to pick up also the nonce from the miner output.