### PR TITLE
Discriminate CI jobs meant for stable tags only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,8 @@ references:
           && cd libsodium-src \
           && ./configure && make -j$(nproc) && sudo make install && sudo ldconfig
 
+  tag_regex: &tag_regex /^v.*$/
+
   rebar_cache_key: &rebar_cache_key rebar-cache-{{ checksum "rebar.lock" }}-{{ checksum "rebar.config" }}
   restore_rebar_cache: &restore_rebar_cache
     restore_cache:
@@ -662,7 +664,7 @@ workflows:
                 - env/dev2
                 - system-tests
             tags:
-              only: /^v.*$/
+              only: *tag_regex
 
       - docker_smoke_tests:
           filters:
@@ -682,7 +684,7 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /^v.*$/
+              only: *tag_regex
 
       - docker_system_smoke_tests:
           requires:
@@ -714,7 +716,7 @@ workflows:
                 - env/dev2
                 - system-tests
             tags:
-              only: /^v.*$/
+              only: *tag_regex
 
       - aevm_tests:
           requires:
@@ -726,7 +728,7 @@ workflows:
                 - env/dev2
                 - system-tests
             tags:
-              only: /^v.*$/
+              only: *tag_regex
 
       - uat_tests:
           requires:
@@ -738,7 +740,7 @@ workflows:
                 - env/dev2
                 - system-tests
             tags:
-              only: /^v.*$/
+              only: *tag_regex
 
       - docker_system_tests:
           filters:
@@ -755,7 +757,7 @@ workflows:
                 - env/dev2
                 - system-tests
             tags:
-              only: /^v.*$/
+              only: *tag_regex
 
       - rebar_lock_check:
           requires:
@@ -767,7 +769,7 @@ workflows:
                 - env/dev2
                 - system-tests
             tags:
-              only: /^v.*$/
+              only: *tag_regex
 
       - linux_package:
           filters:
@@ -775,7 +777,7 @@ workflows:
               ignore:
                 - system-tests
             tags:
-              only: /^v.*$/
+              only: *tag_regex
 
       - upload_build_artifacts:
           requires:
@@ -785,7 +787,7 @@ workflows:
               ignore:
                 - system-tests
             tags:
-              only: /^v.*$/
+              only: *tag_regex
 
       - osx_package:
           filters:
@@ -793,7 +795,7 @@ workflows:
               only:
                 - master
             tags:
-              only: /^v.*$/
+              only: *tag_regex
 
       - deploy_integration:
           requires:
@@ -841,7 +843,7 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /^v.*$/
+              only: *tag_regex
 
       - hodl_green:
           type: approval
@@ -849,7 +851,7 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /^v.*$/
+              only: *tag_regex
 
       - deploy_uat_blue:
           requires:
@@ -862,7 +864,7 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /^v.*$/
+              only: *tag_regex
 
       - deploy_uat_green:
           requires:
@@ -872,7 +874,7 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /^v.*$/
+              only: *tag_regex
 
       - upload_packages_linux:
           requires:
@@ -885,7 +887,7 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /^v.*$/
+              only: *tag_regex
 
       - upload_packages_osx:
           requires:
@@ -898,7 +900,7 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /^v.*$/
+              only: *tag_regex
 
       - docker_push_tag:
           requires:
@@ -910,7 +912,7 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /^v.*$/
+              only: *tag_regex
 
   chain_snapshots:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,6 +72,7 @@ references:
           && ./configure && make -j$(nproc) && sudo make install && sudo ldconfig
 
   tag_regex: &tag_regex /^v.*$/
+  stable_tag_regex: &stable_tag_regex /^v1\..*$/
 
   rebar_cache_key: &rebar_cache_key rebar-cache-{{ checksum "rebar.lock" }}-{{ checksum "rebar.config" }}
   restore_rebar_cache: &restore_rebar_cache
@@ -684,7 +685,7 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: *tag_regex
+              only: *stable_tag_regex
 
       - docker_system_smoke_tests:
           requires:
@@ -843,7 +844,7 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: *tag_regex
+              only: *stable_tag_regex
 
       - hodl_green:
           type: approval
@@ -851,7 +852,7 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: *tag_regex
+              only: *stable_tag_regex
 
       - deploy_uat_blue:
           requires:
@@ -864,7 +865,7 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: *tag_regex
+              only: *stable_tag_regex
 
       - deploy_uat_green:
           requires:
@@ -874,7 +875,7 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: *tag_regex
+              only: *stable_tag_regex
 
       - upload_packages_linux:
           requires:
@@ -887,7 +888,7 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: *tag_regex
+              only: *stable_tag_regex
 
       - upload_packages_osx:
           requires:
@@ -900,7 +901,7 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: *tag_regex
+              only: *stable_tag_regex
 
       - docker_push_tag:
           requires:
@@ -912,7 +913,7 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: *tag_regex
+              only: *stable_tag_regex
 
   chain_snapshots:
     triggers:


### PR DESCRIPTION
In scope of https://www.pivotaltracker.com/story/show/162475176

This PR is for `master`.
It depends on https://github.com/aeternity/epoch/pull/1963 to be merged in `minerva` (so to confirm tag scheme).

TODO:
* [ ] Test that on stable tag `/^v1\..*$/` release workflow works as expected.
  * @dincho How am I meant to test this? Shall we merge it, and at next stable tag&release if we spot any issues we fix CI quickly?