### PR TITLE
resolve double CORS headers in local docker setup

### DIFF
--- a/docker/epoch_node1_mean15.yaml
+++ b/docker/epoch_node1_mean15.yaml
@@ -2,12 +2,13 @@
 peers:
     - aenode://pp_28uQUgsPcsy7TQwnRxhF8GMKU4ykFLKsgf4TwDwPMNaSCXwWV8@node2:3015
     - aenode://pp_Dxq41rJN33j26MLqryvh7AnhuZywefWKEPBiiYu2Da2vDWLBq@node3:3015
-
 http:
     external:
         port: 3013
     internal:
         listen_address: 0.0.0.0
+    cors:
+        allow_domains: [""]
 
 keys:
     peer_password: "top secret"

--- a/docker/epoch_node2_mean15.yaml
+++ b/docker/epoch_node2_mean15.yaml
@@ -8,6 +8,8 @@ http:
         port: 3013
     internal:
         listen_address: 0.0.0.0
+    cors:
+        allow_domains: [""]
 
 keys:
     peer_password: "top secret"

--- a/docker/epoch_node3_mean15.yaml
+++ b/docker/epoch_node3_mean15.yaml
@@ -8,6 +8,8 @@ http:
         port: 3013
     internal:
         listen_address: 0.0.0.0
+    cors:
+        allow_domains: [""]
 
 keys:
     peer_password: "top secret"


### PR DESCRIPTION
Removes CORS headers in epoch nodes because those
headers are set by the NGINX proxy

This solves the issue that CORS header were set twice. Having multiple values for CORS results in a error in the browser

```
Access to XMLHttpRequest at 'http://localhost:3001/api' from origin 'http://localhost:8080' has been blocked by CORS policy: The 'Access-Control-Allow-Origin' header contains multiple values 'http://localhost:8080, *', but only one is allowed.
Cross-Origin Read Blocking (CORB) blocked cross-origin response
```

Before:
```
$ curl -i 'http://localhost:3001/api' -H 'Origin: http://localhost:8080' -H 'Accept: application/json, text/plain, */*' 2> /dev/null | head -n 15 | grep 'llow-[o,O]rigin'
access-control-allow-origin: http://localhost:8080
Access-Control-Allow-Origin: *
```

After:
```
$ curl -i 'http://localhost:3001/api' -H 'Origin: http://localhost:8080' -H 'Accept: application/json, text/plain, */*' 2> /dev/null | head -n 15 | grep 'llow-[o,O]rigin'
Access-Control-Allow-Origin: *
```