### PR TITLE
Make system test more relaxed on release version check

### DIFF
--- a/system_test/aest_commands_SUITE.erl
+++ b/system_test/aest_commands_SUITE.erl
@@ -55,7 +55,7 @@ epoch_commands(Cfg) ->
     wait_for_value({height, 0}, [node1], ?STARTUP_TIMEOUT, Cfg),
     {0, Output1} = aest_nodes:run_cmd_in_node_dir(node1, ["bin/epoch", "versions"], Cfg),
     ?assertMatch({match, _}, re:run(Output1,
-        "Installed versions:[\r\n]*\\*[ \t]*[0-9\\.\\-rc]*[ \t]*permanent[\r\n]*")),
+        "Installed versions:[\r\n]*\\*[ \t]*[0-9\\.\\-a-z]*[ \t]*permanent[\r\n]*")),
 
     {0, Output2} = aest_nodes:run_cmd_in_node_dir(node1, ["bin/epoch", "peer_key"], Cfg),
     {ok, PeerKey} = aehttp_api_encoder:safe_decode(peer_pubkey, list_to_binary(Output2)),


### PR DESCRIPTION
In scope of https://www.pivotaltracker.com/story/show/162475176

Loosely depends on the version schema in #1963 (`2.0.0-minerva.0.1.0` or similar) approved, though this test tweak seems a good idea anyway.