### PR TITLE
raise size limit of inband msgs

### DIFF
--- a/docs/release-notes/next-minerva/PT-162393920-inband-msg-size.md
+++ b/docs/release-notes/next-minerva/PT-162393920-inband-msg-size.md
@@ -1,0 +1,1 @@
+* Increases the maximum size of generic state channel messages to 65535 bytes.


### PR DESCRIPTION
See [PT #162393920](https://www.pivotaltracker.com/story/show/162393920)

PR against Minerva, since nodes running old and new version of the software would not be able to encode/decode each other's inband messages.

Note: size limit set to 65000 bytes, since noise messages are limited to 65535, and message headers + encryption adds a bit of overhead (and an even 65k is at least memorable.)