### PR TITLE
Pt 162725787 revert byte code serialization

### DIFF
--- a/apps/aecontract/src/aect_sophia.erl
+++ b/apps/aecontract/src/aect_sophia.erl
@@ -70,7 +70,8 @@ parse_options(<<_:8, Rest/binary>>, Acc) ->
     parse_options(Rest, Acc);
 parse_options(<<>>, Acc) -> Acc.
 
-serialize(#{byte_code := ByteCode, type_info := TypeInfo, contract_source := ContractString}) ->
+serialize(#{byte_code := ByteCode, type_info := TypeInfo, 
+            contract_source := ContractString, compiler_version := _Version}) ->
     ContractBin = list_to_binary(ContractString),
     Fields = [ {source_hash, aec_hash:hash(sophia_source_code, ContractBin)}
              , {type_info, TypeInfo}

--- a/apps/aecontract/src/aect_sophia.erl
+++ b/apps/aecontract/src/aect_sophia.erl
@@ -19,7 +19,6 @@
         , deserialize/1
         ]).
 
-
 -type wrapped_code() :: #{ source_hash := aec_hash:hash()
                          , type_info   := [binary()]
                          , byte_code   := binary()
@@ -27,8 +26,9 @@
 
 -export_type([ wrapped_code/0 ]).
 
--spec compile(binary(), binary()) -> {ok, binary()} | {error, binary()}.
+-define(SOPHIA_CONTRACT_VSN, 1).
 
+-spec compile(binary(), binary()) -> {ok, binary()} | {error, binary()}.
 compile(ContractAsBinString, OptionsAsBinString) ->
     ContractText = binary_to_list(ContractAsBinString),
     Options = parse_options(OptionsAsBinString),
@@ -72,21 +72,20 @@ parse_options(<<>>, Acc) -> Acc.
 
 serialize(#{byte_code := ByteCode, type_info := TypeInfo, contract_source := ContractString}) ->
     ContractBin = list_to_binary(ContractString),
-    Version = aeso_compiler:version(),
     Fields = [ {source_hash, aec_hash:hash(sophia_source_code, ContractBin)}
              , {type_info, TypeInfo}
              , {byte_code, ByteCode}
              ],
     aec_object_serialization:serialize(compiler_sophia,
-                                       Version,
-                                       serialization_template(Version),
+                                       ?SOPHIA_CONTRACT_VSN,
+                                       serialization_template(?SOPHIA_CONTRACT_VSN),
                                        Fields
                                       ).
 
 -spec deserialize(binary()) -> wrapped_code().
 deserialize(Binary) ->
     case aec_object_serialization:deserialize_type_and_vsn(Binary) of
-        {compiler_sophia = Type, Vsn,_Rest} ->
+        {compiler_sophia = Type, Vsn, _Rest} ->
             Template = serialization_template(Vsn),
             [ {source_hash, Hash}
             , {type_info, TypeInfo}
@@ -100,8 +99,10 @@ deserialize(Binary) ->
             error({illegal_code_object, Other})
     end.
 
-serialization_template(Version) ->
-    aeso_compiler:serialization_template(Version).
+serialization_template(?SOPHIA_CONTRACT_VSN) ->
+    [ {source_hash, binary}
+    , {type_info, [{binary, binary, binary, binary}]} %% {type hash, name, arg type, out type}
+    , {byte_code, binary}].
 
 -spec on_chain_call(binary(), binary(), binary()) -> {ok, binary()} | {error, binary()}.
 on_chain_call(ContractKey, Function, Argument) ->

--- a/apps/aecontract/test/aect_test_utils.erl
+++ b/apps/aecontract/test/aect_test_utils.erl
@@ -130,7 +130,8 @@ create_tx_default_spec(PubKey, State) ->
 dummy_bytecode() ->
     aect_sophia:serialize(#{byte_code => <<"NOT PROPER BYTE CODE">>, 
                             type_info => [],  %% No type info
-                            contract_source => "NOT PROPER SOURCE STRING"}
+                            contract_source => "NOT PROPER SOURCE STRING",
+                            compiler_version => 1}
                          ).
 
 %%%===================================================================

--- a/apps/aesophia/src/aeso_compiler.erl
+++ b/apps/aesophia/src/aeso_compiler.erl
@@ -13,7 +13,6 @@
         , from_string/2
         , check_call/2
         , version/0
-        , serialization_template/1
         ]).
 
 -include_lib("aebytecode/include/aeb_opcodes.hrl").
@@ -169,14 +168,6 @@ extract_type_info(#{functions := Functions} =_Icode) ->
                    not lists:member(private, Attrs)
                ],
     lists:sort(TypeInfo).
-
-
-serialization_template(Vsn) when Vsn == ?COMPILER_VERSION_1;
-                                 Vsn == ?COMPILER_VERSION_2 ->
-    [ {source_hash, binary}
-    , {type_info, [{binary, binary, binary, binary}]} %% {type hash, name, arg type, out type}
-    , {byte_code, binary}].
-
 
 pp_sophia_code(C, Opts)->  pp(C, Opts, pp_sophia_code, fun(Code) ->
                                 io:format("~s\n", [prettypr:format(aeso_pretty:decls(Code))])

--- a/apps/aesophia/src/aeso_compiler.erl
+++ b/apps/aesophia/src/aeso_compiler.erl
@@ -61,7 +61,9 @@ from_string(ContractString, Options) ->
     ByteCodeList = to_bytecode(Assembler, Options),
     ByteCode = << << B:8 >> || B <- ByteCodeList >>,
     ok = pp_bytecode(ByteCode, Options),
-    #{byte_code => ByteCode, type_info => TypeInfo, contract_source => ContractString}.
+    #{byte_code => ByteCode, type_info => TypeInfo, 
+      contract_source => ContractString, 
+      compiler_version => version()}.
 
 -define(CALL_NAME, "__call").
 


### PR DESCRIPTION
Reverted the addition of serialization version 2 for sophia byte code.

But since we need the compielr version in the future, I already prepared the compiler to return it, but ignore the returned value.