### PR TITLE
Use ~/aeternity/node instead of /tmp/node in the docs

### DIFF
--- a/apps/aecore/src/aec_governance.erl
+++ b/apps/aecore/src/aec_governance.erl
@@ -237,7 +237,7 @@ get_network_id() ->
 -spec contributors_messages_hash() -> binary().
 contributors_messages_hash() ->
     %% This is generated using messages_hash tool:
-    %%  > cd /tmp/node
+    %%  > cd ~/aeternity/node
     %%  > bin/epoch messages_hash
     <<158,79,89,57,49,136,245,229,211,220,44,167,79,151,117,42,149,176,13,160,196,61,156,179,95,106,250,133,59,93,3,170>>.
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -120,11 +120,11 @@ make prod-package
 
 Once the packaging is done, the package is created in the `_build/prod/rel/epoch/` directory, e.g. `_build/prod/rel/epoch/epoch-${VERSION:?}.tar.gz`.
 
-To deploy the package for example in `/tmp/node` one should just unarchive it to that directory:
+To deploy the package for example in `~/aeternity/node` one should just unarchive it to that directory:
 
 ```bash
-mkdir /tmp/node
-tar xf _build/prod/rel/epoch/epoch-${VERSION:?}.tar.gz -C /tmp/node
+mkdir -p ~/aeternity/node
+tar xf _build/prod/rel/epoch/epoch-${VERSION:?}.tar.gz -C ~/aeternity/node
 ```
 
 Make sure beneficiary account is set in configuration, as this is mandatory to successfully start a node.
@@ -134,7 +134,7 @@ See [configuration documentation](configuration.md) for configuration details.
 
 Then start the node:
 ```bash
-/tmp/node/bin/epoch start
+~/aeternity/node/bin/epoch start
 ```
 
 See [operation documentation](operation.md) for more details.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -80,16 +80,16 @@ If you don't have your public key yet, you can generate a public/private key pai
 
 An alternative tool `keys_gen` for generating a public-private key pair **for testing purposes only** is included in the package.
 
-The key pair will be encrypted with a password that you shall pass to `keys_gen` tool (below assumes the node is deployed in directory `/tmp/node`).
-Generated public-private key pair will be located in `/tmp/node/generated_keys`, and public key is to be put in epoch configuration file (`mining` > `beneficiary` parameter).
+The key pair will be encrypted with a password that you shall pass to `keys_gen` tool (below assumes the node is deployed in directory `~/aeternity/node`).
+Generated public-private key pair will be located in `~/aeternity/node/generated_keys`, and public key is to be put in epoch configuration file (`mining` > `beneficiary` parameter).
 
-Do make sure you back up `/tmp/node/generated_keys` (and remember the password): if you destroy the node, you can setup a new node and use the same account (public key) as a beneficiary.
+Do make sure you back up `~/aeternity/node/generated_keys` (and remember the password): if you destroy the node, you can setup a new node and use the same account (public key) as a beneficiary.
 You shall not share the private key (or the password) with anyone.
 
 e.g.
 
 ```bash
-cd /tmp/node
+cd ~/aeternity/node
 bin/epoch keys_gen my_secret_password ## This way of generating a key-pair is only for testing purpose, use a proper wallet/mechanism for your mainnet tokens: e.g., [AirGap wallet](https://airgap.it/).
 ```
 ```
@@ -114,13 +114,13 @@ For Roma network the network ID defaults to `ae_mainnet`.
 ## Instructions
 
 The instructions below assume that:
-* The node is deployed in directory `/tmp/node`;
+* The node is deployed in directory `~/aeternity/node`;
 * You already know your `beneficiary` account public key (if you don't, see [Beneficiary account section](#beneficiary-account));
 * No custom peers are specified under the `peers:` key in the config. If the `peers:` key is undefined, the *Roma network* seed peers (built-in in the package source) are used.
 
 If any of the assumptions does not hold, you need to amend the instructions accordingly.
 
-Create the file `/tmp/node/epoch.yaml` with the below content.
+Create the file `~/aeternity/node/epoch.yaml` with the below content.
 Make sure you amend:
 * the `mining` > `beneficiary` parameter, i.e. replace `encoded_beneficiary_pubkey_to_be_replaced` with your public key;
 * the `sync` > `port` parameter with your actual value if you need to change it
@@ -164,7 +164,7 @@ Note that YAML files have significant whitespace so make sure that you indent th
 
 You can validate the configuration file before starting the node:
 ```bash
