### PR TITLE
Define macro for filtering CI jobs only for unstable Minerva tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,7 @@ references:
 
   tag_regex: &tag_regex /^v.*$/
   stable_tag_regex: &stable_tag_regex /^v1\..*$/
+  next_tag_regex: &next_tag_regex /^v2\..*minerva.*$/
   next_branch: &next_branch minerva
 
   rebar_cache_key: &rebar_cache_key rebar-cache-{{ checksum "rebar.lock" }}-{{ checksum "rebar.config" }}


### PR DESCRIPTION
In scope of https://www.pivotaltracker.com/story/show/162475176

This PR is for `minerva`.
It depends on https://github.com/aeternity/epoch/pull/1966 to be merged in `master` (so to be able to rebase on it).

TODO (in order):
* [x] Ensure #1966 merged in `master`
* [x] Merge (do not ~squash~ or ~rebase~) `master` (#1966) to `minerva`
  * https://github.com/aeternity/epoch/pull/1980
* [x] Ensure commit 6482f09a (part of #1980) - on which this PR is based - is part of `minerva` branch
* [x] Edit PR to have `minerva` as base branch
* [x] ~Rebase this PR on `minerva`~
* [ ] Merge to `minerva`
