### PR TITLE
Fix FSM IF

### DIFF
--- a/apps/aechannel/test/aesc_fsm_SUITE.erl
+++ b/apps/aechannel/test/aesc_fsm_SUITE.erl
@@ -117,7 +117,8 @@ init_per_suite(Config) ->
                                  {node, node()},
                                  {cookie, erlang:get_cookie()}]]),
     aecore_suite_utils:create_configs(
-      Config1, #{<<"chain">> => #{<<"persist">> => false}}),
+      Config1, #{<<"chain">> => #{<<"persist">> => false},
+                 <<"mining">> => #{<<"micro_block_cycle">> => 1}}),
     aecore_suite_utils:make_multi(Config1, [dev1, dev2]),
     [{nodes, [aecore_suite_utils:node_tuple(N)
               || N <- [dev1]]} | Config1].


### PR DESCRIPTION
PT [Test throughput.many_chs_msg_loop failed failed on CI - timeout receive_from_fsm](https://www.pivotaltracker.com/story/show/162808119)
When mining keyblocks fast, we only got 1 microblock per generation (default microblock intervals is 3s, keyblock is set to be 0.1s); if mempool has a little bit too much txs those might or might not be mined in time (for when the last keyblock is mined). This introduces some non-determinism.

This PR setups the node being tested to have microblock interval 1ms.