### PR TITLE
Bump version of most OTP apps at each release

### DIFF
--- a/apps/aechannel/src/aechannel.app.src
+++ b/apps/aechannel/src/aechannel.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang; erlang-indent-level: 4; indent-tabs-mode: nil -*-
 {application, aechannel,
  [{description, "AE State Channels"},
-  {vsn, "0.1.0"},
+  {vsn, {cmd, "cat ../../VERSION"}},
   {registered, []},
   {applications,
    [kernel,

--- a/apps/aecontract/src/aecontract.app.src
+++ b/apps/aecontract/src/aecontract.app.src
@@ -1,6 +1,6 @@
 {application, aecontract,
  [{description, "AE Contract"},
-  {vsn, "0.1.0"},
+  {vsn, {cmd, "cat ../../VERSION"}},
   {registered, []},
   {applications,
    [kernel,

--- a/apps/aecore/src/aecore.app.src
+++ b/apps/aecore/src/aecore.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang; erlang-indent-level: 4; indent-tabs-mode: nil -*-
 {application, aecore,
  [{description, "Blockchain for aeapps"},
-  {vsn, "0.1.0"},
+  {vsn, {cmd, "cat ../../VERSION"}},
   {registered, []},
   {mod, { aecore_app, []}},
   {start_phases, [

--- a/apps/aecuckoo/src/aecuckoo.app.src
+++ b/apps/aecuckoo/src/aecuckoo.app.src
@@ -1,6 +1,6 @@
 {application, aecuckoo,
  [{description, "OTP application wrapping build of Cuckoo Cycle proof of work executables"},
-  {vsn, "0.1.0"},
+  {vsn, {cmd, "cat ../../VERSION"}},
   {registered, []},
   {applications,
    [kernel,

--- a/apps/aehttp/src/aehttp.app.src
+++ b/apps/aehttp/src/aehttp.app.src
@@ -1,6 +1,6 @@
 {application, aehttp,
  [{description, "API"},
-  {vsn, "0.1.0"},
+  {vsn, {cmd, "cat ../../VERSION"}},
   {registered, []},
   {mod, { aehttp_app, []}},
   {applications,

--- a/apps/aens/src/aens.app.src
+++ b/apps/aens/src/aens.app.src
@@ -1,6 +1,6 @@
 {application, aens,
  [{description, "AE Naming System"},
-  {vsn, "0.1.0"},
+  {vsn, {cmd, "cat ../../VERSION"}},
   {registered, []},
   {applications,
    [kernel,

--- a/apps/aeoracle/src/aeoracle.app.src
+++ b/apps/aeoracle/src/aeoracle.app.src
@@ -1,6 +1,6 @@
 {application, aeoracle,
  [{description, "AE Oracle"},
-  {vsn, "0.1.0"},
+  {vsn, {cmd, "cat ../../VERSION"}},
   {registered, []},
   {applications,
    [kernel,

--- a/apps/aetx/src/aetx.app.src
+++ b/apps/aetx/src/aetx.app.src
@@ -1,6 +1,6 @@
 {application, aetx,
  [{description, "An OTP library defining aetx behaviour"},
-  {vsn, "0.1.0"},
+  {vsn, {cmd, "cat ../../VERSION"}},
   {registered, []},
   {applications,
    [kernel,

--- a/apps/aeutils/src/aeutils.app.src
+++ b/apps/aeutils/src/aeutils.app.src
@@ -1,6 +1,6 @@
 {application, aeutils,
  [{description, "Aeapps utils"},
-  {vsn, "0.1.0"},
+  {vsn, {cmd, "cat ../../VERSION"}},
   {registered, []},
   {applications,
    [kernel,

--- a/apps/aevarna/src/aevarna.app.src
+++ b/apps/aevarna/src/aevarna.app.src
@@ -1,6 +1,6 @@
 {application, aevarna,
  [{description, "Contract Language for Aethernity"},
-  {vsn, "0.0.1"},
+  {vsn, {cmd, "cat ../../VERSION"}},
   {registered, []},
   {applications,
    [kernel,

--- a/apps/aevm/src/aevm.app.src
+++ b/apps/aevm/src/aevm.app.src
@@ -1,6 +1,6 @@
 {application, aevm,
  [{description, "Virtual machine for Aethernity"},
-  {vsn, "0.1.0"},
+  {vsn, {cmd, "cat ../../VERSION"}},
   {registered, []},
   {mod, { aevm_app, []}},
   {applications,

--- a/apps/check_config/src/check_config.app.src
+++ b/apps/check_config/src/check_config.app.src
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4; indent-tabs-mode: nil -*-
 {application, check_config,
  [{description, "escript for checking epoch user config files"},
-  {vsn, "0.1.0"},
+  {vsn, {cmd, "cat ../../VERSION"}},
   {registered, []},
   {applications,
    [kernel,

--- a/docs/cuda-miner.md
+++ b/docs/cuda-miner.md
@@ -107,6 +107,9 @@ cd apps/aecuckoo && make cuda29
 
 Finally the actual installation of the miner binary is copying it to the node corresponding path, the documentation assumes the `epoch` node is installed in `~/aeternity/node` directory.
 
+The exact path where to copy the binary depends on the version of the node: you can find it by calling `ls -d ~/aeternity/node/lib/aecuckoo-*/priv/bin`.
+E.g. it may be something like `~/aeternity/node/lib/aecuckoo-0.1.0/priv/bin`: the following assumes this path though you may likely need to adapt it.
+
 ```bash
 cp priv/bin/cuda29 ~/aeternity/node/lib/aecuckoo-0.1.0/priv/bin
 ```

--- a/docs/cuda-miner.md
+++ b/docs/cuda-miner.md
@@ -152,7 +152,7 @@ the reward collected from the transaction fees in the micro blocks.)
 
 To fine tune the parameter, you should try running the miner in a shell
 ```
-$ time ~/aeternity/node/lib/aecuckooprebuilt-0.1.0/priv/cuda29 -r 5
+$ time ~/aeternity/node/lib/aecuckooprebuilt-*/priv/cuda29 -r 5
 ...
 real 0m4.634s
 user ...

--- a/docs/release-notes/RELEASE-NOTES-1.2.0.md
+++ b/docs/release-notes/RELEASE-NOTES-1.2.0.md
@@ -35,7 +35,7 @@ For specifying configuration using the Docker image, please refer to [its docume
 
 The node user API is documented:
 * HTTP API endpoints are specified [online in swagger.yaml][swagger-yaml];
-  * A JSON version of the same specification is located in the node at path `lib/aehttp-0.1.0/priv/swagger.json`.
+  * A JSON version of the same specification is located in the node at path `lib/aehttp-*/priv/swagger.json` (you will need to amend the wildcard `*` placeholder in the path with the version).
   * The JSON version can be obtained from a running node using the endpoint `/api`.
   * An interactive visualization of the same specification is available [online][swagger-ui].
 * WebSocket API endpoints are [specified online][api-doc];


### PR DESCRIPTION
Delivers https://www.pivotaltracker.com/story/show/163092045

I may need to make this even more minimal, as the version of some apps is hardcoded in some scripts.

TODO:
* [ ] get_peer_key.sh
* [ ] keys_gen.sh
* [ ] messages_hash.sh

```
$ git grep -e '-0\.1\.0'
apps/aeutils/priv/extensions/get_peer_key.sh:26:LIBPATH1=$PWD/lib/aecore-0.1.0/ebin
apps/aeutils/priv/extensions/get_peer_key.sh:28:LIBPATH3=$PWD/lib/aehttp-0.1.0/ebin
apps/aeutils/priv/extensions/keys_gen.sh:8:"$ERTS_DIR/bin/escript" "$ROOTDIR/lib/aeutils-0.1.0/priv/keys_gen" "$*"
apps/aeutils/priv/extensions/messages_hash.sh:7:"$ERTS_DIR/bin/escript" "$ROOTDIR/lib/aeutils-0.1.0/priv/messages_hash" "$*"
...
```