### PR TITLE
Multi GPU v2 in conductor

### DIFF
--- a/apps/aecore/src/aec_conductor.erl
+++ b/apps/aecore/src/aec_conductor.erl
@@ -174,19 +174,20 @@ init(Options) ->
     Consensus = #consensus{micro_block_cycle = aec_governance:micro_block_cycle(),
                            leader = false},
     {ok, Beneficiary} = get_beneficiary(),
-    State1 = #state{ top_block_hash = TopBlockHash,
-                     top_key_block_hash = TopKeyBlockHash,
-                     consensus = Consensus,
-                     beneficiary = Beneficiary},
+    State1 = #state{ top_block_hash     = TopBlockHash
+                   , top_key_block_hash = TopKeyBlockHash
+                   , consensus          = Consensus
+                   , beneficiary        = Beneficiary},
     State2 = set_option(autostart, Options, State1),
+    State3 = init_miner_instances(State2),
 
     aec_metrics:try_update([ae,epoch,aecore,chain,height],
-                            aec_blocks:height(aec_chain:top_block())),
-    epoch_mining:info("Miner process initilized ~p", [State2]),
+                           aec_blocks:height(aec_chain:top_block())),
+    epoch_mining:info("Miner process initilized ~p", [State3]),
     aec_events:subscribe(candidate_block),
     %% NOTE: The init continues at handle_info(init_continue, State).
     self() ! init_continue,
-    {ok, State2}.
+    {ok, State3}.
 
 init_chain_state() ->
     case aec_chain:genesis_hash() of
@@ -232,7 +233,7 @@ handle_call(stop_mining,_From, State = #state{ consensus = Cons }) ->
     [ aec_tx_pool:garbage_collect() || is_record(Cons, consensus) andalso Cons#consensus.leader ],
     State1 = kill_all_workers(State),
     State2 = State1#state{mining_state = 'stopped',
-                          key_block_candidate = undefined},
+                          key_block_candidates = undefined},
     {reply, ok, create_key_block_candidate(State2)};
 handle_call(start_mining,_From, #state{mining_state = 'running'} = State) ->
     epoch_mining:info("Mining running"),
@@ -265,7 +266,7 @@ handle_call(reinit_chain, _From, State1 = #state{ consensus = Cons }) ->
                 epoch_mining:info("Mining started"),
                 start_mining(State3#state{mining_state = running,
                                           micro_block_candidate = undefined,
-                                          key_block_candidate = undefined,
+                                          key_block_candidates = undefined,
                                           consensus = Cons#consensus{leader = false}})
         end,
     {reply, ok, State};
@@ -337,19 +338,14 @@ try_fetch_and_make_candidate() ->
 
 make_key_candidate(Block) ->
     HeaderBin = aec_headers:serialize_to_binary(aec_blocks:to_header(Block)),
-    LastNonce = aec_pow:pick_nonce(),
-    Nonce     = aec_pow:next_nonce(LastNonce),
-    #candidate{ block = Block,
-                bin = HeaderBin,
-                nonce = Nonce,
-                max_nonce = LastNonce,
-                top_hash = aec_blocks:prev_hash(Block) }.
+    Nonce     = aec_pow:pick_nonce(),
+    {HeaderBin, #candidate{ block     = Block
+                          , nonce     = Nonce
+                          , top_hash  = aec_blocks:prev_hash(Block) }}.
 
 make_micro_candidate(Block) ->
-    HeaderBin = aec_headers:serialize_to_binary(aec_blocks:to_header(Block)),
-    #candidate{ block = Block,
-                bin = HeaderBin,
-                top_hash = aec_blocks:prev_hash(Block) }.
+    #candidate{ block = Block
+              , top_hash = aec_blocks:prev_hash(Block) }.
 
 %%%===================================================================
 %%% Handle init options
@@ -380,10 +376,14 @@ handle_monitor_message(Ref, Pid, Why, State) ->
             State;
         {ok, Tag} ->
             epoch_mining:error("Worker died: ~p", [{Tag, Pid, Why}]),
-            State1 = State#state{workers = orddict:erase(Pid, Workers),
-                                 blocked_tags = ordsets:del_element(Tag, Blocked)
-                                },
-            start_mining(State1)
+            State1 = case Tag of
+                         mining -> deregister_miner_instance(State, Pid);
+                         _Other -> State
+                     end,
+            State2 = State1#state{workers      = orddict:erase(Pid, Workers),
+                                  blocked_tags = ordsets:del_element(Tag, Blocked)
+                                 },
+            start_mining(State2)
     end.
 
 %%%===================================================================
@@ -436,7 +436,11 @@ dispatch_worker(Tag, Fun, State) ->
             {Pid, Info} = spawn_worker(Tag, Fun),
             State1 = block_tag(Tag, State),
             Workers = orddict:store(Pid, Info, State1#state.workers),
-            State1#state{workers = Workers}
+            State2 = State1#state{workers = Workers},
+            case Tag of
+                mining -> {State2, Pid}; %% For mining worker return its Pid for miner_instances handling
+                _      -> State2
+            end
     end.
 
 is_tag_blocked(Tag, State) ->
@@ -481,18 +485,18 @@ handle_worker_reply(Pid, Reply, State) ->
     Blocked = State#state.blocked_tags,
     case orddict:find(Pid, Workers) of
         {ok, Info} ->
-            cleanup_after_worker(Info),
             Tag = Info#worker_info.tag,
-            State1 = State#state{workers = orddict:erase(Pid, Workers),
-                                 blocked_tags = ordsets:del_element(Tag, Blocked)
-                                },
-            worker_reply(Tag, Reply, State1);
+            State1 = state_cleanup_after_worker(State, Info, Pid),
+            cleanup_after_worker(Info),
+            State2 = State1#state{workers      = orddict:erase(Pid, Workers),
+                                  blocked_tags = ordsets:del_element(Tag, Blocked)
+                                 },
+            worker_reply(Tag, Reply, State2);
         error ->
             epoch_mining:info("Got unsolicited worker reply: ~p",
-                               [{Pid, Reply}]),
+                              [{Pid, Reply}]),
             State
     end.
-
 
 worker_reply(create_key_block_candidate, Res, State) ->
     handle_key_block_candidate_reply(Res, State);
@@ -502,6 +506,76 @@ worker_reply(micro_sleep, Res, State) ->
     handle_micro_sleep_reply(Res, State);
 worker_reply(wait_for_keys, Res, State) ->
     handle_wait_for_keys_reply(Res, State).
