### PR TITLE
Add events to Sophia compiler

### DIFF
--- a/apps/aecontract/test/aecontract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_SUITE.erl
@@ -3223,6 +3223,13 @@ sophia_events(_Cfg) ->
     ?assertEqual(<<"12345">>, ?call(call_contract, Acc, IdC, i2s, string, {12345})),
     ?assertEqual(<<"-2345">>, ?call(call_contract, Acc, IdC, i2s, string, {-2345})),
 
+    BAcc = list_to_binary(base58:binary_to_base58(Acc)),
+    ?assertMatch({BAcc, _},
+                  ?call(call_contract, Acc, IdC, a2s, string, {Acc}, #{ return_gas_used => true })),
+
+    BIdC = list_to_binary(base58:binary_to_base58(IdC)),
+    ?assertMatch({BIdC, _},
+                  ?call(call_contract, Acc, IdC, a2s, string, {IdC}, #{ return_gas_used => true })),
     ok.
 
 

--- a/apps/aecontract/test/aecontract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_SUITE.erl
@@ -3219,6 +3219,10 @@ sophia_events(_Cfg) ->
     ?assertMatch({{},[{_, _, <<"1234567890123456789012345678901234567897">>}]},
                  ?call(call_contract, Acc, IdC, f3, {tuple, []}, {1234567890123456789012345678901234567890}, #{ return_logs => true })),
 
+    ?assertEqual(<<"5">>, ?call(call_contract, Acc, IdC, i2s, string, {5})),
+    ?assertEqual(<<"12345">>, ?call(call_contract, Acc, IdC, i2s, string, {12345})),
+    ?assertEqual(<<"-2345">>, ?call(call_contract, Acc, IdC, i2s, string, {-2345})),
+
     ok.
 
 

--- a/apps/aecontract/test/aect_test_utils.erl
+++ b/apps/aecontract/test/aect_test_utils.erl
@@ -128,7 +128,7 @@ create_tx_default_spec(PubKey, State) ->
      }.
 
 dummy_bytecode() ->
-    aect_sophia:serialize(#{byte_code => <<"NOT PROPER BYTE CODE">>, 
+    aect_sophia:serialize(#{byte_code => <<"NOT PROPER BYTE CODE">>,
                             type_info => [],  %% No type info
                             contract_source => "NOT PROPER SOURCE STRING",
                             compiler_version => aeso_compiler:version()}

--- a/apps/aesophia/src/aeso_ast_infer_types.erl
+++ b/apps/aesophia/src/aeso_ast_infer_types.erl
@@ -70,6 +70,7 @@ global_env() ->
     Bool    = {id, Ann, "bool"},
     String  = {id, Ann, "string"},
     Address = {id, Ann, "address"},
+    Event   = {id, Ann, "event"},
     State   = {id, Ann, "state"},
     Hash    = {id, Ann, "hash"},
     Oracle  = fun(Q, R) -> {app_t, Ann, {id, Ann, "oracle"}, [Q, R]} end,
@@ -113,6 +114,7 @@ global_env() ->
      {["Chain",    "block_height"], Int},
      {["Chain",    "difficulty"],   Int},
      {["Chain",    "gas_limit"],    Int},
+     {["Chain",    "event"],        Fun1(Event, Unit)},
      %% State
      {"state", State},
      {"put",   Fun1(State, Unit)},
@@ -143,7 +145,9 @@ global_env() ->
      %% Strings
      {["String", "length"], Fun1(String, Int)},
      {["String", "concat"], Fun([String, String], String)},
-     {["String", "sha3"], Fun1(String, Int)}
+     {["String", "sha3"], Fun1(String, Int)},
+     %% Conversion
+     {["Int", "to_str"], Fun1(Int, String)}
     ].
 
 global_type_env() ->
@@ -275,6 +279,7 @@ check_typedef_sccs(Env, TypeMap, [{acyclic, Name} | SCCs]) ->
                                  end || ConDef <- Cons ],
                     check_repeated_constructors([ {Con, ConType(Args)} || {constr_t, _, Con, Args} <- Cons ]),
                     [ check_constructor_overlap(Env, Con, Target) || {constr_t, _, Con, _} <- Cons ],
+                    [ check_event(Cons) || Name == "event" ],
                     check_typedef_sccs(ConTypes ++ Env, TypeMap, SCCs)
             end
     end;
@@ -282,6 +287,19 @@ check_typedef_sccs(Env, TypeMap, [{cyclic, Names} | SCCs]) ->
     Id = fun(X) -> {type_def, _, D, _, _} = maps:get(X, TypeMap), D end,
     type_error({recursive_types_not_implemented, lists:map(Id, Names)}),
     check_typedef_sccs(Env, TypeMap, SCCs).
+
+check_event(Cons) ->
+    [ check_event(Name, Types) || {constr_t, _, {con, _, Name}, Types} <- Cons ].
+
+%% Initially we limit the type of an event, it can have 0-3 topics/indexed "words"
+%% and 0-1 strings as payload.
+check_event(Name, Types) ->
+    IsIndexed  = fun(T) -> proplists:get_value(indexed, aeso_syntax:get_ann(T), false) end,
+    Indexed    = [ T || T <- Types, IsIndexed(T) ],
+    NonIndexed = Types -- Indexed,
+    %% TODO: Is is possible to check also the types of arguments in a sensible way?
+    [ type_error({event_0_to_3_indexed_values, Name}) || length(Indexed) > 3 ],
+    [ type_error({event_0_to_1_string_values, Name}) || length(NonIndexed) > 1 ].
 
 check_constructor_overlap(Env, Con = {con, _, Name}, NewType) ->
     case proplists:get_value(Name, Env) of
@@ -1360,6 +1378,10 @@ pp_error({recursive_types_not_implemented, Types}) ->
            true              -> " is" end,
     io_lib:format("The following type~s recursive, which is not yet supported:\n~s",
                     [S, [io_lib:format("  - ~s (at ~s)\n", [pp(T), pp_loc(T)]) || T <- Types]]);
+pp_error({event_0_to_3_indexed_values, Constr}) ->
+    io_lib:format("The event constructor ~s has too many indexed values (max 3)\n", [Constr]);
+pp_error({event_0_to_1_string_values, Constr}) ->
+    io_lib:format("The event constructor ~s has too many string values (max 1)\n", [Constr]);
 pp_error({repeated_constructor, Cs}) ->
     io_lib:format("Variant types must have distinct constructor names\n~s",
                   [[ io_lib:format("~s  (at ~s)\n", [pp_typed("  - ", C, T), pp_loc(C)]) || {C, T} <- Cs ]]);

--- a/apps/aesophia/src/aeso_ast_infer_types.erl
+++ b/apps/aesophia/src/aeso_ast_infer_types.erl
@@ -295,7 +295,7 @@ check_event(Cons) ->
 %% Initially we limit the type of an event, it can have 0-3 topics/indexed "words"
 %% and 0-1 strings as payload.
 check_event(Name, Types) ->
-    IsIndexed  = fun(T) -> proplists:get_value(indexed, aeso_syntax:get_ann(T), false) end,
+    IsIndexed  = fun(T) -> aeso_syntax:get_ann(indexed, T, false) end,
     Indexed    = [ T || T <- Types, IsIndexed(T) ],
     NonIndexed = Types -- Indexed,
     %% TODO: Is is possible to check also the types of arguments in a sensible way?

--- a/apps/aesophia/src/aeso_ast_infer_types.erl
+++ b/apps/aesophia/src/aeso_ast_infer_types.erl
@@ -147,7 +147,8 @@ global_env() ->
      {["String", "concat"], Fun([String, String], String)},
      {["String", "sha3"], Fun1(String, Int)},
      %% Conversion
-     {["Int", "to_str"], Fun1(Int, String)}
+     {["Int", "to_str"], Fun1(Int, String)},
+     {["Address", "to_str"], Fun1(Address, String)}
     ].
 
 global_type_env() ->

--- a/apps/aesophia/src/aeso_ast_to_icode.erl
+++ b/apps/aesophia/src/aeso_ast_to_icode.erl
@@ -334,6 +334,9 @@ ast_body(?qid_app(["String", "sha3"], [String], _, _), Icode) ->
 ast_body(?qid_app(["Int", "to_str"], [Int], _, _), Icode) ->
     builtin_call(int_to_str, [ast_body(Int, Icode)]);
 
+ast_body(?qid_app(["Address", "to_str"], [Addr], _, _), Icode) ->
+    builtin_call(addr_to_str, [ast_body(Addr, Icode)]);
+
 %% Other terms
 ast_body({id, _, Name}, _Icode) ->
     %% TODO Look up id in env

--- a/apps/aesophia/src/aeso_ast_to_icode.erl
+++ b/apps/aesophia/src/aeso_ast_to_icode.erl
@@ -10,7 +10,7 @@
 -module(aeso_ast_to_icode).
 
 -export([ast_typerep/1, ast_typerep/2, type_value/1,
-         convert_typed/2]).
+         convert_typed/2, prim_call/5]).
 
 -include_lib("aebytecode/include/aeb_opcodes.hrl").
 -include("aeso_icode.hrl").
@@ -61,6 +61,8 @@ contract_to_icode([{type_def, _Attrib, {id, _, Name}, Args, Def} | Rest],
     Icode2 = case Name of
                 "state" when Args == [] -> Icode1#{ state_type => ast_typerep(Def, Icode) };
                 "state"                 -> gen_error(state_type_cannot_be_parameterized);
+                "event" when Args == [] -> Icode1#{ event_type => Def };
+                "event"                 -> gen_error(event_type_cannot_be_parameterized);
                 _                       -> Icode1
              end,
     contract_to_icode(Rest, Icode2);
@@ -118,6 +120,9 @@ ast_type(T, Icode) ->
 
 ast_body(?qid_app(["Chain","spend"], [To, Amount], _, _), Icode) ->
     prim_call(?PRIM_CALL_SPEND, ast_body(Amount, Icode), [ast_body(To, Icode)], [word], {tuple, []});
+
+ast_body(?qid_app(["Chain","event"], [Event], _, _), Icode) ->
+    builtin_call({event, maps:get(event_type, Icode)}, [ast_body(Event, Icode)]);
 
 %% Chain environment
 ast_body(?qid_app(["Chain", "balance"], [Address], _, _), Icode) ->
@@ -325,6 +330,9 @@ ast_body(?qid_app(["String", "concat"], [String1, String2], _, _), Icode) ->
 ast_body(?qid_app(["String", "sha3"], [String], _, _), Icode) ->
     #unop{ op = 'sha3', rand = ast_body(String, Icode) };
 
+%% -- Conversion
+ast_body(?qid_app(["Int", "to_str"], [Int], _, _), Icode) ->
+    builtin_call(int_to_str, [ast_body(Int, Icode)]);
 
 %% Other terms
 ast_body({id, _, Name}, _Icode) ->
@@ -686,294 +694,6 @@ builtin_call(Builtin, Args) ->
     #funcall{ function = #var_ref{ name = {builtin, Builtin} },
               args = Args }.
 
-builtin_deps(Builtin) ->
-    lists:usort(builtin_deps1(Builtin)).
-
-builtin_deps1({map_lookup_default, Type}) -> [{map_lookup, Type}];
-builtin_deps1({map_get, Type})            -> [{map_lookup, Type}];
-builtin_deps1(map_member)                 -> [{map_lookup, word}];
-builtin_deps1({map_upd, Type})            -> [{map_get, Type}, map_put];
-builtin_deps1({map_upd_default, Type})    -> [{map_lookup_default, Type}, map_put];
-builtin_deps1(map_from_list)              -> [map_put];
-builtin_deps1(str_equal)                  -> [str_equal_p];
-builtin_deps1(string_concat)              -> [string_concat_inner1, string_concat_inner2];
-builtin_deps1(_)                          -> [].
-
-dep_closure(Deps) ->
-    case lists:umerge(lists:map(fun builtin_deps/1, Deps)) of
-        []    -> Deps;
-        Deps1 -> lists:umerge(Deps, dep_closure(Deps1))
-    end.
-
-used_builtins(#funcall{ function = #var_ref{ name = {builtin, Builtin} }, args = Args }) ->
-    lists:umerge(dep_closure([Builtin]), used_builtins(Args));
-used_builtins([H|T]) ->
-  lists:umerge(used_builtins(H), used_builtins(T));
-used_builtins(T) when is_tuple(T) ->
-  used_builtins(tuple_to_list(T));
-used_builtins(M) when is_map(M) ->
-  used_builtins(maps:to_list(M));
-used_builtins(_) -> [].
-
-option_none()  -> {tuple, [{integer, 0}]}.
-option_some(X) -> {tuple, [{integer, 1}, X]}.
-
-v(X) when is_atom(X) -> v(atom_to_list(X));
-v(X) when is_list(X) -> #var_ref{name = X}.
-
-%% Abort primitive.
-builtin_function(abort) ->
-    A = fun(X) -> aeb_opcodes:mnemonic(X) end,
-    {{builtin, abort}, [private],
-     [{"s", string}],
-     {inline_asm, [A(?PUSH1),0,  %% Push a dummy 0 for the first arg
-                   A(?REVERT)]}, %% Stack: 0,Ptr
-     {tuple,[]}};
-
-%% Map primitives
-builtin_function(Builtin = {map_lookup, Type}) ->
-    Ret = aeso_icode:option_typerep(Type),
-    {{builtin, Builtin}, [private],
-        [{"m", word}, {"k", word}],
-            prim_call(?PRIM_CALL_MAP_GET, #integer{value = 0},
-                      [#var_ref{name = "m"}, #var_ref{name = "k"}],
-                      [word, word], Ret),
-     Ret};
-
-builtin_function(Builtin = map_put) ->
-    %% We don't need the types for put.
-    {{builtin, Builtin}, [private],
-        [{"m", word}, {"k", word}, {"v", word}],
-        prim_call(?PRIM_CALL_MAP_PUT, #integer{value = 0},
-                  [v(m), v(k), v(v)],
-                  [word, word, word], word),
-     word};
-
-builtin_function(Builtin = map_delete) ->
-    {{builtin, Builtin}, [private],
-        [{"m", word}, {"k", word}],
-        prim_call(?PRIM_CALL_MAP_DELETE, #integer{value = 0},
-                  [v(m), v(k)],
-                  [word, word], word),
-     word};
-
-builtin_function(Builtin = map_size) ->
-    Name = {builtin, Builtin},
-    {Name, [private], [{"m", word}],
-        prim_call(?PRIM_CALL_MAP_SIZE, #integer{value = 0},
-                  [v(m)], [word], word),
-        word};
-
-%% Map builtins
-builtin_function(Builtin = {map_get, Type}) ->
-    %% function map_get(m, k) =
-    %%   switch(map_lookup(m, k))
-    %%     Some(v) => v
-    {{builtin, Builtin}, [private],
-        [{"m", word}, {"k", word}],
-            {switch, builtin_call({map_lookup, Type}, [v(m), v(k)]),
-                [{option_some(v(v)), v(v)}]},
-     Type};
-
-builtin_function(Builtin = {map_lookup_default, Type}) ->
-    %% function map_lookup_default(m, k, default) =
-    %%   switch(map_lookup(m, k))
-    %%     None    => default
-    %%     Some(v) => v
-    {{builtin, Builtin}, [private],
-        [{"m", word}, {"k", word}, {"default", Type}],
-            {switch, builtin_call({map_lookup, Type}, [v(m), v(k)]),
-                [{option_none(),     v(default)},
-                 {option_some(v(v)), v(v)}]},
-     Type};
-
-builtin_function(Builtin = map_member) ->
-    %% function map_member(m, k) : bool =
-    %%   switch(Map.lookup(m, k))
-    %%     None => false
-    %%     _    => true
-    {{builtin, Builtin}, [private],
-        [{"m", word}, {"k", word}],
-            {switch, builtin_call({map_lookup, word}, [v(m), v(k)]),
-                [{option_none(), {integer, 0}},
-                 {{var_ref, "_"}, {integer, 1}}]},
-     word};
-
-builtin_function(Builtin = {map_upd, Type}) ->
-    %% function map_upd(map, key, fun) =
-    %%   map_put(map, key, fun(map_get(map, key)))
-    {{builtin, Builtin}, [private],
-     [{"map", word}, {"key", word}, {"valfun", word}],
-     builtin_call(map_put,
-        [v(map), v(key),
-         #funcall{ function = v(valfun),
-                   args     = [builtin_call({map_get, Type}, [v(map), v(key)])] }]),
-     word};
-
-builtin_function(Builtin = {map_upd_default, Type}) ->
-    %% function map_upd(map, key, val, fun) =
-    %%   map_put(map, key, fun(map_lookup_default(map, key, val)))
-    {{builtin, Builtin}, [private],
-     [{"map", word}, {"key", word}, {"val", word}, {"valfun", word}],
-     builtin_call(map_put,
-        [v(map), v(key),
-         #funcall{ function = v(valfun),
-                   args     = [builtin_call({map_lookup_default, Type}, [v(map), v(key), v(val)])] }]),
-     word};
-
-builtin_function(Builtin = map_from_list) ->
-    %% function map_from_list(xs, acc) =
-    %%   switch(xs)
-    %%     [] => acc
-    %%     (k, v) :: xs => map_from_list(xs, acc { [k] = v })
-    {{builtin, Builtin}, [private],
-     [{"xs", {list, {tuple, [word, word]}}}, {"acc", word}],
-     {switch, v(xs),
-        [{{list, []}, v(acc)},
-         {{binop, '::', {tuple, [v(k), v(v)]}, v(ys)},
-          builtin_call(map_from_list,
-            [v(ys), builtin_call(map_put, [v(acc), v(k), v(v)])])}]},
-     word};
-
-%% list_concat
-%%
-%% Concatenates two lists.
-builtin_function(list_concat) ->
-    {{builtin, list_concat}, [private],
-     [{"l1", {list, word}}, {"l2", {list, word}}],
-     {switch, v(l1),
-        [{{list, []}, v(l2)},
-         {{binop, '::', v(hd), v(tl)},
-          {binop, '::', v(hd), {funcall, {var_ref, {builtin, list_concat}},
-                                         [v(tl), v(l2)]}}}
-        ]
-     },
-    word};
-
-builtin_function(string_length) ->
-    %% function length(str) =
-    %%   switch(str)
-    %%      {n} -> n  // (ab)use the representation
-    {{builtin, string_length}, [private],
-     [{"s", string}],
-     {switch, v(s), [{{tuple, [v(n)]}, v(n)}]},
-     word};
-
-%% str_concat - concatenate two strings
-%%
-%% Unless the second string is the empty string, a new string is created at the
-%% top of the Heap and the address to it is returned. The tricky bit is when
-%% the words from the second string has to be shifted to fit next to the first
-%% string.
-builtin_function(string_concat) ->
-    I = fun(X) -> {integer, X} end,
-    LetLen = fun(N, S, Body) -> {switch, v(S), [{{tuple, [v(N)]}, Body}]} end,
-    Let = fun(N, E, Body) -> {switch, E, [{v(N), Body}]} end,
-    StepPtr = fun(P) -> {binop, '+', v(P), I(32)} end,
-    A = fun(X) -> aeb_opcodes:mnemonic(X) end,
-    {{builtin, string_concat}, [private],
-     [{"s1", string}, {"s2", string}],
-     LetLen(n1, s1,
-     LetLen(n2, s2,
-        {ifte, {binop, '==', v(n2), I(0)},
-            v(s1), %% Second string is empty return first string
-            Let(ret, {inline_asm, [A(?MSIZE)]},
-                {seq, [{binop, '+', v(n1), v(n2)},
-                       {inline_asm, [A(?MSIZE), A(?MSTORE)]}, %% Store total len
-                       {funcall, {var_ref, {builtin, string_concat_inner1}},
-                            [v(n1), StepPtr(s1), v(n2), StepPtr(s2)]},
-                       {inline_asm, [A(?POP)]}, %% Discard fun ret val
-                       v(ret)                   %% Put the actual return value
-                      ]})})),
-     word};
-
-builtin_function(string_concat_inner1) ->
-    I = fun(X) -> {integer, X} end,
-    Name = {builtin, string_concat_inner1},
-    LetWord = fun(W, P, Body) -> {switch, v(P), [{{tuple, [v(W)]}, Body}]} end,
-    A = fun(X) -> aeb_opcodes:mnemonic(X) end,
-    %% Copy all whole words from the first string, and set up for word fusion
-    %% Special case when the length of the first string is divisible by 32.
-    {Name, [private],
-     [{"n1", word}, {"p1", pointer}, {"n2", word}, {"p2", pointer}],
-     LetWord(w1, p1,
-        {ifte, {binop, '>', v(n1), I(32)},
-            {seq, [v(w1), {inline_asm, [A(?MSIZE), A(?MSTORE)]},
-                   {funcall, {var_ref, Name}, [{binop, '-', v(n1), I(32)},
-                                               {binop, '+', v(p1), I(32)},
-                                               v(n2), v(p2)]}]},
-            {ifte, {binop, '==', v(n1), I(0)},
-                {funcall, {var_ref, {builtin, string_concat_inner2}},
-                          [I(32), I(0), v(n2), v(p2)]},
-                {funcall, {var_ref, {builtin, string_concat_inner2}},
-                          [{binop, '-', I(32), v(n1)}, v(w1), v(n2), v(p2)]}}
-        }),
-     word};
-
-builtin_function(string_concat_inner2) ->
-    I = fun(X) -> {integer, X} end,
-    LetWord = fun(W, P, Body) -> {switch, v(P), [{{tuple, [v(W)]}, Body}]} end,
-    BSR = fun(X, Bytes) -> {binop, 'div', X, {binop, '^', I(2), {binop, '*', Bytes, I(8)}}} end,
-    BSL = fun(X, Bytes) -> {binop, '*', X, {binop, '^', I(2), {binop, '*', Bytes, I(8)}}} end,
-    A = fun(X) -> aeb_opcodes:mnemonic(X) end,
-    Name = {builtin, string_concat_inner2},
-    %% Current "work in progess" word 'x', has 'o' bytes that are "free" - fill them from
-    %% words of the second string.
-    {Name, [private],
-     [{"o", word}, {"x", word}, {"n2", word}, {"p2", pointer}],
-     {ifte, {binop, '<', v(n2), I(1)},
-        {seq, [v(x), {inline_asm, [A(?MSIZE), A(?MSTORE), A(?MSIZE)]}]}, %% Use MSIZE as dummy return value
-        LetWord(w2, p2,
-            {ifte, {binop, '>', v(n2), v(o)},
-                {seq, [{binop, '+', v(x), BSR(v(w2), {binop, '-', I(32), v(o)})},
-                       {inline_asm, [A(?MSIZE), A(?MSTORE)]},
-                       {funcall, {var_ref, Name},
-                                [v(o), BSL(v(w2), v(o)), {binop, '-', v(n2), I(32)}, {binop, '+', v(p2), I(32)}]}
-                      ]},
-                {seq, [{binop, '+', v(x), BSR(v(w2), {binop, '-', I(32), v(o)})},
-                       {inline_asm, [A(?MSIZE), A(?MSTORE), A(?MSIZE)]}]} %% Use MSIZE as dummy return value
-            })
-     },
-     word};
-
-builtin_function(str_equal_p) ->
-    %% function str_equal_p(n, p1, p2) =
-    %%   if(n =< 0) true
-    %%   else
-    %%      let w1 = *p1
-    %%      let w2 = *p2
-    %%      w1 == w2 && str_equal_p(n - 32, p1 + 32, p2 + 32)
-    LetWord = fun(W, P, Body) -> {switch, v(P), [{{tuple, [v(W)]}, Body}]} end,
-    Name = {builtin, str_equal_p},
-    {Name, [private],
-        [{"n", word}, {"p1", pointer}, {"p2", pointer}],
-        {ifte, {binop, '<', v(n), {integer, 1}},
-            {integer, 1},
-            LetWord(w1, p1,
-            LetWord(w2, p2,
-                {binop, '&&', {binop, '==', v(w1), v(w2)},
-                    {funcall, {var_ref, Name},
-                        [{binop, '-', v(n), {integer, 32}},
-                         {binop, '+', v(p1), {integer, 32}},
-                         {binop, '+', v(p2), {integer, 32}}]}}))},
-     word};
-
-builtin_function(str_equal) ->
-    %% function str_equal(s1, s2) =
-    %%   let n1 = length(s1)
-    %%   let n2 = length(s2)
-    %%   n1 == n2 && str_equal_p(n1, s1 + 32, s2 + 32)
-    LetLen = fun(N, S, Body) -> {switch, v(S), [{{tuple, [v(N)]}, Body}]} end,
-    {{builtin, str_equal}, [private],
-        [{"s1", string}, {"s2", string}],
-        LetLen(n1, s1,
-        LetLen(n2, s2,
-            {binop, '&&', {binop, '==', v(n1), v(n2)},
-                {funcall, {var_ref, {builtin, str_equal_p}},
-                    [v(n1), {binop, '+', v(s1), {integer, 32}},
-                            {binop, '+', v(s2), {integer, 32}}]}})),
-        word}.
-
 add_builtins(Icode = #{functions := Funs}) ->
-    Builtins = used_builtins(Funs),
-    Icode#{functions := [ builtin_function(B) || B <- Builtins ] ++ Funs}.
+    Builtins = aeso_builtins:used_builtins(Funs),
+    Icode#{functions := [ aeso_builtins:builtin_function(B) || B <- Builtins ] ++ Funs}.

--- a/apps/aesophia/src/aeso_builtins.erl
+++ b/apps/aesophia/src/aeso_builtins.erl
@@ -68,7 +68,7 @@ option_some(X) -> {tuple, [{integer, 1}, X]}.
 -define(ADD(A, B), op('+', A, B)).
 -define(SUB(A, B), op('-', A, B)).
 -define(MUL(A, B), op('*', A, B)).
--define(DIV(A, B), op('/', A, B)).
+-define(DIV(A, B), op('div', A, B)).
 -define(MOD(A, B), op('mod', A, B)).
 -define(EXP(A, B), op('^', A, B)).
 -define(AND(A, B), op('&&', A, B)).

--- a/apps/aesophia/src/aeso_builtins.erl
+++ b/apps/aesophia/src/aeso_builtins.erl
@@ -1,0 +1,385 @@
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2018, Aeternity Anstalt
+%%% @doc
+%%%     Compiler builtin functions for Aeterinty Sophia language.
+%%% @end
+%%% Created : 20 Dec 2018
+%%%
+%%%-------------------------------------------------------------------
+
+-module(aeso_builtins).
+
+-export([ builtin_function/1
+        , used_builtins/1 ]).
+
+-import(aeso_ast_to_icode, [prim_call/5]).
+
+-include_lib("aebytecode/include/aeb_opcodes.hrl").
+-include("aeso_icode.hrl").
+
+used_builtins(#funcall{ function = #var_ref{ name = {builtin, Builtin} }, args = Args }) ->
+    lists:umerge(dep_closure([Builtin]), used_builtins(Args));
+used_builtins([H|T]) ->
+  lists:umerge(used_builtins(H), used_builtins(T));
+used_builtins(T) when is_tuple(T) ->
+  used_builtins(tuple_to_list(T));
+used_builtins(M) when is_map(M) ->
+  used_builtins(maps:to_list(M));
+used_builtins(_) -> [].
+
+builtin_deps(Builtin) ->
+    lists:usort(builtin_deps1(Builtin)).
+
+builtin_deps1({map_lookup_default, Type}) -> [{map_lookup, Type}];
+builtin_deps1({map_get, Type})            -> [{map_lookup, Type}];
+builtin_deps1(map_member)                 -> [{map_lookup, word}];
+builtin_deps1({map_upd, Type})            -> [{map_get, Type}, map_put];
+builtin_deps1({map_upd_default, Type})    -> [{map_lookup_default, Type}, map_put];
+builtin_deps1(map_from_list)              -> [map_put];
+builtin_deps1(str_equal)                  -> [str_equal_p];
+builtin_deps1(string_concat)              -> [string_concat_inner1, string_concat_inner2];
+builtin_deps1(int_to_str)                 -> [int_to_str_, int_digits];
+builtin_deps1(_)                          -> [].
+
+dep_closure(Deps) ->
+    case lists:umerge(lists:map(fun builtin_deps/1, Deps)) of
+        []    -> Deps;
+        Deps1 -> lists:umerge(Deps, dep_closure(Deps1))
+    end.
+
+%% Helper functions/macros
+v(X) when is_atom(X) -> v(atom_to_list(X));
+v(X) when is_list(X) -> #var_ref{name = X}.
+
+option_none()  -> {tuple, [{integer, 0}]}.
+option_some(X) -> {tuple, [{integer, 1}, X]}.
+
+-define(call(Fun, Args), #funcall{ function = #var_ref{ name = {builtin, Fun} }, args = Args }).
+-define(I(X), {integer, X}).
+-define(V(X), v(X)).
+-define(A(Op), aeb_opcodes:mnemonic(Op)).
+-define(LET(Var, Expr, Body), {switch, Expr, [{v(Var), Body}]}).
+-define(DEREF(Var, Ptr, Body), {switch, v(Ptr), [{{tuple, [v(Var)]}, Body}]}).
+-define(NXT(Ptr), op('+', Ptr, 32)).
+
+-define(EQ(A, B), op('==', A, B)).
+-define(LT(A, B), op('<', A, B)).
+-define(GT(A, B), op('>', A, B)).
+-define(ADD(A, B), op('+', A, B)).
+-define(SUB(A, B), op('-', A, B)).
+-define(MUL(A, B), op('*', A, B)).
+-define(DIV(A, B), op('/', A, B)).
+-define(MOD(A, B), op('mod', A, B)).
+-define(EXP(A, B), op('^', A, B)).
+-define(AND(A, B), op('&&', A, B)).
+
+-define(BSL(X, B), ?MUL(X, ?EXP(2, ?MUL(B, 8)))).
+-define(BSR(X, B), ?DIV(X, ?EXP(2, ?MUL(B, 8)))).
+
+op(Op, A, B) -> {binop, Op, operand(A), operand(B)}.
+
+operand(A) when is_atom(A) -> v(A);
+operand(I) when is_integer(I) -> {integer, I};
+operand(T) -> T.
+
+str_to_icode(String) when is_list(String) ->
+    str_to_icode(list_to_binary(String));
+str_to_icode(BinStr) ->
+    Cpts = [size(BinStr) | aeso_data:binary_to_words(BinStr)],
+    #tuple{ cpts = [ #integer{value = X} || X <- Cpts ] }.
+
+%% Event primitive (dependent on Event type)
+%%
+%% We need to switch on the event and prepare the correct #event for icode_to_asm
+%% NOTE: we assume all errors are already checked!
+builtin_function(Builtin = {event, EventT}) ->
+    A         = fun(X) -> aeb_opcodes:mnemonic(X) end,
+    VIx       = fun(Ix) -> v(lists:concat(["v", Ix])) end,
+    ArgPats   = fun(Ts) -> [ VIx(Ix) || Ix <- lists:seq(0, length(Ts) - 1) ] end,
+    IsIndexed = fun(T) -> proplists:get_value(indexed, aeso_syntax:get_ann(T), false) end,
+    Payload = %% Should put data ptr, length on stack.
+        fun([]) ->  {inline_asm, [A(?PUSH1), 0, A(?PUSH1), 0]};
+           ([V]) -> {seq, [V, {inline_asm, [A(?DUP1), A(?MLOAD),                  %% length, ptr
+                                            A(?SWAP1), A(?PUSH1), 32, A(?ADD)]}]} %% ptr+32, length
+        end,
+    Clause =
+        fun(_Tag, {con, _, Con}, Types) ->
+            Indexed   = [ Var || {Var, Type} <- lists:zip(ArgPats(Types), Types),
+                                 IsIndexed(Type) ],
+            EvtIndex  = {unop, 'sha3', str_to_icode(Con)},
+            {event, lists:reverse(Indexed) ++ [EvtIndex], Payload(ArgPats(Types) -- Indexed)}
+        end,
+    Pat = fun(Tag, Types) -> {tuple, [{integer, Tag} | ArgPats(Types)]} end,
+
+    {variant_t, Cons} = EventT,
+    Tags              = lists:seq(0, length(Cons) - 1),
+
+    {{builtin, Builtin}, [private],
+        [{"e", event}],
+        {switch, v(e),
+            [{Pat(Tag, Types), Clause(Tag, Con, Types)}
+             || {Tag, {constr_t, _, Con, Types}} <- lists:zip(Tags, Cons) ]},
+        {tuple, []}};
+
+%% Abort primitive.
+builtin_function(abort) ->
+    A = fun(X) -> aeb_opcodes:mnemonic(X) end,
+    {{builtin, abort}, [private],
+     [{"s", string}],
+     {inline_asm, [A(?PUSH1),0,  %% Push a dummy 0 for the first arg
+                   A(?REVERT)]}, %% Stack: 0,Ptr
+     {tuple,[]}};
+
+%% Map primitives
+builtin_function(Builtin = {map_lookup, Type}) ->
+    Ret = aeso_icode:option_typerep(Type),
+    {{builtin, Builtin}, [private],
+        [{"m", word}, {"k", word}],
+            prim_call(?PRIM_CALL_MAP_GET, #integer{value = 0},
+                      [#var_ref{name = "m"}, #var_ref{name = "k"}],
+                      [word, word], Ret),
+     Ret};
+
+builtin_function(Builtin = map_put) ->
+    %% We don't need the types for put.
+    {{builtin, Builtin}, [private],
+        [{"m", word}, {"k", word}, {"v", word}],
+        prim_call(?PRIM_CALL_MAP_PUT, #integer{value = 0},
+                  [v(m), v(k), v(v)],
+                  [word, word, word], word),
+     word};
+
+builtin_function(Builtin = map_delete) ->
+    {{builtin, Builtin}, [private],
+        [{"m", word}, {"k", word}],
+        prim_call(?PRIM_CALL_MAP_DELETE, #integer{value = 0},
+                  [v(m), v(k)],
+                  [word, word], word),
+     word};
+
+builtin_function(Builtin = map_size) ->
+    Name = {builtin, Builtin},
+    {Name, [private], [{"m", word}],
+        prim_call(?PRIM_CALL_MAP_SIZE, #integer{value = 0},
+                  [v(m)], [word], word),
+        word};
+
+%% Map builtins
+builtin_function(Builtin = {map_get, Type}) ->
+    %% function map_get(m, k) =
+    %%   switch(map_lookup(m, k))
+    %%     Some(v) => v
+    {{builtin, Builtin}, [private],
+        [{"m", word}, {"k", word}],
+            {switch, ?call({map_lookup, Type}, [v(m), v(k)]),
+                [{option_some(v(v)), v(v)}]},
+     Type};
+
+builtin_function(Builtin = {map_lookup_default, Type}) ->
+    %% function map_lookup_default(m, k, default) =
+    %%   switch(map_lookup(m, k))
+    %%     None    => default
+    %%     Some(v) => v
+    {{builtin, Builtin}, [private],
+        [{"m", word}, {"k", word}, {"default", Type}],
+            {switch, ?call({map_lookup, Type}, [v(m), v(k)]),
+                [{option_none(),     v(default)},
+                 {option_some(v(v)), v(v)}]},
+     Type};
+
+builtin_function(Builtin = map_member) ->
+    %% function map_member(m, k) : bool =
+    %%   switch(Map.lookup(m, k))
+    %%     None => false
+    %%     _    => true
+    {{builtin, Builtin}, [private],
+        [{"m", word}, {"k", word}],
+            {switch, ?call({map_lookup, word}, [v(m), v(k)]),
+                [{option_none(), {integer, 0}},
+                 {{var_ref, "_"}, {integer, 1}}]},
+     word};
+
+builtin_function(Builtin = {map_upd, Type}) ->
+    %% function map_upd(map, key, fun) =
+    %%   map_put(map, key, fun(map_get(map, key)))
+    {{builtin, Builtin}, [private],
+     [{"map", word}, {"key", word}, {"valfun", word}],
+     ?call(map_put,
+        [v(map), v(key),
+         #funcall{ function = v(valfun),
+                   args     = [?call({map_get, Type}, [v(map), v(key)])] }]),
+     word};
+
+builtin_function(Builtin = {map_upd_default, Type}) ->
+    %% function map_upd(map, key, val, fun) =
+    %%   map_put(map, key, fun(map_lookup_default(map, key, val)))
+    {{builtin, Builtin}, [private],
+     [{"map", word}, {"key", word}, {"val", word}, {"valfun", word}],
+     ?call(map_put,
+        [v(map), v(key),
+         #funcall{ function = v(valfun),
+                   args     = [?call({map_lookup_default, Type}, [v(map), v(key), v(val)])] }]),
+     word};
+
+builtin_function(Builtin = map_from_list) ->
+    %% function map_from_list(xs, acc) =
+    %%   switch(xs)
+    %%     [] => acc
+    %%     (k, v) :: xs => map_from_list(xs, acc { [k] = v })
+    {{builtin, Builtin}, [private],
+     [{"xs", {list, {tuple, [word, word]}}}, {"acc", word}],
+     {switch, v(xs),
+        [{{list, []}, v(acc)},
+         {{binop, '::', {tuple, [v(k), v(v)]}, v(ys)},
+          ?call(map_from_list,
+            [v(ys), ?call(map_put, [v(acc), v(k), v(v)])])}]},
+     word};
+
+%% list_concat
+%%
+%% Concatenates two lists.
+builtin_function(list_concat) ->
+    {{builtin, list_concat}, [private],
+     [{"l1", {list, word}}, {"l2", {list, word}}],
+     {switch, v(l1),
+        [{{list, []}, v(l2)},
+         {{binop, '::', v(hd), v(tl)},
+          {binop, '::', v(hd), ?call(list_concat, [v(tl), v(l2)])}}
+        ]
+     },
+     word};
+
+builtin_function(string_length) ->
+    %% function length(str) =
+    %%   switch(str)
+    %%      {n} -> n  // (ab)use the representation
+    {{builtin, string_length}, [private],
+        [{"s", string}],
+        ?DEREF(n, s, ?V(n)),
+     word};
+
+%% str_concat - concatenate two strings
+%%
+%% Unless the second string is the empty string, a new string is created at the
+%% top of the Heap and the address to it is returned. The tricky bit is when
+%% the words from the second string has to be shifted to fit next to the first
+%% string.
+builtin_function(string_concat) ->
+    {{builtin, string_concat}, [private],
+     [{"s1", string}, {"s2", string}],
+     ?DEREF(n1, s1,
+     ?DEREF(n2, s2,
+        {ifte, ?EQ(n2, 0),
+            ?V(s1), %% Second string is empty return first string
+            ?LET(ret, {inline_asm, [?A(?MSIZE)]},
+                {seq, [?ADD(n1, n2), {inline_asm, [?A(?MSIZE), ?A(?MSTORE)]}, %% Store total len
+                       ?call(string_concat_inner1, [?V(n1), ?NXT(s1), ?V(n2), ?NXT(s2)]),
+                       {inline_asm, [?A(?POP)]}, %% Discard fun ret val
+                       ?V(ret)                   %% Put the actual return value
+                      ]})}
+     )),
+     word};
+
+builtin_function(string_concat_inner1) ->
+    %% Copy all whole words from the first string, and set up for word fusion
+    %% Special case when the length of the first string is divisible by 32.
+    {{builtin, string_concat_inner1}, [private],
+     [{"n1", word}, {"p1", pointer}, {"n2", word}, {"p2", pointer}],
+     ?DEREF(w1, p1,
+        {ifte, ?GT(n1, 32),
+            {seq, [?V(w1), {inline_asm, [?A(?MSIZE), ?A(?MSTORE)]},
+                   ?call(string_concat_inner1, [?SUB(n1, 32), ?NXT(p1), ?V(n2), ?V(p2)])]},
+            {ifte, ?EQ(n1, 0),
+                ?call(string_concat_inner2, [?I(32), ?I(0), ?V(n2), ?V(p2)]),
+                ?call(string_concat_inner2, [?SUB(32, n1), ?V(w1), ?V(n2), ?V(p2)])}
+        }),
+     word};
+
+builtin_function(string_concat_inner2) ->
+    %% Current "work in progess" word 'x', has 'o' bytes that are "free" - fill them from
+    %% words of the second string.
+    {{builtin, string_concat_inner2}, [private],
+     [{"o", word}, {"x", word}, {"n2", word}, {"p2", pointer}],
+     {ifte, ?LT(n2, 1),
+        {seq, [?V(x), {inline_asm, [?A(?MSIZE), ?A(?MSTORE), ?A(?MSIZE)]}]}, %% Use MSIZE as dummy return value
+        ?DEREF(w2, p2,
+            {ifte, ?GT(n2, o),
+                {seq, [?ADD(x, ?BSR(w2, ?SUB(32, o))),
+                       {inline_asm, [?A(?MSIZE), ?A(?MSTORE)]},
+                       ?call(string_concat_inner2,
+                             [?V(o), ?BSL(w2, o), ?SUB(n2, 32), ?NXT(p2)])
+                      ]},
+                {seq, [?ADD(x, ?BSR(w2, ?SUB(32, o))),
+                       {inline_asm, [?A(?MSIZE), ?A(?MSTORE), ?A(?MSIZE)]}]} %% Use MSIZE as dummy return value
+            })
+     },
+     word};
+
+builtin_function(str_equal_p) ->
+    %% function str_equal_p(n, p1, p2) =
+    %%   if(n =< 0) true
+    %%   else
+    %%      let w1 = *p1
+    %%      let w2 = *p2
+    %%      w1 == w2 && str_equal_p(n - 32, p1 + 32, p2 + 32)
+    {{builtin, str_equal_p}, [private],
+        [{"n", word}, {"p1", pointer}, {"p2", pointer}],
+        {ifte, ?LT(n, 1),
+            ?I(1),
+            ?DEREF(w1, p1,
+            ?DEREF(w2, p2,
+                ?AND(?EQ(w1, w2),
+                     ?call(str_equal_p, [?SUB(n, 32), ?NXT(p1), ?NXT(p2)]))))},
+     word};
+
+builtin_function(str_equal) ->
+    %% function str_equal(s1, s2) =
+    %%   let n1 = length(s1)
+    %%   let n2 = length(s2)
+    %%   n1 == n2 && str_equal_p(n1, s1 + 32, s2 + 32)
+    {{builtin, str_equal}, [private],
+        [{"s1", string}, {"s2", string}],
+        ?DEREF(n1, s1,
+        ?DEREF(n2, s2,
+            ?AND(?EQ(n1, n2), ?call(str_equal_p, [?V(n1), ?NXT(s1), ?NXT(s2)]))
+        )),
+        word};
+
+builtin_function(int_to_str) ->
+    {{builtin, int_to_str}, [private],
+        [{"i", word}],
+        ?LET(ret, {inline_asm, [?A(?MSIZE)]},
+        ?LET(n,   ?call(int_digits, [?DIV(i, 10), ?I(0)]),
+        ?LET(fac, ?EXP(10, n),
+        {seq,
+            [?ADD(n, 1), {inline_asm, [?A(?MSIZE), ?A(?MSTORE)]}, %% Store str len
+             ?call(int_to_str_,
+                   [?MOD(i, fac), ?BSL(?ADD(48, ?DIV(i, fac)), 31), ?DIV(fac, 10), ?I(1)]),
+             {inline_asm, [?A(?POP)]}, ?V(ret)] %% pop function return, push ret
+        }))),
+        word};
+
+builtin_function(int_to_str_) ->
+    {{builtin, int_to_str_}, [private],
+        [{"x", word}, {"y", word}, {"fac", word}, {"n", word}],
+        {ifte, ?EQ(fac, 0),
+            {seq, [?V(y), {inline_asm, [?A(?MSIZE), ?A(?MSTORE)]}, ?V(n)]},
+            {ifte, ?EQ(?MOD(n, 32), 0),
+                 %% We've filled a word, write it and start on new word
+                 {seq, [?V(y), {inline_asm, [?A(?MSIZE), ?A(?MSTORE)]},
+                        ?call(int_to_str_,
+                              [?MOD(x, fac), ?BSL(?ADD(48, ?DIV(x, fac)), 31),
+                               ?DIV(fac, 10), ?I(1)])]},
+                 ?call(int_to_str_,
+                       [?MOD(x, fac), ?ADD(y, ?BSL(?ADD(48, ?DIV(x, fac)), ?SUB(31, n))),
+                        ?DIV(fac, 10), ?ADD(n, 1)])}
+        },
+        word};
+
+builtin_function(int_digits) ->
+    {{builtin, int_digits}, [private],
+        [{"x", word}, {"n", word}],
+        {ifte, ?EQ(x, 0), ?V(n), ?call(int_digits, [?DIV(x, 10), ?ADD(n, 1)])},
+        word}.
+
+

--- a/apps/aesophia/src/aeso_builtins.erl
+++ b/apps/aesophia/src/aeso_builtins.erl
@@ -102,7 +102,7 @@ builtin_function(Builtin = {event, EventT}) ->
     A         = fun(X) -> aeb_opcodes:mnemonic(X) end,
     VIx       = fun(Ix) -> v(lists:concat(["v", Ix])) end,
     ArgPats   = fun(Ts) -> [ VIx(Ix) || Ix <- lists:seq(0, length(Ts) - 1) ] end,
-    IsIndexed = fun(T) -> proplists:get_value(indexed, aeso_syntax:get_ann(T), false) end,
+    IsIndexed = fun(T) -> aeso_syntax:get_ann(indexed, T, false) end,
     Payload = %% Should put data ptr, length on stack.
         fun([]) ->  {inline_asm, [A(?PUSH1), 0, A(?PUSH1), 0]};
            ([V]) -> {seq, [V, {inline_asm, [A(?DUP1), A(?MLOAD),                  %% length, ptr

--- a/apps/aesophia/src/aeso_compiler.erl
+++ b/apps/aesophia/src/aeso_compiler.erl
@@ -62,8 +62,8 @@ from_string(ContractString, Options) ->
     ByteCodeList = to_bytecode(Assembler, Options),
     ByteCode = << << B:8 >> || B <- ByteCodeList >>,
     ok = pp_bytecode(ByteCode, Options),
-    #{byte_code => ByteCode, type_info => TypeInfo, 
-      contract_source => ContractString, 
+    #{byte_code => ByteCode, type_info => TypeInfo,
+      contract_source => ContractString,
       compiler_version => version()}.
 
 -define(CALL_NAME, "__call").

--- a/apps/aesophia/src/aeso_icode.erl
+++ b/apps/aesophia/src/aeso_icode.erl
@@ -31,6 +31,7 @@
                   , functions => [fun_dec()]
                   , env => [bindings()]
                   , state_type => aeso_sophia:type()
+                  , event_type => aeso_sophia:type()
                   , types => #{ type_name() => type_def() }
                   , type_vars => #{ string() => aeso_sophia:type() }
                   , constructors => #{ string() => integer() }  %% name to tag
@@ -46,8 +47,9 @@ new(Options) ->
     #{ contract_name => ""
      , functions => []
      , env => new_env()
-       %% Default to unit type for state
+       %% Default to unit type for state and event
      , state_type => {tuple, []}
+     , event_type => {tuple, []}
      , types => builtin_types()
      , type_vars => #{}
      , constructors => builtin_constructors()

--- a/apps/aesophia/src/aeso_icode.hrl
+++ b/apps/aesophia/src/aeso_icode.hrl
@@ -64,3 +64,5 @@
                        , args   :: [term()]}).
 
 -record(seq, {exprs :: [expr()]}).
+
+-record(event, {topics :: [expr()], payload :: expr()}).

--- a/apps/aesophia/src/aeso_icode_to_asm.erl
+++ b/apps/aesophia/src/aeso_icode_to_asm.erl
@@ -557,7 +557,7 @@ assemble_infix('-')    -> i(?SUB);
 assemble_infix('*')    -> i(?MUL);
 assemble_infix('/')    -> i(?SDIV);
 assemble_infix('div')  -> i(?DIV);
-assemble_infix('mod')  -> i(?SMOD);
+assemble_infix('mod')  -> i(?MOD);
 assemble_infix('^')    -> i(?EXP);
 assemble_infix('bor')  -> i(?OR);
 assemble_infix('band') -> i(?AND);

--- a/apps/aesophia/src/aeso_icode_to_asm.erl
+++ b/apps/aesophia/src/aeso_icode_to_asm.erl
@@ -209,6 +209,15 @@ assemble_expr(Funs, Stack, _, {unop, '!', A}) ->
              i(?ISZERO)
             ]
     end;
+assemble_expr(Funs, Stack, _, {event, Topics, Payload}) ->
+    [assemble_exprs(Funs, Stack, Topics ++ [Payload]),
+     case length(Topics) of
+        0 -> i(?LOG0);
+        1 -> i(?LOG1);
+        2 -> i(?LOG2);
+        3 -> i(?LOG3);
+        4 -> i(?LOG4)
+     end, i(?MSIZE)];
 assemble_expr(Funs, Stack, _, {unop, Op, A}) ->
     [assemble_expr(Funs, Stack, nontail, A),
      assemble_prefix(Op)];

--- a/apps/aesophia/src/aeso_icode_to_asm.erl
+++ b/apps/aesophia/src/aeso_icode_to_asm.erl
@@ -569,7 +569,8 @@ assemble_infix('<=')   -> [i(?SGT), i(?ISZERO)];
 assemble_infix('=<')   -> [i(?SGT), i(?ISZERO)];
 assemble_infix('>=')   -> [i(?SLT), i(?ISZERO)];
 assemble_infix('!=')   -> [i(?EQ), i(?ISZERO)];
-assemble_infix('!')    -> [i(?ADD), i(?MLOAD)].
+assemble_infix('!')    -> [i(?ADD), i(?MLOAD)];
+assemble_infix('byte') -> i(?BYTE).
 %% assemble_infix('::') -> [i(?MSIZE), write_word(0), write_word(1)].
 
 %% a function may either refer to a top-level function, in which case

--- a/apps/aesophia/src/aeso_parser.erl
+++ b/apps/aesophia/src/aeso_parser.erl
@@ -72,10 +72,13 @@ constructors() ->
 
 constructor() ->    %% TODO: format for Con() vs Con
     choice(?RULE(con(),              {constr_t, get_ann(_1), _1, []}),
-           ?RULE(con(), type_args(), {constr_t, get_ann(_1), _1, _2})).
+           ?RULE(con(), con_args(), {constr_t, get_ann(_1), _1, _2})).
 
+con_args()   -> paren_list(con_arg()).
 type_args()  -> paren_list(type()).
 field_type() -> ?RULE(id(), tok(':'), type(), {field_t, get_ann(_1), _1, _3}).
+
+con_arg()    -> choice(type(), ?RULE(keyword(indexed), type(), set_ann(indexed, true, _2))).
 
 %% -- Let declarations -------------------------------------------------------
 

--- a/apps/aesophia/src/aeso_scan.erl
+++ b/apps/aesophia/src/aeso_scan.erl
@@ -37,7 +37,7 @@ lexer() ->
         , {"[^/*]+|[/*]", skip()} ],
 
     Keywords = ["contract", "import", "let", "rec", "switch", "type", "record", "datatype", "if", "elif", "else", "function",
-                "stateful", "true", "false", "and", "mod", "public", "private", "internal",
+                "stateful", "true", "false", "and", "mod", "public", "private", "indexed", "internal",
                 "band", "bor", "bxor", "bsl", "bsr", "bnot"],
     KW = string:join(Keywords, "|"),
 

--- a/apps/aesophia/test/contracts/events.aes
+++ b/apps/aesophia/test/contracts/events.aes
@@ -14,3 +14,4 @@ contract Events =
     Chain.event(Event1(x, x + 2, Int.to_str(x + 7)))
 
   function i2s(i : int) = Int.to_str(i)
+  function a2s(a : address) = Address.to_str(a)

--- a/apps/aesophia/test/contracts/events.aes
+++ b/apps/aesophia/test/contracts/events.aes
@@ -12,3 +12,5 @@ contract Events =
 
   function f3(x : int) =
     Chain.event(Event1(x, x + 2, Int.to_str(x + 7)))
+
+  function i2s(i : int) = Int.to_str(i)

--- a/apps/aesophia/test/contracts/events.aes
+++ b/apps/aesophia/test/contracts/events.aes
@@ -1,0 +1,14 @@
+contract Events =
+
+  datatype event =
+      Event1(indexed int, indexed int, string)
+    | Event2(string, indexed address)
+
+  function f1(x : int, y : string) =
+    Chain.event(Event1(x, x+1, y))
+
+  function f2(s : string) =
+    Chain.event(Event2(s, Call.caller))
+
+  function f3(x : int) =
+    Chain.event(Event1(x, x + 2, Int.to_str(x + 7)))


### PR DESCRIPTION
Events can now be defined and emitted:

```
contract Events =
  datatype event =
      Event1(indexed int, indexed int, string)
    | Event2(string, indexed address)

  function f1(x : int, y : string) =
    Chain.event(Event1(x, x+1, y))

  function f2(s : string) =
    Chain.event(Event2(s, Call.caller))
```

Also adding a `Int.to_str` to be able to add int/word to event payload. 