### PR TITLE
Refactor protocol and genesis versions to not used shared macros

### DIFF
--- a/apps/aecore/include/blocks.hrl
+++ b/apps/aecore/include/blocks.hrl
@@ -1,10 +1,5 @@
 -include("pow.hrl").
 
--define(PROTOCOL_VERSION, 1).
--define(GENESIS_VERSION, ?PROTOCOL_VERSION).
--define(GENESIS_HEIGHT, 0).
--define(GENESIS_TIME, 0).
-
 -define(BLOCK_HEADER_HASH_BYTES, 32).
 -define(TXS_HASH_BYTES, 32).
 -define(STATE_HASH_BYTES, 32).

--- a/apps/aecore/src/aec_block_genesis.erl
+++ b/apps/aecore/src/aec_block_genesis.erl
@@ -29,16 +29,23 @@
 
 -export([genesis_difficulty/0]).
 
--export([prev_hash/0,
+-export([beneficiary/0,
          height/0,
+         miner/0,
          pow/0,
+         prev_hash/0,
          target/0,
-         beneficiary/0,
-         miner/0]).
+         time_in_msecs/0,
+         version/0
+        ]).
 
 -ifdef(TEST).
 -export([genesis_block_with_state/1]).
 -endif.
+
+-define(GENESIS_VERSION, 1).
+-define(GENESIS_HEIGHT, 0).
+-define(GENESIS_TIME, 0).
 
 -include("blocks.hrl").
 
@@ -61,6 +68,10 @@ height() -> ?GENESIS_HEIGHT.
 miner() -> <<0:?MINER_PUB_BYTES/unit:8>>.
 
 beneficiary() -> <<0:?BENEFICIARY_PUB_BYTES/unit:8>>.
+
+version() -> ?GENESIS_VERSION.
+
+time_in_msecs() -> ?GENESIS_TIME.
 
 -ifdef(TEST).
 target() ->
@@ -86,8 +97,10 @@ genesis_block_with_state() ->
 genesis_block_with_state(Map) ->
     Trees = populated_trees(Map),
 
-    Block = aec_blocks:new_key(height(), prev_hash(), prev_key_hash(), aec_trees:hash(Trees),
-                               target(), 0, 0, ?GENESIS_VERSION, miner(), beneficiary()),
+    Block = aec_blocks:new_key(height(), prev_hash(), prev_key_hash(),
+                               aec_trees:hash(Trees),
+                               target(), 0, time_in_msecs(),
+                               version(), miner(), beneficiary()),
     {Block, Trees}.
 
 %% Returns state trees at genesis block.

