### PR TITLE
PT-162396161 Do not create key block candidate without beneficiary

### DIFF
--- a/apps/aecore/src/aec_conductor.erl
+++ b/apps/aecore/src/aec_conductor.erl
@@ -820,6 +820,8 @@ handle_micro_sleep_reply(ok, State) ->
 create_key_block_candidate(#state{keys_ready = false} = State) ->
     %% Keys are needed for creating a candidate
     wait_for_keys(State);
+create_key_block_candidate(#state{beneficiary = undefined} = State) ->
+    State;
 create_key_block_candidate(#state{top_block_hash = TopHash,
                                   beneficiary    = Beneficiary} = State) ->
     epoch_mining:info("Creating key block candidate on the top"),


### PR DESCRIPTION
Key block candidate creation is still called on:
* https://github.com/aeternity/epoch/blob/master/apps/aecore/src/aec_conductor.erl#L237
* https://github.com/aeternity/epoch/blob/master/apps/aecore/src/aec_conductor.erl#L562.