-cd /tmp/node
+cd ~/aeternity/node
 bin/epoch check_config epoch.yaml
 ```
 You shall read output like the following:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -62,14 +62,14 @@ In case you have installed either of them in a non-default path, you could use s
 
 ## Deploy node
 
-In the instructions below, the node is deployed in directory `/tmp/node`: you may prefer to deploy the node in an alternative (and less ephemeral) location - e.g. a `node` directory inside your home directory - by amending the instructions accordingly.
+In the instructions below, the node is deployed in directory `~/aeternity/node`: you may prefer to deploy the node in an alternative location by amending the instructions accordingly.
 It is recommended that the partition where the node directory is has at least 10 GB free: this is needed for the chain and the log files.
 
 Open a Terminal window or get to the command line.
 
 Create a directory and unpack the downloaded package (you may need to amend the directory and/or file name of the package):
 ```bash
-mkdir /tmp/node
-cd /tmp/node
+mkdir -p ~/aeternity/node
+cd ~/aeternity/node
 tar xf ~/Downloads/epoch-1.1.0-osx-10.13.6.tar.gz
 ```

--- a/docs/operation.md
+++ b/docs/operation.md
@@ -5,7 +5,7 @@ This document describes how to start your epoch node installed using a release b
 ## Assumptions
 
 The instructions below assume that:
-* The node is deployed in directory `/tmp/node`;
+* The node is deployed in directory `~/aeternity/node`;
 * beneficiary account is set under `mining` > `beneficiary` in the config (see [configuration documentation](configuration.md));
 * No custom peers are specified under the `peers:` key in the config. If the `peers:` key is undefined, the *testnet* seed peers (built-in in the package source) are used.
 * The external HTTP endpoint of the user API of the node can be contacted at 127.0.0.1 port 3013.
@@ -22,7 +22,7 @@ When it starts, the node checks the maximum number of open files (`ulimit -n`) a
 
 Start the node:
 ```bash
-cd /tmp/node
+cd ~/aeternity/node
 bin/epoch start
 ```
 
@@ -37,14 +37,14 @@ If the node is unresponsive, inspect the `log` directory for errors.
 
 Back up the peer key pair:
 ```bash
-cp -pr /tmp/node/keys ~/my_epoch_keys
+cp -pr ~/aeternity/node/keys ~/my_epoch_keys
 ```
 
 ### Verify that node mines
 
 Inspect the mining log file of the node:
 ```bash
-less /tmp/node/log/epoch_mining.log
+less ~/aeternity/node/log/epoch_mining.log
 ```
 
 If the node is mining, you shall read log entries like the following:

--- a/scripts/install-ubuntu1804.sh
+++ b/scripts/install-ubuntu1804.sh
@@ -17,7 +17,7 @@ fi
 
 RELEASE_FILE="https://github.com/aeternity/epoch/releases/download/v${RELEASE_VERSION}/epoch-${RELEASE_VERSION}-ubuntu-x86_64.tar.gz"
 TEMP_RELEASE_FILE=${TEMP_RELEASE_FILE:=/tmp/epoch.tgz}
-TARGET_DIR=${TARGET_DIR:=$HOME/epoch}
+TARGET_DIR=${TARGET_DIR:=$HOME/aeternity/node}
 EPOCH_CONFIG=${EPOCH_CONFIG:=$TARGET_DIR/epoch.yaml}
 
 echo -e "\nATTENTION: This script will delete the directory ${TARGET_DIR} if it exists. You should back up any contents before continuing.\n"


### PR DESCRIPTION
Users don't know what /tmp is and that it's ephemeral dir.

PT: https://www.pivotaltracker.com/story/show/162575891
rel: https://github.com/aeternity/epoch/pull/1906