### PR TITLE
SC FSM test: fix IF

### DIFF
--- a/apps/aechannel/test/aesc_fsm_SUITE.erl
+++ b/apps/aechannel/test/aesc_fsm_SUITE.erl
@@ -572,7 +572,9 @@ channel_subverted(Cfg) ->
     #{ priv := IPrivKey } = ?config(initiator, Cfg),
     SignedCloseSoloTx = aec_test_utils:sign_tx(Tx, [IPrivKey]),
     ok = rpc(dev1, aec_tx_pool, push, [SignedCloseSoloTx]),
-    mine_blocks(dev1, 3),
+    TxHash = aehttp_api_encoder:encode(tx_hash, aetx_sign:hash(SignedCloseSoloTx)),
+    aecore_suite_utils:mine_blocks_until_txs_on_chain(
+        aecore_suite_utils:node_name(dev1), [TxHash], 20),
     {ok,_} = receive_from_fsm(info, I, fun died_subverted/1, ?TIMEOUT, Debug),
     {ok,_} = receive_from_fsm(info, R, fun died_subverted/1, ?TIMEOUT, Debug),
     check_info(500).


### PR DESCRIPTION
PTs [Test channel_subverted failed on CI - `receive_from_fsm_`](https://www.pivotaltracker.com/story/show/162813948) and [Test throughput.many_chs_msg_loop failed on minerva CI - timeout receive_from_fsm_](https://www.pivotaltracker.com/story/show/163053849)