### PR TITLE
Make HTTP API backwards compatible w.r.t VM version

### DIFF
--- a/apps/aehttp/priv/swagger.json
+++ b/apps/aehttp/priv/swagger.json
@@ -2323,7 +2323,7 @@
     },
     "RegisteredOracle" : {
       "type" : "object",
-      "required" : [ "abi_version", "id", "query_fee", "query_format", "response_format", "ttl" ],
+      "required" : [ "id", "query_fee", "query_format", "response_format", "ttl" ],
       "properties" : {
         "id" : {
           "$ref" : "#/definitions/EncodedHash"
@@ -2341,6 +2341,11 @@
           "type" : "integer",
           "format" : "int64"
         },
+        "vm_version" : {
+          "type" : "integer",
+          "minimum" : 0,
+          "maximum" : 65535
+        },
         "abi_version" : {
           "type" : "integer",
           "minimum" : 0,
@@ -2348,8 +2353,9 @@
         }
       },
       "example" : {
+        "vm_version" : 9606,
         "response_format" : "response_format",
-        "abi_version" : 9606,
+        "abi_version" : 39072,
         "id" : { },
         "query_fee" : 0,
         "ttl" : 6,
@@ -2521,14 +2527,19 @@
           "type" : "integer",
           "format" : "int64"
         },
+        "vm_version" : {
+          "type" : "integer",
+          "minimum" : 0,
+          "maximum" : 65535
+        },
         "abi_version" : {
           "type" : "integer",
-          "format" : "int64",
           "minimum" : 0,
           "maximum" : 65535
         }
       },
       "example" : {
+        "vm_version" : 36944,
         "response_format" : "response_format",
         "account_id" : { },
         "fee" : 1,
@@ -2536,7 +2547,7 @@
           "type" : "delta",
           "value" : 1
         },
-        "abi_version" : 36944,
+        "abi_version" : 15087,
         "query_fee" : 0,
         "nonce" : 6,
         "ttl" : 5,