+
+state_cleanup_after_worker(State, #worker_info{tag = mining}, Pid) ->
+    deregister_miner_instance(State, Pid);
+state_cleanup_after_worker(State, _, _) ->
+    State.
+
+cleanup_after_worker(Info) ->
+    case Info#worker_info.timer of
+        no_timer -> ok;
+        {t, TRef} -> timer:cancel(TRef)
+    end,
+    demonitor(Info#worker_info.mon, [flush]),
+    ok.
+
+kill_worker(Pid, Info, State) ->
+    Workers = State#state.workers,
+    Blocked = State#state.blocked_tags,
+    State1 = state_cleanup_after_worker(State, Info, Pid),
+    cleanup_after_worker(Info),
+    exit(Pid, shutdown),
+    %% Flush messages from this worker.
+    receive {worker_reply, Pid, _} -> ok
+    after 0 -> ok end,
+    State1#state{workers = orddict:erase(Pid, Workers),
+                 blocked_tags = ordsets:del_element(
+                                  Info#worker_info.tag,
+                                  Blocked)
+                }.
+
+kill_all_workers(#state{workers = Workers} = State) ->
+    lists:foldl(
+      fun({Pid, Info}, S) ->
+              kill_worker(Pid, Info, S)
+      end,
+      State, Workers).
+
+kill_all_workers_with_tag(Tag, #state{workers = Workers} = State) ->
+    lists:foldl(
+      fun({Pid, Info}, S) ->
+              case Tag =:= Info#worker_info.tag of
+                  true  -> kill_worker(Pid, Info, S);
+                  false -> S
+              end
+      end, State, Workers).
+
+%%%===================================================================
+%%% Miner instances handling
+
+init_miner_instances(State) ->
+    MinerInstances = [{N, available} || N <- lists:seq(0, aec_pow_cuckoo:get_miner_instances() - 1)],
+    State#state{miner_instances = MinerInstances}.
+
+available_miner_instance(#state{miner_instances = MinerInstances}) ->
+    get_first_available_instance(MinerInstances).
+
+get_first_available_instance([]) ->
+    all_busy;
+get_first_available_instance([{Instance, available} | _Instances]) ->
+    Instance;
+get_first_available_instance([_Instance | Instances]) ->
+    get_first_available_instance(Instances).
+
+register_miner_instance(#state{miner_instances = MinerInstances0} = State, Instance, Pid) ->
+    MinerInstances = lists:keyreplace(Instance, 1, MinerInstances0, {Instance, Pid}),
+    State#state{miner_instances = MinerInstances}.
+
+deregister_miner_instance(#state{miner_instances = MinerInstances0} = S, Pid) ->
+    {Instance, Pid} = lists:keyfind(Pid, 2, MinerInstances0),
+    MinerInstances = lists:keyreplace(Pid, 2, MinerInstances0, {Instance, available}),
+    S#state{miner_instances = MinerInstances}.
 
 %%%===================================================================
 %%% Preemption of workers if the top of the chain changes.
@@ -535,7 +609,7 @@ preempt_if_new_top(#state{ top_block_hash = OldHash,
                                     key   -> NewHash
                                 end,
                     State5 = State4#state{ top_key_block_hash = NewTopKey,
-                                           key_block_candidate = undefined },
+                                           key_block_candidates = undefined },
 
                     [ aec_keys:promote_candidate(aec_blocks:miner(NewBlock)) || KeyOrNewForkMicro == key ],
 
@@ -568,7 +642,7 @@ maybe_publish_block(block_synced,_Block) ->
     ok;
 maybe_publish_block(BlockReceived,_Block)
   when BlockReceived =:= block_received
-    orelse BlockReceived =:= micro_block_received ->
+       orelse BlockReceived =:= micro_block_received ->
     %% We don't publish all blocks pushed by network peers, only if it
     %% changes the top.
     ok;
@@ -581,48 +655,7 @@ maybe_publish_block(micro_block_created = T, Block) ->
     %% This is a block we created ourselves. Always publish.
     aec_events:publish(block_to_publish, {created, Block}).
 
-
-
-cleanup_after_worker(Info) ->
-    case Info#worker_info.timer of
-        no_timer -> ok;
-        {t, TRef} -> timer:cancel(TRef)
-    end,
-    demonitor(Info#worker_info.mon, [flush]),
-    ok.
-
-kill_worker(Pid, Info, State) ->
-    Workers = State#state.workers,
-    Blocked = State#state.blocked_tags,
-    cleanup_after_worker(Info),
-    exit(Pid, shutdown),
-    %% Flush messages from this worker.
-    receive {worker_reply, Pid, _} -> ok
-    after 0 -> ok end,
-    State#state{workers = orddict:erase(Pid, Workers),
-                blocked_tags = ordsets:del_element(
-                                 Info#worker_info.tag,
-                                 Blocked)
-               }.
-
-kill_all_workers(#state{workers = Workers} = State) ->
-    lists:foldl(
-      fun({Pid, Info}, S) ->
-              kill_worker(Pid, Info, S)
-      end,
-      State, Workers).
-
-kill_all_workers_with_tag(Tag, #state{workers = Workers} = State) ->
-    lists:foldl(
-      fun({Pid, Info}, S) ->
-              case Tag =:= Info#worker_info.tag of
-                  true  -> kill_worker(Pid, Info, S);
-                  false -> S
-              end
-      end, State, Workers).
-
 %%%===================================================================
-
 %%% Worker: Wait for keys to appear
 
 -define(WAIT_FOR_KEYS_RETRIES, 10).
@@ -657,7 +690,7 @@ handle_wait_for_keys_reply(timeout, State) ->
 start_mining(#state{keys_ready = false} = State) ->
     %% We need to get the keys first
     wait_for_keys(State);
-start_mining(#state{key_block_candidate = undefined} = State) ->
+start_mining(#state{key_block_candidates = undefined} = State) ->
     %% If the mining is turned off, the key block candidate is still created, but
     %% not mined. The candidate can be retrieved via the API and other nodes can
     %% mine it.
@@ -665,35 +698,42 @@ start_mining(#state{key_block_candidate = undefined} = State) ->
     create_key_block_candidate(State1);
 start_mining(#state{mining_state = stopped} = State) ->
     State;
-start_mining(#state{key_block_candidate = #candidate{top_hash = OldHash},
+start_mining(#state{key_block_candidates = [{_, #candidate{top_hash = OldHash}} | _],
                     top_block_hash = TopHash } = State) when OldHash =/= TopHash ->
     %% Candidate generated with stale top hash.
     %% Regenerate the candidate.
     create_key_block_candidate(State);
-start_mining(#state{key_block_candidate = Candidate} = State) ->
-    epoch_mining:info("Starting mining"),
-    HeaderBin = Candidate#candidate.bin,
-    Nonce     = Candidate#candidate.nonce,
-    Target    = aec_blocks:target(Candidate#candidate.block),
-    Info      = [{top_block_hash, State#state.top_block_hash}],
-    aec_events:publish(start_mining, Info),
-    Fun = fun() ->
-                  {aec_mining:mine(HeaderBin, Target, Nonce)
-                  , HeaderBin}
-          end,
-    dispatch_worker(mining, Fun, State).
+start_mining(#state{key_block_candidates = [{HeaderBin, Candidate} | Candidates]} = State) ->
+    case available_miner_instance(State) of
+        all_busy -> State;
+        Instance ->
+            epoch_mining:info("Starting miner"),
+            Nonce     = Candidate#candidate.nonce,
+            Target    = aec_blocks:target(Candidate#candidate.block),
+            Info      = [{top_block_hash, State#state.top_block_hash}],
+            aec_events:publish(start_mining, Info),
+            Fun = fun() ->
+                          {aec_mining:mine(HeaderBin, Target, Nonce, Instance)
+                          , HeaderBin}
+                  end,
+            Candidate1 = Candidate#candidate{refs = Candidate#candidate.refs + 1},
+            State1 = State#state{key_block_candidates = [{HeaderBin, Candidate1} | Candidates]},
+            {State2, Pid} = dispatch_worker(mining, Fun, State1),
+            State3 = register_miner_instance(State2, Instance, Pid),
+            start_mining(State3)
+    end.
 
-handle_mining_reply(_Reply, #state{key_block_candidate = undefined} = State) ->
-    %% Something invalidated the block candidate already.
+handle_mining_reply(_Reply, #state{key_block_candidates = undefined} = State) ->
+    %% Something invalidated the block candidates already
     start_mining(State);
 handle_mining_reply({{ok, {Nonce, Evd}}, HeaderBin}, #state{} = State) ->
-    Candidate = State#state.key_block_candidate,
-    %% Check that the solution is for this block
-    case HeaderBin =:= Candidate#candidate.bin of
-        true ->
+    Candidates = State#state.key_block_candidates,
+    %% Check that the solution is for one of the valid candidates
+    case proplists:get_value(HeaderBin, Candidates) of
+        #candidate{block = CandidateBlock} ->
             aec_metrics:try_update([ae,epoch,aecore,mining,blocks_mined], 1),
-            State1 = State#state{key_block_candidate = undefined},
-            Block = aec_blocks:set_nonce_and_pow(Candidate#candidate.block, Nonce, Evd),
+            State1 = State#state{key_block_candidates = undefined},
+            Block = aec_blocks:set_nonce_and_pow(CandidateBlock, Nonce, Evd),
             case handle_mined_block(Block, State1) of
                 {ok, State2} ->
                     State2;
@@ -701,35 +741,40 @@ handle_mining_reply({{ok, {Nonce, Evd}}, HeaderBin}, #state{} = State) ->
                     epoch_mining:error("Block insertion failed: ~p.", [Reason]),
                     start_mining(State2)
             end;
-        _Other ->
+        undefined ->
             %% This mining effort was for an earlier block candidate.
             epoch_mining:error("Found solution for old block", []),
             start_mining(State)
     end;
-handle_mining_reply({{error, no_solution}, _}, State) ->
-    Candidate = State#state.key_block_candidate,
+handle_mining_reply({{error, no_solution}, HeaderBin}, State) ->
     aec_metrics:try_update([ae,epoch,aecore,mining,retries], 1),
-    epoch_mining:debug("Failed to mine block, no solution (nonce ~p); "
-                       "retrying.", [Candidate#candidate.nonce]),
-    retry_mining(State);
-handle_mining_reply({{error, {runtime, Reason}}, _}, State) ->
+    epoch_mining:debug("Failed to mine block, no solution retrying."),
+    retry_mining(State, HeaderBin);
+handle_mining_reply({{error, {runtime, Reason}}, HeaderBin}, State) ->
     aec_metrics:try_update([ae,epoch,aecore,mining,retries], 1),
-    Candidate = State#state.key_block_candidate,
     epoch_mining:error("Failed to mine block, runtime error; "
-                       "retrying with different nonce (was ~p). "
-                       "Error: ~p", [Candidate#candidate.nonce, Reason]),
-    retry_mining(State).
+                       "retrying with different nonce. "
+                       "Error: ~p", [Reason]),
+    retry_mining(State, HeaderBin).
 
 %%%===================================================================
 %%% Retry mining when we failed to find a solution.
 
-retry_mining(S = #state{ key_block_candidate = Candidate }) ->
-    start_mining(S#state{ key_block_candidate = bump_nonce(Candidate) }).
+retry_mining(S = #state{ key_block_candidates = [{HeaderBin, Candidate} | Candidates]}, HeaderBin) ->
+    start_mining(S#state{ key_block_candidates = [{HeaderBin, bump_nonce(Candidate)} | Candidates] });
+retry_mining(S = #state { key_block_candidates = Candidates}, HeaderBin) ->
+    case proplists:get_value(HeaderBin, Candidates) of
+        undefined ->
+            create_key_block_candidate(S);
+        #candidate{refs = 1} ->
+            create_key_block_candidate(S#state{key_block_candidates = Candidates});
+        #candidate{refs = N} = C when N > 1 ->
+            Candidates1 = lists:keyreplace(HeaderBin, 1, Candidates, {HeaderBin, C#candidate{refs = N - 1}}),
+            create_key_block_candidate(S#state{key_block_candidates = Candidates1})
+    end;
+retry_mining(S, _) ->
+    start_mining(S).
 
-bump_nonce(#candidate{ nonce = N, max_nonce = N }) ->
-    epoch_mining:info("Failed to mine block, "
-    "nonce range exhausted (was ~p)", [N]),
-    undefined;
 bump_nonce(C = #candidate{ nonce = N }) ->
     C#candidate{ nonce = aec_pow:next_nonce(N) }.
 
@@ -743,8 +788,8 @@ start_micro_signing(#state{consensus = #consensus{leader = true}, micro_block_ca
     %% We have to wait for a new block candidate first.
     State;
 start_micro_signing(#state{consensus = #consensus{leader = true},
-                    micro_block_candidate = #candidate{top_hash = MicroBlockHash},
-                    top_block_hash = TopHash} = State) when MicroBlockHash =/= TopHash ->
+                           micro_block_candidate = #candidate{top_hash = MicroBlockHash},
+                           top_block_hash = TopHash} = State) when MicroBlockHash =/= TopHash ->
     %% Candidate generated with stale top hash.
     %% Regenerate the candidate.
     State#state{micro_block_candidate = undefined};
@@ -768,9 +813,9 @@ start_micro_signing(#state{consensus = #consensus{leader = true},
     end;
 start_micro_signing(#state{consensus = Consensus,
                            micro_block_candidate = MicroCandidate,
-                           key_block_candidate = KeyBlockCandidate,
+                           key_block_candidates = KeyBlockCandidate,
                            top_block_hash = SeenHash
-                           } = State) ->
+                          } = State) ->
     %% Probably no longer the leader
     epoch_mining:debug("Fallback clause, candidate conditions not met. micro: ~p, key: ~p, seen top: ~p, consensus: ~p",
                        [MicroCandidate, KeyBlockCandidate, SeenHash, Consensus]),
@@ -799,22 +844,31 @@ handle_micro_sleep_reply(ok, State) ->
 create_key_block_candidate(#state{keys_ready = false} = State) ->
     %% Keys are needed for creating a candidate
     wait_for_keys(State);
-create_key_block_candidate(#state{top_block_hash = TopHash,
-                                  beneficiary    = Beneficiary} = State) ->
+create_key_block_candidate(#state{key_block_candidates = [{_, #candidate{top_hash = TopHash}} | _],
+                                  top_block_hash       = TopHash} = State) ->
+    %% We have the most recent candidate already. Just start mining.
+    start_mining(State);
+create_key_block_candidate(#state{top_block_hash       = TopHash,
+                                  beneficiary          = Beneficiary} = State) ->
     epoch_mining:info("Creating key block candidate on the top"),
     Fun = fun() ->
-              {aec_block_key_candidate:create(TopHash, Beneficiary), TopHash}
+                  {aec_block_key_candidate:create(TopHash, Beneficiary), TopHash}
           end,
     dispatch_worker(create_key_block_candidate, Fun, State).
 
 handle_key_block_candidate_reply({{ok, KeyBlockCandidate}, TopHash},
-                                 #state{top_block_hash = TopHash} = State) ->
+                                 #state{top_block_hash = TopHash,
+                                        key_block_candidates = Candidates0} = State) ->
     epoch_mining:info("Created key block candidate "
                       "Its target is ~p (= difficulty ~p).",
                       [aec_blocks:target(KeyBlockCandidate),
                        aec_blocks:difficulty(KeyBlockCandidate)]),
-    Candidate = make_key_candidate(KeyBlockCandidate),
-    State1 = State#state{key_block_candidate = Candidate},
+    {HeaderBin, Candidate} = make_key_candidate(KeyBlockCandidate),
+    Candidates = case Candidates0 of
+                     undefined -> [{HeaderBin, Candidate}];
+                     _         -> [{HeaderBin, Candidate} | Candidates0]
+                 end,
+    State1 = State#state{key_block_candidates = Candidates},
     start_mining(State1);
 handle_key_block_candidate_reply({{ok, _KeyBlockCandidate}, _OldTopHash},
                                  #state{top_block_hash = _TopHash} = State) ->
@@ -851,8 +905,8 @@ handle_mined_block(Block, State) ->
 
 handle_signed_block(Block, State) ->
     epoch_mining:info("Block signed: Height = ~p; Hash = ~s",
-        [aec_blocks:height(Block),
-            as_hex(aec_blocks:root_hash(Block))]),
+                      [aec_blocks:height(Block),
+                       as_hex(aec_blocks:root_hash(Block))]),
     handle_add_block(Block, State, micro_block_created).
 
 as_hex(S) ->
@@ -928,7 +982,7 @@ flush_candidate() ->
         {gproc_ps_event, candidate_block, _} ->
             flush_candidate()
     after 10 ->
-        ok
+            ok
     end.
 
 setup_loop(State = #state{ consensus = Cons }, RestartMining, IsLeader, Origin) ->
@@ -936,7 +990,7 @@ setup_loop(State = #state{ consensus = Cons }, RestartMining, IsLeader, Origin) 
     State2 =
         case Origin of
             Origin when IsLeader, Origin =:= block_created
-                           orelse Origin =:= block_received ->
+                        orelse Origin =:= block_received ->
                 aec_block_generator:start_generation(),
                 start_micro_signing(State1);
             block_received when not IsLeader ->

--- a/apps/aecore/src/aec_conductor.erl
+++ b/apps/aecore/src/aec_conductor.erl
@@ -779,9 +779,7 @@ retry_mining(S = #state{key_block_candidates = Candidates}, HeaderBin) when is_l
         #candidate{refs = N} = C when N > 1 ->
             Candidates1 = lists:keyreplace(HeaderBin, 1, Candidates, {HeaderBin, C#candidate{refs = N - 1}}),
             create_key_block_candidate(S#state{key_block_candidates = Candidates1})
-    end;
-retry_mining(S = #state{key_block_candidates = undefined}, _) ->
-    start_mining(S).
+    end.
 
 %%%===================================================================
 %%% Worker: Start signing microblocks

--- a/apps/aecore/src/aec_conductor.erl
+++ b/apps/aecore/src/aec_conductor.erl
@@ -780,7 +780,7 @@ retry_mining(S = #state { key_block_candidates = Candidates}, HeaderBin) when is
             Candidates1 = lists:keyreplace(HeaderBin, 1, Candidates, {HeaderBin, C#candidate{refs = N - 1}}),
             create_key_block_candidate(S#state{key_block_candidates = Candidates1})
     end;
-retry_mining(S, _) ->
+retry_mining(S = #state {key_block_candidates = undefined}, _) ->
     start_mining(S).
 
 bump_nonce(C = #candidate{ nonce = N }) ->

--- a/apps/aecore/src/aec_conductor.erl
+++ b/apps/aecore/src/aec_conductor.erl
@@ -524,7 +524,7 @@ cleanup_after_worker(Info) ->
     ok.
 
 kill_worker(Pid, Info, State) ->
-    State1 = state_cleanup_after_worker(State, Info, Pid),
+    State1 = state_cleanup_after_worker(State, Info#worker_info.tag, Pid),
     ok     = cleanup_after_worker(Info),
     exit(Pid, shutdown),
     %% Flush messages from this worker.

--- a/apps/aecore/src/aec_conductor.hrl
+++ b/apps/aecore/src/aec_conductor.hrl
@@ -15,27 +15,32 @@
 -type workers() :: orddict:orddict(pid(), worker_info()).
 -type mining_state() :: 'running' | 'stopped'.
 
+-type candidate_hash() :: aec_blocks:block_header_hash().
 -record(candidate, {block     :: aec_blocks:block(),
-                    bin       :: binary(), %% Serialized for hash
                     nonce     :: aec_pow:nonce() | 'undefined',
-                    max_nonce :: aec_pow:nonce() | 'undefined',
-                    top_hash  :: binary()
+                    top_hash  :: binary(),
+                    refs = 0  :: non_neg_integer() %% Number of miner workers operating on candidate
                    }).
 
 -record(consensus, {leader             = false    :: boolean(),
                     micro_block_cycle             :: integer()
                     }).
 
--record(state, {key_block_candidate                       :: #candidate{} | 'undefined',
-                micro_block_candidate                     :: #candidate{} | 'undefined',
-                blocked_tags            = []              :: ordsets:ordset(atom()),
-                keys_ready              = false           :: boolean(),
-                mining_state            = running         :: mining_state(),
-                top_block_hash                            :: binary() | 'undefined',
-                top_key_block_hash                        :: binary() | 'undefined',
-                workers                 = []              :: workers(),
-                consensus                                 :: #consensus{},
-                beneficiary                               :: <<_:(32*8)>>,  % Maybe move beneficiary out of conductor's state
-                fraud_list              = []              :: list({binary(), aec_pof:pof()}),
-                pending_key_block                         :: aec_blocks:block() | 'undefined'
+-type miner_instance()  :: non_neg_integer().
+-type instance_state()  :: pid() | 'available'.
+-type miner_instances() :: list({miner_instance(), instance_state()}).
+
+-record(state, {key_block_candidates              :: list({candidate_hash(), #candidate{}}) | 'undefined',
+                micro_block_candidate             :: #candidate{} | 'undefined',
+                blocked_tags            = []      :: ordsets:ordset(atom()),
+                keys_ready              = false   :: boolean(),
+                mining_state            = running :: mining_state(),
+                top_block_hash                    :: binary() | 'undefined',
+                top_key_block_hash                :: binary() | 'undefined',
+                workers                 = []      :: workers(),
+                miner_instances         = []      :: miner_instances(),
+                consensus                         :: #consensus{},
+                beneficiary                       :: <<_:(32*8)>>,
+                fraud_list              = []      :: list({binary(), aec_pof:pof()}),
+                pending_key_block                 :: aec_blocks:block() | 'undefined'
                }).

--- a/apps/aecore/src/aec_conductor.hrl
+++ b/apps/aecore/src/aec_conductor.hrl
@@ -19,7 +19,7 @@
 -record(candidate, {block     :: aec_blocks:block(),
                     nonce     :: aec_pow:nonce() | 'undefined',
                     top_hash  :: binary(),
-                    refs = 0  :: non_neg_integer() %% Number of miner workers operating on candidate
+                    refs = 0  :: non_neg_integer() %% Number of miner workers operating on the candidate
                    }).
 
 -record(consensus, {leader             = false    :: boolean(),

--- a/apps/aecore/src/aec_conductor.hrl
+++ b/apps/aecore/src/aec_conductor.hrl
@@ -28,7 +28,7 @@
 
 -type miner_instance()  :: non_neg_integer().
 -type instance_state()  :: pid() | 'available'.
--type miner_instances() :: list({miner_instance(), instance_state()}) | 'single_instance'.
+-type miner_instances() :: list({miner_instance(), instance_state()}).
 
 -record(state, {key_block_candidates              :: list({candidate_hash(), #candidate{}}) | 'undefined',
                 micro_block_candidate             :: #candidate{} | 'undefined',

--- a/apps/aecore/src/aec_conductor.hrl
+++ b/apps/aecore/src/aec_conductor.hrl
@@ -28,7 +28,7 @@
 
 -type miner_instance()  :: non_neg_integer().
 -type instance_state()  :: pid() | 'available'.
--type miner_instances() :: list({miner_instance(), instance_state()}).
+-type miner_instances() :: list({miner_instance(), instance_state()}) | 'single_instance'.
 
 -record(state, {key_block_candidates              :: list({candidate_hash(), #candidate{}}) | 'undefined',
                 micro_block_candidate             :: #candidate{} | 'undefined',

--- a/apps/aecore/src/aec_conductor.hrl
+++ b/apps/aecore/src/aec_conductor.hrl
@@ -26,9 +26,8 @@
                     micro_block_cycle             :: integer()
                     }).
 
--type miner_instance()  :: non_neg_integer().
 -type instance_state()  :: pid() | 'available'.
--type miner_instances() :: list({miner_instance(), instance_state()}).
+-type miner_instances() :: list({aec_pow:miner_instance(), instance_state()}).
 
 -record(state, {key_block_candidates              :: list({candidate_hash(), #candidate{}}) | 'undefined',
                 micro_block_candidate             :: #candidate{} | 'undefined',

--- a/apps/aecore/src/aec_mining.erl
+++ b/apps/aecore/src/aec_mining.erl
@@ -4,15 +4,15 @@
 
 -module(aec_mining).
 
--export([mine/3]).
+-export([mine/4]).
 
 -ifdef(TEST).
 -export([get_miner_account_balance/0]).
 -endif.
 
--spec mine(binary(), aec_pow:sci_int(), aec_pow:nonce()) ->  aec_pow:pow_result().
-mine(HeaderBin, Target, Nonce) ->
-    aec_pow_cuckoo:generate(HeaderBin, Target, Nonce).
+-spec mine(binary(), aec_pow:sci_int(), aec_pow:nonce(), non_neg_integer()) ->  aec_pow:pow_result().
+mine(HeaderBin, Target, Nonce, MinerInstance) ->
+    aec_pow_cuckoo:generate(HeaderBin, Target, Nonce, MinerInstance).
 
 -ifdef(TEST).
 -spec get_miner_account_balance() -> {ok, non_neg_integer()} |

--- a/apps/aecore/src/aec_mining.erl
+++ b/apps/aecore/src/aec_mining.erl
@@ -10,7 +10,7 @@
 -export([get_miner_account_balance/0]).
 -endif.
 
--spec mine(binary(), aec_pow:sci_int(), aec_pow:nonce(), non_neg_integer()) ->  aec_pow:pow_result().
+-spec mine(binary(), aec_pow:sci_int(), aec_pow:nonce(), aec_pow:miner_instance()) ->  aec_pow:pow_result().
 mine(HeaderBin, Target, Nonce, MinerInstance) ->
     aec_pow_cuckoo:generate(HeaderBin, Target, Nonce, MinerInstance).
 

--- a/apps/aecore/src/aec_pow.erl
+++ b/apps/aecore/src/aec_pow.erl
@@ -84,7 +84,7 @@
 %%%=============================================================================
 
 -callback generate(Data :: aec_hash:hashable(), Difficulty :: aec_pow:sci_int(),
-                   Nonce :: aec_pow:nonce()) ->
+                   Nonce :: aec_pow:nonce(), non_neg_integer()) ->
     aec_pow:pow_result().
 
 -callback verify(Data :: aec_hash:hashable(), Nonce :: aec_pow:nonce(),
@@ -132,10 +132,10 @@ pick_nonce() ->
 
 -spec next_nonce(aec_pow:nonce()) -> aec_pow:nonce().
 next_nonce(N) ->
-    Step = aec_pow_cuckoo:get_miner_repeats() * aec_pow_cuckoo:get_miner_instances(),
+    Step = aec_pow_cuckoo:get_miner_repeats(),
     case N + 2 * Step < ?MAX_NONCE of
         true  -> N + Step;
-        false -> 0
+        false -> pick_nonce()
     end.
 
 %%------------------------------------------------------------------------------

--- a/apps/aecore/src/aec_pow.erl
+++ b/apps/aecore/src/aec_pow.erl
@@ -74,17 +74,20 @@
 %% over the actual one. Always positive.
 -type difficulty() :: integer().
 
+-type miner_instance() :: non_neg_integer().
+
 -export_type([sci_int/0,
               difficulty/0,
               pow_evidence/0,
-              pow_result/0]).
+              pow_result/0,
+              miner_instance/0]).
 
 %%%=============================================================================
 %%% Behaviour
 %%%=============================================================================
 
 -callback generate(Data :: aec_hash:hashable(), Difficulty :: aec_pow:sci_int(),
-                   Nonce :: aec_pow:nonce(), non_neg_integer()) ->
+                   Nonce :: aec_pow:nonce(), MinerInstance :: aec_pow:miner_instance()) ->
     aec_pow:pow_result().
 
 -callback verify(Data :: aec_hash:hashable(), Nonce :: aec_pow:nonce(),

--- a/apps/aecore/src/aec_pow_cuckoo.erl
+++ b/apps/aecore/src/aec_pow_cuckoo.erl
@@ -71,7 +71,7 @@
 %%  Very slow below 3 threads, not improving significantly above 5, let us take 5.
 %%------------------------------------------------------------------------------
 -spec generate(Data :: aec_hash:hashable(), Target :: aec_pow:sci_int(),
-               Nonce :: aec_pow:nonce(), non_neg_integer()) -> aec_pow:pow_result().
+               Nonce :: aec_pow:nonce(), aec_pow:miner_instance()) -> aec_pow:pow_result().
 generate(Data, Target, Nonce, MinerInstance) when Nonce >= 0,
                                                   Nonce =< ?MAX_NONCE ->
     %% Hash Data and convert the resulting binary to a base64 string for Cuckoo

--- a/apps/aecore/src/aec_pow_cuckoo.erl
+++ b/apps/aecore/src/aec_pow_cuckoo.erl
@@ -135,6 +135,12 @@ get_miner_instances() ->
             Instances
     end.
 
+is_miner_instance_addressation_enabled() ->
+    case get_miner_instances() of
+        1 -> false;
+        N when N > 1 -> true
+    end.
+
 get_miner_options() ->
     case
         {aeu_env:user_config([<<"mining">>, <<"cuckoo">>, <<"miner">>, <<"executable">>]),
@@ -175,7 +181,10 @@ get_hex_encoded_header() ->
                           {'error', term()}.
 generate_int(Hash, Nonce, Target, Instance) ->
     {MinerBin, MinerExtraArgs0} = get_miner_options(),
-    MinerExtraArgs = MinerExtraArgs0 ++ " -d " ++ integer_to_list(Instance),
+    MinerExtraArgs = case is_miner_instance_addressation_enabled() of
+                         true  -> MinerExtraArgs0 ++ " -d " ++ integer_to_list(Instance);
+                         false -> MinerExtraArgs0
+                     end,
     EncodedHash =
         case get_hex_encoded_header() of
             true  -> hex_string(Hash);

--- a/apps/aecore/src/aec_pow_cuckoo.erl
+++ b/apps/aecore/src/aec_pow_cuckoo.erl
@@ -208,10 +208,10 @@ generate_int(Hash, Nonce, Target, MinerBin, MinerExtraArgs) ->
                       {env, [{"SHELL", "/bin/sh"}]},
                       monitor],
     Options =
-        case aeu_env:user_config([<<"mining">>, <<"cuckoo">>, <<"miner">>, <<"nice">>]) of
-            {ok, Niceness} -> DefaultOptions ++ [{nice, Niceness}];
-            undefined -> DefaultOptions
-        end,
+      case aeu_env:user_config([<<"mining">>, <<"cuckoo">>, <<"miner">>, <<"nice">>]) of
+          {ok, Niceness} -> DefaultOptions ++ [{nice, Niceness}];
+          undefined -> DefaultOptions
+      end,
     try exec:run(Cmd, Options) of
         {ok, _ErlPid, OsPid} ->
             wait_for_result(#state{os_pid = OsPid,
@@ -278,7 +278,7 @@ verify_proof_(Header, Solution, EdgeBits) ->
                       Uv0 = sipnode(K0, K1, K2, K3, N, 0, EdgeMask),
                       Uv1 = sipnode(K0, K1, K2, K3, N, 1, EdgeMask),
                       {Xor0C bxor Uv0, Xor1C bxor Uv1, N, [{Uv0, Uv1} | UvsC]}
-              end, {16#0, 16#0, -1, []}, Solution),
+               end, {16#0, 16#0, -1, []}, Solution),
         case Xor0 bor Xor1 of
             0 ->
                 %% check cycle
@@ -301,22 +301,22 @@ sipnode(K0, K1, K2, K3, Proof, UOrV, EdgeMask) ->
     (SipHash bsl 1) bor UOrV.
 
 check_cycle(Nodes0) ->
-    Nodes = lists:keysort(2, Nodes0),
-    {Evens0, Odds} = lists:unzip(Nodes),
-    Evens  = lists:sort(Evens0), %% Odd nodes are already sorted...
-    UEvens = lists:usort(Evens),
-    UOdds  = lists:usort(Odds),
-    %% Check that all nodes appear exactly twice (i.e. each node has
-    %% exactly two edges).
-    case length(UEvens) == (?PROOFSIZE div 2) andalso
+  Nodes = lists:keysort(2, Nodes0),
+  {Evens0, Odds} = lists:unzip(Nodes),
+  Evens  = lists:sort(Evens0), %% Odd nodes are already sorted...
+  UEvens = lists:usort(Evens),
+  UOdds  = lists:usort(Odds),
+  %% Check that all nodes appear exactly twice (i.e. each node has
+  %% exactly two edges).
+  case length(UEvens) == (?PROOFSIZE div 2) andalso
         length(UOdds) == (?PROOFSIZE div 2) andalso
         UOdds == Odds -- UOdds andalso UEvens == Evens -- UEvens of
-        false ->
-            {error, ?POW_BRANCH};
-        true  ->
-            [{X0, Y0}, {X1, Y0} | Nodes1] = Nodes,
-            check_cycle(X0, X1, Nodes1)
-    end.
+      false ->
+          {error, ?POW_BRANCH};
+      true  ->
+          [{X0, Y0}, {X1, Y0} | Nodes1] = Nodes,
+          check_cycle(X0, X1, Nodes1)
+  end.
 
 %% If we reach the end in the last step everything is fine
 check_cycle(X, X, []) ->
@@ -339,9 +339,9 @@ find_node(X, [{X, Y}, {X1, Y} | Nodes], Acc) ->
 find_node(X, [{X1, Y}, {X, Y} | Nodes], Acc) ->
     {X, X1, Nodes ++ Acc};
 find_node(X, [{X, _Y} | _], _Acc) ->
-    {error, ?POW_DEAD_END};
+  {error, ?POW_DEAD_END};
 find_node(X, [N1, N2 | Nodes], Acc) ->
-    find_node(X, Nodes, [N1, N2 | Acc]).
+  find_node(X, Nodes, [N1, N2 | Acc]).
 
 %%------------------------------------------------------------------------------
 %% @doc
@@ -384,7 +384,7 @@ pack_header_and_nonce(Hash, Nonce) when byte_size(Hash) == 32 ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec wait_for_result(#state{}) ->
-                             {'ok', aec_pow:nonce(), pow_cuckoo_solution()} | {'error', term()}.
+            {'ok', aec_pow:nonce(), pow_cuckoo_solution()} | {'error', term()}.
 wait_for_result(#state{os_pid = OsPid,
                        buffer = Buffer} = State) ->
     receive
@@ -448,12 +448,12 @@ handle_fragmented_lines(Str, Buffer) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec parse_generation_result(list(string()), #state{}) ->
-                                     {'ok', Nonce :: aec_pow:nonce(), Solution :: pow_cuckoo_solution()} |
-                                     {'error', term()}.
+            {'ok', Nonce :: aec_pow:nonce(), Solution :: pow_cuckoo_solution()} |
+            {'error', term()}.
 parse_generation_result([], State) ->
     wait_for_result(State);
 parse_generation_result(["Solution" ++ NonceValuesStr | Rest], #state{os_pid = OsPid,
-                                                                      target = Target} = State) ->
+                                                                 target = Target} = State) ->
     [NonceStr | SolStrs] =  string:tokens(NonceValuesStr, " "),
     Soln = [list_to_integer(V, 16) || V <- SolStrs],
     case {length(Soln), test_target(Soln, Target)} of
@@ -526,7 +526,7 @@ node_size(EdgeBits) when is_integer(EdgeBits), EdgeBits >  0 -> 4.
 %% is restricted to be under the target value (0 < target < 2^256).
 %%------------------------------------------------------------------------------
 -spec test_target(Soln :: pow_cuckoo_solution(), Target :: aec_pow:sci_int()) ->
-                         boolean().
+                             boolean().
 test_target(Soln, Target) ->
     test_target(Soln, Target, get_node_size()).
 

--- a/apps/aecore/test/aec_conductor_tests.erl
+++ b/apps/aecore/test/aec_conductor_tests.erl
@@ -154,7 +154,7 @@ test_time_out_miner() ->
     TestPid = self(),
     ok = meck:expect(
            aec_pow_cuckoo, generate,
-           fun(_, _, _) ->
+           fun(_, _, _, _) ->
                    TestPid ! {self(), called},
                    receive after infinity -> never_reached end
            end),
@@ -458,7 +458,7 @@ test_two_mined_block_signing() ->
 test_received_block_signing() ->
     Keys = beneficiary_keys(),
     meck:expect(aec_mining, mine,
-                fun(_, _, _) -> timer:sleep(1000), {error, no_solution} end),
+                fun(_, _, _, _) -> timer:sleep(1000), {error, no_solution} end),
     true = aec_events:subscribe(block_to_publish),
 
     ?TEST_MODULE:start_mining(),

--- a/apps/aecore/test/aec_mining_tests.erl
+++ b/apps/aecore/test/aec_mining_tests.erl
@@ -41,7 +41,7 @@ mine_block_test_() ->
                  HeaderBin = aec_headers:serialize_to_binary(aec_blocks:to_header(BlockCandidate)),
 
                  Target = aec_blocks:target(BlockCandidate),
-                 {ok, {Nonce1, Evd}} = ?TEST_MODULE:mine(HeaderBin, Target, Nonce),
+                 {ok, {Nonce1, Evd}} = ?TEST_MODULE:mine(HeaderBin, Target, Nonce, 0),
 
                  Block = aec_blocks:set_nonce_and_pow(BlockCandidate, Nonce1, Evd),
 
@@ -62,7 +62,7 @@ mine_block_test_() ->
                  HeaderBin = aec_headers:serialize_to_binary(aec_blocks:to_header(BlockCandidate)),
                  Target = aec_blocks:target(BlockCandidate),
                  ?assertEqual({error, no_solution},
-                              ?TEST_MODULE:mine(HeaderBin, Target, Nonce))
+                              ?TEST_MODULE:mine(HeaderBin, Target, Nonce, 0))
          end}}
       ]}.
 

--- a/apps/aecore/test/aec_pow_cuckoo_tests.erl
+++ b/apps/aecore/test/aec_pow_cuckoo_tests.erl
@@ -33,7 +33,7 @@ pow_test_() ->
         fun() ->
                 Target = ?HIGHEST_TARGET_SCI,
                 Nonce = ?TEST_HIGH_NONCE,
-                Res = ?TEST_MODULE:generate(?TEST_BIN, Target, Nonce),
+                Res = ?TEST_MODULE:generate(?TEST_BIN, Target, Nonce, 0),
                 {ok, {Nonce, Soln}} = Res,
                 ?assertMatch(L when length(L) == 42, Soln),
 
@@ -47,7 +47,7 @@ pow_test_() ->
         fun() ->
                 Target = 16#01010000,
                 Nonce = ?TEST_HIGH_NONCE,
-                Res = ?TEST_MODULE:generate(?TEST_BIN, Target, Nonce),
+                Res = ?TEST_MODULE:generate(?TEST_BIN, Target, Nonce, 0),
                 ?assertEqual({error, no_solution}, Res),
 
                 %% Any attempts to verify such nonce with a solution
@@ -56,7 +56,7 @@ pow_test_() ->
                 %% Obtain solution with high target threshold ...
                 HighTarget = ?HIGHEST_TARGET_SCI,
                 {ok, {Nonce, Soln2}} =
-                    ?TEST_MODULE:generate(?TEST_BIN, HighTarget, Nonce),
+                    ?TEST_MODULE:generate(?TEST_BIN, HighTarget, Nonce, 0),
                 ?assertMatch(L when length(L) == 42, Soln2),
                 %% ... then attempt to verify such solution (and
                 %% nonce) with the low target threshold (shall fail).
@@ -67,7 +67,7 @@ pow_test_() ->
        fun() ->
                Target = ?HIGHEST_TARGET_SCI,
                Nonce = ?TEST_HIGH_NONCE,
-               Res = ?TEST_MODULE:generate(?TEST_BIN, Target, Nonce),
+               Res = ?TEST_MODULE:generate(?TEST_BIN, Target, Nonce, 0),
                {ok, {Nonce, Soln}} = Res,
                ?assertMatch(L when length(L) == 42, Soln),
 
@@ -81,7 +81,7 @@ pow_test_() ->
                Target = ?HIGHEST_TARGET_SCI,
                Nonce = 1,
                ?assertMatch({error, no_solution},
-                            ?TEST_MODULE:generate(?TEST_BIN, Target, Nonce)),
+                            ?TEST_MODULE:generate(?TEST_BIN, Target, Nonce, 0)),
 
                DummySoln = lists:seq(0, 41),
                ?assertMatch(L when length(L) == 42, DummySoln),
@@ -140,7 +140,7 @@ kill_ospid_miner_test_() ->
             Self = self(),
             ?assertEqual([], exec:which_children()),  %% no zombies around
             Pid = spawn(fun() ->
-                          Self ! {aec_pow_cuckoo:generate(?TEST_BIN, 12837272, 128253), self()}
+                          Self ! {aec_pow_cuckoo:generate(?TEST_BIN, 12837272, 128253, 0), self()}
                       end),
             timer:sleep(200),                        %% give some time to start the miner OS pid
             ?assertEqual(1, length(exec:which_children())),  %% We did create a new one.

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -1173,7 +1173,7 @@ post_key_block(_CurrentBlockType, Config) ->
     ok.
 
 mine_key_block(HeaderBin, Target, Nonce, Attempts) when Attempts > 0 ->
-    case rpc(aec_mining, mine, [HeaderBin, Target, Nonce]) of
+    case rpc(aec_mining, mine, [HeaderBin, Target, Nonce, 0]) of
         {ok, {_Nonce, _PowEvidence}} = Res ->
             Res;
         {error, no_solution} ->


### PR DESCRIPTION
System tests:
```
%%% aest_channels_SUITE ==> test_simple_same_node_channel: OK
%%% aest_channels_SUITE ==> test_simple_different_nodes_channel: OK
%%% aest_channels_SUITE ==> on_chain_channel: OK
%%% aest_commands_SUITE ==> epoch_commands: OK
%%% aest_compatibility_SUITE ==> test_mining_algorithms_compatibility: OK
%%% aest_genesis_SUITE ==> test_node_starts_with_30k_accounts: OK
%%% aest_mempool_SUITE ==> test_mempool_ttl_cleanup: OK
%%% aest_mempool_SUITE ==> test_mempool_bad_nonce_cleanup: OK
%%% aest_names_SUITE ==> test_name_registration: OK
%%% aest_names_SUITE ==> test_name_transfer: OK
%%% aest_oracles_SUITE ==> test_simple_same_node_query: OK
%%% aest_oracles_SUITE ==> test_simple_two_nodes_query: OK
%%% aest_oracles_SUITE ==> test_oracle_ttl_extension: OK
%%% aest_oracles_SUITE ==> test_pipelined_same_node_query: OK
%%% aest_oracles_SUITE ==> test_pipelined_two_nodes_query: OK
%%% aest_peers_SUITE ==> test_peer_discovery: OK
%%% aest_peers_SUITE ==> test_inbound_limitation: OK
%%% aest_perf_SUITE ==> long_chain.long_chain_mine_and_export: OK
%%% aest_perf_SUITE ==> long_chain.long_chain_tests.mining_governed_rate: OK
%%% aest_perf_SUITE ==> long_chain.long_chain_tests.startup_speed: OK
%%% aest_perf_SUITE ==> long_chain.long_chain_tests.startup_speed_mining: OK
%%% aest_perf_SUITE ==> long_chain.long_chain_tests.sync_speed: OK
%%% aest_perf_SUITE ==> long_chain.long_chain_tests.stay_in_sync: OK
%%% aest_sync_SUITE ==> new_node_joins_network: OK
%%% aest_sync_SUITE ==> docker_keeps_data: OK
%%% aest_sync_SUITE ==> stop_and_continue_sync: OK
%%% aest_sync_SUITE ==> tx_pool_sync: OK
%%% aest_sync_SUITE ==> net_split_recovery: OK
%%% aest_sync_SUITE ==> net_split_mining_power: OK
%%% aest_sync_SUITE ==> abrupt_stop_new_node: SKIPPED
%%% aest_sync_SUITE ==> {tc_user_skip,database_restart_needs_fix}
%%% aest_sync_SUITE ==> abrupt_stop_mining_node: SKIPPED
%%% aest_sync_SUITE ==> {tc_user_skip,database_restart_needs_fix}
EXPERIMENTAL: Writing retry specification at /Users/zp-sd/src/aeternity/epoch/system_test/logs/retry.spec
              call rebar3 ct with '--retry' to re-run failing cases.
Skipped 2 (2, 0) tests. Passed 29 tests.
```