### PR TITLE
Expose state channels' remote call to on-chain object resolution failure

### DIFF
--- a/apps/aesophia/test/contracts/channel_remote_on_chain_contract_name_resolution.aes
+++ b/apps/aesophia/test/contracts/channel_remote_on_chain_contract_name_resolution.aes
@@ -1,0 +1,9 @@
+contract Remote =
+  function get : () => int
+  function can_resolve : (string, string) => bool
+
+contract RemoteCall =
+
+    function remote_resolve(r : Remote, name: string, key: string) : bool =
+        r.can_resolve(name, key)
+


### PR DESCRIPTION
Let's have `contractA`, `contractB` in a state channel.

Lets have `contractB:get_oracle_response()` function. Calling it shall fetch an oracle response, if any. 

`contractB:get_oracle_response()` succeeds.

If `contractA` uses `contractB:get_oracle_response()` in a remote call - it fails.
This is the bug. Tracked as [SC: remote call to on-chain object resolution](https://www.pivotaltracker.com/story/show/162756473)