### PR TITLE
Pt 162537748 channels do not keep old txs

### DIFF
--- a/apps/aechannel/src/aesc_fsm.erl
+++ b/apps/aechannel/src/aesc_fsm.erl
@@ -647,7 +647,7 @@ awaiting_signature(cast, {?SIGNED, ?WDRAW_CREATED, SignedTx} = Msg,
 awaiting_signature(cast, {?SIGNED, ?UPDATE, SignedTx} = Msg, D) ->
     D1 = send_update_msg(
            SignedTx,
-           D#data{state = aesc_offchain_state:add_half_signed_tx(
+           D#data{state = aesc_offchain_state:set_half_signed_tx(
                             SignedTx, D#data.state)}),
     next_state(awaiting_update_ack,
                log(rcv, ?SIGNED, Msg, D1#data{latest = undefined}));
@@ -658,7 +658,7 @@ awaiting_signature(cast, {?SIGNED, ?UPDATE_ACK, SignedTx} = Msg,
     D1 = send_update_ack_msg(NewSignedTx, D),
     {OnChainEnv, OnChainTrees} =
         aetx_env:tx_env_and_trees_from_top(aetx_contract),
-    State = aesc_offchain_state:add_signed_tx(NewSignedTx, D1#data.state,
+    State = aesc_offchain_state:set_signed_tx(NewSignedTx, D1#data.state,
                                               OnChainTrees, OnChainEnv, Opts),
     D2 = D1#data{log   = log_msg(rcv, ?SIGNED, Msg, D1#data.log),
                  state = State,
@@ -763,7 +763,7 @@ dep_signed(Type, Msg, D) ->
 deposit_locked_complete(SignedTx, #data{state = State, opts = Opts} = D) ->
     {OnChainEnv, OnChainTrees} =
         aetx_env:tx_env_and_trees_from_top(aetx_contract),
-    D1   = D#data{state = aesc_offchain_state:add_signed_tx(SignedTx, State,
+    D1   = D#data{state = aesc_offchain_state:set_signed_tx(SignedTx, State,
                                                             OnChainTrees,
                                                             OnChainEnv, Opts)},
     next_state(open, D1).
@@ -818,7 +818,7 @@ wdraw_signed(Type, Msg, D) ->
 withdraw_locked_complete(SignedTx, #data{state = State, opts = Opts} = D) ->
     {OnChainEnv, OnChainTrees} =
         aetx_env:tx_env_and_trees_from_top(aetx_contract),
-    D1   = D#data{state = aesc_offchain_state:add_signed_tx(SignedTx, State,
+    D1   = D#data{state = aesc_offchain_state:set_signed_tx(SignedTx, State,
                                                             OnChainTrees,
                                                             OnChainEnv, Opts)},
     next_state(open, D1).
@@ -950,7 +950,7 @@ signed(Type, Msg, D) ->
 funding_locked_complete(D) ->
     {OnChainEnv, OnChainTrees} =
         aetx_env:tx_env_and_trees_from_top(aetx_contract),
-    D1   = D#data{state = aesc_offchain_state:add_signed_tx(D#data.create_tx,
+    D1   = D#data{state = aesc_offchain_state:set_signed_tx(D#data.create_tx,
                                                             D#data.state,
                                                             OnChainTrees,
                                                             OnChainEnv,
@@ -1943,7 +1943,7 @@ check_signed_update_ack_tx(SignedTx, Msg,
     try  ok = check_update_ack_(SignedTx, HalfSignedTx),
          {OnChainEnv, OnChainTrees} =
             aetx_env:tx_env_and_trees_from_top(aetx_contract),
-         {ok, D#data{state = aesc_offchain_state:add_signed_tx(
+         {ok, D#data{state = aesc_offchain_state:set_signed_tx(
                                SignedTx, State, OnChainTrees, OnChainEnv, Opts),
                      log = log_msg(rcv, ?UPDATE_ACK, Msg, D#data.log)}}
     catch

--- a/apps/aechannel/src/aesc_offchain_state.erl
+++ b/apps/aechannel/src/aesc_offchain_state.erl
@@ -22,8 +22,8 @@
         , is_latest_signed_tx/2       %%  (SignedTx, State) -> boolean()
         , verify_signatures/2         %%  (SignedTx, State)
         , make_update_tx/5            %%  (Updates, State, OnChainTrees, OnChainEnv, Opts) -> Tx
-        , add_signed_tx/5             %%  (SignedTx, State0, OnChainTrees, OnCHainEnv, Opts) -> State
-        , add_half_signed_tx/2        %%  (SignedTx, State0) -> State
+        , set_signed_tx/5             %%  (SignedTx, State0, OnChainTrees, OnCHainEnv, Opts) -> State
+        , set_half_signed_tx/2        %%  (SignedTx, State0) -> State
         , get_latest_half_signed_tx/1 %%  (State) -> SignedTx
         , get_latest_signed_tx/1      %%  (State) -> {Round, SignedTx}
         , get_fallback_state/1        %%  (State) -> {Round, State'}
@@ -231,9 +231,9 @@ run_extra_checks(F, Mod, Tx) when is_function(F, 2) ->
             {error, Errors}
     end.
 
--spec add_signed_tx(aetx_sign:signed_tx(), state(), aec_trees:trees(),
+-spec set_signed_tx(aetx_sign:signed_tx(), state(), aec_trees:trees(),
                     aetx_env:env(), map()) -> state().
-add_signed_tx(SignedTx, #state{}=State, OnChainTrees,
+set_signed_tx(SignedTx, #state{}=State, OnChainTrees,
               OnChainEnv, Opts) ->
     true = mutually_signed(SignedTx), % ensure it is mutually signed
     Tx = aetx_sign:tx(SignedTx),
@@ -270,8 +270,8 @@ add_signed_tx(SignedTx, #state{}=State, OnChainTrees,
                         trees=Trees, calls=Calls}
     end.
 
--spec add_half_signed_tx(aetx_sign:signed_tx(), state()) -> state().
-add_half_signed_tx(SignedTx, #state{}=State) ->
+-spec set_half_signed_tx(aetx_sign:signed_tx(), state()) -> state().
+set_half_signed_tx(SignedTx, #state{}=State) ->
     State#state{half_signed_tx = SignedTx}.
 
 -spec get_latest_half_signed_tx(state()) -> aetx_sign:signed_tx().

--- a/apps/aecontract/src/aect_channel_contract.erl
+++ b/apps/aecontract/src/aect_channel_contract.erl
@@ -82,7 +82,10 @@ run(ContractPubKey, VmVersion, Call, CallData, CallStack, Trees0,
     CallDef = make_call_def(OwnerPubKey, ContractPubKey, Gas, GasPrice, Amount,
               CallData, CallStack, Code, Store, Call, OnChainTrees, OnChainEnv, Trees0),
     {CallRes, Trees} = aect_dispatch:run(VmVersion, CallDef),
-    aect_utils:insert_call_in_trees(CallRes, Trees).
+    UpdatedTrees = aect_utils:insert_call_in_trees(CallRes, Trees),
+    aec_trees:gc_old_nodes(UpdatedTrees, [accounts, contracts]).
+
+
 
 make_call_def(OwnerPubKey, ContractPubKey, GasLimit, GasPrice, Amount,
               CallData, CallStack, Code, Store, Call, OnChainTrees, OnChainEnv,

--- a/apps/aecontract/src/aect_state_tree.erl
+++ b/apps/aecontract/src/aect_state_tree.erl
@@ -18,6 +18,7 @@
         , lookup_contract/2
         , lookup_contract/3
         , new_with_backend/1
+        , gc_old_nodes/1
         , root_hash/1]).
 
 %% API - Proof of inclusion
@@ -63,6 +64,10 @@ empty_with_backend() ->
 new_with_backend(Hash) ->
     CtTree = aeu_mtrees:new_with_backend(Hash, aec_db_backends:contracts_backend()),
     #contract_tree{contracts = CtTree}.
+
+-spec gc_old_nodes(tree()) -> tree().
+gc_old_nodes(#contract_tree{contracts = CtTree} = Tree) ->
+    Tree#contract_tree{contracts =  aeu_mtrees:gc_old_nodes(CtTree)}.
 
 %% -- Contracts --
 

--- a/apps/aecore/src/aec_accounts_trees.erl
+++ b/apps/aecore/src/aec_accounts_trees.erl
@@ -11,6 +11,7 @@
          get/2,
          lookup/2,
          new_with_backend/1,
+         gc_old_nodes/1,
          enter/2]).
 
 %% API - Merkle tree
@@ -58,6 +59,10 @@ empty_with_backend() ->
 -spec new_with_backend(aeu_mtrees:root_hash() | 'empty') -> tree().
 new_with_backend(Hash) ->
     aeu_mtrees:new_with_backend(Hash, aec_db_backends:accounts_backend()).
+
+-spec gc_old_nodes(tree()) -> tree().
+gc_old_nodes(Tree) ->
+    aeu_mtrees:gc_old_nodes(Tree).
 
 -spec get(aec_keys:pubkey(), tree()) -> aec_accounts:account().
 get(Pubkey, Tree) ->

--- a/apps/aecore/src/aec_trees.erl
+++ b/apps/aecore/src/aec_trees.erl
@@ -25,7 +25,8 @@
          set_channels/2,
          set_contracts/2,
          set_ns/2,
-         set_oracles/2
+         set_oracles/2,
+         gc_old_nodes/2
         ]).
 
 -export([ deserialize_from_db/1
@@ -208,6 +209,22 @@ oracles(Trees) ->
 -spec set_oracles(trees(), aeo_state_tree:tree()) -> trees().
 set_oracles(Trees, Oracles) ->
     Trees#trees{oracles = Oracles}.
+
+-spec gc_old_nodes(trees(), [accounts | contracts]) -> trees().
+gc_old_nodes(Trees, TreesToGC) ->
+    lists:foldl(
+        fun(accounts, AccumTrees) ->
+            Accounts0 = accounts(AccumTrees),
+            Accounts = aec_accounts_trees:gc_old_nodes(Accounts0),
+            set_accounts(AccumTrees, Accounts);
+           (contracts, AccumTrees) ->
+            Contracts0 = contracts(AccumTrees),
+            Contracts = aect_state_tree:gc_old_nodes(Contracts0),
+            set_contracts(AccumTrees, Contracts)
+        end,
+        Trees,
+        TreesToGC).
+    
 
 -spec perform_pre_transformations(trees(), aec_blocks:height()) -> trees().
 perform_pre_transformations(Trees, Height) ->

--- a/apps/aeutils/src/aeu_mtrees.erl
+++ b/apps/aeutils/src/aeu_mtrees.erl
@@ -38,6 +38,7 @@
          lookup_proof/3,
          commit_to_db/1,
          new_with_backend/2,
+         gc_old_nodes/1,
          empty_with_backend/1
         ]).
 
@@ -101,6 +102,18 @@ new_with_backend(empty, DB) ->
     empty_with_backend(DB);
 new_with_backend(<<_:256>> = Hash, DB) ->
     aeu_mp_trees:new(Hash, DB).
+
+-spec gc_old_nodes(mtree()) -> mtree().
+gc_old_nodes(Tree) ->
+    %% TODO: this is a workarond and not a proper GC
+    Foldl =
+        fun F('$end_of_table', Accum) -> Accum;
+            F({Key, Value, Iter}, Accum) ->
+                F(aeu_mp_trees:iterator_next(Iter),
+                  insert(Key, Value, Accum))
+        end,
+    Iterator = aeu_mp_trees:iterator(Tree),
+    Foldl(aeu_mp_trees:iterator_next(Iterator), empty()).
 
 delete(Key, Tree) when ?IS_KEY(Key) ->
     aeu_mp_trees:delete(Key, Tree).


### PR DESCRIPTION
This PR closes channels' memory leaks. The code will be further improved:
* a proper GC is due
* the channels' GC shall not be executed on every off-chain tx

PT [SC: do not keep old transactions](https://www.pivotaltracker.com/story/show/162537748)

I will create separate PTs for the improvement bullet points above.