@@ -3835,7 +3846,7 @@
     },
     "ContractObject" : {
       "type" : "object",
-      "required" : [ "abi_version", "active", "deposit", "id", "log", "owner_id", "referrer_ids", "vm_version" ],
+      "required" : [ "active", "deposit", "id", "log", "owner_id", "referrer_ids", "vm_version" ],
       "properties" : {
         "id" : {
           "$ref" : "#/definitions/EncodedHash"
@@ -4171,7 +4182,7 @@
     },
     "ContractCreateTx" : {
       "type" : "object",
-      "required" : [ "abi_version", "amount", "call_data", "code", "deposit", "fee", "gas", "gas_price", "owner_id", "vm_version" ],
+      "required" : [ "amount", "call_data", "code", "deposit", "fee", "gas", "gas_price", "owner_id", "vm_version" ],
       "properties" : {
         "owner_id" : {
           "description" : "Contract owner pub_key",
@@ -4249,7 +4260,7 @@
     },
     "ContractCreateCompute" : {
       "type" : "object",
-      "required" : [ "abi_version", "amount", "code", "deposit", "fee", "gas", "gas_price", "owner_id", "vm_version" ],
+      "required" : [ "amount", "code", "deposit", "fee", "gas", "gas_price", "owner_id", "vm_version" ],
       "properties" : {
         "owner_id" : {
           "type" : "string",
@@ -4332,7 +4343,7 @@
     },
     "ContractCallTx" : {
       "type" : "object",
-      "required" : [ "abi_version", "amount", "call_data", "caller_id", "contract_id", "fee", "gas", "gas_price" ],
+      "required" : [ "amount", "call_data", "caller_id", "contract_id", "fee", "gas", "gas_price" ],
       "properties" : {
         "caller_id" : {
           "description" : "Contract caller pub_key",
@@ -4345,6 +4356,12 @@
         "contract_id" : {
           "description" : "Contract's pub_key",
           "$ref" : "#/definitions/EncodedHash"
+        },
+        "vm_version" : {
+          "type" : "integer",
+          "description" : "VM version",
+          "minimum" : 0,
+          "maximum" : 65535
         },
         "abi_version" : {
           "type" : "integer",
@@ -4384,20 +4401,21 @@
       },
       "example" : {
         "gas_price" : 0,
+        "vm_version" : 39500,
         "amount" : 0,
         "call_data" : { },
         "caller_id" : { },
         "contract_id" : null,
         "fee" : 0,
         "gas" : 0,
-        "abi_version" : 39500,
+        "abi_version" : 9606,
         "nonce" : 0,
         "ttl" : 0
       }
     },
     "ContractCallCompute" : {
       "type" : "object",
-      "required" : [ "abi_version", "amount", "caller_id", "contract_id", "fee", "gas", "gas_price" ],
+      "required" : [ "amount", "caller_id", "contract_id", "fee", "gas", "gas_price" ],
       "properties" : {
         "caller_id" : {
           "description" : "Contract caller pub_key",
@@ -4410,6 +4428,12 @@
         "contract_id" : {
           "description" : "Contract's pub_key",
           "$ref" : "#/definitions/EncodedHash"
+        },
+        "vm_version" : {
+          "type" : "integer",
+          "description" : "VM version",
+          "minimum" : 0,
+          "maximum" : 65535
         },
         "abi_version" : {
           "type" : "integer",
@@ -4457,17 +4481,18 @@
       },
       "example" : {
         "gas_price" : 0,
-        "call" : "call",
         "amount" : 0,
-        "caller_id" : { },
         "contract_id" : null,
         "fee" : 0,
+        "nonce" : 0,
+        "ttl" : 0,
+        "call" : "call",
+        "vm_version" : 39500,
+        "caller_id" : { },
         "function" : "function",
         "gas" : 0,
-        "abi_version" : 39500,
-        "arguments" : "arguments",
-        "nonce" : 0,
-        "ttl" : 0
+        "abi_version" : 9606,
+        "arguments" : "arguments"
       }
     },
     "UnsignedTx" : {
@@ -4631,7 +4656,7 @@
         "$ref" : "#/definitions/OffChainUpdate"
       }, {
         "type" : "object",
-        "required" : [ "abi_version", "call_data", "code", "deposit", "owner", "vm_version" ],
+        "required" : [ "call_data", "code", "deposit", "owner", "vm_version" ],
         "properties" : {
           "owner" : {
             "description" : "Contract owner",
@@ -4669,7 +4694,7 @@
         "$ref" : "#/definitions/OffChainUpdate"
       }, {
         "type" : "object",
-        "required" : [ "abi_version", "amount", "call_data", "caller", "contract", "gas", "gas_price" ],
+        "required" : [ "amount", "call_data", "caller", "contract", "gas", "gas_price" ],
         "properties" : {
           "caller" : {
             "description" : "Contract caller",
@@ -4678,6 +4703,12 @@
           "contract" : {
             "description" : "Contract address",
             "$ref" : "#/definitions/EncodedHash"
+          },
+          "vm_version" : {
+            "type" : "integer",
+            "description" : "ABI version for the call/calldata",
+            "minimum" : 0,
+            "maximum" : 65535
           },
           "abi_version" : {
             "type" : "integer",

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -1928,6 +1928,12 @@ definitions:
       ttl:
         type: integer
         format: int64
+      # vm_version is kept for backwards compatibility and should be
+      # removed later, _and_ abi_version should then be 'required'
+      vm_version:
+        type: integer
+        minimum: 0
+        maximum: 65535
       abi_version:
         type: integer
         minimum: 0
@@ -1938,7 +1944,6 @@ definitions:
       - response_format
       - query_fee
       - ttl
-      - abi_version
   OracleQuery:
     type: object
     properties:
@@ -2034,9 +2039,14 @@ definitions:
       ttl:
         type: integer
         format: int64
+      # vm_version is kept for backwards compatibility and should be
+      # removed later
+      vm_version:
+        type: integer
+        minimum: 0
+        maximum: 65535
       abi_version:
         type: integer
-        format: int64
         minimum: 0
         maximum: 65535
     required:
@@ -2937,6 +2947,7 @@ definitions:
         type: integer
         minimum: 0
         maximum: 65535
+      # abi_version is optional for now, should be required eventually
       abi_version:
         type: integer
         minimum: 0
@@ -2955,7 +2966,8 @@ definitions:
       - id
       - owner_id
       - vm_version
-      - abi_version
+      # abi_version is optional for now, should be required eventually
+      # - abi_version
       - log
       - active
       - referrer_ids
@@ -3165,7 +3177,8 @@ definitions:
       - owner_id
       - code
       - vm_version
-      - abi_version
+      # abi_version is optional for now, should be required eventually
+      # - abi_version
       - deposit
       - amount
       - gas
@@ -3228,7 +3241,8 @@ definitions:
       - owner_id
       - code
       - vm_version
-      - abi_version
+      # abi_version is optional for now, should be required eventually
+      # - abi_version
       - deposit
       - amount
       - gas
@@ -3246,6 +3260,13 @@ definitions:
       contract_id:
         $ref: '#/definitions/EncodedHash'
         description: 'Contract''s pub_key'
+      # Old name vm_version kept for backwards compatibility
+      # should be removed and then abi_version should be required
+      vm_version:
+        description: 'VM version'
+        type: integer
+        minimum: 0
+        maximum: 65535
       abi_version:
         description: 'ABI version'
         type: integer
@@ -3277,7 +3298,8 @@ definitions:
     required:
       - caller_id
       - contract_id
-      - abi_version
+      # Should be requried once vm_version is gone
+      # - abi_version
       - fee
       - amount
       - gas
@@ -3295,6 +3317,13 @@ definitions:
       contract_id:
         $ref: '#/definitions/EncodedHash'
         description: 'Contract''s pub_key'
+      # Old name vm_version kept for backwards compatibility
+      # should be removed and then abi_version should be required
+      vm_version:
+        description: 'VM version'
+        type: integer
+        minimum: 0
+        maximum: 65535
       abi_version:
         description: 'ABI version'
         type: integer
@@ -3332,7 +3361,8 @@ definitions:
     required:
       - caller_id
       - contract_id
-      - abi_version
+      # Should be requried once vm_version is gone
+      # - abi_version
       - fee
       - amount
       - gas
@@ -3470,7 +3500,8 @@ definitions:
         required:
           - owner
           - vm_version
-          - abi_version
+          # Optional for now...
+          # - abi_version
           - code
           - deposit
           - call_data
@@ -3485,6 +3516,12 @@ definitions:
           contract:
             $ref: '#/definitions/EncodedHash'
             description: Contract address
+          # vm_version kept for backwards compatibility, should be removed
+          vm_version:
+            type: integer
+            description: ABI version for the call/calldata
+            minimum: 0
+            maximum: 65535
           abi_version:
             type: integer
             description: ABI version for the call/calldata
@@ -3508,7 +3545,8 @@ definitions:
         required:
           - caller
           - contract
-          - abi_version
+          # should be required once vm_version is removed
+          # - abi_version
           - code
           - amount
           - call_data


### PR DESCRIPTION
This allows for old style API calls to work post Minerva release. And the code changes necessary to remove the backwards compatibility should be minimal!