### PR TITLE
Fix channels FSM IF

### DIFF
--- a/apps/aechannel/test/aesc_fsm_SUITE.erl
+++ b/apps/aechannel/test/aesc_fsm_SUITE.erl
@@ -764,7 +764,7 @@ multiple_channels_t(NumCs, FromPort, Msg, Slogan, Cfg) ->
             end,
             Txs),
     aecore_suite_utils:mine_blocks_until_txs_on_chain(
-        aecore_suite_utils:node_name(dev1), TxHashes, 20),
+        aecore_suite_utils:node_name(dev1), TxHashes, 10),
     mine_blocks(dev1, ?MINIMUM_DEPTH),
     Cs = collect_acks(Cs, channel_ack, NumCs),
     ct:log("channel pids collected: ~p", [Cs]),


### PR DESCRIPTION
PT [Test throughput.many_chs_msg_loop failed failed on CI - timeout receive_from_fsm](https://www.pivotaltracker.com/story/show/162808119)

When mining for transactions inclusion, we aim at mining keyblocks in hope that all expected transactions will be included in microblocks before the timeout of keyblocks runs out. Since same genesis microblocks have a minimal time interval between them 3 seconds, if the expected key block interval is set to be lower than 3s, there will be at most 1 micro block per generation. If there are a lot of transactions in the mempool, they might not be included (so we are epxected to bump the maximum key block height to be mined). This is quite non-deterministic. This PR aims at improving the throughput in test suites.