### PR TITLE
Make integration SUITE more stable

### DIFF
--- a/apps/aecore/test/aecore_suite_utils.erl
+++ b/apps/aecore/test/aecore_suite_utils.erl
@@ -22,6 +22,7 @@
          delete_node_db_if_persisted/1,
          mine_blocks/2,
          mine_blocks/3,
+         mine_all_txs/1,
          mine_blocks_until_txs_on_chain/3,
          mine_key_blocks/2,
          mine_micro_blocks/2,
@@ -228,6 +229,15 @@ mine_blocks(Node, NumBlocksToMine, MiningRate, Type) ->
             erlang:error(Reason)
     end.
 
+
+mine_all_txs(Node) ->
+    MaxBlocks = 5,
+    case rpc:call(Node, aec_tx_pool, peek, [infinity]) of
+        {ok, []} -> {ok, []};
+        {ok, Txs} ->
+            TxsHs = [ aehttp_api_encoder:encode(tx_hash, aetx_sign:hash(T)) || T <- Txs],
+            mine_blocks_until_txs_on_chain(Node, TxsHs, MaxBlocks)
+    end.
 
 mine_blocks_until_txs_on_chain(Node, TxHashes, MaxBlocks) ->
     mine_blocks_until_txs_on_chain(Node, TxHashes, 100, MaxBlocks).

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -601,7 +601,9 @@ init_per_suite(Config) ->
 
     aecore_suite_utils:create_configs(Config1, #{<<"chain">> =>
                                                  #{<<"persist">> => true,
-                                                   <<"hard_forks">> => Forks}}),
+                                                   <<"hard_forks">> => Forks},
+                                                  <<"mining">> =>
+                                                  #{<<"micro_block_cycle">> => 1}}),
     aecore_suite_utils:make_multi(Config1, [?NODE]),
     [{nodes, [aecore_suite_utils:node_tuple(?NODE)]}]  ++ Config1.
 
@@ -1499,12 +1501,7 @@ nonce_limit(Config) ->
     [{_, Node} | _] = ?config(nodes, Config),
     aecore_suite_utils:mock_mempool_nonce_offset(Node, 5),
 
-    case rpc(aec_tx_pool, peek, [infinity]) of
-        {ok, []}   -> ok;
-        {ok, Txs0} ->
-            Txs0Hs = [ aehttp_api_encoder:encode(tx_hash, aetx_sign:hash(T)) || T <- Txs0 ],
-            aecore_suite_utils:mine_blocks_until_txs_on_chain(Node, Txs0Hs, 5)
-    end,
+    aecore_suite_utils:mine_all_txs(Node),
     {ok, []} = rpc(aec_tx_pool, peek, [infinity]),
 
     Txs = lists:map(


### PR DESCRIPTION
PT [Tests  enhancement: mine transactions](https://www.pivotaltracker.com/story/show/162847138)
Lowering the microblock cycle will improve the probability of including all txs in a generation and will generaly improve test's stability