--- a/apps/aecore/src/aec_blocks.erl
+++ b/apps/aecore/src/aec_blocks.erl
@@ -339,18 +339,24 @@ update_micro_candidate(#mic_block{} = Block, TxsRootHash, RootHash, Txs) ->
 serialize_to_binary(#key_block{} = Block) ->
     aec_headers:serialize_to_binary(to_key_header(Block));
 serialize_to_binary(#mic_block{} = Block) ->
-    Hdr = aec_headers:serialize_to_binary(to_micro_header(Block)),
-    Txs = [ aetx_sign:serialize_to_binary(Tx) || Tx <- txs(Block)],
-    Vsn = version(Block),
-    {ok, Template} = serialization_template(micro, Vsn),
-    Rest = aec_object_serialization:serialize(
-             micro_block,
-             Vsn,
-             Template,
-             [ {txs, Txs}
-             , {pof, aec_pof:serialize(pof(Block))}
-             ]),
-    <<Hdr/binary, Rest/binary>>.
+    Hdr    = to_micro_header(Block),
+    HdrBin = aec_headers:serialize_to_binary(Hdr),
+    Height = aec_headers:height(Hdr),
+    Vsn    = version(Block),
+    case serialization_template(micro, Height, Vsn) of
+        {error, What} ->
+            error({serialization_error, What});
+        {ok, Template} ->
+            Txs = [ aetx_sign:serialize_to_binary(Tx) || Tx <- txs(Block)],
+            Rest = aec_object_serialization:serialize(
+                     micro_block,
+                     Vsn,
+                     Template,
+                     [ {txs, Txs}
+                     , {pof, aec_pof:serialize(pof(Block))}
+                     ]),
+            <<HdrBin/binary, Rest/binary>>
+    end.
 
 -spec deserialize_from_binary(binary()) -> {'error', term()} | {'ok', block()}.
 deserialize_from_binary(Bin) ->
@@ -365,7 +371,7 @@ deserialize_from_binary(Bin) ->
 
 deserialize_micro_block_from_binary(Bin, Header) ->
     Vsn = aec_headers:version(Header),
-    case serialization_template(micro, Vsn) of
+    case serialization_template(micro, aec_headers:height(Header), Vsn) of
         {ok, Template} ->
             [{txs, Txs0}, {pof, PoF0}] =
                 aec_object_serialization:deserialize(micro_block, Vsn, Template, Bin),
@@ -377,11 +383,14 @@ deserialize_micro_block_from_binary(Bin, Header) ->
             Err
     end.
 
-serialization_template(micro, Vsn) when Vsn >= ?GENESIS_VERSION andalso Vsn =< ?PROTOCOL_VERSION ->
-    {ok, [ {txs, [binary]}
-         , {pof, [binary]}]};
-serialization_template(_BlockType, Vsn) ->
-    {error, {bad_block_vsn, Vsn}}.
+serialization_template(micro, Height, Vsn) ->
+    case aec_hard_forks:protocol_effective_at_height(Height) of
+        Vsn ->
+            {ok, [ {txs, [binary]}
+                 , {pof, [binary]}]};
+        Other ->
+            {error, {bad_block_vsn, Other}}
+    end.
 
 -spec serialize_to_map(block()) -> map().
 serialize_to_map(#key_block{} = Block) ->

--- a/apps/aecore/src/aec_chain_state.erl
+++ b/apps/aecore/src/aec_chain_state.erl
@@ -310,13 +310,14 @@ fake_key_node(PrevNode, Height, Miner, Beneficiary) ->
                       key   -> hash(PrevNode);
                       micro -> prev_key_hash(PrevNode)
                   end,
+    Vsn = aec_hard_forks:protocol_effective_at_height(Height),
     Block = aec_blocks:new_key(Height,
                                hash(PrevNode),
                                PrevKeyHash,
                                <<123:?STATE_HASH_BYTES/unit:8>>,
                                ?HIGHEST_TARGET_SCI,
                                0, aeu_time:now_in_msecs(),
-                               ?PROTOCOL_VERSION,
+                               Vsn,
                                Miner,
                                Beneficiary),
     wrap_header(aec_blocks:to_header(Block)).
@@ -558,7 +559,7 @@ median_timestamp_and_headers(Node) ->
     TimeStampKeyBlocks = aec_governance:median_timestamp_key_blocks(),
     case node_height(Node) =< TimeStampKeyBlocks of
         true ->
-            {ok, ?GENESIS_TIME, []};
+            {ok, aec_block_genesis:time_in_msecs(), []};
         false ->
             PrevKeyNode = db_get_node(prev_key_hash(Node)),
             case get_n_key_headers_from(PrevKeyNode, TimeStampKeyBlocks) of

--- a/apps/aecore/src/aec_governance.erl
+++ b/apps/aecore/src/aec_governance.erl
@@ -35,11 +35,6 @@
 -include("blocks.hrl").
 -include_lib("aebytecode/include/aeb_opcodes.hrl").
 
--define(SORTED_VERSIONS, lists:sort(maps:keys(?PROTOCOLS))).
--define(PROTOCOLS,
-        #{?PROTOCOL_VERSION => ?GENESIS_HEIGHT
-         }).
-
 -define(NETWORK_ID, <<"ae_mainnet">>).
 -define(BLOCKS_TO_CHECK_DIFFICULTY_COUNT, 17).
 -define(TIMESTAMP_MEDIAN_BLOCKS, 11).
@@ -73,11 +68,13 @@
 
 
 sorted_protocol_versions() ->
-    ?SORTED_VERSIONS.
+    lists:sort(maps:keys(protocols())).
 
 protocols() ->
     case aeu_env:user_map([<<"chain">>, <<"hard_forks">>]) of
-        undefined -> ?PROTOCOLS;
+        undefined ->
+            #{aec_block_genesis:version() => aec_block_genesis:height()
+             };
         {ok, M} ->
             maps:from_list(
               lists:map(

--- a/apps/aecore/src/aec_sync.erl
+++ b/apps/aecore/src/aec_sync.erl
@@ -649,8 +649,9 @@ do_work_on_sync_task(PeerId, Task, LastResult) ->
             LocalHeight = aec_headers:height(LocalHeader),
             MinAgreedHash = aec_chain:genesis_hash(),
             MaxAgree = min(LocalHeight, TopHeight),
+            GenesisHeight = aec_block_genesis:height(),
             case  agree_on_height(PeerId, TopHash, TopHeight,
-                                  MaxAgree, MaxAgree, ?GENESIS_HEIGHT, MinAgreedHash) of
+                                  MaxAgree, MaxAgree, GenesisHeight, MinAgreedHash) of
                 {ok, AHeight, AHash} ->
                     epoch_sync:debug("Agreed upon height (~p): ~p", [ppp(PeerId), AHeight]),
                     Agreement = {agreed_height, #{ height => AHeight, hash => AHash }},

--- a/apps/aecore/src/aec_trees.erl
+++ b/apps/aecore/src/aec_trees.erl
@@ -94,6 +94,8 @@
              , poi/0
              ]).
 
+-define(VERSION, 1).
+
 %%%%=============================================================================
 %% API
 %%%=============================================================================
@@ -375,7 +377,7 @@ internal_hash(Trees) ->
 
 internal_hash(Trees, {calls_hash, CallsRootHash}) ->
     %% Note that all hash sizes are checked in pad_empty/2
-    Bin = <<?PROTOCOL_VERSION:64,
+    Bin = <<?VERSION:64,
             (pad_empty(accounts_hash(Trees)))  /binary,
             CallsRootHash                      /binary,
             (pad_empty(channels_hash(Trees)))  /binary,
@@ -503,7 +505,7 @@ internal_new_poi(Trees) ->
 
 internal_poi_hash(#poi{} = POI) ->
     %% Note that all hash sizes are checked in pad_empty/2
-    Bin = <<?PROTOCOL_VERSION:64,
+    Bin = <<?VERSION:64,
             (part_poi_hash(POI#poi.accounts)) /binary,
             (part_poi_hash(POI#poi.calls))    /binary,
             (part_poi_hash(POI#poi.channels)) /binary,

--- a/apps/aecore/test/aec_chain_tests.erl
+++ b/apps/aecore/test/aec_chain_tests.erl
@@ -41,6 +41,7 @@
 
 -define(FACTOR, 1000000000).
 -define(GENESIS_TARGET, 553713663).
+-define(GENESIS_HEIGHT, aec_block_genesis:height()).
 
 %% GENESIS DIFFICULTY = float(trunc(?FACTOR / 553713663))
 -define(GENESIS_DIFFICULTY, 1.0).

--- a/apps/aecore/test/aec_headers_tests.erl
+++ b/apps/aecore/test/aec_headers_tests.erl
@@ -9,6 +9,9 @@
                      ]).
 
 -define(TEST_MODULE, aec_headers).
+-define(GENESIS_HEIGHT, aec_block_genesis:height()).
+-define(GENESIS_VERSION, aec_block_genesis:version()).
+-define(GENESIS_TIME, aec_block_genesis:time_in_msecs()).
 
 network_key_serialization_test() ->
     Header = raw_key_header(),

--- a/apps/aecore/test/aec_mining_tests.erl
+++ b/apps/aecore/test/aec_mining_tests.erl
@@ -27,7 +27,7 @@ mine_block_test_() ->
         {"Find a new block",
          fun() ->
                  RawBlock = aec_blocks:raw_key_block(),
-                 TopBlock = aec_blocks:set_height(RawBlock, ?GENESIS_HEIGHT),
+                 TopBlock = aec_blocks:set_height(RawBlock, aec_block_genesis:height()),
                  % if there is a change in the structure of the block
                  % this will result in a change in the hash of the header
                  % and will invalidate the nonce value below
@@ -53,7 +53,7 @@ mine_block_test_() ->
         {"Proof of work fails with no_solution",
          fun() ->
                  RawBlock = aec_blocks:raw_key_block(),
-                 TopBlock = aec_blocks:set_height(RawBlock, ?GENESIS_HEIGHT),
+                 TopBlock = aec_blocks:set_height(RawBlock, aec_block_genesis:height()),
                  meck:expect(aec_pow, pick_nonce, 0, 18),
                  {BlockCandidate,_} = aec_test_utils:create_keyblock_with_state(
                                         [{TopBlock, aec_trees:new()}], ?TEST_PUB),

--- a/apps/aecore/test/aec_pow_sim.erl
+++ b/apps/aecore/test/aec_pow_sim.erl
@@ -17,7 +17,9 @@
 -define(ADJUST_WINDOW, 10).
 
 genesis_block() ->
-    H0 = aec_headers:set_version_and_height(raw_key_header(), ?PROTOCOL_VERSION, 0),
+    Vsn = aec_block_genesis:version(),
+    Height = aec_block_genesis:height(),
+    H0 = aec_headers:set_version_and_height(raw_key_header(), Vsn, Height),
     H1 = aec_headers:set_time_in_msecs(H0, 0),
     aec_headers:set_target(H1, ?HIGHEST_TARGET_SCI).
 

--- a/apps/aens/test/aens_SUITE.erl
+++ b/apps/aens/test/aens_SUITE.erl
@@ -525,7 +525,8 @@ prune_preclaim(Cfg) ->
     PubKey     = aens_commitments:owner_pubkey(C),
 
     TTL = aens_commitments:ttl(C),
-    NSTree = do_prune_until(?GENESIS_HEIGHT, TTL + 1, aec_trees:ns(Trees2)),
+    GenesisHeight = aec_block_genesis:height(),
+    NSTree = do_prune_until(GenesisHeight, TTL + 1, aec_trees:ns(Trees2)),
     none = aens_state_tree:lookup_commitment(CHash, NSTree),
     ok.
 

--- a/apps/aeoracle/test/aeoracle_SUITE.erl
+++ b/apps/aeoracle/test/aeoracle_SUITE.erl
@@ -42,6 +42,8 @@
 -include_lib("apps/aeoracle/include/oracle_txs.hrl").
 -include_lib("apps/aecontract/src/aecontract.hrl").
 
+-define(GENESIS_HEIGHT, aec_block_genesis:height()).
+
 %%%===================================================================
 %%% Common test framework
 %%%===================================================================

--- a/apps/aetx/src/aetx_env.erl
+++ b/apps/aetx/src/aetx_env.erl
@@ -131,7 +131,8 @@ contract_env(Height, ConsensusVersion, Time, Beneficiary, Difficulty,
      }.
 
 tx_env(Height) ->
-    #env{ consensus_version = ?PROTOCOL_VERSION
+    Vsn = aec_hard_forks:protocol_effective_at_height(Height),
+    #env{ consensus_version = Vsn
         , context = aetx_transaction
         , height  = Height
         , signed_tx = none

--- a/test/aevm_chain_SUITE.erl
+++ b/test/aevm_chain_SUITE.erl
@@ -56,7 +56,9 @@ setup_chain() ->
     {Contract1, S3} = create_contract(Account1, S2),
     {Contract2, S4} = create_contract(Account2, S3),
     Trees = aect_test_utils:trees(S4),
-    TxEnv = aetx_env:contract_env(_Height = 1, ?PROTOCOL_VERSION,
+    Height = 1,
+    Vsn = aec_hard_forks:protocol_effective_at_height(Height),
+    TxEnv = aetx_env:contract_env(Height, Vsn,
                                   aeu_time:now_in_msecs(),
                                   ?BENEFICIARY_PUBKEY, _Difficulty = 0,
                                   ?BOGUS_PREV_HASH


### PR DESCRIPTION
* Move genesis fields from macros to function calls

* Remove macro for protocol version and use hard fork information instead

https://www.pivotaltracker.com/story/show/162474517