### PR TITLE
OTP release rename with backward compatible bin/epoch - preparation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,6 +122,17 @@ references:
         mv _build/prod/rel/epoch/epoch-$(cat VERSION).tar.gz ${PACKAGE_TARBALL:?}
 
   package_tests_workspace: &package_tests_workspace /tmp/package_tests
+  test_package: &test_package
+    run:
+      name: Test Package Tarball
+      environment:
+        PACKAGES_DIR: *packages_workspace
+        PACKAGE_TESTS_DIR: *package_tests_workspace
+      command: |
+        epmd -daemon
+        make python-env
+        mkdir ${PACKAGE_TESTS_DIR:?}
+        make python-release-test WORKDIR=${PACKAGE_TESTS_DIR:?} TARBALL=${PACKAGE_TARBALL:?}
 
   store_package_artifacts: &store_package_artifacts
     store_artifacts:
@@ -388,6 +399,7 @@ jobs:
       - checkout
       - *set_package_path
       - *build_package
+      - *test_package
       - store_artifacts:
           path: /tmp/package_tests/node1/log
       - store_artifacts:
@@ -440,6 +452,7 @@ jobs:
             brew install file://`pwd`/deployment/homebrew/erlang.rb
       - *set_package_path
       - *build_package
+      - *test_package
       - store_artifacts:
           path: /tmp/package_tests/node1/log
       - store_artifacts:

--- a/config/dev.config
+++ b/config/dev.config
@@ -5,9 +5,6 @@
     ]
   },
 
-  { epoch, [
-  ]},
-
   { aehttp, [
       {external, [
           {acceptors, 10},

--- a/config/dev1/sys.config
+++ b/config/dev1/sys.config
@@ -5,9 +5,6 @@
     ]
   },
 
-  { epoch, [
-  ]},
-
   { aehttp, [
       {external, [
           {acceptors, 10},

--- a/config/dev2/sys.config
+++ b/config/dev2/sys.config
@@ -5,9 +5,6 @@
     ]
   },
 
-  { epoch, [
-  ]},
-
   { aehttp, [
       {external, [
           {acceptors, 10},

--- a/config/dev3/sys.config
+++ b/config/dev3/sys.config
@@ -5,9 +5,6 @@
     ]
   },
 
-  { epoch, [
-  ]},
-
   { aehttp, [
       {external, [
           {acceptors, 10},

--- a/config/sys.config
+++ b/config/sys.config
@@ -6,9 +6,6 @@
     ]
   },
 
-  { epoch, [
-  ]},
-
   { aehttp, [
       {external, [
           {acceptors, 10},

--- a/py/tests/release.py
+++ b/py/tests/release.py
@@ -50,6 +50,7 @@ websocket:
         acceptors: 100
 
 mining:
+    autostart: true
     beneficiary: "ak_RShHyLiaQJF8AZ7Thi4Sgjm6ncHhqguqBBqCzQRG3fyjvKj6V"
     cuckoo:
         edge_bits: 15
@@ -60,6 +61,9 @@ mining:
 chain:
     persist: true
     db_path: ./my_db
+
+fork_management:
+    network_id: ae_uat
 ''',
             "config": '''[
 {aecore,
@@ -106,6 +110,9 @@ mining:
 chain:
     persist: true
     db_path: ./my_db
+
+fork_management:
+    network_id: ae_uat
 ''',
             "config": '''[
 {aecore,
@@ -152,6 +159,9 @@ mining:
 chain:
     persist: true
     db_path: ./my_db
+
+fork_management:
+    network_id: ae_uat
 ''',
             "config": '''[
 {aecore,

--- a/py/tests/release.py
+++ b/py/tests/release.py
@@ -63,7 +63,7 @@ chain:
     db_path: ./my_db
 
 fork_management:
-    network_id: ae_uat
+    network_id: ae_smoke_test
 ''',
             "config": '''[
 {aecore,
@@ -112,7 +112,7 @@ chain:
     db_path: ./my_db
 
 fork_management:
-    network_id: ae_uat
+    network_id: ae_smoke_test
 ''',
             "config": '''[
 {aecore,
@@ -161,7 +161,7 @@ chain:
     db_path: ./my_db
 
 fork_management:
-    network_id: ae_uat
+    network_id: ae_smoke_test
 ''',
             "config": '''[
 {aecore,


### PR DESCRIPTION
In scope of https://www.pivotaltracker.com/story/show/163191726

Without non-mainnet network id, mining the first block would take too long for a smoke test. [Proof](https://circleci.com/gh/aeternity/epoch/54369).